### PR TITLE
feat: start publishing release metadata json file

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -21,6 +21,7 @@ jobs:
         run: |
           make embedded-cluster-linux-amd64
           tar -C output/bin -czvf embedded-cluster-linux-amd64.tgz embedded-cluster
+          ./output/bin/embedded-cluster version metadata > metadata.json
           make clean
       - name: Build darwin-amd64
         run: |
@@ -41,3 +42,4 @@ jobs:
           title: Development Release Build
           files: |
             *.tgz
+            metadata.json

--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -23,6 +23,7 @@ jobs:
         run: |
           make embedded-cluster-linux-amd64 VERSION=$TAG_NAME
           tar -C output/bin -czvf embedded-cluster-linux-amd64.tgz embedded-cluster
+          ./output/bin/embedded-cluster version metadata > metadata.json
           make clean
       - name: Build darwin-amd64
         run: |
@@ -41,3 +42,4 @@ jobs:
           prerelease: false
           files: |
             *.tgz
+            metadata.json


### PR DESCRIPTION
whenever a release is built we now publish a metadata json file with a content similar to this:

```json
{
        "Versions": {
                "AdminConsole": "v1.104.3",
                "EmbeddedClusterOperator": "v0.4.1",
                "Installer": "v1.28.4+ec.0-dirty",
                "Kubernetes": "v1.28.4+k0s.0",
                "OpenEBS": "v3.9.0"
        },
        "K0sSHA": "926bcb68478f0eb5bb8479bf01d39524102346d9f24b9f536aeddf71fdd5a975"
}
```

a new hidden topic has been added to the version topic, this is how we generate the version (or release) metadata:

```
$ embedded-cluster version metadata
{
        "Versions": {
                "AdminConsole": "v1.104.3",
                "EmbeddedClusterOperator": "v0.4.1",
                "Installer": "v1.28.4+ec.0-dirty",
                "Kubernetes": "v1.28.4+k0s.0",
                "OpenEBS": "v3.9.0"
        },
        "K0sSHA": "926bcb68478f0eb5bb8479bf01d39524102346d9f24b9f536aeddf71fdd5a975"
}
$
```