### PR TITLE
generate support bundles in e2e tests

### DIFF
--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -77,6 +77,18 @@ runs:
       export TESTIM_ACCESS_TOKEN=${{ inputs.testim-access-token }}
       export TESTIM_BRANCH=${{ inputs.testim-branch }}
       make e2e-test TEST_NAME=${{ inputs.test-name }}
+  - name: Upload Host Support Bundle
+    uses: actions/upload-artifact@v4
+    if: ${{ failure() }}
+    with:
+      name: ${{ github.job }}-support-bundle-host.tar.gz
+      path: ./e2e/support-bundle-host.tar.gz
+  - name: Upload Cluster Support Bundle
+    uses: actions/upload-artifact@v4
+    if: ${{ failure() }}
+    with:
+      name: ${{ github.job }}-support-bundle-cluster.tar.gz
+      path: ./e2e/support-bundle-cluster.tar.gz
 #  - name: Setup upterm session (ssh)
 #    uses: lhotari/action-upterm@v1
 #    if: always()

--- a/e2e/cluster/cluster.go
+++ b/e2e/cluster/cluster.go
@@ -477,6 +477,27 @@ func CopyFileToNode(in *Input, node string, file File) {
 	}
 }
 
+// CopyFileFromNode copies a file from a node to the host.
+func CopyFileFromNode(node, source, dest string) error {
+	client, err := lxd.ConnectLXDUnix(lxdSocket, nil)
+	if err != nil {
+		return fmt.Errorf("Failed to connect to LXD: %v", err)
+	}
+	content, _, err := client.GetContainerFile(node, source)
+	if err != nil {
+		return fmt.Errorf("Failed to get file %s: %v", source, err)
+	}
+	fp, err := os.Create(dest)
+	if err != nil {
+		return fmt.Errorf("Failed to create file %s: %v", dest, err)
+	}
+	defer fp.Close()
+	if _, err := io.Copy(fp, content); err != nil {
+		return fmt.Errorf("Failed to copy file %s: %v", dest, err)
+	}
+	return nil
+}
+
 // CreateNodes creats the nodes for the cluster. The amount of nodes is
 // specified in the input.
 func CreateNodes(in *Input) []string {

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -52,9 +52,6 @@ func TestSingleNodeInstallation(t *testing.T) {
 		t.Fatalf("fail to check postupgrade state: %v", err)
 	}
 
-	// TODO: remove after validating that this works
-	t.Fatal("support bundle generated, failing test")
-
 	t.Logf("%s: test complete", time.Now().Format(time.RFC3339))
 }
 
@@ -67,7 +64,12 @@ func TestSingleNodeInstallationRockyLinux8(t *testing.T) {
 		LicensePath:         "license.yaml",
 		EmbeddedClusterPath: "../output/bin/embedded-cluster",
 	})
-	defer tc.Destroy()
+	defer func() {
+		if t.Failed() {
+			generateAndCopySupportBundle(t, tc)
+		}
+		tc.Destroy()
+	}()
 
 	t.Logf("%s: installing tar", time.Now().Format(time.RFC3339))
 	line := []string{"yum-install-tar.sh"}
@@ -111,7 +113,12 @@ func TestSingleNodeInstallationDebian12(t *testing.T) {
 		LicensePath:         "license.yaml",
 		EmbeddedClusterPath: "../output/bin/embedded-cluster",
 	})
-	defer tc.Destroy()
+	defer func() {
+		if t.Failed() {
+			generateAndCopySupportBundle(t, tc)
+		}
+		tc.Destroy()
+	}()
 
 	t.Logf("%s: installing test dependencies on node 0", time.Now().Format(time.RFC3339))
 	commands := [][]string{
@@ -159,7 +166,12 @@ func TestSingleNodeInstallationCentos8Stream(t *testing.T) {
 		LicensePath:         "license.yaml",
 		EmbeddedClusterPath: "../output/bin/embedded-cluster",
 	})
-	defer tc.Destroy()
+	defer func() {
+		if t.Failed() {
+			generateAndCopySupportBundle(t, tc)
+		}
+		tc.Destroy()
+	}()
 
 	t.Logf("%s: installing tar", time.Now().Format(time.RFC3339))
 	line := []string{"yum-install-tar.sh"}
@@ -236,7 +248,12 @@ func TestMultiNodeInstallation(t *testing.T) {
 		LicensePath:         "license.yaml",
 		EmbeddedClusterPath: "../output/bin/embedded-cluster",
 	})
