### PR TITLE
fix kots install upstream uri

### DIFF
--- a/pkg/addons/adminconsole/adminconsole.go
+++ b/pkg/addons/adminconsole/adminconsole.go
@@ -264,15 +264,22 @@ func (a *AdminConsole) Outro(ctx context.Context, cli client.Client) error {
 	}
 
 	var appVersionLabel string
+	var channelSlug string
 	if channelRelease, err := release.GetChannelRelease(); err != nil {
 		return fmt.Errorf("unable to get channel release: %w", err)
 	} else if channelRelease != nil {
 		appVersionLabel = channelRelease.VersionLabel
+		channelSlug = channelRelease.ChannelSlug
+	}
+
+	upstreamURI := license.Spec.AppSlug
+	if channelSlug != "" && channelSlug != "stable" {
+		upstreamURI = fmt.Sprintf("%s/%s", upstreamURI, channelSlug)
 	}
 
 	installArgs := []string{
 		"install",
-		license.Spec.AppSlug,
+		upstreamURI,
 		"--license-file",
 		a.licenseFile,
 		"--namespace",

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -153,6 +153,7 @@ func (r *ReleaseData) GetEmbeddedClusterConfig() (*embeddedclusterv1beta1.Config
 type ChannelRelease struct {
 	VersionLabel string `yaml:"versionLabel"`
 	ChannelID    string `yaml:"channelID"`
+	ChannelSlug  string `yaml:"channelSlug"`
 	AppSlug      string `yaml:"appSlug"`
 }
 


### PR DESCRIPTION
This PR fixes the upstream URI used for the `kots install` command so that the channel slug from the embedded release is used, when necessary.

This fixes an issue where the incorrect application metadata was fetched from the upstream endpoint during the initial install.