### PR TITLE
feat: allow materialize with a prefix

### DIFF
--- a/cmd/embedded-cluster/materialize.go
+++ b/cmd/embedded-cluster/materialize.go
@@ -13,6 +13,13 @@ var materializeCommand = &cli.Command{
 	Name:   "materialize",
 	Usage:  "Materialize embedded assets on /var/lib/embedded-cluster",
 	Hidden: true,
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "basedir",
+			Usage: "Base directory to materialize assets",
+			Value: "",
+		},
+	},
 	Before: func(c *cli.Context) error {
 		if os.Getuid() != 0 {
 			return fmt.Errorf("materialize command must be run as root")
@@ -20,7 +27,8 @@ var materializeCommand = &cli.Command{
 		return nil
 	},
 	Action: func(c *cli.Context) error {
-		if err := goods.Materialize(); err != nil {
+		materializer := goods.NewMaterializer(c.String("basedir"))
+		if err := materializer.Materialize(); err != nil {
 			return fmt.Errorf("unable to materialize: %v", err)
 		}
 		return nil

--- a/pkg/goods/goods.go
+++ b/pkg/goods/goods.go
@@ -3,208 +3,43 @@
 package goods
 
 import (
-	"crypto/sha256"
 	"embed"
-	"encoding/hex"
-	"fmt"
-	"io"
-	"os"
+)
 
-	"github.com/replicatedhq/embedded-cluster/pkg/defaults"
+var (
+	// materializer is our default instace of the artifact materializer.
+	materializer = NewMaterializer("")
+	//go:embed bins/*
+	binfs embed.FS
+	//go:embed support/*
+	supportfs embed.FS
+	//go:embed systemd/*
+	systemdfs embed.FS
+	//go:embed internal/bins/*
+	internalBinfs embed.FS
 )
 
 // K0sBinarySHA256 returns the SHA256 checksum of the embedded k0s binary.
 func K0sBinarySHA256() (string, error) {
-	fp, err := binfs.Open("bins/k0s")
-	if err != nil {
-		return "", fmt.Errorf("unable to open embedded k0s binary: %w", err)
-	}
-	defer fp.Close()
-	hasher := sha256.New()
-	if _, err := io.Copy(hasher, fp); err != nil {
-		return "", fmt.Errorf("unable to copy embedded k0s binary: %w", err)
-	}
-	return hex.EncodeToString(hasher.Sum(nil)), nil
+	return materializer.K0sBinarySHA256()
 }
 
-//go:embed bins/*
-var binfs embed.FS
-
-// materializeOurselves makes a copy of the embedded-cluster binary into the PathToEmbeddedClusterBinary()
-// directory. We are doing this copy for three reasons: 1. We make sure we have it in a standard location
-// across all installations. 2. We can overwrite it during cluster upgrades. 3. we can serve a copy of the
-// binary through the local-artifact-mirror daemon.
-func materializeOurselves() error {
-	srcpath, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("unable to get our own executable path: %w", err)
-	}
-
-	dstpath := defaults.PathToEmbeddedClusterBinary(defaults.BinaryName())
-	if srcpath == dstpath {
-		return nil
-	}
-
-	if _, err := os.Stat(dstpath); err == nil {
-		tmp := fmt.Sprintf("%s.bkp", dstpath)
-		if err := os.Rename(dstpath, tmp); err != nil {
-			return fmt.Errorf("unable to rename %s to %s: %w", dstpath, tmp, err)
-		}
-		defer os.Remove(tmp)
-	}
-
-	src, err := os.Open(srcpath)
-	if err != nil {
-		return fmt.Errorf("unable to open source file: %w", err)
-	}
-	defer src.Close()
-
-	opts := os.O_CREATE | os.O_WRONLY | os.O_TRUNC
-	dst, err := os.OpenFile(dstpath, opts, 0755)
-	if err != nil {
-		return fmt.Errorf("unable to open destination file: %w", err)
-	}
-	defer dst.Close()
-
-	if _, err := io.Copy(dst, src); err != nil {
-		return fmt.Errorf("unable to write file: %w", err)
-	}
-	return nil
-}
-
-// materializeBinaries materializes all binary files from inside bins directory. If the
-// file already exists a copy of it is made first before overwriting it, this is done
-// because we can't overwrite a running binary. Copies are removed. This function also
-// creates a copy of this binary into the PathToEmbeddedClusterBinary() directory.
-func materializeBinaries() error {
-	entries, err := binfs.ReadDir("bins")
-	if err != nil {
-		return fmt.Errorf("unable to read embedded-cluster bins dir: %w", err)
-	}
-
-	if err := materializeOurselves(); err != nil {
-		return fmt.Errorf("unable to materialize ourselves: %w", err)
-	}
-
-	var remove []string
-	defer func() {
-		for _, f := range remove {
-			os.Remove(f)
-		}
-	}()
-
-	for _, entry := range entries {
-		srcpath := fmt.Sprintf("bins/%s", entry.Name())
-		srcfile, err := binfs.ReadFile(srcpath)
-		if err != nil {
-			return fmt.Errorf("unable to read asset: %w", err)
-		}
-
-		dstpath := defaults.PathToEmbeddedClusterBinary(entry.Name())
-		if _, err := os.Stat(dstpath); err == nil {
-			tmp := fmt.Sprintf("%s.bkp", dstpath)
-			if err := os.Rename(dstpath, tmp); err != nil {
-				return fmt.Errorf("unable to rename %s to %s: %w", dstpath, tmp, err)
-			}
-			remove = append(remove, tmp)
-		}
-
-		if err := os.WriteFile(dstpath, srcfile, 0755); err != nil {
-			return fmt.Errorf("unable to write file: %w", err)
-		}
-	}
-
-	return nil
-}
-
-//go:embed support/*
-var supportfs embed.FS
-
-// materializeSupportFiles materializes all support files from inside support directory.
-func materializeSupportFiles() error {
-	entries, err := supportfs.ReadDir("support")
-	if err != nil {
-		return fmt.Errorf("unable to read embedded-cluster support dir: %w", err)
-	}
-	for _, entry := range entries {
-		srcpath := fmt.Sprintf("support/%s", entry.Name())
-		srcfile, err := supportfs.ReadFile(srcpath)
-		if err != nil {
-			return fmt.Errorf("unable to read asset: %w", err)
-		}
-		dstpath := defaults.PathToEmbeddedClusterSupportFile(entry.Name())
-		if err := os.WriteFile(dstpath, srcfile, 0700); err != nil {
-			return fmt.Errorf("unable to write file: %w", err)
-		}
-	}
-	return nil
-}
-
-// Materialize writes to disk all embedded assets.
+// Materialize writes to disk all embedded assets using the default materializer.
 func Materialize() error {
-	if err := materializeBinaries(); err != nil {
-		return fmt.Errorf("unable to materialize embedded binaries: %w", err)
-	}
-	if err := materializeSupportFiles(); err != nil {
-		return fmt.Errorf("unable to materialize embedded support files: %w", err)
-	}
-	return nil
+	return materializer.Materialize()
 }
 
-//go:embed systemd/*
-var systemdfs embed.FS
-
-// MaterializeCalicoNetworkManagerConfig materializes a configuration file for the network manager.
-// This configuration file instructs the network manager to ignore any interface being managed by
-// the calico network cni.
+// MaterializeCalicoNetworkManagerConfig is a helper function that uses the default materializer.
 func MaterializeCalicoNetworkManagerConfig() error {
-	content, err := systemdfs.ReadFile("systemd/calico-network-manager.conf")
-	if err != nil {
-		return fmt.Errorf("unable to open network manager config file: %w", err)
-	}
-	dstpath := "/etc/NetworkManager/conf.d/embedded-cluster.conf"
-	if err := os.WriteFile(dstpath, content, 0644); err != nil {
-		return fmt.Errorf("unable to write file: %w", err)
-	}
-	return nil
+	return materializer.CalicoNetworkManagerConfig()
 }
 
-// MaterializeLocalArtifactMirrorUnitFile writes to disk the local-artifact-mirror systemd unit file.
+// MaterializeLocalArtifactMirrorUnitFile is a helper function that uses the default materializer.
 func MaterializeLocalArtifactMirrorUnitFile() error {
-	content, err := systemdfs.ReadFile("systemd/local-artifact-mirror.service")
-	if err != nil {
-		return fmt.Errorf("unable to open unit file: %w", err)
-	}
-	dstpath := "/etc/systemd/system/local-artifact-mirror.service"
-	if err := os.WriteFile(dstpath, content, 0644); err != nil {
-		return fmt.Errorf("unable to write file: %w", err)
-	}
-	return nil
+	return materializer.LocalArtifactMirrorUnitFile()
 }
 
-//go:embed internal/bins/*
-var internalBinfs embed.FS
-
-// MaterializeInternalBinary materializes an internal binary from inside internal/bins directory
-// and writes it to a tmp file. It returns the path to the materialized binary.
-// The binary should be deleted after it is used.
-// This is used for binaries that are not meant to be exposed to the user.
+// MaterializeInternalBinary is a helper for the default materializer.
 func MaterializeInternalBinary(name string) (string, error) {
-	srcpath := fmt.Sprintf("internal/bins/%s", name)
-	srcfile, err := internalBinfs.ReadFile(srcpath)
-	if err != nil {
-		return "", fmt.Errorf("unable to read asset: %w", err)
-	}
-	dstpath, err := os.CreateTemp("", fmt.Sprintf("embedded-cluster-%s-bin-", name))
-	if err != nil {
-		return "", fmt.Errorf("unable to create temp file: %w", err)
-	}
-	defer dstpath.Close()
-	if _, err := dstpath.Write(srcfile); err != nil {
-		return "", fmt.Errorf("unable to write file: %w", err)
-	}
-	if err := dstpath.Chmod(0755); err != nil {
-		return "", fmt.Errorf("unable to set executable permissions: %w", err)
-	}
-	return dstpath.Name(), nil
+	return materializer.InternalBinary(name)
 }

--- a/pkg/goods/materializer.go
+++ b/pkg/goods/materializer.go
@@ -1,0 +1,206 @@
+package goods
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/replicatedhq/embedded-cluster/pkg/defaults"
+)
+
+// Materializer is an entity capable of materialize (write to disk) embedded assets.
+type Materializer struct {
+	def *defaults.Provider
+}
+
+// NewMaterializer returns a new entity capable of materialize (write to disk) embedded
+// assets. Other operations on embedded assets are also available.
+func NewMaterializer(basedir string) *Materializer {
+	return &Materializer{def: defaults.NewProvider(basedir)}
+}
+
+// InternalBinary materializes an internal binary from inside internal/bins directory
+// and writes it to a tmp file. It returns the path to the materialized binary.
+// The binary should be deleted after it is used.
+// This is used for binaries that are not meant to be exposed to the user.
+func (m *Materializer) InternalBinary(name string) (string, error) {
+	srcpath := fmt.Sprintf("internal/bins/%s", name)
+	srcfile, err := internalBinfs.ReadFile(srcpath)
+	if err != nil {
+		return "", fmt.Errorf("unable to read asset: %w", err)
+	}
+	dstpath, err := os.CreateTemp("", fmt.Sprintf("embedded-cluster-%s-bin-", name))
+	if err != nil {
+		return "", fmt.Errorf("unable to create temp file: %w", err)
+	}
+	defer dstpath.Close()
+	if _, err := dstpath.Write(srcfile); err != nil {
+		return "", fmt.Errorf("unable to write file: %w", err)
+	}
+	if err := dstpath.Chmod(0755); err != nil {
+		return "", fmt.Errorf("unable to set executable permissions: %w", err)
+	}
+	return dstpath.Name(), nil
+}
+
+// LocalArtifactMirrorUnitFile writes to disk the local-artifact-mirror systemd unit file.
+func (m *Materializer) LocalArtifactMirrorUnitFile() error {
+	content, err := systemdfs.ReadFile("systemd/local-artifact-mirror.service")
+	if err != nil {
+		return fmt.Errorf("unable to open unit file: %w", err)
+	}
+	dstpath := "/etc/systemd/system/local-artifact-mirror.service"
+	if err := os.WriteFile(dstpath, content, 0644); err != nil {
+		return fmt.Errorf("unable to write file: %w", err)
+	}
+	return nil
+}
+
+// CalicoNetworkManagerConfig materializes a configuration file for the network manager. This
+// configuration file instructs the network manager to ignore any interface being managed by
+// the calico network cni.
+func (m *Materializer) CalicoNetworkManagerConfig() error {
+	content, err := systemdfs.ReadFile("systemd/calico-network-manager.conf")
+	if err != nil {
+		return fmt.Errorf("unable to open network manager config file: %w", err)
+	}
+	dstpath := "/etc/NetworkManager/conf.d/embedded-cluster.conf"
+	if err := os.WriteFile(dstpath, content, 0644); err != nil {
+		return fmt.Errorf("unable to write file: %w", err)
+	}
+	return nil
+}
+
+// Materialize writes to disk all embedded assets.
+func (m *Materializer) Materialize() error {
+	if err := m.Binaries(); err != nil {
+		return fmt.Errorf("unable to materialize embedded binaries: %w", err)
+	}
+	if err := m.SupportFiles(); err != nil {
+		return fmt.Errorf("unable to materialize embedded support files: %w", err)
+	}
+	return nil
+}
+
+// SupportFiles materializes files under the support directory.
+func (m *Materializer) SupportFiles() error {
+	entries, err := supportfs.ReadDir("support")
+	if err != nil {
+		return fmt.Errorf("unable to read embedded-cluster support dir: %w", err)
+	}
+	for _, entry := range entries {
+		srcpath := fmt.Sprintf("support/%s", entry.Name())
+		srcfile, err := supportfs.ReadFile(srcpath)
+		if err != nil {
+			return fmt.Errorf("unable to read asset: %w", err)
+		}
+		dstpath := m.def.PathToEmbeddedClusterSupportFile(entry.Name())
+		if err := os.WriteFile(dstpath, srcfile, 0700); err != nil {
+			return fmt.Errorf("unable to write file: %w", err)
+		}
+	}
+	return nil
+}
+
+// Binaries materializes all binary files from inside bins directory. If the file already
+// exists a copy of it is made first before overwriting it, this is done because we can't
+// overwrite a running binary. Copies are removed. This function also creates a copy of
+// this binary into the PathToEmbeddedClusterBinary() directory.
+func (m *Materializer) Binaries() error {
+	entries, err := binfs.ReadDir("bins")
+	if err != nil {
+		return fmt.Errorf("unable to read embedded-cluster bins dir: %w", err)
+	}
+
+	if err := m.Ourselves(); err != nil {
+		return fmt.Errorf("unable to materialize ourselves: %w", err)
+	}
+
+	var remove []string
+	defer func() {
+		for _, f := range remove {
+			os.Remove(f)
+		}
+	}()
+
+	for _, entry := range entries {
+		srcpath := fmt.Sprintf("bins/%s", entry.Name())
+		srcfile, err := binfs.ReadFile(srcpath)
+		if err != nil {
+			return fmt.Errorf("unable to read asset: %w", err)
+		}
+
+		dstpath := m.def.PathToEmbeddedClusterBinary(entry.Name())
+		if _, err := os.Stat(dstpath); err == nil {
+			tmp := fmt.Sprintf("%s.bkp", dstpath)
+			if err := os.Rename(dstpath, tmp); err != nil {
+				return fmt.Errorf("unable to rename %s to %s: %w", dstpath, tmp, err)
+			}
+			remove = append(remove, tmp)
+		}
+
+		if err := os.WriteFile(dstpath, srcfile, 0755); err != nil {
+			return fmt.Errorf("unable to write file: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// K0sBinarySHA256 returns the SHA256 checksum of the embedded k0s binary.
+func (m *Materializer) K0sBinarySHA256() (string, error) {
+	fp, err := binfs.Open("bins/k0s")
+	if err != nil {
+		return "", fmt.Errorf("unable to open embedded k0s binary: %w", err)
+	}
+	defer fp.Close()
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, fp); err != nil {
+		return "", fmt.Errorf("unable to copy embedded k0s binary: %w", err)
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+// Ourselves makes a copy of the embedded-cluster binary into the PathToEmbeddedClusterBinary() directory.
+// We are doing this copy for three reasons: 1. We make sure we have it in a standard location across all
+// installations. 2. We can overwrite it during cluster upgrades. 3. we can serve a copy of the binary
+// through the local-artifact-mirror daemon.
+func (m *Materializer) Ourselves() error {
+	srcpath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("unable to get our own executable path: %w", err)
+	}
+
+	dstpath := m.def.PathToEmbeddedClusterBinary(m.def.BinaryName())
+	if srcpath == dstpath {
+		return nil
+	}
+
+	if _, err := os.Stat(dstpath); err == nil {
+		tmp := fmt.Sprintf("%s.bkp", dstpath)
+		if err := os.Rename(dstpath, tmp); err != nil {
+			return fmt.Errorf("unable to rename %s to %s: %w", dstpath, tmp, err)
+		}
+		defer os.Remove(tmp)
+	}
+
+	src, err := os.Open(srcpath)
+	if err != nil {
+		return fmt.Errorf("unable to open source file: %w", err)
+	}
+	defer src.Close()
+
+	opts := os.O_CREATE | os.O_WRONLY | os.O_TRUNC
+	dst, err := os.OpenFile(dstpath, opts, 0755)
+	if err != nil {
+		return fmt.Errorf("unable to open destination file: %w", err)
+	}
+	defer dst.Close()
+
+	if _, err := io.Copy(dst, src); err != nil {
+		return fmt.Errorf("unable to write file: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
allow for materialize subcommand to accept a prefix so all materialized binaries will be placed under the provided directory.

this pr does not introduce any functional change. functions were moved to a struct and helper functions were created so no other changes in the source code is necessary (similar to what is made in the `defaults` package).