### PR TITLE
feat: improve user feedback upon reinstall

### DIFF
--- a/cmd/embedded-cluster/install.go
+++ b/cmd/embedded-cluster/install.go
@@ -26,6 +26,12 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/release"
 )
 
+// ErrNothingElseToAdd is an error returned when there is nothing else to add to the
+// screen. This is useful when we want to exit an error from a function here but
+// don't want to print anything else (possibly because we have already printed the
+// necessary data to the screen).
+var ErrNothingElseToAdd = fmt.Errorf("")
+
 // runCommand spawns a command and capture its output. Outputs are logged using the
 // logrus package and stdout is returned as a string.
 func runCommand(bin string, args ...string) (string, error) {
@@ -307,7 +313,7 @@ var installCommand = &cli.Command{
 			logrus.Infof("If you want to reinstall you need to remove the existing installation")
 			logrus.Infof("first. You can do this by running the following command:")
 			logrus.Infof("\n  %s node reset\n", defaults.BinaryName())
-			return fmt.Errorf("%s is already installed", defaults.BinaryName())
+			return ErrNothingElseToAdd
 		}
 		metrics.ReportApplyStarted(c)
 		logrus.Debugf("materializing binaries")

--- a/cmd/embedded-cluster/join.go
+++ b/cmd/embedded-cluster/join.go
@@ -112,7 +112,7 @@ var joinCommand = &cli.Command{
 			logrus.Infof("If you want to reinstall you need to remove the existing installation")
 			logrus.Infof("first. You can do this by running the following command:")
 			logrus.Infof("\n  %s node reset\n", defaults.BinaryName())
-			return fmt.Errorf("%s is already installed", defaults.BinaryName())
+			return ErrNothingElseToAdd
 		}
 
 		binname := defaults.BinaryName()

--- a/cmd/embedded-cluster/join.go
+++ b/cmd/embedded-cluster/join.go
@@ -104,6 +104,7 @@ var joinCommand = &cli.Command{
 		return nil
 	},
 	Action: func(c *cli.Context) error {
+		logrus.Debugf("checking if %s is already installed", defaults.BinaryName())
 		if installed, err := isAlreadyInstalled(); err != nil {
 			return err
 		} else if installed {

--- a/cmd/embedded-cluster/join.go
+++ b/cmd/embedded-cluster/join.go
@@ -104,6 +104,16 @@ var joinCommand = &cli.Command{
 		return nil
 	},
 	Action: func(c *cli.Context) error {
+		if installed, err := isAlreadyInstalled(); err != nil {
+			return err
+		} else if installed {
+			logrus.Errorf("An installation has been detected on this machine.")
+			logrus.Infof("If you want to reinstall you need to remove the existing installation")
+			logrus.Infof("first. You can do this by running the following command:")
+			logrus.Infof("\n  %s node reset\n", defaults.BinaryName())
+			return fmt.Errorf("%s is already installed", defaults.BinaryName())
+		}
+
 		binname := defaults.BinaryName()
 		if c.Args().Len() != 2 {
 			return fmt.Errorf("usage: %s node join <url> <token>", binname)

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/canonical/lxd v0.0.0-20230814092713-c77ee90f5032
 	github.com/creack/pty v1.1.21
+	github.com/fatih/color v1.15.0
 	github.com/google/uuid v1.6.0
 	github.com/gosimple/slug v1.13.1
 	github.com/jedib0t/go-pretty v4.3.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/evanphx/json-patch v5.9.0+incompatible h1:fBXyNpNMuTTDdquAq/uisOr2lSh
 github.com/evanphx/json-patch v5.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.8.0 h1:lRj6N9Nci7MvzrXuX6HFzU8XjmhPiXPlsKEy1u0KQro=
 github.com/evanphx/json-patch/v5 v5.8.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
+github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
+github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/flosch/pongo2 v0.0.0-20200913210552-0d938eb266f3 h1:fmFk0Wt3bBxxwZnu48jqMdaOR/IZ4vdtJFuaFV8MpIE=
 github.com/flosch/pongo2 v0.0.0-20200913210552-0d938eb266f3/go.mod h1:bJWSKrZyQvfTnb2OudyUjurSG4/edverV7n82+K3JiM=
 github.com/frankban/quicktest v1.0.0/go.mod h1:R98jIehRai+d1/3Hv2//jOVCTJhW1VBavT6B6CuGq2k=
@@ -237,8 +239,6 @@ github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
 github.com/replicatedhq/embedded-cluster-operator v0.22.5 h1:7xW/dlNoJGoJykiJW7i5+tUfIp5Jmht9MXPa4AN//lA=
 github.com/replicatedhq/embedded-cluster-operator v0.22.5/go.mod h1:hBLJHrVuUW0X9444FJm+dQegfFDdmLAzIyDz6XhhSOc=
-github.com/replicatedhq/embedded-cluster-utils v0.0.0-20240214174642-c4acfad05b93 h1:IE1+6/Wn34nJ9ReOyQZXP8uwNB5YezZvs+JkgdUiYEI=
-github.com/replicatedhq/embedded-cluster-utils v0.0.0-20240214174642-c4acfad05b93/go.mod h1:4JmMC2CwMCLxq05GEW3XSPPVotqyamAF/omrbB3pH+c=
 github.com/replicatedhq/embedded-cluster-utils v0.0.0-20240214185439-68a1dfae58be h1:wuHmBUANuvCUeX4WmUVf7AWOlRTJMAmAR/GsYOY0Jdo=
 github.com/replicatedhq/embedded-cluster-utils v0.0.0-20240214185439-68a1dfae58be/go.mod h1:4JmMC2CwMCLxq05GEW3XSPPVotqyamAF/omrbB3pH+c=
 github.com/replicatedhq/kotskinds v0.0.0-20230724164735-f83482cc9cfe h1:3AJInd06UxzqHmgy8+24CPsT2tYSE0zToJZyuX9q+MA=

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -9,18 +9,20 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/sirupsen/logrus"
 
 	"github.com/replicatedhq/embedded-cluster/pkg/defaults"
 )
 
-// StdoutLogger is a Logrus hook for routing Info, Error, and Fatal logs to the screen.
+// StdoutLogger is a Logrus hook for routing Info, Error, Warn, and Fatal logs to the screen.
 type StdoutLogger struct{}
 
 // Levels defines on which log levels this hook would trigger.
 func (hook *StdoutLogger) Levels() []logrus.Level {
 	return []logrus.Level{
 		logrus.InfoLevel,
+		logrus.WarnLevel,
 		logrus.ErrorLevel,
 		logrus.FatalLevel,
 	}
@@ -33,7 +35,16 @@ func (hook *StdoutLogger) Fire(entry *logrus.Entry) error {
 	if entry.Level != logrus.InfoLevel {
 		output = os.Stderr
 	}
-	output.Write([]byte(message))
+	var writer *color.Color
+	switch entry.Level {
+	case logrus.WarnLevel:
+		writer = color.New(color.FgYellow)
+	case logrus.ErrorLevel, logrus.FatalLevel:
+		writer = color.New(color.FgRed)
+	default:
+		writer = color.New(color.FgWhite)
+	}
+	writer.Fprintf(output, message)
 	return nil
 }
 


### PR DESCRIPTION
- put a better user feedback in place in case of multiple attempts to run install or join on a machine.
- add color capabilities to our screen logging.
- make sure warnings are directed also to the screen and not only to the log.
- limit the max number of log files to 100.
- changes the log file name so we don't include `-` or `:` into it.

<img width="508" alt="Screenshot 2024-02-15 at 11 22 42" src="https://github.com/replicatedhq/embedded-cluster/assets/1385436/110146ab-937f-4b92-a60d-53260092d3b2">