### PR TITLE
bug: bring systemd unit file installation back

### DIFF
--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -150,6 +150,15 @@ func TestMultiNodeInteractiveInstallation(t *testing.T) {
 	if _, _, err := RunCommandOnNode(t, tc, 0, line); err != nil {
 		t.Fatalf("nodes not reporting ready: %v", err)
 	}
+	t.Log("restarting embedded-cluster service in all nodes")
+	for i := range tc.Nodes {
+		cmd := []string{"systemctl", "restart", "embedded-cluster"}
+		if stdout, stderr, err := RunCommandOnNode(t, tc, i, cmd); err != nil {
+			t.Logf("stdout: %s", stdout)
+			t.Logf("stderr: %s", stderr)
+			t.Fatalf("fail to restart service node %d: %v", i, err)
+		}
+	}
 }
 
 func TestInstallWithDisabledAddons(t *testing.T) {

--- a/e2e/scripts/embed-and-install.sh
+++ b/e2e/scripts/embed-and-install.sh
@@ -136,6 +136,10 @@ main() {
         echo "Memcached pods not present"
         exit 1
     fi
+    if ! systemctl restart embedded-cluster; then
+        echo "Failed to restart embedded-cluster service"
+        exit 1
+    fi
 }
 
 export EMBEDDED_CLUSTER_METRICS_BASEURL="https://staging.replicated.app"

--- a/e2e/scripts/embedded-preflight.sh
+++ b/e2e/scripts/embedded-preflight.sh
@@ -182,6 +182,10 @@ main() {
         echo "Failed to install embedded-cluster"
         exit 1
     fi
+    if ! systemctl restart embedded-cluster; then
+        echo "Failed to restart embedded-cluster service"
+        exit 1
+    fi
 }
 
 export EMBEDDED_CLUSTER_METRICS_BASEURL="https://staging.replicated.app"

--- a/e2e/scripts/install-with-disabled-addons.sh
+++ b/e2e/scripts/install-with-disabled-addons.sh
@@ -87,6 +87,10 @@ main() {
         echo "Pods found on embedded-cluster namespace"
         exit 1
     fi
+    if ! systemctl restart embedded-cluster; then
+        echo "Failed to restart embedded-cluster service"
+        exit 1
+    fi
 }
 
 export EMBEDDED_CLUSTER_METRICS_BASEURL="https://staging.replicated.app"

--- a/e2e/scripts/single-node-install.sh
+++ b/e2e/scripts/single-node-install.sh
@@ -63,6 +63,10 @@ main() {
         echo "Failed to install embedded-cluster"
         exit 1
     fi
+    if ! systemctl restart embedded-cluster; then
+        echo "Failed to restart embedded-cluster service"
+        exit 1
+    fi
 }
 
 export EMBEDDED_CLUSTER_METRICS_BASEURL="https://staging.replicated.app"

--- a/e2e/scripts/zz-scripts.go
+++ b/e2e/scripts/zz-scripts.go
@@ -1,9 +1,11 @@
-// package scripts embeds all shell scripts we use for testing.
+// Package scripts embeds all shell scripts we use for testing.
 // this file is named zz_ so it is the last file to show up
 // in the editor.
 package scripts
 
 import "embed"
 
+// FS is the embedded filesystem for scripts.
+//
 //go:embed *
 var FS embed.FS


### PR DESCRIPTION
during our co-working session this feature has been lost so the command

```
systemctl restart embedded-cluster
```

was failing because the systemd unit file wasn't being created anymore. this commit brings the feature back while also adding it to our e2e tests so we don't loose it anymore.