### PR TITLE
feat: add 'new line' capability to spinner

### DIFF
--- a/pkg/spinner/options.go
+++ b/pkg/spinner/options.go
@@ -10,6 +10,15 @@ func WithWriter(w WriteFn) Option {
 	}
 }
 
+// WithLineBreaker sets a function that determines if if is time
+// to break the line thus creating a new spinner line. The previous
+// step is flagged as success.
+func WithLineBreaker(lb LineBreakerFn) Option {
+	return func(m *MessageWriter) {
+		m.lbreak = lb
+	}
+}
+
 // WithMask sets the MaskFn on the MessageWriter.
 func WithMask(mfn MaskFn) Option {
 	return func(m *MessageWriter) {

--- a/pkg/spinner/spinner_test.go
+++ b/pkg/spinner/spinner_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -106,4 +107,27 @@ func TestMask(t *testing.T) {
 	pb.Close()
 	assert.Contains(t, buf.String(), "masked 0")
 	assert.Contains(t, buf.String(), "masked 1")
+}
+
+func TestLineBreak(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	lbreak := func(s string) bool {
+		return s == "test 3" || s == "test 8"
+	}
+	pb := Start(
+		WithWriter(WriteTo(buf)),
+		WithLineBreaker(lbreak),
+	)
+	for i := 0; i < 100; i++ {
+		pb.Infof("test %d", i)
+	}
+	pb.Close()
+	// we expect the following output:
+	// ✔  test 3 (\n)
+	// ✔  test 8 (\n)
+	// ✔  test 99 (\n)
+	assert.Equal(t, strings.Count(buf.String(), "\n"), 3)
+	assert.Contains(t, buf.String(), "test 3")
+	assert.Contains(t, buf.String(), "test 8")
+	assert.Contains(t, buf.String(), "test 99")
 }


### PR DESCRIPTION
we should be able to create new spinners based on what is being printed on the screen. this is useful when we want to create multiple spinners while running commands like `kots install`.