### PR TITLE
fix missing admin console branding

### DIFF
--- a/e2e/scripts/check-installation-state.sh
+++ b/e2e/scripts/check-installation-state.sh
@@ -34,6 +34,9 @@ main() {
     echo "ensure that installation is installed"
     wait_for_installation
     kubectl get installations --no-headers | grep -q "Installed"
+
+    echo "ensure that the admin console branding is available"
+    kubectl get cm -n kotsadm kotsadm-application-metadata
 }
 
 export EMBEDDED_CLUSTER_METRICS_BASEURL="https://staging.replicated.app"

--- a/e2e/scripts/check-postupgrade-state.sh
+++ b/e2e/scripts/check-postupgrade-state.sh
@@ -74,6 +74,9 @@ main() {
         kubectl logs -n embedded-cluster -l app.kubernetes.io/name=embedded-cluster-operator --tail=100
         exit 1
     fi
+
+    echo "ensure that the admin console branding is available"
+    kubectl get cm -n kotsadm kotsadm-application-metadata
 }
 
 export EMBEDDED_CLUSTER_METRICS_BASEURL="https://staging.replicated.app"

--- a/pkg/addons/adminconsole/adminconsole.go
+++ b/pkg/addons/adminconsole/adminconsole.go
@@ -39,7 +39,7 @@ var (
 )
 
 // protectedFields are helm values that are not overwritten when upgrading the addon.
-var protectedFields = []string{"automation", "embeddedClusterID"}
+var protectedFields = []string{"automation", "embeddedClusterID", "kotsApplication"}
 
 const DEFAULT_ADMIN_CONSOLE_NODE_PORT = 30000
 


### PR DESCRIPTION
This PR adds `kotsApplication` to the list of protected values for the admin console add-on to prevent it from being overwritten during reconciliation. This fixes an issue where the admin console was missing application branding after the initial cluster install.

Added validation for branding to `check-installation-state.sh`. Example failure: https://github.com/replicatedhq/embedded-cluster/actions/runs/7965716798/job/21745820483?pr=393#step:4:9597