### PR TITLE
chore: Add hostname mismatch support bundle check

### DIFF
--- a/pkg/goods/support/host-support-bundle.yaml
+++ b/pkg/goods/support/host-support-bundle.yaml
@@ -191,3 +191,14 @@ spec:
       - pass:
           when:  "local-artifact-mirror = active"
           message: Local Artifact Mirror is active
+  - textAnalyze:
+      checkName: Hostname Mismatch
+      fileName: host-collectors/run-host/k0scontroller-logs.txt
+      regex: ".*can only access node lease with the same name as the requesting node.*"
+      outcomes:
+        - fail:
+            when: "true"
+            message: "Possible hostname change. Verify that the current hostname matches what's expected by the k8s control plane"
+        - pass:
+            when: "false"
+            message: "No signs of hostname changes found"


### PR DESCRIPTION
Fixes: https://app.shortcut.com/replicated/story/108807/analyzers-in-default-spec-not-compatible-with-k0s-deployments
Demo: https://asciinema.org/a/jX7izIBEaFbWZP9pTUiWvvmap