### PR TITLE
release three airgap versions in on-merge tests as well as on-pr

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -195,6 +195,8 @@ jobs:
           - TestMultiNodeAirgapHAInstallation
           - TestMultiNodeAirgapUpgradeSameK0s
         include:
+          - test: TestMultiNodeAirgapUpgrade
+            runner: embedded-cluster
           - test: TestMultiNodeAirgapHAInstallation
             runner: embedded-cluster
     steps:

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -94,11 +94,13 @@ jobs:
         run: |
           export SHORT_SHA=dev-$(git rev-parse --short=7 HEAD)
           echo "${SHORT_SHA}"
+          rm e2e/kots-release-install/release.yaml
+          replicated release create --yaml-dir e2e/kots-release-install --promote CI-airgap --version "appver-${SHORT_SHA}"
+
           # airgap tests install the previous k0s version to ensure an upgrade occurs
           sed -i "s/${SHORT_SHA}/${SHORT_SHA}-previous-k0s/g" e2e/kots-release-install/cluster-config.yaml
           
-          rm e2e/kots-release-install/release.yaml
-          replicated release create --yaml-dir e2e/kots-release-install --promote CI-airgap --version "appver-${SHORT_SHA}"
+          replicated release create --yaml-dir e2e/kots-release-install --promote CI-airgap --version "appver-${SHORT_SHA}-previous-k0s"
           replicated release create --yaml-dir e2e/kots-release-upgrade --promote CI-airgap --version "appver-${SHORT_SHA}-upgrade"
 
       - name: upload binary

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -148,6 +148,8 @@ jobs:
           - TestMultiNodeAirgapHAInstallation
           - TestMultiNodeAirgapUpgradeSameK0s
         include:
+          - test: TestMultiNodeAirgapUpgrade
+            runner: embedded-cluster
           - test: TestMultiNodeAirgapHAInstallation
             runner: embedded-cluster
     steps:


### PR DESCRIPTION
This PR updates the on-merge test code to make the same set of releases as the on-pr test code does.