### PR TITLE
feat: create version metadata config map

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -51,7 +51,7 @@ jobs:
     - name: Build Linux AMD64
       run: |
         export SHORT_SHA=dev-$(git rev-parse --short=7 HEAD)
-        make embedded-cluster-linux-amd64 VERSION=$SHORT_SHA
+        make embedded-cluster-linux-amd64 VERSION="${SHORT_SHA}"
         tar -C output/bin -czvf embedded-cluster-linux-amd64.tgz embedded-cluster
     - name: Output Metadata
       run: |
@@ -90,7 +90,7 @@ jobs:
         echo "versionLabel: \"${SHORT_SHA}\"" >> e2e/kots-release-install/release.yaml
         cat e2e/kots-release-install/release.yaml
         cp output/bin/embedded-cluster output/bin/embedded-cluster-original
-        make embedded-release # this is done after the metadata.json is generated so as to not include additional charts
+        make embedded-release VERSION="${SHORT_SHA}" # this is done after the metadata.json is generated so as to not include additional charts
     - name: Cache files for integration test
       env:
         S3_BUCKET: "tf-staging-embedded-cluster-bin"

--- a/cmd/embedded-cluster/install.go
+++ b/cmd/embedded-cluster/install.go
@@ -344,6 +344,13 @@ func waitForK0s() error {
 func runOutro(c *cli.Context) error {
 	os.Setenv("KUBECONFIG", defaults.PathToKubeConfig())
 	opts := []addons.Option{}
+
+	metadata, err := gatherVersionMetadata()
+	if err != nil {
+		return fmt.Errorf("unable to gather release metadata: %w", err)
+	}
+	opts = append(opts, addons.WithVersionMetadata(metadata))
+
 	if l := c.String("license"); l != "" {
 		opts = append(opts, addons.WithLicense(l))
 	}

--- a/cmd/embedded-cluster/version.go
+++ b/cmd/embedded-cluster/version.go
@@ -60,67 +60,10 @@ var metadataCommand = &cli.Command{
 	Usage:  "Print metadata about this release",
 	Hidden: true,
 	Action: func(c *cli.Context) error {
-		opts := []addons.Option{addons.Quiet(), addons.WithoutPrompt(), addons.OnlyDefaults()}
-		versions, err := addons.NewApplier(opts...).Versions(config.AdditionalCharts())
+		meta, err := gatherVersionMetadata()
 		if err != nil {
-			return fmt.Errorf("unable to get versions: %w", err)
+			return err
 		}
-		versions["Kubernetes"] = defaults.K0sVersion
-		versions["Installer"] = defaults.Version
-		versions["Troubleshoot"] = defaults.TroubleshootVersion
-		versions["Kubectl"] = defaults.KubectlVersion
-		channelRelease, err := release.GetChannelRelease()
-		if err == nil && channelRelease != nil {
-			versions[defaults.BinaryName()] = channelRelease.VersionLabel
-		}
-		sha, err := goods.K0sBinarySHA256()
-		if err != nil {
-			return fmt.Errorf("unable to get k0s binary sha256: %w", err)
-		}
-		meta := types.ReleaseMetadata{
-			Versions:     versions,
-			K0sSHA:       sha,
-			K0sBinaryURL: defaults.K0sBinaryURL,
-		}
-		applier := addons.NewApplier(opts...)
-		chtconfig, repconfig, err := applier.GenerateHelmConfigs(config.AdditionalCharts(), config.AdditionalRepositories())
-		if err != nil {
-			return fmt.Errorf("unable to apply addons: %w", err)
-		}
-		meta.Configs = k0sconfig.HelmExtensions{
-			ConcurrencyLevel: 1,
-			Charts:           chtconfig,
-			Repositories:     repconfig,
-		}
-		protectedFields, err := applier.ProtectedFields()
-		if err != nil {
-			return fmt.Errorf("unable to get protected fields: %w", err)
-		}
-		meta.Protected = protectedFields
-
-		// Airgap
-		airgapCht, airgapRepo, err := applier.GetAirgapCharts()
-		if err != nil {
-			return fmt.Errorf("unable to get airgap charts: %w", err)
-		}
-		meta.AirgapConfigs = k0sconfig.HelmExtensions{
-			ConcurrencyLevel: 1,
-			Charts:           airgapCht,
-			Repositories:     airgapRepo,
-		}
-		additionalImages, err := applier.GetAdditionalImages()
-		if err != nil {
-			return fmt.Errorf("unable to get airgap images: %w", err)
-		}
-
-		// Render k0s config to get the images contained within
-		k0sConfig := config.RenderK0sConfig()
-		if err != nil {
-			return fmt.Errorf("unable to render k0s config: %w", err)
-		}
-		meta.K0sImages = airgap.GetImageURIs(k0sConfig.Spec, true)
-		meta.K0sImages = append(meta.K0sImages, additionalImages...)
-
 		data, err := json.MarshalIndent(meta, "", "\t")
 		if err != nil {
 			return fmt.Errorf("unable to marshal versions: %w", err)
@@ -128,6 +71,84 @@ var metadataCommand = &cli.Command{
 		fmt.Println(string(data))
 		return nil
 	},
+}
+
+// gatherVersionMetadata returns the release metadata for this version of
+// embedded cluster. Release metadata involves the default versions of the
+// components that are included in the release plus the default values used
+// when deploying them.
+func gatherVersionMetadata() (*types.ReleaseMetadata, error) {
+	applier := addons.NewApplier(
+		addons.WithoutPrompt(),
+		addons.OnlyDefaults(),
+		addons.Quiet(),
+	)
+
+	versions, err := applier.Versions(config.AdditionalCharts())
+	if err != nil {
+		return nil, fmt.Errorf("unable to get versions: %w", err)
+	}
+	versions["Kubernetes"] = defaults.K0sVersion
+	versions["Installer"] = defaults.Version
+	versions["Troubleshoot"] = defaults.TroubleshootVersion
+	versions["Kubectl"] = defaults.KubectlVersion
+
+	channelRelease, err := release.GetChannelRelease()
+	if err == nil && channelRelease != nil {
+		versions[defaults.BinaryName()] = channelRelease.VersionLabel
+	}
+
+	sha, err := goods.K0sBinarySHA256()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get k0s binary sha256: %w", err)
+	}
+
+	meta := types.ReleaseMetadata{
+		Versions:     versions,
+		K0sSHA:       sha,
+		K0sBinaryURL: defaults.K0sBinaryURL,
+	}
+
+	chtconfig, repconfig, err := applier.GenerateHelmConfigs(
+		config.AdditionalCharts(),
+		config.AdditionalRepositories(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to apply addons: %w", err)
+	}
+
+	meta.Configs = k0sconfig.HelmExtensions{
+		ConcurrencyLevel: 1,
+		Charts:           chtconfig,
+		Repositories:     repconfig,
+	}
+
+	protectedFields, err := applier.ProtectedFields()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get protected fields: %w", err)
+	}
+	meta.Protected = protectedFields
+
+	// Airgap
+	airgapCht, airgapRepo, err := applier.GetAirgapCharts()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get airgap charts: %w", err)
+	}
+	meta.AirgapConfigs = k0sconfig.HelmExtensions{
+		ConcurrencyLevel: 1,
+		Charts:           airgapCht,
+		Repositories:     airgapRepo,
+	}
+	additionalImages, err := applier.GetAdditionalImages()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get airgap images: %w", err)
+	}
+
+	// Render k0s config to get the images contained within
+	k0sConfig := config.RenderK0sConfig()
+	meta.K0sImages = airgap.GetImageURIs(k0sConfig.Spec, true)
+	meta.K0sImages = append(meta.K0sImages, additionalImages...)
+	return &meta, nil
 }
 
 var embeddedDataCommand = &cli.Command{

--- a/e2e/scripts/check-installation-state.sh
+++ b/e2e/scripts/check-installation-state.sh
@@ -66,21 +66,6 @@ ensure_app_not_upgraded() {
     fi
 }
 
-ensure_version_metadata_present() {
-    if ! kubectl get cm -n embedded-cluster | grep -q version-metadata-; then
-        echo "version metadata configmap not found"
-        kubectl get cm -n embedded-cluster
-        return 1
-    fi
-    local name
-    name=$(kubectl get cm -n embedded-cluster | grep version-metadata- | awk '{print $1}')
-    if ! kubectl get cm -n embedded-cluster "$name" -o yaml | grep -q Versions ; then
-        echo "version metadata configmap does not contain Versions entry"
-        kubectl get cm -n embedded-cluster "$name" -o yaml
-        return 1
-    fi
-}
-
 main() {
     local version="$1"
     sleep 30 # wait for kubectl to become available
@@ -103,11 +88,6 @@ main() {
         exit 1
     fi
     if ! ensure_app_not_upgraded; then
-        exit 1
-    fi
-
-    echo "ensure that versions configmap is present"
-    if ! ensure_version_metadata_present; then
         exit 1
     fi
 }

--- a/e2e/scripts/check-installation-state.sh
+++ b/e2e/scripts/check-installation-state.sh
@@ -66,6 +66,21 @@ ensure_app_not_upgraded() {
     fi
 }
 
+ensure_version_metadata_present() {
+    if ! kubectl get cm -n embedded-cluster | grep -q version-metadata-; then
+        echo "version metadata configmap not found"
+        kubectl get cm -n embedded-cluster
+        return 1
+    fi
+    local name
+    name=$(kubectl get cm -n embedded-cluster | grep version-metadata- | awk '{print $1}')
+    if ! kubectl get cm -n embedded-cluster "$name" -o yaml | grep -q Versions ; then
+        echo "version metadata configmap does not contain Versions entry"
+        kubectl get cm -n embedded-cluster "$name" -o yaml
+        return 1
+    fi
+}
+
 main() {
     local version="$1"
     sleep 30 # wait for kubectl to become available
@@ -88,6 +103,11 @@ main() {
         exit 1
     fi
     if ! ensure_app_not_upgraded; then
+        exit 1
+    fi
+
+    echo "ensure that versions configmap is present"
+    if ! ensure_version_metadata_present; then
         exit 1
     fi
 }

--- a/pkg/addons/embeddedclusteroperator/embeddedclusteroperator.go
+++ b/pkg/addons/embeddedclusteroperator/embeddedclusteroperator.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gosimple/slug"
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/replicatedhq/embedded-cluster-kinds/types"
 	embeddedclusterv1beta1 "github.com/replicatedhq/embedded-cluster-operator/api/v1beta1"
@@ -112,11 +113,12 @@ func (e *EmbeddedClusterOperator) createVersionMetadataConfigmap(ctx context.Con
 		return fmt.Errorf("unable to marshal release metadata: %w", err)
 	}
 
-	version := strings.TrimPrefix(defaults.Version, "v")
-	version = strings.ReplaceAll(version, "+", "-")
+	// we trim out the prefix v from the version and then slugify it, we use
+	// the result as a suffix for the config map name.
+	slugver := slug.Make(strings.TrimPrefix(defaults.Version, "v"))
 	configmap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("version-metadata-%s", version),
+			Name:      fmt.Sprintf("version-metadata-%s", slugver),
 			Namespace: e.namespace,
 		},
 		Data: map[string]string{

--- a/pkg/addons/options.go
+++ b/pkg/addons/options.go
@@ -2,6 +2,7 @@ package addons
 
 import (
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+	"github.com/replicatedhq/embedded-cluster-kinds/types"
 	embeddedclusterv1beta1 "github.com/replicatedhq/embedded-cluster-operator/api/v1beta1"
 )
 
@@ -56,5 +57,12 @@ func WithLicense(licenseFile string) Option {
 func WithAirgapBundle(airgapBundle string) Option {
 	return func(a *Applier) {
 		a.airgapBundle = airgapBundle
+	}
+}
+
+// WithVersionMetadata sets the release version metadata to be used during addons installation.
+func WithVersionMetadata(metadata *types.ReleaseMetadata) Option {
+	return func(a *Applier) {
+		a.releaseMetadata = metadata
 	}
 }


### PR DESCRIPTION
during install we should create a config map in the embedded cluster operator namespace containing the version metadata (add-on versions, values, images, etc). this is specially useful for airgap environments.