### PR TITLE
do not update go.mod for PREVIOUS_K0S_VERSION tests

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -50,6 +50,9 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: "1.21.0"
+    - name: Make go.mod # this ensures that the k0s version in the go.mod file matches that in the Makefile
+      run: |
+        make go.mod
     - name: Build Linux AMD64 and Output Metadata
       run: |
         export SHORT_SHA=dev-$(git rev-parse --short=7 HEAD)

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -17,6 +17,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.21"
+      - name: Make go.mod # this ensures that the k0s version in the go.mod file matches that in the Makefile
+        run: |
+          make go.mod
       - name: Build Linux AMD64 and Output Metadata
         run: |
           export SHORT_SHA=dev-$(git rev-parse --short=7 HEAD)

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,8 @@ output/bin/embedded-cluster-release-builder:
 embedded-release: embedded-cluster-linux-amd64 output/tmp/release.tar.gz output/bin/embedded-cluster-release-builder
 	./output/bin/embedded-cluster-release-builder output/bin/embedded-cluster output/tmp/release.tar.gz output/bin/embedded-cluster
 
-go.mod: Makefile
+.PHONY: go.mod
+go.mod:
 	go get github.com/k0sproject/k0s@$(K0S_VERSION)
 	go mod tidy
 
@@ -135,14 +136,14 @@ static: pkg/goods/bins/k0s \
 	pkg/goods/bins/kubectl-support_bundle \
 	pkg/goods/bins/local-artifact-mirror \
 	pkg/goods/internal/bins/kubectl-kots
-	
+
 .PHONY: embedded-cluster-linux-amd64
-embedded-cluster-linux-amd64: static go.mod
+embedded-cluster-linux-amd64: static
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$(LD_FLAGS)" -o ./output/bin/$(APP_NAME) ./cmd/embedded-cluster
 
 # for testing
 .PHONY: embedded-cluster-darwin-arm64
-embedded-cluster-darwin-arm64: go.mod
+embedded-cluster-darwin-arm64:
 	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags "$(LD_FLAGS)" -o ./output/bin/$(APP_NAME) ./cmd/embedded-cluster
 
 .PHONY: unit-tests


### PR DESCRIPTION
This is not perfectly ideal, as it means that we'll possibly be using infrastructure images for the wrong k0s version when upgrading from PREVIOUS_K0S_VERSION in our testing - this means that we will not be changing k0s infra images when doing an airgap upgrade, which is a slight loss of test coverage. We will still be changing chart images, so there's still coverage of that aspect.

On the other hand, this is only in our testing, and not in the release version - and so we won't be shipping k0s using the wrong images.