### PR TITLE
bug: show success in the previous step instead of current

### DIFF
--- a/pkg/spinner/spinner.go
+++ b/pkg/spinner/spinner.go
@@ -96,6 +96,8 @@ func (m *MessageWriter) loop() {
 	var ticker = time.NewTicker(50 * time.Millisecond)
 	var end bool
 	for {
+		previous := message
+
 		select {
 		case msg, open := <-m.ch:
 			if !open {
@@ -108,7 +110,7 @@ func (m *MessageWriter) loop() {
 		}
 
 		var lbreak bool
-		if m.lbreak != nil {
+		if m.lbreak != nil && previous != message {
 			lbreak = m.lbreak(message)
 		}
 
@@ -118,11 +120,10 @@ func (m *MessageWriter) loop() {
 
 		pos := counter % len(blocks)
 		if !end {
-			prefix, suffix := blocks[pos], ""
 			if lbreak {
-				prefix, suffix = "✔", "\n"
+				m.printf("\033[K\r✔  %s\n", previous)
 			}
-			m.printf("\033[K\r%s  %s %s", prefix, message, suffix)
+			m.printf("\033[K\r%s  %s", blocks[pos], message)
 			continue
 		}
 

--- a/pkg/spinner/spinner_test.go
+++ b/pkg/spinner/spinner_test.go
@@ -123,11 +123,11 @@ func TestLineBreak(t *testing.T) {
 	}
 	pb.Close()
 	// we expect the following output:
-	// ✔  test 3 (\n)
-	// ✔  test 8 (\n)
+	// ✔  test 2 (\n)
+	// ✔  test 7 (\n)
 	// ✔  test 99 (\n)
 	assert.Equal(t, strings.Count(buf.String(), "\n"), 3)
-	assert.Contains(t, buf.String(), "test 3")
-	assert.Contains(t, buf.String(), "test 8")
+	assert.Contains(t, buf.String(), "test 2")
+	assert.Contains(t, buf.String(), "test 7")
 	assert.Contains(t, buf.String(), "test 99")
 }


### PR DESCRIPTION
when we break the line for a new message we need to flag the previous as success and not the current one. this commit addresses it.