### PR TITLE
feat: support for unsupported config overrides

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,7 +21,8 @@ import (
 	k0sversion "github.com/k0sproject/version"
 	embeddedclusterv1beta1 "github.com/replicatedhq/embedded-cluster-operator/api/v1beta1"
 	"github.com/sirupsen/logrus"
-	"sigs.k8s.io/yaml"
+	"gopkg.in/yaml.v2"
+	k8syaml "sigs.k8s.io/yaml"
 
 	"github.com/replicatedhq/embedded-cluster/pkg/addons"
 	"github.com/replicatedhq/embedded-cluster/pkg/customization"
@@ -43,7 +44,7 @@ func ReadConfigFile(cfgPath string) (*v1beta1.Cluster, error) {
 		return nil, fmt.Errorf("unable to read current config: %w", err)
 	}
 	var cfg v1beta1.Cluster
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	if err := k8syaml.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("unable to unmarshal current config: %w", err)
 	}
 	return &cfg, nil
@@ -280,12 +281,12 @@ func UpdateHelmConfigs(cfg *v1beta1.Cluster, opts ...addons.Option) error {
 		return fmt.Errorf("invalid cluster configuration")
 	}
 	currentSpec := cfg.Spec.K0s.Config
-	configString, err := yaml.Marshal(currentSpec)
+	configString, err := k8syaml.Marshal(currentSpec)
 	if err != nil {
 		return fmt.Errorf("unable to marshal helm config: %w", err)
 	}
 	k0s := k0sconfig.ClusterConfig{}
-	if err := yaml.Unmarshal(configString, &k0s); err != nil {
+	if err := k8syaml.Unmarshal(configString, &k0s); err != nil {
 		return fmt.Errorf("unable to unmarshal k0s config: %w", err)
 	}
 	opts = append(opts, addons.WithConfig(k0s))
@@ -302,12 +303,12 @@ func UpdateHelmConfigs(cfg *v1beta1.Cluster, opts ...addons.Option) error {
 	}
 
 	// marshal and unmarshal to convert key names from struct tags
-	newClusterExtensionsBytes, err := yaml.Marshal(newClusterExtensions)
+	newClusterExtensionsBytes, err := k8syaml.Marshal(newClusterExtensions)
 	if err != nil {
 		return fmt.Errorf("unable to marshal new cluster extensions: %w", err)
 	}
 	newClusterExtensionsMap := dig.Mapping{}
-	if err := yaml.Unmarshal(newClusterExtensionsBytes, &newClusterExtensionsMap); err != nil {
+	if err := k8syaml.Unmarshal(newClusterExtensionsBytes, &newClusterExtensionsMap); err != nil {
 		return fmt.Errorf("unable to unmarshal new cluster extensions: %w", err)
 	}
 
@@ -333,7 +334,7 @@ func ApplyEmbeddedUnsupportedOverrides(config *v1beta1.Cluster, embconfig string
 	if embconfig == "" {
 		return nil
 	}
-	newConfigBytes, err := yaml.Marshal(config.Spec.K0s.Config)
+	newConfigBytes, err := yaml.Marshal(config.Spec.K0s)
 	if err != nil {
 		return fmt.Errorf("unable to marshal original cluster config: %w", err)
 	}
@@ -353,11 +354,11 @@ func ApplyEmbeddedUnsupportedOverrides(config *v1beta1.Cluster, embconfig string
 	if err != nil {
 		return fmt.Errorf("unable to convert patched configuration to json: %w", err)
 	}
-	var newK0sConfig dig.Mapping
-	if err := yaml.Unmarshal(newConfigBytes, &newK0sConfig); err != nil {
+	var newK0sConfig cluster.K0s
+	if err := k8syaml.Unmarshal(newConfigBytes, &newK0sConfig); err != nil {
 		return fmt.Errorf("unable to unmarshal patched cluster config: %w", err)
 	}
-	config.Spec.K0s.Config = newK0sConfig
+	config.Spec.K0s = &newK0sConfig
 	return nil
 }
 

--- a/pkg/config/testdata/override-change-name.yaml
+++ b/pkg/config/testdata/override-change-name.yaml
@@ -33,8 +33,9 @@ override: |-
   spec:
     unsupportedOverrides:
       k0s: |
-        metadata:
-          name: foo
+        config:
+          metadata:
+            name: foo
 expected: |-
   apiVersion: k0sctl.k0sproject.io/v1beta1
   kind: Cluster

--- a/pkg/config/testdata/override-enable-telemetry.yaml
+++ b/pkg/config/testdata/override-enable-telemetry.yaml
@@ -33,9 +33,10 @@ override: |-
   spec:
     unsupportedOverrides:
       k0s: |
-        spec:
-          telemetry:
-            enabled: true
+        config:
+          spec:
+            telemetry:
+              enabled: true
 expected: |-
   apiVersion: k0sctl.k0sproject.io/v1beta1
   kind: Cluster

--- a/pkg/config/testdata/override-setting-ip-forward.yaml
+++ b/pkg/config/testdata/override-setting-ip-forward.yaml
@@ -33,11 +33,12 @@ override: |-
   spec:
     unsupportedOverrides:
       k0s: |
-        spec:
-          workerProfiles:
-          - name: ip-forward
-            values:
-              allowedUnsafeSysctls:
+        config:
+          spec:
+            workerProfiles:
+            - name: ip-forward
+              values:
+                allowedUnsafeSysctls:
                 - net.ipv4.ip_forward
 expected: |-
   apiVersion: k0sctl.k0sproject.io/v1beta1

--- a/pkg/config/testdata/override-zero-out-sans-list.yaml
+++ b/pkg/config/testdata/override-zero-out-sans-list.yaml
@@ -37,9 +37,10 @@ override: |-
   spec:
     unsupportedOverrides:
       k0s: |
-        spec:
-          api:
-            sans: null
+        config:
+          spec:
+            api:
+              sans: null
 expected: |-
   apiVersion: k0sctl.k0sproject.io/v1beta1
   kind: Cluster


### PR DESCRIPTION
make sure we are overriding everything from `k0s` property of the k0sctl config inwards.