### PR TITLE
CLI flag and password prompt improvements

### DIFF
--- a/cmd/embedded-cluster/install.go
+++ b/cmd/embedded-cluster/install.go
@@ -529,10 +529,18 @@ func runOutro(c *cli.Context, cfg *k0sconfig.ClusterConfig, adminConsolePwd stri
 }
 
 func askAdminConsolePassword(c *cli.Context) (string, error) {
-	defaultPass := "password"
+	defaultPassword := "password"
+	userProvidedPassword := c.String("admin-console-password")
 	if c.Bool("no-prompt") {
-		logrus.Infof("The Admin Console password is set to %s", defaultPass)
-		return defaultPass, nil
+		if userProvidedPassword != "" {
+			return userProvidedPassword, nil
+		} else {
+			logrus.Infof("The Admin Console password is set to %s", defaultPassword)
+			return defaultPassword, nil
+		}
+	}
+	if userProvidedPassword != "" {
+		return userProvidedPassword, nil
 	}
 	maxTries := 3
 	for i := 0; i < maxTries; i++ {
@@ -565,6 +573,11 @@ var installCommand = &cli.Command{
 	},
 	Flags: []cli.Flag{
 		&cli.StringFlag{
+			Name:   "admin-console-password",
+			Usage:  "Password for the Admin Console",
+			Hidden: false,
+		},
+		&cli.StringFlag{
 			Name:   "airgap-bundle",
 			Usage:  "Path to the air gap bundle. If set, the installation will complete without internet access.",
 			Hidden: true,
@@ -580,11 +593,10 @@ var installCommand = &cli.Command{
 			Hidden: false,
 		},
 		&cli.StringFlag{
-			Name:     "license",
-			Aliases:  []string{"l"},
-			Usage:    "Path to the license file",
-			Hidden:   false,
-			Required: true,
+			Name:    "license",
+			Aliases: []string{"l"},
+			Usage:   "Path to the license file",
+			Hidden:  false,
 		},
 		&cli.BoolFlag{
 			Name:  "no-prompt",

--- a/cmd/embedded-cluster/install.go
+++ b/cmd/embedded-cluster/install.go
@@ -531,21 +531,21 @@ func runOutro(c *cli.Context, cfg *k0sconfig.ClusterConfig, adminConsolePwd stri
 func askAdminConsolePassword(c *cli.Context) (string, error) {
 	defaultPass := "password"
 	if c.Bool("no-prompt") {
-		logrus.Infof("Admin Console password set to: %s", defaultPass)
+		logrus.Infof("The Admin Console password is set to %s", defaultPass)
 		return defaultPass, nil
 	}
 	maxTries := 3
 	for i := 0; i < maxTries; i++ {
-		promptA := prompts.New().Password("Enter an Admin Console password:")
-		promptB := prompts.New().Password("Confirm password:")
+		promptA := prompts.New().Password("Set the Admin Console password:")
+		promptB := prompts.New().Password("Confirm the Admin Console password:")
 
 		if promptA == promptB {
 			// TODO: Should we add extra password validation here? e.g length, complexity etc
 			return promptA, nil
 		}
-		logrus.Info("Passwords don't match, please try again.")
+		logrus.Info("Passwords don't match. Please try again.")
 	}
-	return "", fmt.Errorf("unable to set Admin Console password after %d tries", maxTries)
+	return "", fmt.Errorf("unable to set the Admin Console password after %d tries", maxTries)
 }
 
 // installCommands executes the "install" command. This will ensure that a k0s.yaml file exists
@@ -566,7 +566,7 @@ var installCommand = &cli.Command{
 	Flags: []cli.Flag{
 		&cli.BoolFlag{
 			Name:  "no-prompt",
-			Usage: "Disable interactive prompts. Admin console password will be set to password.",
+			Usage: "Disable interactive prompts. The Admin Console password will be set to password.",
 			Value: false,
 		},
 		&cli.StringFlag{

--- a/cmd/embedded-cluster/install.go
+++ b/cmd/embedded-cluster/install.go
@@ -577,27 +577,27 @@ var installCommand = &cli.Command{
 		&cli.StringFlag{
 			Name:    "license",
 			Aliases: []string{"l"},
-			Usage:   "Path to the application license file",
+			Usage:   "Path to the license file",
 			Hidden:  false,
 		},
 		&cli.StringFlag{
 			Name:   "airgap-bundle",
-			Usage:  "Path to the airgap bundle. If set, the installation will be completed without internet access.",
+			Usage:  "Path to the air gap bundle. If set, the installation will complete without internet access.",
 			Hidden: true,
 		},
 		&cli.StringFlag{
 			Name:   "http-proxy",
-			Usage:  "HTTP proxy to use for the installation",
+			Usage:  "Proxy server to use for HTTP",
 			Hidden: false,
 		},
 		&cli.StringFlag{
 			Name:   "https-proxy",
-			Usage:  "HTTPS proxy to use for the installation",
+			Usage:  "Proxy server to use for HTTPS",
 			Hidden: false,
 		},
 		&cli.StringFlag{
 			Name:   "no-proxy",
-			Usage:  "Comma separated list of hosts to bypass the proxy for",
+			Usage:  "Comma-separated list of hosts for which not to use a proxy",
 			Hidden: false,
 		},
 		&cli.BoolFlag{
@@ -607,17 +607,17 @@ var installCommand = &cli.Command{
 		},
 		&cli.StringFlag{
 			Name:   "pod-cidr",
-			Usage:  "pod CIDR range to use for the installation",
+			Usage:  "IP address range for pods",
 			Hidden: false,
 		},
 		&cli.StringFlag{
 			Name:   "service-cidr",
-			Usage:  "service CIDR range to use for the installation",
+			Usage:  "IP address range for services",
 			Hidden: false,
 		},
 		&cli.BoolFlag{
 			Name:  "skip-host-preflights",
-			Usage: "Skip host preflight checks. This is not recommended unless you are sure your system is compatible.",
+			Usage: "Skip host preflight checks. This is not recommended.",
 			Value: false,
 		},
 	},

--- a/cmd/embedded-cluster/install.go
+++ b/cmd/embedded-cluster/install.go
@@ -564,22 +564,6 @@ var installCommand = &cli.Command{
 		return nil
 	},
 	Flags: []cli.Flag{
-		&cli.BoolFlag{
-			Name:  "no-prompt",
-			Usage: "Disable interactive prompts. The Admin Console password will be set to password.",
-			Value: false,
-		},
-		&cli.StringFlag{
-			Name:   "overrides",
-			Usage:  "File with an EmbeddedClusterConfig object to override the default configuration",
-			Hidden: true,
-		},
-		&cli.StringFlag{
-			Name:    "license",
-			Aliases: []string{"l"},
-			Usage:   "Path to the license file",
-			Hidden:  false,
-		},
 		&cli.StringFlag{
 			Name:   "airgap-bundle",
 			Usage:  "Path to the air gap bundle. If set, the installation will complete without internet access.",
@@ -596,19 +580,36 @@ var installCommand = &cli.Command{
 			Hidden: false,
 		},
 		&cli.StringFlag{
+			Name:     "license",
+			Aliases:  []string{"l"},
+			Usage:    "Path to the license file",
+			Hidden:   false,
+			Required: true,
+		},
+		&cli.BoolFlag{
+			Name:  "no-prompt",
+			Usage: "Disable interactive prompts. The Admin Console password will be set to password.",
+			Value: false,
+		},
+		&cli.StringFlag{
 			Name:   "no-proxy",
 			Usage:  "Comma-separated list of hosts for which not to use a proxy",
 			Hidden: false,
 		},
-		&cli.BoolFlag{
-			Name:   "proxy",
-			Usage:  "Use the system proxy settings for the install operation. These variables are currently only passed through to Velero and the Admin Console.",
+		&cli.StringFlag{
+			Name:   "overrides",
+			Usage:  "File with an EmbeddedClusterConfig object to override the default configuration",
 			Hidden: true,
 		},
 		&cli.StringFlag{
 			Name:   "pod-cidr",
 			Usage:  "IP address range for pods",
 			Hidden: false,
+		},
+		&cli.BoolFlag{
+			Name:   "proxy",
+			Usage:  "Use the system proxy settings for the install operation. These variables are currently only passed through to Velero and the Admin Console.",
+			Hidden: true,
 		},
 		&cli.StringFlag{
 			Name:   "service-cidr",

--- a/cmd/embedded-cluster/join.go
+++ b/cmd/embedded-cluster/join.go
@@ -136,7 +136,7 @@ var joinCommand = &cli.Command{
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:   "airgap-bundle",
-			Usage:  "Path to the airgap bundle. If set, the installation will be completed without internet access.",
+			Usage:  "Path to the air gap bundle. If set, the installation will complete without internet access.",
 			Hidden: true,
 		},
 		&cli.BoolFlag{
@@ -146,7 +146,7 @@ var joinCommand = &cli.Command{
 		},
 		&cli.BoolFlag{
 			Name:  "skip-host-preflights",
-			Usage: "Skip host preflight checks. This is not recommended unless you are sure your system is compatible.",
+			Usage: "Skip host preflight checks. This is not recommended.",
 			Value: false,
 		},
 	},

--- a/cmd/embedded-cluster/restore.go
+++ b/cmd/embedded-cluster/restore.go
@@ -923,12 +923,12 @@ var restoreCommand = &cli.Command{
 		},
 		&cli.StringFlag{
 			Name:   "pod-cidr",
-			Usage:  "pod CIDR range to use for the installation",
+			Usage:  "IP address range for pods. Must match range provided during install.",
 			Hidden: false,
 		},
 		&cli.StringFlag{
 			Name:   "service-cidr",
-			Usage:  "service CIDR range to use for the installation",
+			Usage:  "IP address range for services. Must match range provided during install.",
 			Hidden: false,
 		},
 		&cli.BoolFlag{

--- a/cmd/embedded-cluster/restore.go
+++ b/cmd/embedded-cluster/restore.go
@@ -898,22 +898,22 @@ var restoreCommand = &cli.Command{
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:   "airgap-bundle",
-			Usage:  "Path to the airgap bundle. If set, the restore will be completed without internet access.",
+			Usage:  "Path to the air gap bundle. If set, the restore will complete without internet access.",
 			Hidden: true,
 		},
 		&cli.StringFlag{
 			Name:   "http-proxy",
-			Usage:  "HTTP proxy to use for the restore",
+			Usage:  "Proxy server to use for HTTP",
 			Hidden: false,
 		},
 		&cli.StringFlag{
 			Name:   "https-proxy",
-			Usage:  "HTTPS proxy to use for the restore",
+			Usage:  "Proxy server to use for HTTPS",
 			Hidden: false,
 		},
 		&cli.StringFlag{
 			Name:   "no-proxy",
-			Usage:  "Comma separated list of hosts to bypass the proxy for",
+			Usage:  "Comma-separated list of hosts for which not to use a proxy",
 			Hidden: false,
 		},
 		&cli.BoolFlag{
@@ -933,7 +933,7 @@ var restoreCommand = &cli.Command{
 		},
 		&cli.BoolFlag{
 			Name:  "skip-host-preflights",
-			Usage: "Skip host preflight checks. This is not recommended unless you are sure your system is compatible.",
+			Usage: "Skip host preflight checks. This is not recommended.",
 			Value: false,
 		},
 	},

--- a/cmd/embedded-cluster/uninstall.go
+++ b/cmd/embedded-cluster/uninstall.go
@@ -334,15 +334,15 @@ var resetCommand = &cli.Command{
 	Args: false,
 	Flags: []cli.Flag{
 		&cli.BoolFlag{
-			Name:  "no-prompt",
-			Usage: "Disable interactive prompts",
-			Value: false,
-		},
-		&cli.BoolFlag{
 			Name:    "force",
 			Aliases: []string{"f"},
 			Usage:   "Ignore errors encountered when resetting the node (implies --no-prompt)",
 			Value:   false,
+		},
+		&cli.BoolFlag{
+			Name:  "no-prompt",
+			Usage: "Disable interactive prompts",
+			Value: false,
 		},
 		&cli.BoolFlag{
 			Name:  "reboot",


### PR DESCRIPTION
- Adds `--admin-console-password` flag to `install`
- Alphabetizes CLI flags in help menus
- Updates descriptions for some CLI flags
- Updates wording for password prompt to make it clear you're setting the Admin Console password