### PR TITLE
feat: add protected helm values to release metadata

### DIFF
--- a/cmd/embedded-cluster/version.go
+++ b/cmd/embedded-cluster/version.go
@@ -70,29 +70,25 @@ var metadataCommand = &cli.Command{
 			K0sSHA:       sha,
 			K0sBinaryURL: defaults.K0sBinaryURL,
 		}
-
-		chtconfig, repconfig, err := addons.NewApplier(opts...).GenerateHelmConfigs()
+		applier := addons.NewApplier(opts...)
+		chtconfig, repconfig, err := applier.GenerateHelmConfigs()
 		if err != nil {
 			return fmt.Errorf("unable to apply addons: %w", err)
 		}
-
 		meta.Configs = k0sconfig.HelmExtensions{
 			ConcurrencyLevel: 1,
 			Charts:           chtconfig,
 			Repositories:     repconfig,
 		}
-
-		protectedFields, err := addons.NewApplier(opts...).ProtectedFields()
+		protectedFields, err := applier.ProtectedFields()
 		if err != nil {
 			return fmt.Errorf("unable to get protected fields: %w", err)
 		}
 		meta.Protected = protectedFields
-
 		data, err := json.MarshalIndent(meta, "", "\t")
 		if err != nil {
 			return fmt.Errorf("unable to marshal versions: %w", err)
 		}
-
 		fmt.Println(string(data))
 		return nil
 	},

--- a/cmd/embedded-cluster/version.go
+++ b/cmd/embedded-cluster/version.go
@@ -46,6 +46,7 @@ type ReleaseMetadata struct {
 	K0sSHA       string
 	K0sBinaryURL string
 	Configs      k0sconfig.HelmExtensions
+	Protected    map[string][]string
 }
 
 var metadataCommand = &cli.Command{
@@ -80,6 +81,12 @@ var metadataCommand = &cli.Command{
 			Charts:           chtconfig,
 			Repositories:     repconfig,
 		}
+
+		protectedFields, err := addons.NewApplier(opts...).ProtectedFields()
+		if err != nil {
+			return fmt.Errorf("unable to get protected fields: %w", err)
+		}
+		meta.Protected = protectedFields
 
 		data, err := json.MarshalIndent(meta, "", "\t")
 		if err != nil {

--- a/pkg/addons/adminconsole/adminconsole.go
+++ b/pkg/addons/adminconsole/adminconsole.go
@@ -35,6 +35,12 @@ var (
 	MigrationsImageOverride = ""
 )
 
+// protectedFields are helm values that are not overwritten when upgrading the addon.
+var protectedFields = []string{
+	"password",
+	"license",
+}
+
 var helmValues = map[string]interface{}{
 	"minimalRBAC":   false,
 	"isHelmManaged": false,
@@ -88,6 +94,11 @@ func (a *AdminConsole) askPassword() (string, error) {
 // Version returns the embedded admin console version.
 func (a *AdminConsole) Version() (map[string]string, error) {
 	return map[string]string{"AdminConsole": "v" + Version}, nil
+}
+
+// GetProtectedFields returns the helm values that are not overwritten when upgrading
+func (a *AdminConsole) GetProtectedFields() map[string][]string {
+	return map[string][]string{releaseName: protectedFields}
 }
 
 // HostPreflights returns the host preflight objects found inside the adminconsole

--- a/pkg/addons/adminconsole/adminconsole.go
+++ b/pkg/addons/adminconsole/adminconsole.go
@@ -38,7 +38,7 @@ var (
 // protectedFields are helm values that are not overwritten when upgrading the addon.
 var protectedFields = []string{
 	"password",
-	"license",
+	"automation",
 }
 
 var helmValues = map[string]interface{}{

--- a/pkg/addons/custom/custom.go
+++ b/pkg/addons/custom/custom.go
@@ -57,6 +57,13 @@ func (c *Custom) HostPreflights() (*v1beta2.HostPreflightSpec, error) {
 	return nil, nil
 }
 
+// GetProtectedFields returns the protected fields for the embedded charts.
+// placeholder for now.
+func (c *Custom) GetProtectedFields() map[string][]string {
+	protectedFields := []string{}
+	return map[string][]string{"custom": protectedFields}
+}
+
 // GenerateHelmConfig generates the helm config for all the embedded charts.
 // and writes the charts to the disk.
 func (c *Custom) GenerateHelmConfig(onlyDefaults bool) ([]v1beta1.Chart, []v1beta1.Repository, error) {

--- a/pkg/addons/embeddedclusteroperator/embeddedclusteroperator.go
+++ b/pkg/addons/embeddedclusteroperator/embeddedclusteroperator.go
@@ -59,6 +59,13 @@ func (e *EmbeddedClusterOperator) HostPreflights() (*v1beta2.HostPreflightSpec, 
 	return nil, nil
 }
 
+// GetProtectedFields returns the protected fields for the embedded charts.
+// placeholder for now.
+func (e *EmbeddedClusterOperator) GetProtectedFields() map[string][]string {
+	protectedFields := []string{}
+	return map[string][]string{releaseName: protectedFields}
+}
+
 // GenerateHelmConfig generates the helm config for the embedded cluster operator chart.
 func (e *EmbeddedClusterOperator) GenerateHelmConfig(onlyDefaults bool) ([]v1beta1.Chart, []v1beta1.Repository, error) {
 	chartConfig := v1beta1.Chart{

--- a/pkg/addons/openebs/openebs.go
+++ b/pkg/addons/openebs/openebs.go
@@ -51,6 +51,13 @@ func (o *OpenEBS) HostPreflights() (*v1beta2.HostPreflightSpec, error) {
 	return nil, nil
 }
 
+// GetProtectedFields returns the protected fields for the embedded charts.
+// placeholder for now.
+func (o *OpenEBS) GetProtectedFields() map[string][]string {
+	protectedFields := []string{}
+	return map[string][]string{releaseName: protectedFields}
+}
+
 // GenerateHelmConfig generates the helm config for the OpenEBS chart.
 func (o *OpenEBS) GenerateHelmConfig(onlyDefaults bool) ([]v1beta1.Chart, []v1beta1.Repository, error) {
 	chartConfig := v1beta1.Chart{


### PR DESCRIPTION
This is to inform the embedded-cluster-operator which helm values it's not allowed to override with our defaults when upgrading addons. 