### PR TITLE
chore: remove job to update upstream add ons

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -27,38 +27,6 @@ jobs:
       run: |
         export VERSION=`curl https://raw.githubusercontent.com/docker-library/busybox/master/versions.json | jq -r .latest.version`
         sed -i "/^EMBEDDED_OPERATOR_UTILS_IMAGE/c\EMBEDDED_OPERATOR_UTILS_IMAGE = busybox:$VERSION" Makefile
-    - name: OpenEBS
-      run: |
-        export VERSION=`curl https://api.github.com/repos/openebs/openebs/releases/latest | jq -r .name | tr -d v`
-        sed -i "/^OPENEBS_CHART_VERSION/c\OPENEBS_CHART_VERSION = $VERSION" Makefile
-    - name: OpenEBS utils
-      run: |
-        export VERSION=`curl https://api.github.com/repos/openebs/linux-utils/releases/latest | jq -r .name | tr -d v`
-        sed -i "/^OPENEBS_UTILS_VERSION/c\OPENEBS_UTILS_VERSION = $VERSION" Makefile
-    - name: SeaweedFS
-      run: |
-        export VERSION=`curl https://raw.githubusercontent.com/seaweedfs/seaweedfs/master/k8s/charts/seaweedfs/Chart.yaml | grep version | tr -d 'version: '`
-        sed -i "/^SEAWEEDFS_CHART_VERSION/c\SEAWEEDFS_CHART_VERSION = $VERSION" Makefile
-    - name: Registry Chart
-      run: |
-        export VERSION=`curl https://api.github.com/repos/twuni/docker-registry.helm/tags | jq -r .[].name | head -1 | tr -d v`
-        sed -i "/^REGISTRY_CHART_VERSION/c\REGISTRY_CHART_VERSION = $VERSION" Makefile
-    - name: Registry Image
-      run: |
-        export VERSION=`curl https://api.github.com/repos/distribution/distribution/tags | jq -r '.[].name'  | tr -d v | grep -v alpha | grep -v beta | head -n 1`
-        sed -i "/^REGISTRY_IMAGE_VERSION/c\REGISTRY_IMAGE_VERSION = $VERSION" Makefile
-    - name: Velero Chart
-      run: |
-        export VERSION=`curl https://api.github.com/repos/vmware-tanzu/helm-charts/tags | jq -r '.[].name' | grep velero | tr -d 'velero-' | head -n 1`
-        sed -i "/^VELERO_CHART_VERSION/c\VELERO_CHART_VERSION = $VERSION" Makefile
-    - name: Velero Image
-      run: |
-        export VERSION=`curl https://api.github.com/repos/vmware-tanzu/velero/tags | jq -r '.[].name' | grep -v 'rc' | head -n 1`
-        sed -i "/^VELERO_IMAGE_VERSION/c\VELERO_IMAGE_VERSION = $VERSION" Makefile
-    - name: Velero AWS Plugin Image
-      run: |
-        export VERSION=`curl https://api.github.com/repos/vmware-tanzu/velero-plugin-for-aws/tags | jq -r '.[].name' | grep -v 'rc' | head -n 1`
-        sed -i "/^VELERO_AWS_PLUGIN_IMAGE_VERSION/c\VELERO_AWS_PLUGIN_IMAGE_VERSION = $VERSION" Makefile
     - name: Kubectl
       run: |
         export VERSION=`curl -L -s https://dl.k8s.io/release/stable.txt`


### PR DESCRIPTION
we now have a different job that updates these add ons while also mirroring helm charts in our registry.