### PR TITLE
promote pre-minio-removal in release-dev workflow too

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -51,6 +51,9 @@ jobs:
           echo "${SHORT_SHA}"
           sed -i "s/__version_string__/${SHORT_SHA}/g" e2e/kots-release-install/cluster-config.yaml
           sed -i "s/__version_string__/${SHORT_SHA}-upgrade/g" e2e/kots-release-upgrade/cluster-config.yaml
+
+          # re-promote a release containing an old version of embedded-cluster to test upgrades
+          replicated release promote 807 2cHXb1RCttzpR0xvnNWyaZCgDBP --version "${SHORT_SHA}-pre-minio-removal"
           
           replicated release create --yaml-dir e2e/kots-release-install --promote CI --version "${SHORT_SHA}"
           replicated release create --yaml-dir e2e/kots-release-upgrade --promote CI --version "${SHORT_SHA}-upgrade"

--- a/e2e/scripts/vandoor-prepare.sh
+++ b/e2e/scripts/vandoor-prepare.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -x
 set -euo pipefail
 
 


### PR DESCRIPTION
Addresses an issue where the workflow running on main would fail during the "download embedded-cluster" step: https://github.com/replicatedhq/embedded-cluster/actions/runs/8194465936/job/22441201694