### PR TITLE
Disable analytics on openEBS

### DIFF
--- a/pkg/addons/openebs/openebs.go
+++ b/pkg/addons/openebs/openebs.go
@@ -29,6 +29,9 @@ var (
 )
 
 var helmValues = map[string]interface{}{
+	"analytics": map[string]interface{}{
+		"enabled": false,
+	},
 	"ndmOperator": map[string]interface{}{
 		"enabled": false,
 	},


### PR DESCRIPTION
It was noticed in kURL that openEBS reaches out to an analytics endpoint during installation, this disables that similar to us disabling analytics on k0s.