### PR TITLE
feat: stop building darwin binaries

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -39,9 +39,6 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - name: Check system storage
-      run: |
-        sudo df -h
     - name: Remove unnecessary files
       run: |
         sudo rm -rf /usr/share/dotnet
@@ -51,9 +48,6 @@ jobs:
         sudo rm -rf /usr/local/lib/android
         sudo rm -rf /opt/hostedtoolcache/CodeQL
         sudo rm -rf /opt/hostedtoolcache/Python
-    - name: Check system storage
-      run: |
-        sudo df -h
     - name: Checkout
       uses: actions/checkout@v4
     - name: Get short commit hash
@@ -62,21 +56,6 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: "1.21.0"
-    - name: Check system storage
-      run: |
-        sudo df -h
     - name: Build Linux AMD64
       run: |
         make embedded-cluster-linux-amd64 VERSION=dev-$SHORT_SHA
-    - name: Check system storage
-      run: |
-        sudo df -h
-    - name: Build Darwin AMD64
-      run: |
-        make embedded-cluster-darwin-amd64
-    - name: Check system storage
-      run: |
-        sudo df -h
-    - name: Build Darwin ARM64 VERSION=dev-$SHORT_SHA
-      run: |
-        make embedded-cluster-darwin-arm64 VERSION=dev-$SHORT_SHA

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -22,17 +22,6 @@ jobs:
           make embedded-cluster-linux-amd64
           tar -C output/bin -czvf embedded-cluster-linux-amd64.tgz embedded-cluster
           ./output/bin/embedded-cluster version metadata > metadata.json
-          make clean
-      - name: Build darwin-amd64
-        run: |
-          make embedded-cluster-darwin-amd64
-          tar -C output/bin -czvf embedded-cluster-darwin-amd64.tgz embedded-cluster
-          make clean
-      - name: Build darwin-arm64
-        run: |
-          make embedded-cluster-darwin-arm64
-          tar -C output/bin -czvf embedded-cluster-darwin-arm64.tgz embedded-cluster
-          make clean
       - name: Publish development release
         uses: marvinpinto/action-automatic-releases@latest
         with:

--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -24,17 +24,6 @@ jobs:
           make embedded-cluster-linux-amd64 VERSION=$TAG_NAME
           tar -C output/bin -czvf embedded-cluster-linux-amd64.tgz embedded-cluster
           ./output/bin/embedded-cluster version metadata > metadata.json
-          make clean
-      - name: Build darwin-amd64
-        run: |
-          make embedded-cluster-darwin-amd64 VERSION=$TAG_NAME
-          tar -C output/bin -czvf embedded-cluster-darwin-amd64.tgz embedded-cluster
-          make clean
-      - name: Build darwin-arm64
-        run: |
-          make embedded-cluster-darwin-arm64 VERSION=$TAG_NAME
-          tar -C output/bin -czvf embedded-cluster-darwin-arm64.tgz embedded-cluster
-          make clean
       - name: Publish release
         uses: marvinpinto/action-automatic-releases@latest
         with:

--- a/Makefile
+++ b/Makefile
@@ -49,30 +49,10 @@ pkg/goods/bins/embedded-cluster/kubectl-linux-amd64:
 	curl -L -o pkg/goods/bins/embedded-cluster/kubectl-linux-amd64 "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/amd64/kubectl"
 	chmod +x pkg/goods/bins/embedded-cluster/kubectl-linux-amd64
 
-pkg/goods/bins/embedded-cluster/kubectl-darwin-amd64:
-	mkdir -p pkg/goods/bins/embedded-cluster
-	curl -L -o pkg/goods/bins/embedded-cluster/kubectl-darwin-amd64 "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/darwin/amd64/kubectl"
-	chmod +x pkg/goods/bins/embedded-cluster/kubectl-darwin-amd64
-
-pkg/goods/bins/embedded-cluster/kubectl-darwin-arm64:
-	mkdir -p pkg/goods/bins/embedded-cluster
-	curl -L -o pkg/goods/bins/embedded-cluster/kubectl-darwin-arm64 "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/darwin/arm64/kubectl"
-	chmod +x pkg/goods/bins/embedded-cluster/kubectl-darwin-arm64
-
 pkg/goods/bins/embedded-cluster/k0sctl-linux-amd64:
 	mkdir -p pkg/goods/bins/embedded-cluster
 	curl -L -o pkg/goods/bins/embedded-cluster/k0sctl-linux-amd64 "https://github.com/k0sproject/k0sctl/releases/download/$(K0SCTL_VERSION)/k0sctl-linux-x64"
 	chmod +x pkg/goods/bins/embedded-cluster/k0sctl-linux-amd64
-
-pkg/goods/bins/embedded-cluster/k0sctl-darwin-amd64:
-	mkdir -p pkg/goods/bins/embedded-cluster
-	curl -L -o pkg/goods/bins/embedded-cluster/k0sctl-darwin-amd64 "https://github.com/k0sproject/k0sctl/releases/download/$(K0SCTL_VERSION)/k0sctl-darwin-x64"
-	chmod +x pkg/goods/bins/embedded-cluster/k0sctl-darwin-amd64
-
-pkg/goods/bins/embedded-cluster/k0sctl-darwin-arm64:
-	mkdir -p pkg/goods/bins/embedded-cluster
-	curl -L -o pkg/goods/bins/embedded-cluster/k0sctl-darwin-arm64 "https://github.com/k0sproject/k0sctl/releases/download/$(K0SCTL_VERSION)/k0sctl-darwin-arm64"
-	chmod +x pkg/goods/bins/embedded-cluster/k0sctl-darwin-arm64
 
 pkg/goods/bins/embedded-cluster/kubectl-support_bundle-linux-amd64:
 	mkdir -p pkg/goods/bins/embedded-cluster
