### PR TITLE
bug: fix wrong url protocol for kotsadm access

### DIFF
--- a/pkg/addons/adminconsole/adminconsole.go
+++ b/pkg/addons/adminconsole/adminconsole.go
@@ -246,7 +246,7 @@ func (a *AdminConsole) printSuccessMessage() {
 		}
 	}
 	nodePort := helmValues["service"].(map[string]interface{})["nodePort"]
-	successMessage := fmt.Sprintf("Admin Console accessible at: %shttps://%s:%v%s", successColor, ipaddr, nodePort, colorReset)
+	successMessage := fmt.Sprintf("Admin Console accessible at: %shttp://%s:%v%s", successColor, ipaddr, nodePort, colorReset)
 	fmt.Println(successMessage)
 }
 


### PR DESCRIPTION
so far kotsadm is only available over http, not https.