### PR TITLE
Add host-preflight to check for default route

### DIFF
--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -24,7 +24,22 @@ spec:
     - time: {}
     - ipv4Interfaces: {}
     - kernelConfigs: {}
+    - run:
+        collectorName: "ip-route-table"
+        command: "ip"
+        args: ["route"]
   analyzers:
+    - textAnalyze:
+        checkName: Default route
+        fileName: host-collectors/run-host/ip-route-table.txt
+        regex: "default"
+        outcomes:
+          - fail:
+              when: "false"
+              message: "No default route found. A default route is required for cluster initialization"
+          - pass:
+              when: "true"
+              message: "Host has default route"
     - cpu:
         checkName: 'Number of CPUs in the system'
         outcomes:

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -36,7 +36,7 @@ spec:
         outcomes:
           - fail:
               when: "false"
-              message: "No default route found. A default route is required for cluster initialization"
+              message: "No default route found. A default route is required for cluster initialization."
           - pass:
               when: "true"
               message: "Host has default route"

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -39,7 +39,7 @@ spec:
               message: "No default route found. A default route is required for cluster initialization."
           - pass:
               when: "true"
-              message: "Host has default route"
+              message: "Host has a default route."
     - cpu:
         checkName: 'Number of CPUs in the system'
         outcomes:


### PR DESCRIPTION
This prevents a situation where an airgaped cluster install can be left hanging waiting for calico to initialize. 