### PR TITLE
feat: materialize containerd config + allow shell on worker

### DIFF
--- a/cmd/embedded-cluster/materialize.go
+++ b/cmd/embedded-cluster/materialize.go
@@ -3,15 +3,57 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/replicatedhq/embedded-cluster/pkg/airgap"
+	"github.com/replicatedhq/embedded-cluster/pkg/defaults"
 	"github.com/replicatedhq/embedded-cluster/pkg/goods"
+	"github.com/replicatedhq/embedded-cluster/pkg/kubeutils"
 )
+
+// materializeContainerdConfig materializes the expected containerd configuration. this is
+// useful only when running on airgap environments so this function assess if there is a
+// registry running in the cluster and if not bails out without error. this function is
+// meant to be ran against a running cluster in both worker or control plane nodes.
+func materializeContainerdConfig(c *cli.Context) error {
+	cli, err := kubeutils.KubeClient()
+	if err != nil {
+		return fmt.Errorf("unable to create kube client: %w", err)
+	}
+
+	var svc corev1.Service
+	nsn := types.NamespacedName{Namespace: "registry", Name: "registry"}
+	if err := cli.Get(c.Context, nsn, &svc); err != nil {
+		if errors.IsNotFound(err) {
+			logrus.Info("registry service not found, skipping containerd config")
+			return nil
+		}
+		return fmt.Errorf("unable to get registry service: %w", err)
+	}
+	registryAddress := fmt.Sprintf("%s:5000", svc.Spec.ClusterIP)
+
+	parent := defaults.NewProvider(c.String("basedir")).PathToK0sContainerdConfig()
+	if err := os.MkdirAll(parent, 0755); err != nil {
+		return fmt.Errorf("unable to create containerd config directory: %w", err)
+	}
+
+	contents := airgap.RenderContainerdRegistryConfig(registryAddress)
+	path := filepath.Join(parent, "embedded-registry.toml")
+	if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
+		return fmt.Errorf("unable to write embedded-registry.toml: %w", err)
+	}
+	return nil
+}
 
 var materializeCommand = &cli.Command{
 	Name:   "materialize",
-	Usage:  "Materialize embedded assets on /var/lib/embedded-cluster",
+	Usage:  "Materialize embedded assets",
 	Hidden: true,
 	Flags: []cli.Flag{
 		&cli.StringFlag{
@@ -30,6 +72,9 @@ var materializeCommand = &cli.Command{
 		materializer := goods.NewMaterializer(c.String("basedir"))
 		if err := materializer.Materialize(); err != nil {
 			return fmt.Errorf("unable to materialize: %v", err)
+		}
+		if err := materializeContainerdConfig(c); err != nil {
+			return fmt.Errorf("unable to materialize containerd config: %v", err)
 		}
 		return nil
 	},

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 )
 
 require (
-	github.com/Masterminds/semver/v3 v3.2.1 // indirect
+	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -132,7 +132,7 @@ require (
 	github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913 // indirect
 	github.com/zitadel/oidc/v2 v2.7.0 // indirect
 	go.mongodb.org/mongo-driver v1.11.3 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/oauth2 v0.18.0 // indirect

--- a/pkg/airgap/containerd.go
+++ b/pkg/airgap/containerd.go
@@ -11,18 +11,24 @@ import (
 const registryConfigTemplate = `
 [plugins."io.containerd.grpc.v1.cri".registry]
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."%s"]
-      endpoint = ["http://%s"]
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."%[1]s"]
+      endpoint = ["http://%[1]s"]
   [plugins."io.containerd.grpc.v1.cri".registry.configs]
-    [plugins."io.containerd.grpc.v1.cri".registry.configs."%s".tls]
+    [plugins."io.containerd.grpc.v1.cri".registry.configs."%[1]s".tls]
       insecure_skip_verify = true
 `
+
+// RenderContainerdRegistryConfig returns the contents of the containerd configuration
+// allowing insecure access to the embedded cluster internal registry.
+func RenderContainerdRegistryConfig(registry string) string {
+	return fmt.Sprintf(registryConfigTemplate, registry)
+}
 
 // AddInsecureRegistry adds a registry to the list of registries that
 // are allowed to be accessed over HTTP.
 func AddInsecureRegistry(registry string) error {
 	parentDir := defaults.PathToK0sContainerdConfig()
-	contents := fmt.Sprintf(registryConfigTemplate, registry, registry, registry)
+	contents := RenderContainerdRegistryConfig(registry)
 
 	if err := os.MkdirAll(parentDir, 0755); err != nil {
 		return fmt.Errorf("failed to ensure containerd directory exists: %w", err)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -76,6 +76,12 @@ func PathToLog(name string) string {
 	return def().PathToLog(name)
 }
 
+// PathToWorkerKubeConfig calls PathToWorkerKubeConfig on the default provider.
+func PathToWorkerKubeConfig() string {
+	return def().PathToWorkerKubeConfig()
+}
+
+// PathToKubeConfig calls PathToKubeConfig on the default provider.
 func PathToKubeConfig() string {
 	return def().PathToKubeConfig()
 }

--- a/pkg/defaults/provider.go
+++ b/pkg/defaults/provider.go
@@ -102,7 +102,7 @@ func (d *Provider) EmbeddedClusterHomeDirectory() string {
 // does not return the binary just after we materilized it but the path we want it to be
 // once it is installed.
 func (d *Provider) K0sBinaryPath() string {
-	return "/usr/local/bin/k0s"
+	return filepath.Join(d.Base, "/usr/local/bin/k0s")
 }
 
 // PathToEmbeddedClusterBinary is an utility function that returns the full path to a
@@ -112,8 +112,17 @@ func (d *Provider) PathToEmbeddedClusterBinary(name string) string {
 	return filepath.Join(d.EmbeddedClusterBinsSubDir(), name)
 }
 
+// PathToWorkerKubeConfig returns the path to the kubeconfig used by the worker nodes when
+// talking to the api server. Note that this kubeconfig may not have all the permissions
+// that the admin kubeconfig has.
+func (d *Provider) PathToWorkerKubeConfig() string {
+	return filepath.Join(d.Base, "/var/lib/k0s/kubelet.conf")
+}
+
+// PathToKubeConfig returns the full path to the kubeconfig file. This file contain auth
+// for the admin of the cluster.
 func (d *Provider) PathToKubeConfig() string {
-	return "/var/lib/k0s/pki/admin.conf"
+	return filepath.Join(d.Base, "/var/lib/k0s/pki/admin.conf")
 }
 
 // PreferredNodeIPAddress returns the ip address the node uses when reaching
@@ -173,17 +182,17 @@ func (d *Provider) TryDiscoverPublicIP() string {
 
 // PathToK0sStatusSocket returns the full path to the k0s status socket.
 func (d *Provider) PathToK0sStatusSocket() string {
-	return "/run/k0s/status.sock"
+	return filepath.Join(d.Base, "/run/k0s/status.sock")
 }
 
 // PathToK0sConfig returns the full path to the k0s configuration file.
 func (d *Provider) PathToK0sConfig() string {
-	return "/etc/k0s/k0s.yaml"
+	return filepath.Join(d.Base, "/etc/k0s/k0s.yaml")
 }
 
 // PathToK0sContainerdConfig returns the full path to the k0s containerd configuration directory
 func (d *Provider) PathToK0sContainerdConfig() string {
-	return "/etc/k0s/containerd.d/"
+	return filepath.Join(d.Base, "/etc/k0s/containerd.d/")
 }
 
 // EmbeddedClusterSupportSubDir returns the path to the directory where embedded-cluster


### PR DESCRIPTION
- materialize the containerd configuration through the materialize command (when the svc registry exists on the registry namespace).
- allow shell on worker nodes: this may be removed but as i was debugging this it was really handy so i left it.

the recording of the shell on a worker node can be found [here](https://www.loom.com/share/c7dbc0d8b8124c28b79c524c71d21798).