### PR TITLE
feature: implement artifact puller

### DIFF
--- a/cmd/local-artifact-mirror/artifact.go
+++ b/cmd/local-artifact-mirror/artifact.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content/file"
+	"oras.land/oras-go/v2/registry"
+	"oras.land/oras-go/v2/registry/remote"
+	"oras.land/oras-go/v2/registry/remote/auth"
+)
+
+// registryAuth returns the credentials to reach the registry. These credentials are
+// read from the cluster. XXX It is still not defined the secret name from where we
+// are going to read the credentials so this returns empty credentials instead.
+func registryAuth(_ context.Context) (auth.Credential, error) {
+	return auth.Credential{}, nil
+}
+
+// pullArtifact fetches an artifact from the registry pointed by 'from'. The artifact
+// is stored in a temporary directory and the path to this directory is returned.
+// Callers are responsible for removing the temporary directory when it is no longer
+// needed. In case of error, the temporary directory is removed here.
+func pullArtifact(ctx context.Context, from string) (string, error) {
+	creds, err := registryAuth(ctx)
+	if err != nil {
+		return "", fmt.Errorf("unable to get registry auth: %w", err)
+	}
+
+	imgref, err := registry.ParseReference(from)
+	if err != nil {
+		return "", fmt.Errorf("unable to parse image reference: %w", err)
+	}
+
+	tmpdir, err := os.MkdirTemp("", "embedded-cluster-artifact-*")
+	if err != nil {
+		return "", fmt.Errorf("unable to create temp dir: %w", err)
+	}
+
+	repo, err := remote.NewRepository(from)
+	if err != nil {
+		return "", fmt.Errorf("unable to create repository: %w", err)
+	}
+
+	fs, err := file.New(tmpdir)
+	if err != nil {
+		return "", fmt.Errorf("unable to create file store: %w", err)
+	}
+	defer fs.Close()
+
+	// XXX for now we are using a custom transport to skip the certificate validation
+	//     because the test environment is using a self-signed certificate. This should
+	//     be changed.
+	repo.Client = &auth.Client{
+		Credential: auth.StaticCredential(imgref.Registry, creds),
+		Client: &http.Client{
+			Transport: &http.Transport{
+				Proxy:                 http.ProxyFromEnvironment,
+				TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
+				ForceAttemptHTTP2:     true,
+				MaxIdleConns:          100,
+				IdleConnTimeout:       90 * time.Second,
+				TLSHandshakeTimeout:   10 * time.Second,
+				ExpectContinueTimeout: 1 * time.Second,
+			},
+		},
+	}
+
+	tag := imgref.Reference
+	if _, err := oras.Copy(ctx, repo, tag, fs, tag, oras.DefaultCopyOptions); err != nil {
+		os.RemoveAll(tmpdir)
+		return "", fmt.Errorf("unable to copy: %w", err)
+	}
+	return tmpdir, nil
+}

--- a/cmd/local-artifact-mirror/main.go
+++ b/cmd/local-artifact-mirror/main.go
@@ -3,18 +3,12 @@ package main
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"os"
 	"os/signal"
 	"path"
-	"strings"
 	"syscall"
-	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
-
-	"github.com/replicatedhq/embedded-cluster/pkg/defaults"
 )
 
 func main() {
@@ -27,68 +21,11 @@ func main() {
 	name := path.Base(os.Args[0])
 	var app = &cli.App{
 		Name:     name,
-		Usage:    "Runs the local artifact mirror",
-		Commands: []*cli.Command{serveCommand},
+		Usage:    "Runs or pulls data for the local artifact mirror",
+		Commands: []*cli.Command{serveCommand, pullCommand},
 	}
 	if err := app.RunContext(ctx, os.Args); err != nil {
-		logrus.Fatal(err)
+		fmt.Println(err)
+		os.Exit(1)
 	}
-}
-
-// logAndFilterRequest is a middleware that logs the HTTP request details. Returns 404
-// if attempting to read the log files as those are not served by this server.
-func logAndFilterRequest(handler http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Printf("%s %s %s\n", r.RemoteAddr, r.Method, r.URL)
-		if strings.HasPrefix(r.URL.Path, "/logs") {
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
-		handler.ServeHTTP(w, r)
-	})
-}
-
-// serveCommand starts a http server that serves files from the /var/lib/embedded-cluster
-// directory. This servers listen only on localhost and is used to serve files needed by
-// the autopilot during an upgrade.
-var serveCommand = &cli.Command{
-	Name:  "serve",
-	Usage: "Serve /var/lib/embedded-cluster files over HTTP",
-	Before: func(c *cli.Context) error {
-		if os.Getuid() != 0 {
-			return fmt.Errorf("serve command must be run as root")
-		}
-		return nil
-	},
-	Action: func(c *cli.Context) error {
-		dir := defaults.EmbeddedClusterHomeDirectory()
-
-		fileServer := http.FileServer(http.Dir(dir))
-		loggedFileServer := logAndFilterRequest(fileServer)
-		http.Handle("/", loggedFileServer)
-
-		stop := make(chan os.Signal, 1)
-		signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
-
-		server := &http.Server{Addr: "127.0.0.1:50000"}
-		go func() {
-			fmt.Println("Starting server on 127.0.0.1:50000")
-			if err := server.ListenAndServe(); err != nil {
-				if err != http.ErrServerClosed {
-					panic(err)
-				}
-			}
-		}()
-
-		<-stop
-		fmt.Println("Shutting down server...")
-
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		if err := server.Shutdown(ctx); err != nil {
-			panic(err)
-		}
-		fmt.Println("Server gracefully stopped")
-		return nil
-	},
 }

