### PR TITLE
feat: wait for coredns and metrics-server, mk2

### DIFF
--- a/cmd/embedded-cluster/restore.go
+++ b/cmd/embedded-cluster/restore.go
@@ -684,6 +684,19 @@ var restoreCommand = &cli.Command{
 			if err := waitForK0s(); err != nil {
 				return fmt.Errorf("unable to wait for node: %w", err)
 			}
+
+			kcli, err := kubeutils.KubeClient()
+			if err != nil {
+				return fmt.Errorf("unable to create kube client: %w", err)
+			}
+			errCh := kubeutils.WaitForKubernetes(c.Context, kcli)
+			defer func() {
+				for len(errCh) > 0 {
+					err := <-errCh
+					logrus.Error(fmt.Errorf("the Kubernetes Infrastructure failed to become ready: %w", err))
+				}
+			}()
+
 			logrus.Debugf("running outro")
 			if err := runOutroForRestore(c); err != nil {
 				return fmt.Errorf("unable to run outro: %w", err)

--- a/pkg/addons/applier.go
+++ b/pkg/addons/applier.go
@@ -60,14 +60,17 @@ func (a *Applier) Outro(ctx context.Context) error {
 		return fmt.Errorf("unable to load addons: %w", err)
 	}
 
-	err = a.waitForKubernetes(ctx, kcli)
-	if err != nil {
-		return fmt.Errorf("unable to wait for kubernetes: %w", err)
-	}
+	errCh := a.waitForKubernetes(ctx, kcli)
 
 	for _, addon := range addons {
 		if err := addon.Outro(ctx, kcli); err != nil {
+			if len(errCh) != 0 {
+				return fmt.Errorf("unable to run outro for %s with error %w: %w", addon.Name(), err, <-errCh)
+			}
 			return err
+		}
+		if len(errCh) != 0 {
+			return fmt.Errorf("the Kubernetes Infrastructure failed to become ready: %w", <-errCh)
 		}
 	}
 	if err := spinForInstallation(ctx, kcli); err != nil {
@@ -322,29 +325,26 @@ func (a *Applier) Versions(additionalCharts []v1beta1.Chart) (map[string]string,
 	return versions, nil
 }
 
-// waitForKubernetes waits for coredns and metrics-server to be ready in kube-system.
-func (a *Applier) waitForKubernetes(ctx context.Context, cli client.Client) error {
-	loading := spinner.Start()
-	loading.Infof("Waiting for Kubernetes System Infrastructure to be ready")
+// waitForKubernetes waits for coredns and metrics-server to be ready in kube-system, and returns an error channel.
+// if either of them fails to become healthy, an error is returned via the channel.
+func (a *Applier) waitForKubernetes(ctx context.Context, cli client.Client) <-chan error {
+	errch := make(chan error, 1)
 
-	//err := kubeutils.WaitForDeployment(ctx, cli, "kube-system", "coredns")
-	//if err != nil {
-	//	loading.Errorf("CoreDNS failed to become healthy, check your /etc/resolv.conf configuration")
-	//	loading.CloseWithError()
-	//	return fmt.Errorf("unable to wait for CoreDNS: %w", err)
-	//}
-	//
-	//loading.Infof("Waiting for Kubernetes System Infrastructure to be ready 1/2")
+	go func() {
+		err := kubeutils.WaitForDeployment(ctx, cli, "kube-system", "coredns")
+		if err != nil {
+			errch <- fmt.Errorf("CoreDNS failed to become healthy: %w", err)
+		}
+	}()
 
-	err := kubeutils.WaitForDeployment(ctx, cli, "kube-system", "metrics-server")
-	if err != nil {
-		loading.Errorf("Metrics Server failed to become healthy - this may be a firewall or network issue.")
-		loading.CloseWithError()
-		return fmt.Errorf("unable to wait for Metrics Server: %w", err)
-	}
+	go func() {
+		err := kubeutils.WaitForDeployment(ctx, cli, "kube-system", "metrics-server")
+		if err != nil {
+			errch <- fmt.Errorf("Metrics Server failed to become healthy: %w", err)
+		}
+	}()
 
-	loading.Closef("Kubernetes System Infrastructure ready")
-	return nil
+	return errch
 }
 
 func spinForInstallation(ctx context.Context, cli client.Client) error {

--- a/pkg/addons/applier.go
+++ b/pkg/addons/applier.go
@@ -6,8 +6,6 @@ package addons
 import (
 	"context"
 	"fmt"
-	"time"
-
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	k0sconfig "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	embeddedclusterv1beta1 "github.com/replicatedhq/embedded-cluster-kinds/apis/v1beta1"
@@ -15,7 +13,6 @@ import (
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	"github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/adminconsole"
@@ -62,6 +59,12 @@ func (a *Applier) Outro(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("unable to load addons: %w", err)
 	}
+
+	err = a.waitForKubernetes(ctx, kcli)
+	if err != nil {
+		return fmt.Errorf("unable to wait for kubernetes: %w", err)
+	}
+
 	for _, addon := range addons {
 		if err := addon.Outro(ctx, kcli); err != nil {
 			return err
@@ -319,37 +322,29 @@ func (a *Applier) Versions(additionalCharts []v1beta1.Chart) (map[string]string,
 	return versions, nil
 }
 
-// waitForKubernetes waits until we manage to make a successful connection to the
-// Kubernetes API server.
-func (a *Applier) waitForKubernetes(ctx context.Context) error {
+// waitForKubernetes waits for coredns and metrics-server to be ready in kube-system.
+func (a *Applier) waitForKubernetes(ctx context.Context, cli client.Client) error {
 	loading := spinner.Start()
-	defer func() {
-		loading.Closef("Kubernetes API server is ready")
-	}()
-	kcli, err := kubeutils.KubeClient()
+	loading.Infof("Waiting for Kubernetes System Infrastructure to be ready 0/2")
+
+	err := kubeutils.WaitForDeployment(ctx, cli, "kube-system", "coredns")
 	if err != nil {
-		return fmt.Errorf("unable to create kubernetes client: %w", err)
+		loading.Errorf("CoreDNS failed to become healthy, check your /etc/resolv.conf configuration")
+		loading.CloseWithError()
+		return fmt.Errorf("unable to wait for CoreDNS: %w", err)
 	}
-	ticker := time.NewTicker(3 * time.Second)
-	defer ticker.Stop()
-	counter := 1
-	loading.Infof("1/n Waiting for Kubernetes API server to be ready")
-	for {
-		select {
-		case <-ticker.C:
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-		counter++
-		if err := kcli.List(ctx, &corev1.NamespaceList{}); err != nil {
-			loading.Infof(
-				"%d/n Waiting for Kubernetes API server to be ready.",
-				counter,
-			)
-			continue
-		}
-		return nil
+
+	loading.Infof("Waiting for Kubernetes System Infrastructure to be ready 1/2")
+
+	err = kubeutils.WaitForDeployment(ctx, cli, "kube-system", "metrics-server")
+	if err != nil {
+		loading.Errorf("Metrics Server failed to become healthy - this may be a firewall or network issue.")
+		loading.CloseWithError()
+		return fmt.Errorf("unable to wait for Metrics Server: %w", err)
 	}
+
+	loading.Closef("Kubernetes System Infrastructure ready")
+	return nil
 }
 
 func spinForInstallation(ctx context.Context, cli client.Client) error {

--- a/pkg/addons/applier.go
+++ b/pkg/addons/applier.go
@@ -65,7 +65,7 @@ func (a *Applier) Outro(ctx context.Context) error {
 	for _, addon := range addons {
 		if err := addon.Outro(ctx, kcli); err != nil {
 			if len(errCh) != 0 {
-				return fmt.Errorf("unable to run outro for %s with error %w: %w", addon.Name(), err, <-errCh)
+				return fmt.Errorf("failed to run outro for %s with error %w. This may be because %w", addon.Name(), err, <-errCh)
 			}
 			return err
 		}

--- a/pkg/addons/applier.go
+++ b/pkg/addons/applier.go
@@ -325,18 +325,18 @@ func (a *Applier) Versions(additionalCharts []v1beta1.Chart) (map[string]string,
 // waitForKubernetes waits for coredns and metrics-server to be ready in kube-system.
 func (a *Applier) waitForKubernetes(ctx context.Context, cli client.Client) error {
 	loading := spinner.Start()
-	loading.Infof("Waiting for Kubernetes System Infrastructure to be ready 0/2")
+	loading.Infof("Waiting for Kubernetes System Infrastructure to be ready")
 
-	err := kubeutils.WaitForDeployment(ctx, cli, "kube-system", "coredns")
-	if err != nil {
-		loading.Errorf("CoreDNS failed to become healthy, check your /etc/resolv.conf configuration")
-		loading.CloseWithError()
-		return fmt.Errorf("unable to wait for CoreDNS: %w", err)
-	}
+	//err := kubeutils.WaitForDeployment(ctx, cli, "kube-system", "coredns")
+	//if err != nil {
+	//	loading.Errorf("CoreDNS failed to become healthy, check your /etc/resolv.conf configuration")
+	//	loading.CloseWithError()
+	//	return fmt.Errorf("unable to wait for CoreDNS: %w", err)
+	//}
+	//
+	//loading.Infof("Waiting for Kubernetes System Infrastructure to be ready 1/2")
 
-	loading.Infof("Waiting for Kubernetes System Infrastructure to be ready 1/2")
-
-	err = kubeutils.WaitForDeployment(ctx, cli, "kube-system", "metrics-server")
+	err := kubeutils.WaitForDeployment(ctx, cli, "kube-system", "metrics-server")
 	if err != nil {
 		loading.Errorf("Metrics Server failed to become healthy - this may be a firewall or network issue.")
 		loading.CloseWithError()

--- a/pkg/kubeutils/kubeutils.go
+++ b/pkg/kubeutils/kubeutils.go
@@ -40,7 +40,11 @@ func WaitForNamespace(ctx context.Context, cli client.Client, ns string) error {
 			return ready, nil
 		},
 	); err != nil {
-		return fmt.Errorf("timed out waiting for namespace %s: %v", ns, lasterr)
+		if lasterr != nil {
+			return fmt.Errorf("timed out waiting for namespace %s: %v", ns, lasterr)
+		} else {
+			return fmt.Errorf("timed out waiting for namespace %s", ns)
+		}
 	}
 	return nil
 
@@ -60,7 +64,11 @@ func WaitForDeployment(ctx context.Context, cli client.Client, ns, name string) 
 			return ready, nil
 		},
 	); err != nil {
-		return fmt.Errorf("timed out waiting for %s to deploy: %v", name, lasterr)
+		if lasterr != nil {
+			return fmt.Errorf("timed out waiting for %s to deploy: %v", name, lasterr)
+		} else {
+			return fmt.Errorf("timed out waiting for %s to deploy", name)
+		}
 	}
 	return nil
 }
@@ -79,7 +87,11 @@ func WaitForDaemonset(ctx context.Context, cli client.Client, ns, name string) e
 			return ready, nil
 		},
 	); err != nil {
-		return fmt.Errorf("timed out waiting for %s to deploy: %v", name, lasterr)
+		if lasterr != nil {
+			return fmt.Errorf("timed out waiting for %s to deploy: %v", name, lasterr)
+		} else {
+			return fmt.Errorf("timed out waiting for %s to deploy", name)
+		}
 	}
 	return nil
 }
@@ -98,7 +110,11 @@ func WaitForService(ctx context.Context, cli client.Client, ns, name string) err
 			return svc.Spec.ClusterIP != "", nil
 		},
 	); err != nil {
-		return fmt.Errorf("timed out waiting for service %s to have an IP: %v", name, lasterr)
+		if lasterr != nil {
+			return fmt.Errorf("timed out waiting for service %s to have an IP: %v", name, lasterr)
+		} else {
+			return fmt.Errorf("timed out waiting for service %s to have an IP", name)
+		}
 	}
 	return nil
 }
@@ -144,7 +160,11 @@ func WaitForInstallation(ctx context.Context, cli client.Client, writer *spinner
 			return false, nil
 		},
 	); err != nil {
-		return fmt.Errorf("timed out waiting for the installation to finish: %v", lasterr)
+		if lasterr != nil {
+			return fmt.Errorf("timed out waiting for the installation to finish: %v", lasterr)
+		} else {
+			return fmt.Errorf("timed out waiting for the installation to finish")
+		}
 	}
 	return nil
 }
@@ -200,7 +220,11 @@ func WaitForNodes(ctx context.Context, cli client.Client) error {
 			return readynodes == len(nodes.Items), nil
 		},
 	); err != nil {
-		return fmt.Errorf("timed out waiting for nodes to be ready: %v", lasterr)
+		if lasterr != nil {
+			return fmt.Errorf("timed out waiting for nodes to be ready: %v", lasterr)
+		} else {
+			return fmt.Errorf("timed out waiting for nodes to be ready")
+		}
 	}
 	return nil
 }

--- a/pkg/kubeutils/kubeutils.go
+++ b/pkg/kubeutils/kubeutils.go
@@ -290,7 +290,7 @@ func IsDaemonsetReady(ctx context.Context, cli client.Client, ns, name string) (
 // WaitForKubernetes waits for coredns and metrics-server to be ready in kube-system, and returns an error channel.
 // if either of them fails to become healthy, an error is returned via the channel.
 func WaitForKubernetes(ctx context.Context, cli client.Client) <-chan error {
-	errch := make(chan error, 1)
+	errch := make(chan error, 2)
 
 	go func() {
 		err := WaitForDeployment(ctx, cli, "kube-system", "coredns")

--- a/pkg/kubeutils/kubeutils.go
+++ b/pkg/kubeutils/kubeutils.go
@@ -169,11 +169,11 @@ func WaitForInstallation(ctx context.Context, cli client.Client, writer *spinner
 		},
 	); err != nil {
 		if wait.Interrupted(err) {
-      if lasterr != nil {
-		    return fmt.Errorf("timed out waiting for the installation to finish: %v", lasterr)
-		  } else {
-			  return fmt.Errorf("timed out waiting for the installation to finish")
-      }
+			if lasterr != nil {
+				return fmt.Errorf("timed out waiting for the installation to finish: %v", lasterr)
+			} else {
+				return fmt.Errorf("timed out waiting for the installation to finish")
+			}
 		}
 		return fmt.Errorf("error waiting for installation: %v", err)
 	}


### PR DESCRIPTION
Reverts replicatedhq/embedded-cluster#623, but runs in the background so that display is unchanged except in case of errors