### PR TITLE
Adds a reboot flag to `reset`

### DIFF
--- a/cmd/embedded-cluster/uninstall.go
+++ b/cmd/embedded-cluster/uninstall.go
@@ -233,7 +233,6 @@ func stopAndResetK0s() error {
 	if err != nil {
 		return fmt.Errorf("could not reset k0s: %w, %s", err, string(out))
 	}
-	logrus.Infof("Node has been reset. Please reboot to ensure transient configuration is also reset.")
 	return nil
 }
 
@@ -382,7 +381,11 @@ var resetCommand = &cli.Command{
 		err = stopAndResetK0s()
 		if !checkErrPrompt(c, err) {
 			return err
-		}
+		} 
+
+    if !c.Bool("reboot") {
+      logrus.Infof("Node has been reset. Please reboot to ensure transient configuration is also reset.")
+    }
 
 		if _, err := os.Stat(defaults.PathToK0sConfig()); err == nil {
 			if err := os.Remove(defaults.PathToK0sConfig()); err != nil {
@@ -410,15 +413,17 @@ var resetCommand = &cli.Command{
 		}
 
 		if c.Bool("reboot") {
-			// this is a bit more graceful that using sync(2) and reboot(2) but
-			// can take a bit longer
-			if _, err := exec.Command("reboot").Output(); err != nil {
-				return err
-			}
-		} else {
-			return fmt.Errorf("Aborting reboot")
+      if prompts.New().Confirm("Continue with reboot?", false)
+        // this is a bit more graceful that using sync(2) and reboot(2) but
+        // can take a bit longer
+        if _, err := exec.Command("reboot").Output(); err != nil {
+          return err
+        }
+      } else {
+        return fmt.Errorf("Aborting reboot")
+      }
 		}
-
+ 
 		return nil
 	},
 }

--- a/cmd/embedded-cluster/uninstall.go
+++ b/cmd/embedded-cluster/uninstall.go
@@ -311,6 +311,11 @@ var resetCommand = &cli.Command{
 			Usage: "Ignore errors encountered when resetting the node (implies --no-prompt)",
 			Value: false,
 		},
+		&cli.BoolFlag{
+			Name:  "reboot",
+			Usage: "Reboot system after reseting the node",
+			Value: false,
+		},
 	},
 	Usage: fmt.Sprintf("Uninstall %s from the current node", binName),
 	Action: func(c *cli.Context) error {
@@ -402,6 +407,16 @@ var resetCommand = &cli.Command{
 			if err := os.RemoveAll(defaults.EmbeddedClusterHomeDirectory()); err != nil {
 				return err
 			}
+		}
+
+		if c.Bool("reboot") {
+			// this is a bit more graceful that using sync(2) and reboot(2) but
+			// can take a bit longer
+			if _, err := exec.Command("reboot").Output(); err != nil {
+				return err
+			}
+		} else {
+			return fmt.Errorf("Aborting reboot")
 		}
 
 		return nil

--- a/cmd/embedded-cluster/uninstall.go
+++ b/cmd/embedded-cluster/uninstall.go
@@ -381,11 +381,11 @@ var resetCommand = &cli.Command{
 		err = stopAndResetK0s()
 		if !checkErrPrompt(c, err) {
 			return err
-		} 
+		}
 
-    if !c.Bool("reboot") {
-      logrus.Infof("Node has been reset. Please reboot to ensure transient configuration is also reset.")
-    }
+		if !c.Bool("reboot") {
+			logrus.Infof("Node has been reset. Please reboot to ensure transient configuration is also reset.")
+		}
 
 		if _, err := os.Stat(defaults.PathToK0sConfig()); err == nil {
 			if err := os.Remove(defaults.PathToK0sConfig()); err != nil {
@@ -413,17 +413,17 @@ var resetCommand = &cli.Command{
 		}
 
 		if c.Bool("reboot") {
-      if prompts.New().Confirm("Continue with reboot?", false)
-        // this is a bit more graceful that using sync(2) and reboot(2) but
-        // can take a bit longer
-        if _, err := exec.Command("reboot").Output(); err != nil {
-          return err
-        }
-      } else {
-        return fmt.Errorf("Aborting reboot")
-      }
+			if prompts.New().Confirm("Continue with reboot?", false) {
+				// this is a bit more graceful that using sync(2) and reboot(2) but
+				// can take a bit longer
+				if _, err := exec.Command("reboot").Output(); err != nil {
+					return err
+				}
+			} else {
+				return fmt.Errorf("Aborting reboot")
+			}
 		}
- 
+
 		return nil
 	},
 }

--- a/cmd/embedded-cluster/uninstall.go
+++ b/cmd/embedded-cluster/uninstall.go
@@ -413,14 +413,8 @@ var resetCommand = &cli.Command{
 		}
 
 		if c.Bool("reboot") {
-			if prompts.New().Confirm("Continue with reboot?", false) {
-				// this is a bit more graceful that using sync(2) and reboot(2) but
-				// can take a bit longer
-				if _, err := exec.Command("reboot").Output(); err != nil {
-					return err
-				}
-			} else {
-				return fmt.Errorf("Aborting reboot")
+			if _, err := exec.Command("reboot").Output(); err != nil {
+				return err
 			}
 		}
 


### PR DESCRIPTION
TL;DR
-----

Simplifies resetting a node iwth a reboot flag

Details
-------

Encourages better behavior by making it easier to reboot a node after resetting it. Instead of having to run two commands to assure a clean reset:

```
$ sudo ./embedded-cluster reset
$ sudo reboot
```

you just have to

```
$ sudo ./embedded-cluster reset --reboot
```

to do the same.

My implementation shells out to the `reboot` command which takes a little longer than making the minimum required syscalls (`sync(2)` and `reboot(2)`) because of the niceties it brings along like sending a wall message and signaling processes more gracefully.

My first implementation just made the syscalls and it was a lot faster but I decided it probably makes more sense to play nice. I could be convinced it's not needed since the node shouldn't be running any other workloads and the app and cluster are already nicely taken care of.