--- a/cmd/local-artifact-mirror/pull.go
+++ b/cmd/local-artifact-mirror/pull.go
@@ -129,7 +129,7 @@ var helmChartsCommand = &cli.Command{
 		dst := defaults.EmbeddedClusterChartsSubDir()
 		src := filepath.Join(location, HelmChartsArtifactName)
 		logrus.Infof("uncompressing %s", src)
-		if err := tgzutils.Uncompress(src, dst); err != nil {
+		if err := tgzutils.Decompress(src, dst); err != nil {
 			return fmt.Errorf("unable to uncompress helm charts: %w", err)
 		}
 

--- a/cmd/local-artifact-mirror/pull.go
+++ b/cmd/local-artifact-mirror/pull.go
@@ -20,6 +20,7 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/tgzutils"
 )
 
+// These constant define the expected names of the files in the registry.
 const (
 	EmbeddedClusterBinaryArtifactName = "embedded-cluster-amd64"
 	ImagesArtifactName                = "images-amd64.tar"

--- a/cmd/local-artifact-mirror/pull.go
+++ b/cmd/local-artifact-mirror/pull.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/replicatedhq/embedded-cluster-operator/api/v1beta1"
+	"github.com/replicatedhq/embedded-cluster/pkg/defaults"
+	"github.com/replicatedhq/embedded-cluster/pkg/helpers"
+	"github.com/replicatedhq/embedded-cluster/pkg/kubeutils"
+	"github.com/replicatedhq/embedded-cluster/pkg/tgzutils"
+)
+
+const (
+	EmbeddedClusterBinaryArtifactName = "embedded-cluster-amd64"
+	ImagesArtifactName                = "images-amd64.tar"
+	HelmChartsArtifactName            = "charts.tar.gz"
+)
+
+// pullCommand pulls artifacts from the registry running in the cluster and stores
+// them locally. This command is used during cluster upgrades when we want to fetch
+// the most up to date images, binaries and helm charts.
+var pullCommand = &cli.Command{
+	Name:        "pull",
+	Usage:       "Pull artifacts for an disconnect installation",
+	Subcommands: []*cli.Command{binariesCommand, imagesCommand, helmChartsCommand},
+}
+
+// imagesCommand pulls images from the registry running in the cluster and stores
+// them locally. This command is used during cluster upgrades when we want to fetch
+// the most up to date images. Images are stored in a tarball file in the default
+// location.
+var imagesCommand = &cli.Command{
+	Name:      "images",
+	Usage:     "Pull image artifacts for an airgap installation",
+	UsageText: `embedded-cluster-operator pull images <installation-name>`,
+	Before: func(c *cli.Context) error {
+		if os.Getuid() != 0 {
+			return fmt.Errorf("pull images command must be run as root")
+		}
+		if len(c.Args().Slice()) != 1 {
+			return fmt.Errorf("expected installation name as argument")
+		}
+		return nil
+	},
+	Action: func(c *cli.Context) error {
+		in, err := fetchAndValidateInstallation(c.Context, c.Args().First())
+		if err != nil {
+			return err
+		}
+
+		from := in.Spec.Artifacts.Images
+		logrus.Infof("fetching images artifact from %s", from)
+		location, err := pullArtifact(c.Context, from)
+		if err != nil {
+			return fmt.Errorf("unable to fetch artifact: %w", err)
+		}
+		defer func() {
+			logrus.Infof("removing temporary directory %s", location)
+			os.RemoveAll(location)
+		}()
+
+		dst := filepath.Join(defaults.EmbeddedClusterImagesSubDir(), ImagesArtifactName)
+		src := filepath.Join(location, ImagesArtifactName)
+		logrus.Infof("%s > %s", src, dst)
+		if err := helpers.MoveFile(src, dst); err != nil {
+			return fmt.Errorf("unable to move images bundle: %w", err)
+		}
+
+		logrus.Infof("images materialized under %s", dst)
+		return nil
+	},
+}
+
+// helmChartsCommand pulls helm charts from the registry running in the cluster and
+// stores them locally. This command is used during cluster upgrades when we want to
+// fetch the most up to date helm charts. Helm charts are stored in a tarball file
+// in the default location.
+var helmChartsCommand = &cli.Command{
+	Name:      "helmcharts",
+	Usage:     "Pull helm chart artifacts for an airgap installation",
+	UsageText: `embedded-cluster-operator pull helmcharts <installation-name>`,
+	Before: func(c *cli.Context) error {
+		if os.Getuid() != 0 {
+			return fmt.Errorf("pull helmcharts command must be run as root")
+		}
+		if len(c.Args().Slice()) != 1 {
+			return fmt.Errorf("expected installation name as argument")
+		}
+		return nil
+	},
+	Action: func(c *cli.Context) error {
+		in, err := fetchAndValidateInstallation(c.Context, c.Args().First())
+		if err != nil {
+			return err
+		}
+
+		from := in.Spec.Artifacts.HelmCharts
+		logrus.Infof("fetching helm charts artifact from %s", from)
+		location, err := pullArtifact(c.Context, from)
+		if err != nil {
+			return fmt.Errorf("unable to fetch artifact: %w", err)
+		}
+		defer func() {
+			logrus.Infof("removing temporary directory %s", location)
+			os.RemoveAll(location)
+		}()
+
+		dst := defaults.EmbeddedClusterChartsSubDir()
+		src := filepath.Join(location, HelmChartsArtifactName)
+		logrus.Infof("uncompressing %s", src)
+		if err := tgzutils.Uncompress(src, dst); err != nil {
+			return fmt.Errorf("unable to uncompress images: %w", err)
+		}
+
+		logrus.Infof("helm charts materialized under %s", dst)
+		return nil
+	},
+}
+
+// binariesCommands pulls the binary artifact from the registry running in the cluster and stores
+// it locally. This command is used during cluster upgrades when we want to fetch the most up to
+// date binaries. The binaries is stored in the /usr/local/bin directory and they overwrite the
+// existing binaries.
+var binariesCommand = &cli.Command{
+	Name:      "binaries",
+	Usage:     "Pull binaries artifacts for an airgap installation",
+	UsageText: `embedded-cluster-operator pull binaries <installation-name>`,
+	Before: func(c *cli.Context) error {
+		if os.Getuid() != 0 {
+			return fmt.Errorf("pull binaries command must be run as root")
+		}
+		if len(c.Args().Slice()) != 1 {
+			return fmt.Errorf("expected installation name as argument")
+		}
+		return nil
+	},
+	Action: func(c *cli.Context) error {
+		in, err := fetchAndValidateInstallation(c.Context, c.Args().First())
+		if err != nil {
+			return err
+		}
+
+		from := in.Spec.Artifacts.EmbeddedClusterBinary
+		logrus.Infof("fetching embedded cluster binary artifact from %s", from)
+		location, err := pullArtifact(c.Context, from)
+		if err != nil {
+			return fmt.Errorf("unable to fetch artifact: %w", err)
+		}
+		defer func() {
+			logrus.Infof("removing temporary directory %s", location)
+			os.RemoveAll(location)
+		}()
+
+		bin := filepath.Join(location, EmbeddedClusterBinaryArtifactName)
+		if err := os.Chmod(bin, 0755); err != nil {
+			return fmt.Errorf("unable to change permissions on %s: %w", bin, err)
+		}
+
+		out := bytes.NewBuffer(nil)
+		cmd := exec.Command(bin, "materialize")
+		cmd.Stdout = out
+		cmd.Stderr = out
+
+		logrus.Infof("running command: %s materialize", bin)
+		if err := cmd.Run(); err != nil {
+			logrus.Error(out.String())
+			return err
+		}
+
+		logrus.Infof("embedded cluster binaries materialized")
+		return nil
+	},
+}
+
+// fetchAndValidateInstallation fetches an Installation object from its name and
+// checks if it is valid for an airgap cluster deployment.
+func fetchAndValidateInstallation(ctx context.Context, iname string) (*v1beta1.Installation, error) {
+	kubeclient, err := kubeutils.KubeClient()
+	if err != nil {
+		return nil, fmt.Errorf("unable to create kube client: %w", err)
+	}
+	v1beta1.AddToScheme(kubeclient.Scheme())
+
+	logrus.Infof("reading installation %q", iname)
+	nsn := types.NamespacedName{Name: iname}
+	var in v1beta1.Installation
+	if err := kubeclient.Get(ctx, nsn, &in); err != nil {
+		return nil, fmt.Errorf("unable to get installation: %w", err)
+	}
+
+	if !in.Spec.AirGap {
+		return nil, fmt.Errorf("installation is not airgapped")
+	} else if in.Spec.Artifacts == nil {
+		return nil, fmt.Errorf("installation has no artifacts")
+	}
+
+	return &in, nil
+}

--- a/cmd/local-artifact-mirror/pull.go
+++ b/cmd/local-artifact-mirror/pull.go
@@ -130,7 +130,7 @@ var helmChartsCommand = &cli.Command{
 		src := filepath.Join(location, HelmChartsArtifactName)
 		logrus.Infof("uncompressing %s", src)
 		if err := tgzutils.Uncompress(src, dst); err != nil {
-			return fmt.Errorf("unable to uncompress images: %w", err)
+			return fmt.Errorf("unable to uncompress helm charts: %w", err)
 		}
 
 		logrus.Infof("helm charts materialized under %s", dst)

--- a/cmd/local-artifact-mirror/serve.go
+++ b/cmd/local-artifact-mirror/serve.go
@@ -16,7 +16,7 @@ import (
 )
 
 // serveCommand starts a http server that serves files from the /var/lib/embedded-cluster
-// directory. This servers listen only on localhost and is used to serve files needed by
+// directory. This server listen only on localhost and is used to serve files needed by
 // the autopilot during an upgrade.
 var serveCommand = &cli.Command{
 	Name:  "serve",

--- a/cmd/local-artifact-mirror/serve.go
+++ b/cmd/local-artifact-mirror/serve.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/replicatedhq/embedded-cluster/pkg/defaults"
+)
+
+// serveCommand starts a http server that serves files from the /var/lib/embedded-cluster
+// directory. This servers listen only on localhost and is used to serve files needed by
+// the autopilot during an upgrade.
+var serveCommand = &cli.Command{
+	Name:  "serve",
+	Usage: "Serve /var/lib/embedded-cluster files over HTTP",
+	Before: func(c *cli.Context) error {
+		if os.Getuid() != 0 {
+			return fmt.Errorf("serve command must be run as root")
+		}
+		return nil
+	},
+	Action: func(c *cli.Context) error {
+		dir := defaults.EmbeddedClusterHomeDirectory()
+
+		fileServer := http.FileServer(http.Dir(dir))
+		loggedFileServer := logAndFilterRequest(fileServer)
+		http.Handle("/", loggedFileServer)
+
+		stop := make(chan os.Signal, 1)
+		signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
+
+		server := &http.Server{Addr: "127.0.0.1:50000"}
+		go func() {
+			fmt.Println("Starting server on 127.0.0.1:50000")
+			if err := server.ListenAndServe(); err != nil {
+				if err != http.ErrServerClosed {
+					panic(err)
+				}
+			}
+		}()
+
+		<-stop
+		fmt.Println("Shutting down server...")
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := server.Shutdown(ctx); err != nil {
+			panic(err)
+		}
+		fmt.Println("Server gracefully stopped")
+		return nil
+	},
+}
+
+// logAndFilterRequest is a middleware that logs the HTTP request details. Returns 404
+// if attempting to read the log files as those are not served by this server.
+func logAndFilterRequest(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Printf("%s %s %s\n", r.RemoteAddr, r.Method, r.URL)
+		if strings.HasPrefix(r.URL.Path, "/logs") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		handler.ServeHTTP(w, r)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.29.3
 	k8s.io/apimachinery v0.29.3
+	oras.land/oras-go/v2 v2.5.0
 	sigs.k8s.io/controller-runtime v0.17.2
 	sigs.k8s.io/yaml v1.4.0
 )
@@ -47,6 +48,7 @@ require (
 	github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect
 	github.com/ohler55/ojg v1.21.4 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/prometheus/client_golang v1.18.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect
@@ -59,6 +61,7 @@ require (
 	go.etcd.io/etcd/client/pkg/v3 v3.5.12 // indirect
 	go.etcd.io/etcd/client/v3 v3.5.12 // indirect
 	golang.org/x/exp v0.0.0-20240222234643-814bf88cf225 // indirect
+	golang.org/x/sync v0.6.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20231106174013-bbf56f31fb17 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20231106174013-bbf56f31fb17 // indirect

--- a/go.sum
+++ b/go.sum
@@ -218,6 +218,8 @@ github.com/onsi/gomega v1.31.1 h1:KYppCUK+bUgAZwHOu7EXVBKyQA6ILvOESHkn/tgoqvo=
 github.com/onsi/gomega v1.31.1/go.mod h1:y40C95dwAD1Nz36SsEnxvfFe8FFfNxzI5eJ0EYGyAy0=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
+github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
+github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
 github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=
 github.com/pborman/uuid v1.2.1/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
@@ -358,6 +360,8 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
+golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -485,6 +489,8 @@ k8s.io/kube-openapi v0.0.0-20231113174909-778a5567bc1e h1:snPmy96t93RredGRjKfMFt
 k8s.io/kube-openapi v0.0.0-20231113174909-778a5567bc1e/go.mod h1:AsvuZPBlUDVuCdzJ87iajxtXuR9oktsTctW/R9wwouA=
 k8s.io/utils v0.0.0-20231121161247-cf03d44ff3cf h1:iTzha1p7Fi83476ypNSz8nV9iR9932jIIs26F7gNLsU=
 k8s.io/utils v0.0.0-20231121161247-cf03d44ff3cf/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+oras.land/oras-go/v2 v2.5.0 h1:o8Me9kLY74Vp5uw07QXPiitjsw7qNXi8Twd+19Zf02c=
+oras.land/oras-go/v2 v2.5.0/go.mod h1:z4eisnLP530vwIOUOJeBIj0aGI0L1C3d53atvCBqZHg=
 sigs.k8s.io/controller-runtime v0.17.2 h1:FwHwD1CTUemg0pW2otk7/U5/i5m2ymzvOXdbeGOUvw0=
 sigs.k8s.io/controller-runtime v0.17.2/go.mod h1:+MngTvIQQQhfXtwfdGw/UOQ/aIaqsYywfCINOtwMO/s=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -49,6 +49,11 @@ func EmbeddedClusterChartsSubDir() string {
 	return def().EmbeddedClusterChartsSubDir()
 }
 
+// EmbeddedClusterImagesSubDir calls EmbeddedClusterImagesSubDir on the default provider.
+func EmbeddedClusterImagesSubDir() string {
+	return def().EmbeddedClusterImagesSubDir()
+}
+
 // EmbeddedClusterLogsSubDir calls EmbeddedClusterLogsSubDir on the default provider.
 func EmbeddedClusterLogsSubDir() string {
 	return def().EmbeddedClusterLogsSubDir()

--- a/pkg/defaults/provider.go
+++ b/pkg/defaults/provider.go
@@ -83,6 +83,15 @@ func (d *Provider) EmbeddedClusterChartsSubDir() string {
 	return path
 }
 
+// EmbeddedClusterImagesSubDir returns the path to the directory where docker images are stored.
+func (d *Provider) EmbeddedClusterImagesSubDir() string {
+	path := filepath.Join(d.EmbeddedClusterHomeDirectory(), "images")
+	if err := os.MkdirAll(path, 0755); err != nil {
+		logrus.Fatalf("unable to create embedded-cluster images dir: %s", err)
+	}
+	return path
+}
+
 // EmbeddedClusterHomeDirectory returns the parent directory. Inside this parent directory we
 // store all the embedded-cluster related files.
 func (d *Provider) EmbeddedClusterHomeDirectory() string {

--- a/pkg/tgzutils/tgz.go
+++ b/pkg/tgzutils/tgz.go
@@ -1,0 +1,61 @@
+package tgzutils
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// Uncompress decompresses a .tgz file into a directory.
+func Uncompress(tgz, dst string) error {
+	fp, err := os.Open(tgz)
+	if err != nil {
+		return fmt.Errorf("unable to open tgz file: %v", err)
+	}
+	defer fp.Close()
+
+	gzreader, err := gzip.NewReader(fp)
+	if err != nil {
+		return fmt.Errorf("unable to create gzip reader: %v", err)
+	}
+
+	tarreader := tar.NewReader(gzreader)
+	for {
+		header, err := tarreader.Next()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return fmt.Errorf("unable to read tar header: %v", err)
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			mode := os.FileMode(header.Mode)
+			dst := filepath.Join(dst, header.Name)
+			if err := os.Mkdir(dst, mode); err != nil {
+				return fmt.Errorf("unable to create directory: %v", err)
+			}
+		case tar.TypeReg:
+			mode := os.FileMode(header.Mode)
+			dst := filepath.Join(dst, header.Name)
+			opts := os.O_CREATE | os.O_WRONLY | os.O_TRUNC
+			outfp, err := os.OpenFile(dst, opts, mode)
+			if err != nil {
+				return fmt.Errorf("unable to create file: %v", err)
+			}
+			if _, err := io.Copy(outfp, tarreader); err != nil {
+				return fmt.Errorf("unable to write file: %v", err)
+			}
+			outfp.Close()
+			if err := os.Chmod(dst, os.FileMode(header.Mode)); err != nil {
+				return fmt.Errorf("unable to chmod file: %v", err)
+			}
+		default:
+			return fmt.Errorf("unknown type: %v", header.Typeflag)
+		}
+	}
+	return nil
+}

--- a/pkg/tgzutils/tgz.go
+++ b/pkg/tgzutils/tgz.go
@@ -9,8 +9,8 @@ import (
 	"path/filepath"
 )
 
-// Uncompress decompresses a .tgz file into a directory.
-func Uncompress(tgz, dst string) error {
+// Decompress decompresses a .tgz file into a directory.
+func Decompress(tgz, dst string) error {
 	fp, err := os.Open(tgz)
 	if err != nil {
 		return fmt.Errorf("unable to open tgz file: %v", err)


### PR DESCRIPTION
the artifact puller pulls assets from a remote registry and store them locally under `/var/lib/embedded-cluster`. this command works hand in hand with an installation object as the latter provides the source from where the first pulls the artifacts.

the idea is that we will have a job that will run the following command:

```
local-artifact-mirror pull binaries <installation name>
local-artifact-mirror pull images <installation name>
local-artifact-mirror pull helmcharts <installation name>
```

the artifact puller will then read the installation `<installation name>` and fetch the artifacts, storing them in the right place under `/var/lib/embedded-cluster`.

this is an example of an installation object that provides source for such artifacts:

```yaml
apiVersion: embeddedcluster.replicated.com/v1beta1
kind: Installation
metadata:
  creationTimestamp: "2024-03-12T15:30:08Z"
  generation: 8
  name: "20240312153008"
  resourceVersion: "637286"
  uid: 6558c016-c14b-4f59-9a08-691fb5daedfd
spec:
  airGap: true
  artifacts:
    embeddedClusterBinary: 10.110.90.56:5000/embedded-cluster-bundle:v1
    helmCharts: 10.110.90.56:5000/embedded-cluster-charts:v1
    images: 10.110.90.56:5000/embedded-cluster-images:v1
  clusterID: f863807b-957e-4f26-afcc-204d755d2c85
  metricsBaseURL: https://replicated.app
```

and this is a skeleton of the job that will be executed by the operator whenever a new installation object is created:

```yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: embedded-cluster-updater
  namespace: embedded-cluster
spec:
  backoffLimit: 0
  template:
    spec:
      serviceAccount: embedded-cluster-operator
      serviceAccountName: embedded-cluster-operator
      volumes:
      - name: host
        hostPath:
          path: /var/lib/embedded-cluster
          type: Directory
      restartPolicy: Never
      containers:
      - name: embedded-cluster-updater
        image: busybox:latest
        env:
        - name: INSTALLATION
          value: "20240312153008"
        volumeMounts:
        - mountPath: /var/lib/embedded-cluster
          name: host
          readOnly: false
        command:
        - /bin/sh
        - -e
        - -c
        - |
          /var/lib/embedded-cluster/bin/local-artifact-mirror pull binaries $INSTALLATION
          /var/lib/embedded-cluster/bin/local-artifact-mirror pull images $INSTALLATION
          /var/lib/embedded-cluster/bin/local-artifact-mirror pull helmcharts $INSTALLATION
```
