### PR TITLE
remove the 'restic' backup setting in velero as we are moving forward with kopia

### DIFF
--- a/pkg/addons/velero/velero.go
+++ b/pkg/addons/velero/velero.go
@@ -33,7 +33,6 @@ var helmValues = map[string]interface{}{
 	"backupsEnabled":   false,
 	"snapshotsEnabled": false,
 	"deployNodeAgent":  true,
-	"uploaderType":     "restic",
 	"nodeAgent": map[string]interface{}{
 		"podVolumePath": "/var/lib/k0s/kubelet/pods",
 	},


### PR DESCRIPTION
(also it was in the wrong place and not applied, so this makes sure no one will 'fix' it in the future)