### PR TITLE
fix: metadata has wrong ec version

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -67,6 +67,7 @@ jobs:
         export LOCAL_ARTIFACT_MIRROR_IMAGE=registry.staging.replicated.com/library/embedded-cluster-local-artifact-mirror
         make build-and-push-local-artifact-mirror-image VERSION="${SHORT_SHA}"
         make build-and-push-local-artifact-mirror-image VERSION="${SHORT_SHA}-previous-k0s"
+        make build-and-push-local-artifact-mirror-image VERSION="${SHORT_SHA}-upgrade"
 
     - name: Build Linux AMD64 and Output Metadata
       run: |
@@ -75,6 +76,9 @@ jobs:
         make -B embedded-cluster-linux-amd64 K0S_VERSION=$(make print-PREVIOUS_K0S_VERSION) VERSION="${SHORT_SHA}-previous-k0s"
         tar -C output/bin -czvf embedded-cluster-linux-amd64-previous-k0s.tgz embedded-cluster
         ./output/bin/embedded-cluster version metadata > metadata-previous-k0s.json
+        make -B embedded-cluster-linux-amd64 VERSION="${SHORT_SHA}-upgrade"
+        tar -C output/bin -czvf embedded-cluster-linux-amd64-upgrade.tgz embedded-cluster
+        ./output/bin/embedded-cluster version metadata > metadata-upgrade.json
         make -B embedded-cluster-linux-amd64 VERSION="${SHORT_SHA}"
         tar -C output/bin -czvf embedded-cluster-linux-amd64.tgz embedded-cluster
         ./output/bin/embedded-cluster version metadata > metadata.json

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -229,6 +229,8 @@ jobs:
             runner: embedded-cluster
           - test: TestMultiNodeAirgapHADisasterRecovery
             runner: embedded-cluster
+          - test: TestSingleNodeAirgapDisasterRecovery
+            runner: embedded-cluster
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -34,6 +34,7 @@ jobs:
           export LOCAL_ARTIFACT_MIRROR_IMAGE=registry.staging.replicated.com/library/embedded-cluster-local-artifact-mirror
           make build-and-push-local-artifact-mirror-image VERSION="${SHORT_SHA}"
           make build-and-push-local-artifact-mirror-image VERSION="${SHORT_SHA}-previous-k0s"
+          make build-and-push-local-artifact-mirror-image VERSION="${SHORT_SHA}-upgrade"
 
       - name: Build Linux AMD64 and Output Metadata
         run: |
@@ -42,6 +43,9 @@ jobs:
           make -B embedded-cluster-linux-amd64 K0S_VERSION=$(make print-PREVIOUS_K0S_VERSION) VERSION="${SHORT_SHA}-previous-k0s"
           tar -C output/bin -czvf embedded-cluster-linux-amd64-previous-k0s.tgz embedded-cluster
           ./output/bin/embedded-cluster version metadata > metadata-previous-k0s.json
+          make -B embedded-cluster-linux-amd64 VERSION="${SHORT_SHA}-upgrade"
+          tar -C output/bin -czvf embedded-cluster-linux-amd64-upgrade.tgz embedded-cluster
+          ./output/bin/embedded-cluster version metadata > metadata-upgrade.json
           make -B embedded-cluster-linux-amd64 VERSION="${SHORT_SHA}"
           tar -C output/bin -czvf embedded-cluster-linux-amd64.tgz embedded-cluster
           ./output/bin/embedded-cluster version metadata > metadata.json

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -181,6 +181,8 @@ jobs:
             runner: embedded-cluster
           - test: TestMultiNodeAirgapHADisasterRecovery
             runner: embedded-cluster
