### PR TITLE
feat: protect embeddedClusterID

### DIFF
--- a/pkg/addons/adminconsole/adminconsole.go
+++ b/pkg/addons/adminconsole/adminconsole.go
@@ -37,9 +37,7 @@ var (
 )
 
 // protectedFields are helm values that are not overwritten when upgrading the addon.
-var protectedFields = []string{
-	"automation",
-}
+var protectedFields = []string{"automation", "embeddedClusterID"}
 
 const DEFAULT_ADMIN_CONSOLE_NODE_PORT = 30000
 

--- a/pkg/addons/embeddedclusteroperator/embeddedclusteroperator.go
+++ b/pkg/addons/embeddedclusteroperator/embeddedclusteroperator.go
@@ -63,9 +63,7 @@ func (e *EmbeddedClusterOperator) HostPreflights() (*v1beta2.HostPreflightSpec, 
 // GetProtectedFields returns the protected fields for the embedded charts.
 // placeholder for now.
 func (e *EmbeddedClusterOperator) GetProtectedFields() map[string][]string {
-	protectedFields := []string{
-		"embeddedBinaryName",
-	}
+	protectedFields := []string{"embeddedBinaryName", "embeddedClusterID"}
 	return map[string][]string{releaseName: protectedFields}
 }
 


### PR DESCRIPTION
embeddedClusterID should not be overwritten during upgrades or operator reconcile cycles.