### PR TITLE
feat: reset should be run as root + k0s path

### DIFF
--- a/cmd/embedded-cluster/reset.go
+++ b/cmd/embedded-cluster/reset.go
@@ -49,7 +49,7 @@ type k0sVars struct {
 
 var (
 	binName = defaults.BinaryName()
-	k0s     = defaults.K0sBinaryPath()
+	k0s     = "/usr/local/bin/k0s"
 )
 
 // deleteNode removes the node from the cluster
@@ -301,7 +301,9 @@ var resetCommand = &cli.Command{
 	},
 	Usage: "Reset the current node",
 	Action: func(c *cli.Context) error {
-
+		if os.Getuid() != 0 {
+			return fmt.Errorf("reset command must be run as root")
+		}
 		fmt.Println("This will remove this node from the cluster and completely reset it.")
 		fmt.Println("Do not reset another node until this reset is complete.")
 		if !c.Bool("force") && !c.Bool("no-prompt") && !prompts.New().Confirm("Do you want to continue?", false) {


### PR DESCRIPTION
`k0sctl` and `embedded-cluster node join` install k0s binary on /usr/local/bin/k0s. k0s binary is also not accessible for regular users (only root can run it).