### PR TITLE
chore: use k0s full path when collecting bundle

### DIFF
--- a/pkg/goods/support/host-support-bundle.yaml
+++ b/pkg/goods/support/host-support-bundle.yaml
@@ -18,7 +18,7 @@ spec:
       path: /var/openebs/local
   - run:
       collectorName: k0s-status
-      command: k0s
+      command: /usr/local/bin/k0s
       args: [ "status" ]
   - run:
       collectorName: k0s-issue-template
@@ -26,7 +26,7 @@ spec:
       args: [ "-c", "uname -srvmo; cat /etc/os-release || lsb_release -a" ]
   - run:
       collectorName: k0s-sysinfo
-      command: k0s
+      command: /usr/local/bin/k0s
       args: [ "sysinfo" ]
   - copy:
       collectorName: installer-logs


### PR DESCRIPTION
let's just make this very specific. i have just seen a case where /usr/loca/bin isn't in the root's path.