-	defer tc.Destroy()
+	defer func() {
+		if t.Failed() {
+			generateAndCopySupportBundle(t, tc)
+		}
+		tc.Destroy()
+	}()
 
 	// bootstrap the first node and makes sure it is healthy. also executes the kots
 	// ssl certificate configuration (kurl-proxy).
@@ -319,7 +336,12 @@ func TestInstallWithoutEmbed(t *testing.T) {
 		LicensePath:         "license.yaml",
 		EmbeddedClusterPath: "../output/bin/embedded-cluster-original",
 	})
-	defer tc.Destroy()
+	defer func() {
+		if t.Failed() {
+			generateAndCopySupportBundle(t, tc)
+		}
+		tc.Destroy()
+	}()
 	t.Logf("%s: installing embedded-cluster on node 0", time.Now().Format(time.RFC3339))
 	line := []string{"default-install.sh"}
 	if _, _, err := RunCommandOnNode(t, tc, 0, line); err != nil {
@@ -336,7 +358,12 @@ func TestInstallFromReplicatedApp(t *testing.T) {
 		Nodes: 1,
 		Image: "ubuntu/jammy",
 	})
-	defer tc.Destroy()
+	defer func() {
+		if t.Failed() {
+			generateAndCopySupportBundle(t, tc)
+		}
+		tc.Destroy()
+	}()
 	t.Logf("%s: downloading embedded-cluster on node 0", time.Now().Format(time.RFC3339))
 	line := []string{"vandoor-prepare.sh", os.Getenv("SHORT_SHA"), os.Getenv("LICENSE_ID"), "false"}
 	if _, _, err := RunCommandOnNode(t, tc, 0, line); err != nil {
@@ -379,7 +406,12 @@ func TestResetAndReinstall(t *testing.T) {
 		LicensePath:         "license.yaml",
 		EmbeddedClusterPath: "../output/bin/embedded-cluster",
 	})
-	defer tc.Destroy()
+	defer func() {
+		if t.Failed() {
+			generateAndCopySupportBundle(t, tc)
+		}
+		tc.Destroy()
+	}()
 	t.Logf("%s: installing embedded-cluster on node 0", time.Now().Format(time.RFC3339))
 	line := []string{"single-node-install.sh", "cli"}
 	if _, _, err := RunCommandOnNode(t, tc, 0, line); err != nil {
@@ -457,7 +489,12 @@ func TestResetAndReinstallAirgap(t *testing.T) {
 		WithProxy:               true,
 		AirgapInstallBundlePath: airgapBundlePath,
 	})
-	defer tc.Destroy()
+	defer func() {
+		if t.Failed() {
+			generateAndCopySupportBundle(t, tc)
+		}
+		tc.Destroy()
+	}()
 
 	t.Logf("%s: preparing embedded cluster airgap files", time.Now().Format(time.RFC3339))
 	line := []string{"airgap-prepare.sh"}
@@ -494,7 +531,12 @@ func TestOldVersionUpgrade(t *testing.T) {
 		Nodes: 1,
 		Image: "ubuntu/jammy",
 	})
-	defer tc.Destroy()
+	defer func() {
+		if t.Failed() {
+			generateAndCopySupportBundle(t, tc)
+		}
+		tc.Destroy()
+	}()
 	t.Logf("%s: downloading embedded-cluster on node 0", time.Now().Format(time.RFC3339))
 	line := []string{"vandoor-prepare.sh", fmt.Sprintf("%s-pre-minio-removal", os.Getenv("SHORT_SHA")), os.Getenv("LICENSE_ID"), "false"}
 	if _, _, err := RunCommandOnNode(t, tc, 0, line); err != nil {
@@ -636,7 +678,12 @@ func TestInstallSnapshotFromReplicatedApp(t *testing.T) {
 		Nodes: 1,
 		Image: "ubuntu/jammy",
 	})
-	defer tc.Destroy()
+	defer func() {
+		if t.Failed() {
+			generateAndCopySupportBundle(t, tc)
+		}
+		tc.Destroy()
+	}()
 	t.Logf("%s: downloading embedded-cluster on node 0", time.Now().Format(time.RFC3339))
 	line := []string{"vandoor-prepare.sh", os.Getenv("SHORT_SHA"), os.Getenv("SNAPSHOT_LICENSE_ID"), "false"}
 	if _, _, err := RunCommandOnNode(t, tc, 0, line); err != nil {

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -21,7 +21,12 @@ func TestSingleNodeInstallation(t *testing.T) {
 		LicensePath:         "license.yaml",
 		EmbeddedClusterPath: "../output/bin/embedded-cluster",
 	})