+          - test: TestSingleNodeAirgapDisasterRecovery
+            runner: embedded-cluster
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/scripts/create-previous-k0s-release.sh
+++ b/scripts/create-previous-k0s-release.sh
@@ -45,6 +45,8 @@ function metadata() {
         sudo apt-get install jq -y
 
         jq '(.Configs.charts[] | select(.name == "embedded-cluster-operator")).values += "resources:\n  requests:\n    cpu: 123m"' metadata-previous-k0s.json > install-metadata.json
+        sed -i 's/"Installer": "'"${EC_VERSION_ORIG_NOV}"'",/"Installer": "'"${EC_VERSION_NOV}"'",/g' install-metadata.json
+        sed -i 's/embeddedClusterVersion: '"${EC_VERSION_ORIG_NOV}"'/embeddedClusterVersion: '"${EC_VERSION_NOV}"'/g' install-metadata.json
         cat install-metadata.json
 
         retry 3 aws s3 cp install-metadata.json "s3://${S3_BUCKET}/metadata/${EC_VERSION}.json"
@@ -69,6 +71,10 @@ function embeddedcluster() {
 }
 
 function main() {
+    export EC_VERSION_ORIG_NOV
+    # shellcheck disable=SC2001
+    EC_VERSION_ORIG_NOV="$(echo "$EC_VERSION" | sed 's/^v//')"
+    export EC_VERSION_NOV="${EC_VERSION_ORIG_NOV}-previous-k0s"
     export EC_VERSION="${EC_VERSION}-previous-k0s"
     metadata
     embeddedcluster

--- a/scripts/create-previous-k0s-release.sh
+++ b/scripts/create-previous-k0s-release.sh
@@ -45,8 +45,6 @@ function metadata() {
         sudo apt-get install jq -y
 
         jq '(.Configs.charts[] | select(.name == "embedded-cluster-operator")).values += "resources:\n  requests:\n    cpu: 123m"' metadata-previous-k0s.json > install-metadata.json
-        sed -i 's/"Installer": "'"${EC_VERSION_ORIG_NOV}"'",/"Installer": "'"${EC_VERSION_NOV}"'",/g' install-metadata.json
-        sed -i 's/embeddedClusterVersion: '"${EC_VERSION_ORIG_NOV}"'/embeddedClusterVersion: '"${EC_VERSION_NOV}"'/g' install-metadata.json
         cat install-metadata.json
 
         retry 3 aws s3 cp install-metadata.json "s3://${S3_BUCKET}/metadata/${EC_VERSION}.json"
@@ -71,10 +69,6 @@ function embeddedcluster() {
 }
 
 function main() {
-    export EC_VERSION_ORIG_NOV
-    # shellcheck disable=SC2001
-    EC_VERSION_ORIG_NOV="$(echo "$EC_VERSION" | sed 's/^v//')"
-    export EC_VERSION_NOV="${EC_VERSION_ORIG_NOV}-previous-k0s"
     export EC_VERSION="${EC_VERSION}-previous-k0s"
     metadata
     embeddedcluster

--- a/scripts/create-upgrade-release.sh
+++ b/scripts/create-upgrade-release.sh
@@ -45,6 +45,8 @@ function metadata() {
         sudo apt-get install jq -y
 
         jq '(.Configs.charts[] | select(.name == "embedded-cluster-operator")).values += "resources:\n  requests:\n    cpu: 123m"' metadata.json > upgrade-metadata.json
+        sed -i 's/"Installer": "'"${EC_VERSION_ORIG_NOV}"'",/"Installer": "'"${EC_VERSION_NOV}"'",/g' upgrade-metadata.json
+        sed -i 's/embeddedClusterVersion: '"${EC_VERSION_ORIG_NOV}"'/embeddedClusterVersion: '"${EC_VERSION_NOV}"'/g' upgrade-metadata.json
         cat upgrade-metadata.json
 
         retry 3 aws s3 cp upgrade-metadata.json "s3://${S3_BUCKET}/metadata/${EC_VERSION}.json"
@@ -69,6 +71,10 @@ function embeddedcluster() {
 }
 
 function main() {
+    export EC_VERSION_ORIG_NOV
+    # shellcheck disable=SC2001
+    EC_VERSION_ORIG_NOV="$(echo "$EC_VERSION" | sed 's/^v//')"
+    export EC_VERSION_NOV="${EC_VERSION_ORIG_NOV}-upgrade"
     export EC_VERSION="${EC_VERSION}-upgrade"
     metadata
     embeddedcluster

--- a/scripts/create-upgrade-release.sh
+++ b/scripts/create-upgrade-release.sh
@@ -44,9 +44,7 @@ function metadata() {
     if [ -f metadata.json ]; then
         sudo apt-get install jq -y
 
-        jq '(.Configs.charts[] | select(.name == "embedded-cluster-operator")).values += "resources:\n  requests:\n    cpu: 123m"' metadata.json > upgrade-metadata.json
-        sed -i 's/"Installer": "'"${EC_VERSION_ORIG_NOV}"'",/"Installer": "'"${EC_VERSION_NOV}"'",/g' upgrade-metadata.json
-        sed -i 's/embeddedClusterVersion: '"${EC_VERSION_ORIG_NOV}"'/embeddedClusterVersion: '"${EC_VERSION_NOV}"'/g' upgrade-metadata.json
+        jq '(.Configs.charts[] | select(.name == "embedded-cluster-operator")).values += "resources:\n  requests:\n    cpu: 123m"' metadata-upgrade.json > upgrade-metadata.json
         cat upgrade-metadata.json
 
         retry 3 aws s3 cp upgrade-metadata.json "s3://${S3_BUCKET}/metadata/${EC_VERSION}.json"
@@ -71,10 +69,6 @@ function embeddedcluster() {
 }
 
 function main() {
-    export EC_VERSION_ORIG_NOV
-    # shellcheck disable=SC2001
-    EC_VERSION_ORIG_NOV="$(echo "$EC_VERSION" | sed 's/^v//')"
-    export EC_VERSION_NOV="${EC_VERSION_ORIG_NOV}-upgrade"
     export EC_VERSION="${EC_VERSION}-upgrade"
     metadata
     embeddedcluster


### PR DESCRIPTION
This is blocking work on new upgrade feature as wrong version is set in the new chart.