### PR TITLE
feat: make a copy of the binary under /var/lib/embedded-cluster

### DIFF
--- a/e2e/scripts/single-node-install.sh
+++ b/e2e/scripts/single-node-install.sh
@@ -233,6 +233,10 @@ ensure_binary_copy() {
         ls -la /var/lib/embedded-cluster/bin
         return 1
     fi
+    if ! /var/lib/embedded-cluster/bin/embedded-cluster version ; then
+        echo "embedded-cluster binary is not executable"
+        return 1
+    fi
 }
 
 main() {

--- a/e2e/scripts/single-node-install.sh
+++ b/e2e/scripts/single-node-install.sh
@@ -225,6 +225,16 @@ ensure_version_metadata_present() {
     fi
 }
 
+# ensure_binary_copy verifies that the installer is copying itself to the default location of
+# banaries in the node.
+ensure_binary_copy() {
+    if ! ls /var/lib/embedded-cluster/bin/embedded-cluster ; then
+        echo "embedded-cluster binary not found on default location"
+        ls -la /var/lib/embedded-cluster/bin
+        return 1
+    fi
+}
+
 main() {
     local app_deploy_method="$1"
 
@@ -243,6 +253,10 @@ main() {
     fi
     if ! ensure_version_metadata_present; then
         echo "Failed to check the presence of the version metadata configmap"
+        exit 1
+    fi
+    if ! ensure_binary_copy; then
+        echo "Failed to ensure the embedded binary has been copied to /var/lib/embedded-cluster/bin"
         exit 1
     fi
     if ! install_kots_cli; then

--- a/pkg/goods/goods.go
+++ b/pkg/goods/goods.go
@@ -30,13 +30,62 @@ func K0sBinarySHA256() (string, error) {
 //go:embed bins/*
 var binfs embed.FS
 
+// materializeOurselves makes a copy of the embedded-cluster binary into the PathToEmbeddedClusterBinary()
+// directory. We are doing this copy for three reasons: 1. We make sure we have it in a standard location
+// across all installations. 2. We can overwrite it during cluster upgrades. 3. we can serve a copy of the
+// binary through the local-artifact-mirror daemon.
+func materializeOurselves() error {
+	srcpath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("unable to get our own executable path: %w", err)
+	}
+
+	dstpath := defaults.PathToEmbeddedClusterBinary(defaults.BinaryName())
+	if srcpath == dstpath {
+		return nil
+	}
+
+	if _, err := os.Stat(dstpath); err == nil {
+		tmp := fmt.Sprintf("%s.bkp", dstpath)
+		if err := os.Rename(dstpath, tmp); err != nil {
+			return fmt.Errorf("unable to rename %s to %s: %w", dstpath, tmp, err)
+		}
+		defer os.Remove(tmp)
+	}
+
+	src, err := os.Open(srcpath)
+	if err != nil {
+		return fmt.Errorf("unable to open source file: %w", err)
+	}
+	defer src.Close()
+
+	opts := os.O_CREATE | os.O_WRONLY | os.O_TRUNC
+	dst, err := os.OpenFile(dstpath, opts, 0755)
+	if err != nil {
+		return fmt.Errorf("unable to open destination file: %w", err)
+	}
+	defer dst.Close()
+
+	if _, err := io.Copy(dst, src); err != nil {
+		return fmt.Errorf("unable to write file: %w", err)
+	}
+	return nil
+}
+
 // materializeBinaries materializes all binary files from inside bins directory. If the
 // file already exists a copy of it is made first before overwriting it, this is done
-// because we can't overwrite a running binary. Copies are removed.
+// because we can't overwrite a running binary. Copies are removed. This function also
+// creates a copy of this binary into the PathToEmbeddedClusterBinary() directory. This
+// function also creates a copy of the embedded cluster binary into a default location
+// so we have this standardized across all installations.
 func materializeBinaries() error {
 	entries, err := binfs.ReadDir("bins")
 	if err != nil {
 		return fmt.Errorf("unable to read embedded-cluster bins dir: %w", err)
+	}
+
+	if err := materializeOurselves(); err != nil {
+		return fmt.Errorf("unable to materialize ourselves: %w", err)
 	}
 
 	var remove []string
@@ -66,6 +115,7 @@ func materializeBinaries() error {
 			return fmt.Errorf("unable to write file: %w", err)
 		}
 	}
+
 	return nil
 }
 

--- a/pkg/goods/goods.go
+++ b/pkg/goods/goods.go
@@ -75,9 +75,7 @@ func materializeOurselves() error {
 // materializeBinaries materializes all binary files from inside bins directory. If the
 // file already exists a copy of it is made first before overwriting it, this is done
 // because we can't overwrite a running binary. Copies are removed. This function also
-// creates a copy of this binary into the PathToEmbeddedClusterBinary() directory. This
-// function also creates a copy of the embedded cluster binary into a default location
-// so we have this standardized across all installations.
+// creates a copy of this binary into the PathToEmbeddedClusterBinary() directory.
 func materializeBinaries() error {
 	entries, err := binfs.ReadDir("bins")
 	if err != nil {


### PR DESCRIPTION
as part of the installation we also want to copy the binary to the default location so we can later on serve it to other nodes wishing to join the cluster.

by placing it the standard location we can also guarantee it will be upgraded by the local-artifact-mirror binary everytime a cluster upgrade is executed.