### PR TITLE
fix(ci): add back LDFLAGS for kots regression tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VERSION ?= $(shell git describe --tags --dirty)
 UNAME := $(shell uname)
 ARCH := $(shell uname -m)
 APP_NAME = embedded-cluster
-ADMIN_CONSOLE_CHART_REPO = registry.replicated.com/library/admin-console
+ADMIN_CONSOLE_CHART_REPO_OVERRIDE =
 ADMIN_CONSOLE_CHART_VERSION = 1.109.13
 ADMIN_CONSOLE_IMAGE_OVERRIDE =
 ADMIN_CONSOLE_MIGRATIONS_IMAGE_OVERRIDE =
@@ -33,7 +33,7 @@ LD_FLAGS = -X github.com/replicatedhq/embedded-cluster/pkg/defaults.K0sVersion=$
 	-X github.com/replicatedhq/embedded-cluster/pkg/defaults.TroubleshootVersion=$(TROUBLESHOOT_VERSION) \
 	-X github.com/replicatedhq/embedded-cluster/pkg/defaults.KubectlVersion=$(KUBECTL_VERSION) \
 	-X github.com/replicatedhq/embedded-cluster/pkg/defaults.LocalArtifactMirrorImage=$(LOCAL_ARTIFACT_MIRROR_IMAGE_LOCATION) \
-	-X github.com/replicatedhq/embedded-cluster/pkg/addons/adminconsole.ChartRepo=$(ADMIN_CONSOLE_CHART_REPO) \
+	-X github.com/replicatedhq/embedded-cluster/pkg/addons/adminconsole.ChartRepoOverride=$(ADMIN_CONSOLE_CHART_REPO_OVERRIDE) \
 	-X github.com/replicatedhq/embedded-cluster/pkg/addons/adminconsole.Version=$(ADMIN_CONSOLE_CHART_VERSION) \
 	-X github.com/replicatedhq/embedded-cluster/pkg/addons/adminconsole.ImageOverride=$(ADMIN_CONSOLE_IMAGE_OVERRIDE) \
 	-X github.com/replicatedhq/embedded-cluster/pkg/addons/adminconsole.MigrationsImageOverride=$(ADMIN_CONSOLE_MIGRATIONS_IMAGE_OVERRIDE) \

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ VERSION ?= $(shell git describe --tags --dirty)
 UNAME := $(shell uname)
 ARCH := $(shell uname -m)
 APP_NAME = embedded-cluster
+ADMIN_CONSOLE_CHART_REPO = registry.replicated.com/library/admin-console
 ADMIN_CONSOLE_CHART_VERSION = 1.109.13
 ADMIN_CONSOLE_IMAGE_OVERRIDE =
 ADMIN_CONSOLE_MIGRATIONS_IMAGE_OVERRIDE =
@@ -32,6 +33,7 @@ LD_FLAGS = -X github.com/replicatedhq/embedded-cluster/pkg/defaults.K0sVersion=$
 	-X github.com/replicatedhq/embedded-cluster/pkg/defaults.TroubleshootVersion=$(TROUBLESHOOT_VERSION) \
 	-X github.com/replicatedhq/embedded-cluster/pkg/defaults.KubectlVersion=$(KUBECTL_VERSION) \
 	-X github.com/replicatedhq/embedded-cluster/pkg/defaults.LocalArtifactMirrorImage=$(LOCAL_ARTIFACT_MIRROR_IMAGE_LOCATION) \
+	-X github.com/replicatedhq/embedded-cluster/pkg/addons/adminconsole.ChartRepo=$(ADMIN_CONSOLE_CHART_REPO) \
 	-X github.com/replicatedhq/embedded-cluster/pkg/addons/adminconsole.Version=$(ADMIN_CONSOLE_CHART_VERSION) \
 	-X github.com/replicatedhq/embedded-cluster/pkg/addons/adminconsole.ImageOverride=$(ADMIN_CONSOLE_IMAGE_OVERRIDE) \
 	-X github.com/replicatedhq/embedded-cluster/pkg/addons/adminconsole.MigrationsImageOverride=$(ADMIN_CONSOLE_MIGRATIONS_IMAGE_OVERRIDE) \

