### PR TITLE
feat: check sshd config before starting the install

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -91,6 +91,7 @@ jobs:
           - TestMultiNodeInstallation
           - TestMultiNodeReset
           - TestCommandsRequireSudo
+          - TestInstallWithoutRootSSHAccess
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -59,6 +59,7 @@ jobs:
           - TestMultiNodeInstallation
           - TestMultiNodeReset
           - TestCommandsRequireSudo
+          - TestInstallWithoutRootSSHAccess
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/e2e/scripts/single-node-install-without-root.sh
+++ b/e2e/scripts/single-node-install-without-root.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+main() {
+    echo "PermitRootLogin no" >> /etc/ssh/sshd_config
+    if ! systemctl restart sshd; then
+        echo "Failed to restart sshd"
+        return 1
+    fi
+    if embedded-cluster install --no-prompt 2>&1 | tee /tmp/log ; then
+        cat /tmp/log
+        echo "This should never happen, able to install!"
+        exit 1
+    fi
+    if ! grep -q "You can temporarily enable root login by changing" /tmp/log ; then
+        cat /tmp/log
+        echo "Failed to find expected error message"
+        return 1
+    fi
+    sed -i '/^PermitRootLogin/c\PermitRootLogin without-password' /etc/ssh/sshd_config
+    if ! systemctl restart sshd; then
+        echo "Failed to restart sshd"
+        return 1
+    fi
+    if ! embedded-cluster install --no-prompt 2>&1 | tee /tmp/log ; then
+        cat /tmp/log
+        echo "Unable to install with root login enabled without password"
+        exit 1
+    fi
+}
+
+export EMBEDDED_CLUSTER_METRICS_BASEURL="https://staging.replicated.app"
+export KUBECONFIG=/root/.config/embedded-cluster/etc/kubeconfig
+export PATH=$PATH:/root/.config/embedded-cluster/bin
+main


### PR DESCRIPTION
now that we only allow installations with root the ssh installation method became a huge problem. we can only install if ssh access is allowed for the root user using a ssh key.

while we work on moving ourselves out of the ssh based installation we need to at least provide the users with valid information on how to work around this issue.

this pr does exactly that, upon finding an "invalid" ssh config this is what is printed on the terminal:

```
rmarasch@ec:~$ sudo ./embedded-cluster install
PermitRootLogin config is set to 'no' in /etc/ssh/sshd_config
This will prevent embedded-cluster from installing.
You can temporarily enable root login by changing the
PermitRootLogin config to 'without-password' and restarting
the sshd service. Once the installation is finished you can
restore the original configuration.
FATA[0000] ssh root access is not allowed
rmarasch@ec:~$
```