### PR TITLE
feat: do not return fields that are not supposed to be overwritten

### DIFF
--- a/pkg/addons/embeddedclusteroperator/embeddedclusteroperator.go
+++ b/pkg/addons/embeddedclusteroperator/embeddedclusteroperator.go
@@ -63,9 +63,7 @@ func (e *EmbeddedClusterOperator) HostPreflights() (*v1beta2.HostPreflightSpec, 
 // GetProtectedFields returns the protected fields for the embedded charts.
 // placeholder for now.
 func (e *EmbeddedClusterOperator) GetProtectedFields() map[string][]string {
-	protectedFields := []string{
-		"embeddedBinaryName",
-	}
+	protectedFields := []string{}
 	return map[string][]string{releaseName: protectedFields}
 }
 
@@ -78,7 +76,16 @@ func (e *EmbeddedClusterOperator) GenerateHelmConfig(onlyDefaults bool) ([]v1bet
 		TargetNS:  "embedded-cluster",
 		Order:     2,
 	}
-	valuesStringData, err := yaml.Marshal(helmValues)
+	values := map[string]interface{}{}
+	for key, value := range helmValues {
+		// we do not want to override embeddedClusterID and embeddedBinaryName
+		// as these vary from cluster to cluster.
+		if onlyDefaults && (key == "embeddedClusterID" || key == "embeddedBinaryName") {
+			continue
+		}
+		values[key] = value
+	}
+	valuesStringData, err := yaml.Marshal(values)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to marshal helm values: %w", err)
 	}


### PR DESCRIPTION
`embedded-cluster version metadata` should not return things like cluster id or embedded cluster binary name. instead of "protecting" such fields they must not be present at all.

this is how `version metadata` looks like now:

```json
{
        "Versions": {
                "AdminConsole": "v1.107.1",
                "EmbeddedClusterOperator": "v0.22.1",
                "Installer": "v1.28.6+ec.0-1-g3562549",
                "Kubernetes": "v1.28.6+k0s.0",
                "OpenEBS": "v3.10.0"
        },
        "K0sSHA": "298cc05b1b4521006f470eccf6c5e780e5601b60c97eb259732b622be922ceee",
        "K0sBinaryURL": "",
        "Configs": {
                "concurrencyLevel": 1,
                "repositories": [
                        {
                                "name": "openebs",
                                "url": "https://openebs.github.io/charts",
                                "caFile": "",
                                "certFile": "",
                                "insecure": false,
                                "keyfile": "",
                                "username": "",
                                "password": ""
                        }
                ],
                "charts": [
                        {
                                "name": "openebs",
                                "chartname": "openebs/openebs",
                                "version": "3.10.0",
                                "values": "localprovisioner:\n  hostpathClass:\n    isDefaultClass: true\nndm:\n  enabled: false\nndmOperator:\n  enabled: false\n",
                                "namespace": "openebs",
                                "timeout": 0,
                                "order": 1
                        },
                        {
                                "name": "embedded-cluster-operator",
                                "chartname": "oci://registry.replicated.com/library/embedded-cluster-operator",
                                "version": "0.22.1",
                                "values": "embeddedClusterK0sVersion: v1.28.6+k0s.0\nembeddedClusterVersion: v1.28.6+ec.0-1-g3562549\nkotsVersion: 1.107.1\n",
                                "namespace": "embedded-cluster",
                                "timeout": 0,
                                "order": 2
                        },
                        {
                                "name": "admin-console",
                                "chartname": "oci://registry.replicated.com/library/admin-console",
                                "version": "1.107.1",
                                "values": "isHelmManaged: false\nkurlProxy:\n    enabled: true\n    nodePort: 30000\nminimalRBAC: false\nservice:\n    enabled: false\n",
                                "namespace": "kotsadm",
                                "timeout": 0,
                                "order": 3
                        }
                ]
        },
        "Protected": {
                "admin-console": [],
                "embedded-cluster-operator": [],
                "openebs": []
        }
}

```