### PR TITLE
fix prod release builds

### DIFF
--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -21,7 +21,7 @@ jobs:
           go-version: "1.21"
       - name: Build linux-amd64
         run: |
-          make embedded-cluster VERSION=$TAG_NAME
+          make embedded-cluster-linux-amd64 VERSION=$TAG_NAME
           tar -C output/bin -czvf embedded-cluster-linux-amd64.tgz embedded-cluster
           ./output/bin/embedded-cluster version metadata > metadata.json
       - name: Cache files


### PR DESCRIPTION
https://github.com/replicatedhq/embedded-cluster/actions/runs/7907096603/job/21583366051

this make command doesn't exist anymore, instead there's the full `embedded-cluster-linux-amd64` command