### PR TITLE
chore(dev): uploading uncompressed ec release

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -83,6 +83,10 @@ jobs:
         tar -C output/bin -czvf embedded-cluster-linux-amd64.tgz embedded-cluster
         ./output/bin/embedded-cluster version metadata > metadata.json
 
+        # XXX we are going to upload this "raw" binary to the bucket together with the
+        # compressed version. this is done for sake of performance evaluations.
+        cp -Rfp output/bin/embedded-cluster embedded-cluster-linux-amd64
+
     - name: Install Replicated CLI
       run: |
         curl -s https://api.github.com/repos/replicatedhq/replicated/releases/latest \

--- a/scripts/cache-files.sh
+++ b/scripts/cache-files.sh
@@ -154,6 +154,14 @@ function embeddedcluster() {
     else
         echo "embedded-cluster-linux-amd64.tgz not found, skipping upload"
     fi
+
+    # check if a file 'embedded-cluster-linux-amd64' exists in the directory if it
+    # does, upload it as releases/${ec_version}.
+    if [ -f embedded-cluster-linux-amd64 ]; then
+        retry 3 aws s3 cp embedded-cluster-linux-amd64 "s3://${S3_BUCKET}/releases/${EC_VERSION}"
+    else
+        echo "embedded-cluster-linux-amd64 not found, skipping upload"
+    fi
 }
 
 # there are three files to be uploaded for each release - the k0s binary, the metadata file, and the embedded-cluster release


### PR DESCRIPTION
uploads the uncompressed binary to the bucket, we are looking to evaluate if there is a performance gain in comparison.

this is temporary and should not be merged.