### PR TITLE
unmask access key id input during restore

### DIFF
--- a/cmd/embedded-cluster/restore.go
+++ b/cmd/embedded-cluster/restore.go
@@ -239,7 +239,7 @@ func newS3BackupStore() *s3BackupStore {
 	store.region = prompts.New().Input("Region:", "", true)
 	store.bucket = prompts.New().Input("Bucket:", "", true)
 	store.prefix = prompts.New().Input("Prefix (press Enter to skip):", "", false)
-	store.accessKeyID = prompts.New().Password("Access key ID:")
+	store.accessKeyID = prompts.New().Input("Access key ID:", "", true)
 	store.secretAccessKey = prompts.New().Password("Secret access key:")
 	logrus.Info("")
 	return store


### PR DESCRIPTION
This PR unmasks the access key ID input during the CLI restore process as this piece of data is not considered sensitive and doing this make the experience consistent with the UI.

Part of: https://app.shortcut.com/replicated/story/105248/various-quick-dr-fixes