### PR TITLE
feat: install kotsadm in default namespace, not embedded-cluster

### DIFF
--- a/e2e/scripts/unsupported-overrides.sh
+++ b/e2e/scripts/unsupported-overrides.sh
@@ -41,7 +41,7 @@ spec:
                 version: 0.13.0
               - chartname: oci://registry.replicated.com/library/admin-console
                 name: admin-console
-                namespace: embedded-cluster
+                namespace: default
                 order: 3
                 version: 1.105.1
                 values: |

--- a/e2e/scripts/unsupported-overrides.sh
+++ b/e2e/scripts/unsupported-overrides.sh
@@ -41,7 +41,7 @@ spec:
                 version: 0.13.0
               - chartname: oci://registry.replicated.com/library/admin-console
                 name: admin-console
-                namespace: default
+                namespace: kotsadm
                 order: 3
                 version: 1.105.1
                 values: |

--- a/pkg/addons/applier.go
+++ b/pkg/addons/applier.go
@@ -135,7 +135,7 @@ func (a *Applier) load() (map[string]AddOn, error) {
 		addons["embeddedclusteroperator"] = embedoperator
 	}
 	if _, disabledAddons := a.disabledAddons["adminconsole"]; !disabledAddons {
-		aconsole, err := adminconsole.New("embedded-cluster", a.prompt, a.config)
+		aconsole, err := adminconsole.New("default", a.prompt, a.config)
 		if err != nil {
 			return nil, fmt.Errorf("unable to create admin console addon: %w", err)
 		}

--- a/pkg/addons/applier.go
+++ b/pkg/addons/applier.go
@@ -135,7 +135,7 @@ func (a *Applier) load() (map[string]AddOn, error) {
 		addons["embeddedclusteroperator"] = embedoperator
 	}
 	if _, disabledAddons := a.disabledAddons["adminconsole"]; !disabledAddons {
-		aconsole, err := adminconsole.New("default", a.prompt, a.config)
+		aconsole, err := adminconsole.New("kotsadm", a.prompt, a.config)
 		if err != nil {
 			return nil, fmt.Errorf("unable to create admin console addon: %w", err)
 		}


### PR DESCRIPTION
This will probably break upgrades, but we really shouldn't be placing kotsadm and the operator in the same namespace. As such, the sooner we make the change the better, and I should have done this weeks ago.