### PR TITLE
Revert "chore: temporarily enable linuxcontainers.org for testing (#524)

### DIFF
--- a/e2e/cluster/cluster.go
+++ b/e2e/cluster/cluster.go
@@ -230,8 +230,7 @@ func CreateProxy(in *Input) {
 		Type: api.InstanceTypeContainer,
 		Source: api.InstanceSource{
 			Type:  "image",
-			Alias: "ubuntu/jammy",
-			// Alias: "j",
+			Alias: "j",
 		},
 		InstancePut: api.InstancePut{
 			Profiles:     []string{profile},
@@ -671,18 +670,12 @@ func PullImage(in *Input) {
 
 	for _, server := range []string{
 		"https://images.lxd.canonical.com",
-		"https://images.linuxcontainers.org",
 		"https://cloud-images.ubuntu.com/releases",
 	} {
 		in.T.Logf("Pulling %q image from %s", in.Image, server)
 		remote, err := lxd.ConnectSimpleStreams(server, nil)
 		if err != nil {
 			in.T.Fatalf("Failed to connect to image server: %v", err)
-		}
-
-		// temporary workaround for the unavailable cloud-images.ubuntu.com.
-		if strings.Contains(server, "linuxcontainers") && in.Image == "j" {
-			in.Image = "ubuntu/jammy"
 		}
 
 		alias, _, err := remote.GetImageAlias(in.Image)


### PR DESCRIPTION
This reverts commit 5ad0f98542d9eb4118cd7d2099f839667cfd6f0a.

In a nutshell: removes `linuxcontainers.org` and starts to use `https://images.lxd.canonical.com/`