### PR TITLE
add basic config command

### DIFF
--- a/cmd/embedded-cluster/config.go
+++ b/cmd/embedded-cluster/config.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/urfave/cli/v2"
+	"gopkg.in/yaml.v2"
+
+	"github.com/replicatedhq/embedded-cluster/pkg/addons"
+	"github.com/replicatedhq/embedded-cluster/pkg/config"
+)
+
+var configCommand = &cli.Command{
+	Name:  "config",
+	Usage: "Dumps generated config to stdout",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:   "overrides",
+			Usage:  "File with an EmbeddedClusterConfig object to override the default configuration",
+			Hidden: true,
+		},
+		&cli.BoolFlag{
+			Name:  "no-prompt",
+			Usage: "Do not prompt user when it is not necessary",
+			Value: false,
+		},
+	},
+	Action: func(c *cli.Context) error {
+		multi := false
+
+		cfg, err := config.RenderClusterConfig(c.Context, multi)
+		if err != nil {
+			return fmt.Errorf("unable to render config: %w", err)
+		}
+
+		if c.String("overrides") != "" {
+			eucfg, err := parseEndUserConfig(c.String("overrides"))
+			if err != nil {
+				return fmt.Errorf("unable to process overrides file: %w", err)
+			}
+			if err := config.ApplyEmbeddedUnsupportedOverrides(
+				cfg, eucfg.Spec.UnsupportedOverrides.K0s,
+			); err != nil {
+				return fmt.Errorf("unable to apply overrides: %w", err)
+			}
+		}
+		opts := []addons.Option{}
+		if c.Bool("no-prompt") {
+			opts = append(opts, addons.WithoutPrompt())
+		}
+		for _, addon := range c.StringSlice("disable-addon") {
+			opts = append(opts, addons.WithoutAddon(addon))
+		}
+		if err := config.UpdateHelmConfigs(cfg, opts...); err != nil {
+			return fmt.Errorf("unable to update helm configs: %w", err)
+		}
+
+		if err := yaml.NewEncoder(os.Stdout).Encode(cfg); err != nil {
+			return fmt.Errorf("unable to write config file: %w", err)
+		}
+
+		return nil
+	},
+}

--- a/cmd/embedded-cluster/main.go
+++ b/cmd/embedded-cluster/main.go
@@ -37,6 +37,7 @@ func main() {
 			shellCommand,
 			nodeCommands,
 			versionCommand,
+      configCommand,
 		},
 	}
 	if err := app.Run(os.Args); err != nil {


### PR DESCRIPTION
Adds a new  subcommand `config` for outputting generated config to stdout without installing a cluster