### PR TITLE
log kots install cmd before close on failure

### DIFF
--- a/pkg/addons/adminconsole/adminconsole.go
+++ b/pkg/addons/adminconsole/adminconsole.go
@@ -286,8 +286,8 @@ func (a *AdminConsole) Outro(ctx context.Context, cli client.Client) error {
 	}
 
 	if _, err := helpers.RunCommand(kotsBinPath, installArgs...); err != nil {
-		loading.Close()
 		loading.Debugf("kubectl-kots %v", installArgs)
+		loading.Close()
 		return fmt.Errorf("unable to install the application: %w", err)
 	}
 


### PR DESCRIPTION
Fixes:
```
sudo ./gitea-mastodon install -l license.yaml --airgap-bundle ./gitea-mastodon.airgap
✔  Host files materialized
? Enter a new Admin Console password: ******
? Confirm password: ******
✔  Node installation finished
✔  Storage is ready!
✔  Registry is ready!
✔  Embedded Cluster Operator is ready!
✔  Finalizing
panic: send on closed channel

goroutine 1 [running]:
github.com/replicatedhq/embedded-cluster/pkg/spinner.(*MessageWriter).Debugf(...)
	/home/runner/work/embedded-cluster/embedded-cluster/pkg/spinner/spinner.go:67
github.com/replicatedhq/embedded-cluster/pkg/addons/adminconsole.(*AdminConsole).Outro(0xc0479082c0, {0x24a14e38, 0xc0005fa380}, {0x24a1e4e0, 0xc04765db00})
	/home/runner/work/embedded-cluster/embedded-cluster/pkg/addons/adminconsole/adminconsole.go:290 +0x8ab
github.com/replicatedhq/embedded-cluster/pkg/addons.(*Applier).Outro(0xc04757fce0, {0x24a14e38, 0xc0005fa380})
	/home/runner/work/embedded-cluster/embedded-cluster/pkg/addons/applier.go:61 +0xfe
main.runOutro(0xc0002c4340)
	/home/runner/work/embedded-cluster/embedded-cluster/cmd/embedded-cluster/install.go:367 +0x4c5
main.init.func6(0xc0002c4340)
	/home/runner/work/embedded-cluster/embedded-cluster/cmd/embedded-cluster/install.go:468 +0x598
github.com/urfave/cli/v2.(*Command).Run(0x2586a440, 0xc0002c4340, {0xc00035e280, 0x5, 0x5})
	/home/runner/go/pkg/mod/github.com/urfave/cli/v2@v2.27.1/command.go:279 +0x97d
github.com/urfave/cli/v2.(*Command).Run(0xc000630160, 0xc0002c4280, {0xc0000501e0, 0x6, 0x6})
	/home/runner/go/pkg/mod/github.com/urfave/cli/v2@v2.27.1/command.go:272 +0xbb7
github.com/urfave/cli/v2.(*App).RunContext(0xc000125200, {0x24a14e38, 0xc0005fa380}, {0xc0000501e0, 0x6, 0x6})
	/home/runner/go/pkg/mod/github.com/urfave/cli/v2@v2.27.1/app.go:337 +0x58b
main.main()
	/home/runner/work/embedded-cluster/embedded-cluster/cmd/embedded-cluster/main.go:39 +0x2a7
```