### PR TITLE
Make suggestions if typo in command name

### DIFF
--- a/cmd/embedded-cluster/main.go
+++ b/cmd/embedded-cluster/main.go
@@ -24,8 +24,9 @@ func main() {
 	logging.SetupLogging()
 	name := path.Base(os.Args[0])
 	var app = &cli.App{
-		Name:  name,
-		Usage: fmt.Sprintf("Install and manage %s", name),
+		Name:    name,
+		Usage:   fmt.Sprintf("Install and manage %s", name),
+		Suggest: true,
 		Commands: []*cli.Command{
 			installCommand,
 			shellCommand,


### PR DESCRIPTION
Example:
```
alex@alex-ec-pr:~$ sudo ./embedded-cluster-smoke-test-staging-app instal
No help topic for 'instal'. Did you mean "install"?
```