### PR TITLE
specify velero credentials secret name

### DIFF
--- a/pkg/addons/velero/velero.go
+++ b/pkg/addons/velero/velero.go
@@ -54,9 +54,6 @@ var helmValues = map[string]interface{}{
 			},
 		},
 	},
-	"podLabels": map[string]interface{}{
-		"component": "velero",
-	},
 	"credentials": map[string]interface{}{
 		"existingSecret": credentialsSecretName,
 	},

--- a/pkg/addons/velero/velero.go
+++ b/pkg/addons/velero/velero.go
@@ -51,6 +51,9 @@ var helmValues = map[string]interface{}{
 			},
 		},
 	},
+	"credentials": map[string]interface{}{
+		"name": "cloud-credentials",
+	},
 }
 
 // Velero manages the installation of the Velero helm chart.


### PR DESCRIPTION
This PR adds the `credentials.name` [value](https://github.com/vmware-tanzu/helm-charts/blob/main/charts/velero/values.yaml#L487) to the Velero add-on to specify the secret name used for backup storage location credentials. Without this set, it will fall back to a secret named `velero`, which does not work with KOTS as the credentials secret name there is expected to be `cloud-credentials` ([reference](https://github.com/replicatedhq/kots/blob/v1.108.9/pkg/snapshot/store.go#L51)).