### PR TITLE
fix: add spinner to show installation of k0s

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/aws/aws-sdk-go v1.54.1
 	github.com/canonical/lxd v0.0.0-20230814092713-c77ee90f5032
-	github.com/coreos/go-semver v0.3.1
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/creack/pty v1.1.21
 	github.com/fatih/color v1.17.0
@@ -45,6 +44,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/containerd/containerd v1.7.17 // indirect
 	github.com/containerd/log v0.1.0 // indirect
+	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.5 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/cli v26.1.3+incompatible // indirect

--- a/pkg/preflights/preflights.go
+++ b/pkg/preflights/preflights.go
@@ -11,10 +11,9 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/replicatedhq/embedded-cluster/pkg/defaults"
 	"github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"sigs.k8s.io/yaml"
-
-	"github.com/replicatedhq/embedded-cluster/pkg/defaults"
 )
 
 // SerializeSpec serialize the provided spec inside a HostPreflight object and


### PR DESCRIPTION
After preflights complete, installing k0s would start. This code path that installs k0s did not have progress output which made the UI look slightly odd. This PR adds code that starts the spinner immediately after preflights complete to indicate the start of node installation. We additionally, attach appropriate status progress messages to the spinner.

Below are recordings of some sample outputs

In these recordings, note that we now have `Installing <application> node` progress output right after preflights complete.

**Original implementation where after preflights complete, there would be a moment of no progress output**

https://github.com/replicatedhq/embedded-cluster/assets/681087/ce8e60f5-5fc0-4b2f-a129-322ca4c55143

**Spinner with default host preflights. The preflights run is quite fast for the human eye**

https://github.com/replicatedhq/embedded-cluster/assets/681087/637d8ee9-480e-43cb-b33d-2c5fbb453700

**Spinner with default host preflights plus a collector that runs for a few seconds. This better visualises this code path**

https://github.com/replicatedhq/embedded-cluster/assets/681087/c3183470-83a9-4427-bf51-d3e2aadd716c

**Spinner with default host preflights with failure**

https://github.com/replicatedhq/embedded-cluster/assets/681087/aa012094-a7ba-4ecc-a569-5c53492a688c