--- a/pkg/addons/adminconsole/adminconsole.go
+++ b/pkg/addons/adminconsole/adminconsole.go
@@ -31,11 +31,11 @@ import (
 
 const (
 	releaseName = "admin-console"
-	chartURL    = "oci://proxy.replicated.com/anonymous/registry.replicated.com/library/admin-console"
 )
 
 // Overwritten by -ldflags in Makefile
 var (
+	ChartRepo               = "registry.replicated.com/library/admin-console"
 	Version                 = "v0.0.0"
 	ImageOverride           = ""
 	MigrationsImageOverride = ""
@@ -156,9 +156,10 @@ func (a *AdminConsole) GenerateHelmConfig(onlyDefaults bool) ([]v1beta1.Chart, [
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to marshal helm values: %w", err)
 	}
+
 	chartConfig := v1beta1.Chart{
 		Name:      releaseName,
-		ChartName: chartURL,
+		ChartName: fmt.Sprintf("oci://proxy.replicated.com/anonymous/%s", ChartRepo),
 		Version:   Version,
 		Values:    string(values),
 		TargetNS:  a.namespace,

--- a/pkg/addons/adminconsole/adminconsole.go
+++ b/pkg/addons/adminconsole/adminconsole.go
@@ -36,6 +36,7 @@ const (
 
 // Overwritten by -ldflags in Makefile
 var (
+	// ChartRepoOverride is used by KOTS regression automation to override the default chart repo.
 	ChartRepoOverride       = ""
 	Version                 = "v0.0.0"
 	ImageOverride           = ""

--- a/pkg/addons/adminconsole/adminconsole.go
+++ b/pkg/addons/adminconsole/adminconsole.go
@@ -30,12 +30,13 @@ import (
 )
 
 const (
+	chartRepo   = "registry.replicated.com/library/admin-console"
 	releaseName = "admin-console"
 )
 
 // Overwritten by -ldflags in Makefile
 var (
-	ChartRepo               = "registry.replicated.com/library/admin-console"
+	ChartRepoOverride       = ""
 	Version                 = "v0.0.0"
 	ImageOverride           = ""
 	MigrationsImageOverride = ""
@@ -157,9 +158,16 @@ func (a *AdminConsole) GenerateHelmConfig(onlyDefaults bool) ([]v1beta1.Chart, [
 		return nil, nil, fmt.Errorf("unable to marshal helm values: %w", err)
 	}
 
+	var chartName string
+	if ChartRepoOverride != "" {
+		chartName = fmt.Sprintf("oci://proxy.replicated.com/anonymous/%s", ChartRepoOverride)
+	} else {
+		chartName = fmt.Sprintf("oci://proxy.replicated.com/anonymous/%s", chartRepo)
+	}
+
 	chartConfig := v1beta1.Chart{
 		Name:      releaseName,
-		ChartName: fmt.Sprintf("oci://proxy.replicated.com/anonymous/%s", ChartRepo),
+		ChartName: chartName,
 		Version:   Version,
 		Values:    string(values),
 		TargetNS:  a.namespace,


### PR DESCRIPTION
Tests are currently failing with error:

> Jul 09 13:39:11 ethanm-testim-1 k0s[17319]: time="2024-07-09 13:39:11" level=error msg="Reconciler error" Chart="{k0s-addon-chart-admin-console kube-system}" component=extensions_controller controller=chart controllerGroup=helm.k0sproject.io controllerKind=Chart error="can't update or install chart: can't reconcile installation for \"k0s-addon-chart-admin-console\": can't locate chart `oci://proxy.replicated.com/anonymous/registry.replicated.com/library/admin-console-2024.7.8-0e7299-nightly`: proxy.replicated.com/anonymous/registry.replicated.com/library/admin-console:2024.7.8-0e7299-nightly: not found" name=k0s-addon-chart-admin-console namespace=kube-system reconcileID="\"18f050e0-1b45-436f-b8aa-833a421517ad\""

https://github.com/replicatedhq/kots/actions/runs/9848077473/job/27189811167

Related:
https://github.com/replicatedhq/kots-regression-automation/pull/118