### PR TITLE
feat: publish alternative k0s url in release metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ K0S_BINARY_SOURCE_OVERRIDE =
 TROUBLESHOOT_VERSION = v0.78.1
 LD_FLAGS = -X github.com/replicatedhq/embedded-cluster/pkg/defaults.K0sVersion=$(K0S_VERSION) \
 	-X github.com/replicatedhq/embedded-cluster/pkg/defaults.Version=$(VERSION) \
+	-X github.com/replicatedhq/embedded-cluster/pkg/defaults.K0sBinaryURL=$(K0S_BINARY_SOURCE_OVERRIDE) \
 	-X github.com/replicatedhq/embedded-cluster/pkg/addons/adminconsole.ChartURL=$(ADMIN_CONSOLE_CHART_URL) \
 	-X github.com/replicatedhq/embedded-cluster/pkg/addons/adminconsole.ChartName=$(ADMIN_CONSOLE_CHART_NAME) \
 	-X github.com/replicatedhq/embedded-cluster/pkg/addons/adminconsole.Version=$(ADMIN_CONSOLE_CHART_VERSION) \

--- a/cmd/embedded-cluster/version.go
+++ b/cmd/embedded-cluster/version.go
@@ -41,8 +41,9 @@ var versionCommand = &cli.Command{
 // ReleaseMetadata holds the metadata about a specific release, including addons and
 // their versions.
 type ReleaseMetadata struct {
-	Versions map[string]string
-	K0sSHA   string
+	Versions     map[string]string
+	K0sSHA       string
+	K0sBinaryURL string
 }
 
 var metadataCommand = &cli.Command{
@@ -61,7 +62,11 @@ var metadataCommand = &cli.Command{
 		if err != nil {
 			return fmt.Errorf("unable to get k0s binary sha256: %w", err)
 		}
-		meta := ReleaseMetadata{Versions: versions, K0sSHA: sha}
+		meta := ReleaseMetadata{
+			Versions:     versions,
+			K0sSHA:       sha,
+			K0sBinaryURL: defaults.K0sBinaryURL,
+		}
 		data, err := json.MarshalIndent(meta, "", "\t")
 		if err != nil {
 			return fmt.Errorf("unable to marshal versions: %w", err)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -11,6 +11,11 @@ var (
 	K0sVersion = "0.0.0"
 	// provider holds a global reference to the default provider.
 	provider *Provider
+	// K0sBinaryURL holds an alternative URL from where to download the k0s
+	// binary that has been embedded in this version of the binary. If this
+	// is empty then it means we have shipped the official k0s binary. This
+	// is set at compile time via ldflags.
+	K0sBinaryURL = ""
 )
 
 // def returns a global reference to the default provider. creates one if not


### PR DESCRIPTION
if we are using an alternative k0s binary for a release we need to expose this as part of the release metadata. without this we can't make upgrades use the right binary.

the idea here is: if for a given release we need to replace the k0s binary we will create a branch for it and make sure that the makefile points to the right location on the branch. we can then create a tag on such branch and get a release that points to a different location.

for instace: let's suppose we want to override the k0s binary for the next release, we could add a value for K0S_BINARY_SOURCE_OVERRIDE in the makefile, push and tag. this is not optimal as we need to remember to remove the value from K0S_BINARY_SOURCE_OVERRIDE for subsequent releases hence the idea of making this in a tag.

relates to https://github.com/replicatedhq/embedded-cluster-operator/pull/45