### PR TITLE
fix admin-console license embedding

### DIFF
--- a/pkg/addons/adminconsole/adminconsole.go
+++ b/pkg/addons/adminconsole/adminconsole.go
@@ -11,9 +11,9 @@ import (
 	"github.com/k0sproject/k0s/pkg/apis/v1beta1"
 	"github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"gopkg.in/yaml.v3"
-	k8syaml "sigs.k8s.io/yaml"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	k8syaml "sigs.k8s.io/yaml"
 
 	"github.com/replicatedhq/embedded-cluster/pkg/customization"
 	"github.com/replicatedhq/embedded-cluster/pkg/defaults"

--- a/pkg/addons/adminconsole/adminconsole.go
+++ b/pkg/addons/adminconsole/adminconsole.go
@@ -11,6 +11,7 @@ import (
 	"github.com/k0sproject/k0s/pkg/apis/v1beta1"
 	"github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"gopkg.in/yaml.v3"
+	k8syaml "sigs.k8s.io/yaml"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -89,7 +90,7 @@ func (a *AdminConsole) addLicenseToHelmValues() error {
 	if license == nil {
 		return nil
 	}
-	raw, err := yaml.Marshal(license)
+	raw, err := k8syaml.Marshal(license)
 	if err != nil {
 		return fmt.Errorf("unable to marshal license: %w", err)
 	}


### PR DESCRIPTION
This PR switches the yaml marshaller used when reading in the kots license so that it will embed correctly. 