### PR TITLE
feat: publishing versions as part of the release

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -21,6 +21,7 @@ jobs:
         run: |
           make embedded-cluster-linux-amd64
           tar -C output/bin -czvf embedded-cluster-linux-amd64.tgz embedded-cluster
+          ./output/bin/embedded-cluster version --json > versions.json
           make clean
       - name: Build darwin-amd64
         run: |
@@ -41,3 +42,4 @@ jobs:
           title: Development Release Build
           files: |
             *.tgz
+            versions.json

--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -23,6 +23,7 @@ jobs:
         run: |
           make embedded-cluster-linux-amd64 VERSION=$TAG_NAME
           tar -C output/bin -czvf embedded-cluster-linux-amd64.tgz embedded-cluster
+          ./output/bin/embedded-cluster version --json > versions.json
           make clean
       - name: Build darwin-amd64
         run: |
@@ -41,3 +42,4 @@ jobs:
           prerelease: false
           files: |
             *.tgz
+            versions.json


### PR DESCRIPTION
start to publish a file called versions.json with a content similar to the following:

```json
{
        "AdminConsole": "v1.104.3",
        "EmbeddedClusterOperator": "v0.4.1",
        "Installer": "v1.28.4+ec.0-dirty",
        "Kubernetes": "v1.28.4+k0s.0",
        "OpenEBS": "v3.9.0"
}
```

this file will be useful later on when we need to check what versions are included in a given embedded cluster release.