### PR TITLE
Clean up existing embedded cluster systemd service before creating symlink

### DIFF
--- a/cmd/embedded-cluster/join.go
+++ b/cmd/embedded-cluster/join.go
@@ -212,7 +212,7 @@ var joinCommand = &cli.Command{
 		}
 
 		logrus.Debugf("creating systemd unit files")
-		if err := createSystemdUnitFiles(strings.Contains(jcmd.K0sJoinCommand, "worker")); err != nil {
+		if err := createSystemdUnitFiles(!strings.Contains(jcmd.K0sJoinCommand, "enable-worker")); err != nil {
 			err := fmt.Errorf("unable to create systemd unit files: %w", err)
 			metrics.ReportJoinFailed(c.Context, jcmd.MetricsBaseURL, jcmd.ClusterID, err)
 			return err

--- a/cmd/embedded-cluster/join.go
+++ b/cmd/embedded-cluster/join.go
@@ -388,7 +388,7 @@ func systemdUnitFileName() string {
 // systemd unit file for the local artifact mirror service.
 func createSystemdUnitFiles(isWorker bool) error {
 	dst := systemdUnitFileName()
-	if _, err := os.Stat(dst); err == nil {
+	if _, err := os.Lstat(dst); err == nil {
 		if err := os.Remove(dst); err != nil {
 			return err
 		}

--- a/cmd/embedded-cluster/join.go
+++ b/cmd/embedded-cluster/join.go
@@ -212,6 +212,8 @@ var joinCommand = &cli.Command{
 		}
 
 		logrus.Debugf("creating systemd unit files")
+		// both controller and worker nodes will have 'worker' in the join command, but only controllers will have 'enable-worker'
+		// https://github.com/replicatedhq/kots/blob/6a0602f4054d5d5f2d97e649b3303a059f0064d9/pkg/embeddedcluster/node_join.go#L183
 		if err := createSystemdUnitFiles(!strings.Contains(jcmd.K0sJoinCommand, "enable-worker")); err != nil {
 			err := fmt.Errorf("unable to create systemd unit files: %w", err)
 			metrics.ReportJoinFailed(c.Context, jcmd.MetricsBaseURL, jcmd.ClusterID, err)

--- a/cmd/embedded-cluster/restore.go
+++ b/cmd/embedded-cluster/restore.go
@@ -762,9 +762,9 @@ var restoreCommand = &cli.Command{
 			if err := installK0s(); err != nil {
 				return fmt.Errorf("unable update cluster: %w", err)
 			}
-			logrus.Debugf("running post install")
-			if err := runPostInstall(); err != nil {
-				return fmt.Errorf("unable to run post install: %w", err)
+			logrus.Debugf("creating systemd unit files")
+			if err := createSystemdUnitFiles(false); err != nil {
+				return fmt.Errorf("unable to create systemd unit files: %w", err)
 			}
 			logrus.Debugf("waiting for k0s to be ready")
 			if err := waitForK0s(); err != nil {

--- a/cmd/embedded-cluster/uninstall.go
+++ b/cmd/embedded-cluster/uninstall.go
@@ -412,7 +412,7 @@ var resetCommand = &cli.Command{
 			}
 		}
 
-		if _, err := os.Stat(systemdUnitFileName()); err == nil {
+		if _, err := os.Lstat(systemdUnitFileName()); err == nil {
 			if err := os.Remove(systemdUnitFileName()); err != nil {
 				return fmt.Errorf("failed to remove systemd unit file: %w", err)
 			}


### PR DESCRIPTION
Fixes this issue when resetting then reinstalling on the same machine:

```bash
unable to create systemd unit files: symlink /etc/systemd/system/k0sworker.service /etc/systemd/system/embedded-cluster.service: file exists
```