### PR TITLE
fix on-merge testim branch

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -145,4 +145,4 @@ jobs:
           license-id: ${{ secrets.STAGING_EMBEDDED_CLUSTER_LICENSE_ID }}
           license: ${{ secrets.STAGING_EMBEDDED_CLUSTER_LICENSE }}
           testim-access-token: ${{ secrets.TESTIM_ACCESS_TOKEN }}
-          testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
+          testim-branch: 'master'


### PR DESCRIPTION
It seems that `${{ github.head_ref == 'main' && 'master' || github.head_ref }}` was evaluating to an empty string when running in the on-merge workflow. Since this workflow only runs on the main branch, we can safely set this to the master testim branch.

Example failure: https://github.com/replicatedhq/embedded-cluster/actions/runs/8557269930/job/23449207021#step:4:265