### PR TITLE
Enable dynamic config

### DIFF
--- a/cmd/embedded-cluster/join.go
+++ b/cmd/embedded-cluster/join.go
@@ -223,7 +223,7 @@ func runK0sInstallCommand(fullcmd string) error {
 	args := strings.Split(fullcmd, " ")
 	args = append(args, "--token-file", "/etc/k0s/join-token")
 	if strings.Contains(fullcmd, "controller") {
-		args = append(args, "--disable-components", "konnectivity-server")
+		args = append(args, "--disable-components", "konnectivity-server", "--enable-dynamic-config")
 	}
 	cmd := exec.Command(args[0], args[1:]...)
 	stdout := bytes.NewBuffer(nil)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -232,8 +232,9 @@ func generateConfigForHosts(ctx context.Context, hosts ...*cluster.Host) (*v1bet
 		Spec: &cluster.Spec{
 			Hosts: hosts,
 			K0s: &cluster.K0s{
-				Version: k0sversion.MustParse(defaults.K0sVersion),
-				Config:  k0sconfig,
+				DynamicConfig: true,
+				Version:       k0sversion.MustParse(defaults.K0sVersion),
+				Config:        k0sconfig,
 			},
 		},
 	}, nil

--- a/pkg/config/host.go
+++ b/pkg/config/host.go
@@ -27,7 +27,7 @@ type hostcfg struct {
 func (h *hostcfg) render() *cluster.Host {
 	var ifls []string
 	if h.Role != "worker" {
-		ifls = []string{"--disable-components konnectivity-server"}
+		ifls = []string{"--disable-components konnectivity-server --enable-dynamic-config"}
 	}
 	ifls = append(ifls, labelsToArg(h.Labels)...)
 	return &cluster.Host{

--- a/pkg/config/testdata/override-change-name.yaml
+++ b/pkg/config/testdata/override-change-name.yaml
@@ -16,7 +16,7 @@ config: |-
       noTaints: true
     k0s:
       version: v1.27.5+k0s.0
-      dynamicConfig: false
+      dynamicConfig: true
       config:
         apiVersion: k0s.k0sproject.io/v1beta1
         kind: ClusterConfig
@@ -53,7 +53,7 @@ expected: |-
       noTaints: true
     k0s:
       version: v1.27.5+k0s.0
-      dynamicConfig: false
+      dynamicConfig: true
       config:
         apiVersion: k0s.k0sproject.io/v1beta1
         kind: ClusterConfig

--- a/pkg/config/testdata/override-enable-telemetry.yaml
+++ b/pkg/config/testdata/override-enable-telemetry.yaml
@@ -16,7 +16,7 @@ config: |-
       noTaints: true
     k0s:
       version: v1.27.5+k0s.0
-      dynamicConfig: false
+      dynamicConfig: true
       config:
         apiVersion: k0s.k0sproject.io/v1beta1
         kind: ClusterConfig
@@ -54,7 +54,7 @@ expected: |-
       noTaints: true
     k0s:
       version: v1.27.5+k0s.0
-      dynamicConfig: false
+      dynamicConfig: true
       config:
         apiVersion: k0s.k0sproject.io/v1beta1
         kind: ClusterConfig

--- a/pkg/config/testdata/override-setting-ip-forward.yaml
+++ b/pkg/config/testdata/override-setting-ip-forward.yaml
@@ -16,7 +16,7 @@ config: |-
       noTaints: true
     k0s:
       version: v1.27.5+k0s.0
-      dynamicConfig: false
+      dynamicConfig: true
       config:
         apiVersion: k0s.k0sproject.io/v1beta1
         kind: ClusterConfig
@@ -57,7 +57,7 @@ expected: |-
       noTaints: true
     k0s:
       version: v1.27.5+k0s.0
-      dynamicConfig: false
+      dynamicConfig: true
       config:
         apiVersion: k0s.k0sproject.io/v1beta1
         kind: ClusterConfig

--- a/pkg/config/testdata/override-zero-out-sans-list.yaml
+++ b/pkg/config/testdata/override-zero-out-sans-list.yaml
@@ -16,7 +16,7 @@ config: |-
       noTaints: true
     k0s:
       version: v1.27.5+k0s.0
-      dynamicConfig: false
+      dynamicConfig: true
       config:
         apiVersion: k0s.k0sproject.io/v1beta1
         kind: ClusterConfig
@@ -58,7 +58,7 @@ expected: |-
       noTaints: true
     k0s:
       version: v1.27.5+k0s.0
-      dynamicConfig: false
+      dynamicConfig: true
       config:
         apiVersion: k0s.k0sproject.io/v1beta1
         kind: ClusterConfig


### PR DESCRIPTION
this PR enables dynamic config. 

The k0s dynamic config feature loads the initial config into the cluster as a `clusterconfig` object. 

https://docs.k0sproject.io/head/dynamic-configuration/

this gives us the following benefits:
- config is no longer centralised 
- can manipulate the config from in-cluster
- k0s config reconciler will enact any config changes made in-cluster without the need to reboot

this enables us to add/update helm charts installed as extensions by bumping thier chart version in the `clusterconfig` object. 