### PR TITLE
chore: change metrics endpoint path

### DIFF
--- a/pkg/metrics/sender.go
+++ b/pkg/metrics/sender.go
@@ -41,7 +41,7 @@ type Sender struct {
 
 // Send sends an event to the metrics endpoint.
 func (s *Sender) Send(ctx context.Context, ev Event) {
-	url := fmt.Sprintf("%s/helmbin_metrics/%s", s.baseURL, ev.Title())
+	url := fmt.Sprintf("%s/embedded_cluster_metrics/%s", s.baseURL, ev.Title())
 	payload, err := s.payload(ev)
 	if err != nil {
 		logrus.Debugf("unable to get payload for event %s: %s", ev.Title(), err)

--- a/pkg/metrics/sender_test.go
+++ b/pkg/metrics/sender_test.go
@@ -120,7 +120,7 @@ func TestSend(t *testing.T) {
 				http.HandlerFunc(
 					func(rw http.ResponseWriter, req *http.Request) {
 						evname := reflect.TypeOf(tt.event).Name()
-						path := fmt.Sprintf("/helmbin_metrics/%s", evname)
+						path := fmt.Sprintf("/embedded_cluster_metrics/%s", evname)
 						assert.Equal(t, req.URL.Path, path)
 						assert.Equal(t, "POST", req.Method)
 						received, err := io.ReadAll(req.Body)


### PR DESCRIPTION
the old endpoint isn't going to work anymore.