@@ -80,20 +60,6 @@ pkg/goods/bins/embedded-cluster/kubectl-support_bundle-linux-amd64:
 	curl -L -o output/tmp/support-bundle/support-bundle.tar.gz https://github.com/replicatedhq/troubleshoot/releases/download/$(TROUBLESHOOT_VERSION)/support-bundle_linux_amd64.tar.gz
 	tar -xzf output/tmp/support-bundle/support-bundle.tar.gz -C output/tmp/support-bundle
 	mv output/tmp/support-bundle/support-bundle pkg/goods/bins/embedded-cluster/kubectl-support_bundle-linux-amd64
-
-pkg/goods/bins/embedded-cluster/kubectl-support_bundle-darwin-amd64:
-	mkdir -p pkg/goods/bins/embedded-cluster
-	mkdir -p output/tmp/support-bundle
-	curl -L -o output/tmp/support-bundle/support-bundle.tar.gz https://github.com/replicatedhq/troubleshoot/releases/download/$(TROUBLESHOOT_VERSION)/support-bundle_darwin_amd64.tar.gz
-	tar -xzf output/tmp/support-bundle/support-bundle.tar.gz -C output/tmp/support-bundle
-	mv output/tmp/support-bundle/support-bundle pkg/goods/bins/embedded-cluster/kubectl-support_bundle-darwin-amd64
-
-pkg/goods/bins/embedded-cluster/kubectl-support_bundle-darwin-arm64:
-	mkdir -p pkg/goods/bins/embedded-cluster
-	mkdir -p output/tmp/support-bundle
-	curl -L -o output/tmp/support-bundle/support-bundle.tar.gz https://github.com/replicatedhq/troubleshoot/releases/download/$(TROUBLESHOOT_VERSION)/support-bundle_darwin_arm64.tar.gz
-	tar -xzf output/tmp/support-bundle/support-bundle.tar.gz -C output/tmp/support-bundle
-	mv output/tmp/support-bundle/support-bundle pkg/goods/bins/embedded-cluster/kubectl-support_bundle-darwin-arm64
 
 pkg/goods/bins/embedded-cluster/kubectl-preflight:
 	mkdir -p pkg/goods/bins/embedded-cluster
@@ -117,26 +83,12 @@ embedded-release: embedded-cluster-linux-amd64 release.tar.gz
 static: pkg/goods/bins/embedded-cluster/kubectl-preflight \
 	pkg/goods/bins/k0sctl/k0s-$(K0S_VERSION)
 
-.PHONY: static-darwin-arm64
-static-darwin-arm64: pkg/goods/bins/embedded-cluster/kubectl-darwin-arm64 pkg/goods/bins/embedded-cluster/k0sctl-darwin-arm64 pkg/goods/bins/embedded-cluster/kubectl-support_bundle-darwin-arm64
-
-.PHONY: static-darwin-amd64
-static-darwin-amd64: pkg/goods/bins/embedded-cluster/kubectl-darwin-amd64 pkg/goods/bins/embedded-cluster/k0sctl-darwin-amd64 pkg/goods/bins/embedded-cluster/kubectl-support_bundle-darwin-amd64
-
 .PHONY: static-linux-amd64
 static-linux-amd64: pkg/goods/bins/embedded-cluster/kubectl-linux-amd64 pkg/goods/bins/embedded-cluster/k0sctl-linux-amd64 pkg/goods/bins/embedded-cluster/kubectl-support_bundle-linux-amd64
 
 .PHONY: embedded-cluster-linux-amd64
 embedded-cluster-linux-amd64: static static-linux-amd64
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$(LD_FLAGS)" -o ./output/bin/$(APP_NAME) ./cmd/embedded-cluster
-
-.PHONY: embedded-cluster-darwin-amd64
-embedded-cluster-darwin-amd64: static static-darwin-amd64
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "$(LD_FLAGS)" -o ./output/bin/$(APP_NAME) ./cmd/embedded-cluster
-
-.PHONY: embedded-cluster-darwin-arm64
-embedded-cluster-darwin-arm64: static static-darwin-arm64
-	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags "$(LD_FLAGS)" -o ./output/bin/$(APP_NAME) ./cmd/embedded-cluster
 
 .PHONY: unit-tests
 unit-tests:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ $ make embedded-cluster-linux-amd64
 ```
 
 The binary will be located on `output/bin/embedded-cluster`.
-You can also build binaries for other architectures with the following targets: `embedded-cluster-darwin-amd64` and  `embedded-cluster-darwin-arm64` are available.
 
 ## Single node deployment
 

--- a/pkg/defaults/provider.go
+++ b/pkg/defaults/provider.go
@@ -16,8 +16,7 @@ import (
 )
 
 const (
-	k0sBinsSubDirDarwin = "Library/Caches/k0sctl/k0s/linux/amd64"
-	k0sBinsSubDirLinux  = ".cache/k0sctl/k0s/linux/amd64"
+	k0sBinsSubDirLinux = ".cache/k0sctl/k0s/linux/amd64"
 )
 
 // NewProvider returns a new Provider using the provided base dir.
@@ -136,9 +135,6 @@ func (d *Provider) PathToLog(name string) string {
 // are stored. This is a subdirectory of the user's home directory. Follows
 // the k0sctl directory convention.
 func (d *Provider) K0sctlBinsSubDir() string {
-	if runtime.GOOS == "darwin" {
-		return filepath.Join(d.Base, d.home(), k0sBinsSubDirDarwin)
-	}
 	return filepath.Join(d.Base, d.home(), k0sBinsSubDirLinux)
 }
 


### PR DESCRIPTION
we are driving far away from the "ssh based installation" so this pr speeds things up by dropping the release of darwin binaries.