-	defer tc.Destroy()
+	defer func() {
+		if t.Failed() {
+			generateAndCopySupportBundle(t, tc)
+		}
+		tc.Destroy()
+	}()
 	t.Logf("%s: installing embedded-cluster on node 0", time.Now().Format(time.RFC3339))
 	line := []string{"single-node-install.sh", "ui"}
 	if _, _, err := RunCommandOnNode(t, tc, 0, line); err != nil {
@@ -47,8 +52,8 @@ func TestSingleNodeInstallation(t *testing.T) {
 		t.Fatalf("fail to check postupgrade state: %v", err)
 	}
 
-	// TODO: remove after validating that this
-	generateAndCopySupportBundle(t, tc)
+	// TODO: remove after validating that this works
+	t.Fatal("support bundle generated, failing test")
 
 	t.Logf("%s: test complete", time.Now().Format(time.RFC3339))
 }

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -47,6 +47,9 @@ func TestSingleNodeInstallation(t *testing.T) {
 		t.Fatalf("fail to check postupgrade state: %v", err)
 	}
 
+	// TODO: remove after validating that this
+	generateAndCopySupportBundle(t, tc)
+
 	t.Logf("%s: test complete", time.Now().Format(time.RFC3339))
 }
 
@@ -752,7 +755,6 @@ func generateAndCopySupportBundle(t *testing.T, tc *cluster.Output) {
 		t.Logf("stdout: %s", stdout)
 		t.Logf("stderr: %s", stderr)
 		t.Errorf("fail to generate support bundle: %v", err)
-		return
 	}
 
 	t.Logf("%s: copying host support bundle to local machine", time.Now().Format(time.RFC3339))

--- a/e2e/scripts/collect-support-bundle.sh
+++ b/e2e/scripts/collect-support-bundle.sh
@@ -7,20 +7,8 @@ main() {
         return 1
     fi
 
-    tar -zxvf host.tar.gz
-    if ! ls host/host-collectors/run-host/k0s-sysinfo.txt; then
-        echo "Failed to find 'k0s sysinfo' inside the host support bundle"
-        return 1
-    fi
-
     if ! kubectl support-bundle --output cluster.tar.gz --interactive=false --load-cluster-specs; then
         echo "Failed to collect cluster support bundle"
-        return 1
-    fi
-
-    tar -zxvf cluster.tar.gz
-    if ! ls cluster/podlogs/embedded-cluster-operator; then
-        echo "Failed to find operator logs inside the cluster support bundle"
         return 1
     fi
 }

--- a/e2e/scripts/validate-support-bundle.sh
+++ b/e2e/scripts/validate-support-bundle.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+main() {
+    tar -zxvf host.tar.gz
+    if ! ls host/host-collectors/run-host/k0s-sysinfo.txt; then
+        echo "Failed to find 'k0s sysinfo' inside the host support bundle"
+        return 1
+    fi
+
+    tar -zxvf cluster.tar.gz
+    if ! ls cluster/podlogs/embedded-cluster-operator; then
+        echo "Failed to find operator logs inside the cluster support bundle"
+        return 1
+    fi
+}
+
+main "$@"

--- a/e2e/support-bundle_test.go
+++ b/e2e/support-bundle_test.go
@@ -26,10 +26,18 @@ func TestCollectSupportBundle(t *testing.T) {
 	line = []string{"collect-support-bundle.sh"}
 	stdout, stderr, err := RunCommandOnNode(t, tc, 0, line)
 	if err != nil {
-		t.Fatalf("fail to install collect support bundle on node %s: %v", tc.Nodes[0], err)
+		t.Log("stdout:", stdout)
+		t.Log("stderr:", stderr)
+		t.Fatalf("fail to collect support bundle on node %s: %v", tc.Nodes[0], err)
 	}
 
-	t.Log("stdout:", stdout)
-	t.Log("stderr:", stderr)
+	line = []string{"validate-support-bundle.sh"}
+	stdout, stderr, err = RunCommandOnNode(t, tc, 0, line)
+	if err != nil {
+		t.Log("stdout:", stdout)
+		t.Log("stderr:", stderr)
+		t.Fatalf("fail to validate support bundle on node %s: %v", tc.Nodes[0], err)
+	}
+
 	t.Logf("%s: test complete", time.Now().Format(time.RFC3339))
 }


### PR DESCRIPTION
This PR adds logic for generating host and cluster support bundles for e2e tests. If the test fails, bundles will be generated and uploaded as GH artifacts. The goal is to provide easier debugging of failed e2e tests (failed install, upgrade, etc).

Example failed test: https://github.com/replicatedhq/embedded-cluster/actions/runs/8896887451/job/24430845285?pr=541#step:4:495