### PR TITLE
feat: require uid 0 for install, shell and node commands

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -90,6 +90,7 @@ jobs:
           - TestUnsupportedOverrides
           - TestMultiNodeInstallation
           - TestMultiNodeReset
+          - TestCommandsRequireSudo
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -58,6 +58,7 @@ jobs:
           - TestUnsupportedOverrides
           - TestMultiNodeInstallation
           - TestMultiNodeReset
+          - TestCommandsRequireSudo
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ pkg/goods/bins
 pkg/goods/images
 *tgz
 .pre-commit-config.yaml
+vendor

--- a/cmd/embedded-cluster/install.go
+++ b/cmd/embedded-cluster/install.go
@@ -413,9 +413,14 @@ func runOutro(c *cli.Context) error {
 // Once this is finished then a "kubeconfig" file is created.
 // Resulting k0sctl.yaml and kubeconfig are stored in the configuration dir.
 var installCommand = &cli.Command{
-	Name:    "install",
-	Aliases: []string{"apply"},
-	Usage:   "Installs a new or upgrades an existing cluster",
+	Name:  "install",
+	Usage: "Installs a new or upgrades an existing cluster",
+	Before: func(c *cli.Context) error {
+		if os.Getuid() != 0 {
+			return fmt.Errorf("install command must be run as root")
+		}
+		return nil
+	},
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:  "config",

--- a/cmd/embedded-cluster/join.go
+++ b/cmd/embedded-cluster/join.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"runtime"
 	"strings"
 	"time"
 
@@ -105,9 +104,6 @@ var joinCommand = &cli.Command{
 		binname := defaults.BinaryName()
 		if c.Args().Len() != 2 {
 			return fmt.Errorf("usage: %s node join <url> <token>", binname)
-		}
-		if err := canRunJoin(c); err != nil {
-			return err
 		}
 		loading := pb.Start()
 		defer loading.Close()
@@ -289,18 +285,6 @@ func startK0sService() error {
 		fmt.Fprintf(os.Stderr, "%s\n", stderr.String())
 		fmt.Fprintf(os.Stdout, "%s\n", stdout.String())
 		return err
-	}
-	return nil
-}
-
-// canRunJoin checks if we can run the join command. Checks if we are running on linux,
-// if we are root, and if a token has been provided through the command line.
-func canRunJoin(c *cli.Context) error {
-	if runtime.GOOS != "linux" {
-		return fmt.Errorf("join command is only supported on linux")
-	}
-	if os.Getuid() != 0 {
-		return fmt.Errorf("join command must be run as root")
 	}
 	return nil
 }

--- a/cmd/embedded-cluster/node.go
+++ b/cmd/embedded-cluster/node.go
@@ -13,6 +13,12 @@ import (
 var nodeCommands = &cli.Command{
 	Name:  "node",
 	Usage: "Manage cluster nodes",
+	Before: func(c *cli.Context) error {
+		if os.Getuid() != 0 {
+			return fmt.Errorf("node command must be run as root")
+		}
+		return nil
+	},
 	Subcommands: []*cli.Command{
 		nodeStopCommand,
 		nodeStartCommand,

--- a/cmd/embedded-cluster/reset.go
+++ b/cmd/embedded-cluster/reset.go
@@ -304,9 +304,6 @@ var resetCommand = &cli.Command{
 	},
 	Usage: "Reset the current node",
 	Action: func(c *cli.Context) error {
-		if os.Getuid() != 0 {
-			return fmt.Errorf("reset command must be run as root")
-		}
 		fmt.Println("This will remove this node from the cluster and completely reset it.")
 		fmt.Println("Do not reset another node until this reset is complete.")
 		if !c.Bool("force") && !c.Bool("no-prompt") && !prompts.New().Confirm("Do you want to continue?", false) {

--- a/cmd/embedded-cluster/shell.go
+++ b/cmd/embedded-cluster/shell.go
@@ -37,6 +37,12 @@ func handleResize(ch chan os.Signal, tty *os.File) {
 var shellCommand = &cli.Command{
 	Name:  "shell",
 	Usage: "Starts a shell with access to the running cluster",
+	Before: func(c *cli.Context) error {
+		if os.Getuid() != 0 {
+			return fmt.Errorf("shell command must be run as root")
+		}
+		return nil
+	},
 	Action: func(c *cli.Context) error {
 		cfgpath := defaults.PathToConfig("kubeconfig")
 		if _, err := os.Stat(cfgpath); err != nil {

--- a/e2e/sudo_test.go
+++ b/e2e/sudo_test.go
@@ -1,0 +1,41 @@
+package e2e
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/replicatedhq/embedded-cluster/e2e/cluster"
+)
+
+func TestCommandsRequireSudo(t *testing.T) {
+	t.Parallel()
+	tc := cluster.NewTestCluster(&cluster.Input{
+		T:                   t,
+		Nodes:               1,
+		CreateRegularUser:   true,
+		Image:               "ubuntu/jammy",
+		SSHPublicKey:        "../output/tmp/id_rsa.pub",
+		SSHPrivateKey:       "../output/tmp/id_rsa",
+		EmbeddedClusterPath: "../output/bin/embedded-cluster",
+	})
+	defer tc.Destroy()
+	command := []string{"embedded-cluster", "version"}
+	if _, _, err := RunRegularUserCommandOnNode(t, tc, 0, command); err != nil {
+		t.Errorf("expected no error running `version` as regular user, got %v", err)
+	}
+	for _, cmd := range [][]string{
+		{"embedded-cluster", "node", "join", "https://test", "token"},
+		{"embedded-cluster", "node", "reset", "--force"},
+		{"embedded-cluster", "shell"},
+		{"embedded-cluster", "install", "--no-prompt"},
+	} {
+		stdout, stderr, err := RunRegularUserCommandOnNode(t, tc, 0, cmd)
+		if err == nil {
+			t.Fatalf("expected error running `%v` as regular user, got none", cmd)
+		}
+		if !strings.Contains(stderr, "command must be run as root") {
+			t.Logf("stdout:\n%s\nstderr:%s\n", stdout, stderr)
+			t.Fatalf("invalid error found running `%v` as regular user", cmd)
+		}
+	}
+}

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -33,6 +33,26 @@ func RunCommandsOnNode(t *testing.T, cl *cluster.Output, node int, cmds [][]stri
 	return nil
 }
 
+// RunRegularUserCommandOnNode runs a command on a node as a regular user (not root) with a timeout.
+func RunRegularUserCommandOnNode(t *testing.T, cl *cluster.Output, node int, line []string) (string, string, error) {
+	stdout := &buffer{bytes.NewBuffer(nil)}
+	stderr := &buffer{bytes.NewBuffer(nil)}
+	cmd := cluster.Command{
+		Node:        cl.Nodes[node],
+		Line:        line,
+		Stdout:      stdout,
+		Stderr:      stderr,
+		RegularUser: true,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+	if err := cluster.Run(ctx, t, cmd); err != nil {
+		t.Logf("stdout:\n%s\nstderr:%s\n", stdout.String(), stderr.String())
+		return stdout.String(), stderr.String(), err
+	}
+	return stdout.String(), stderr.String(), nil
+}
+
 // RunCommandOnNode runs a command on a node with a timeout.
 func RunCommandOnNode(t *testing.T, cl *cluster.Output, node int, line []string) (string, string, error) {
 	stdout := &buffer{bytes.NewBuffer(nil)}


### PR DESCRIPTION
the following commands now require uid 0 to run:

- install
- shell
- node

the apply command was removed and the version command works just fine as a regular user (uid != 0).