### PR TITLE
fix: pass service node port range to installation for join

### DIFF
--- a/cmd/embedded-cluster/list_images.go
+++ b/cmd/embedded-cluster/list_images.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/replicatedhq/embedded-cluster/pkg/config"
 	"github.com/urfave/cli/v2"
 )
 
@@ -11,7 +12,9 @@ var listImagesCommand = &cli.Command{
 	Usage:  "List images embedded in the cluster",
 	Hidden: true,
 	Action: func(c *cli.Context) error {
-		metadata, err := gatherVersionMetadata()
+		k0sCfg := config.RenderK0sConfig()
+
+		metadata, err := gatherVersionMetadata(k0sCfg)
 		if err != nil {
 			return fmt.Errorf("failed to gather version metadata: %w", err)
 		}

--- a/pkg/addons/embeddedclusteroperator/embeddedclusteroperator.go
+++ b/pkg/addons/embeddedclusteroperator/embeddedclusteroperator.go
@@ -200,10 +200,8 @@ func (e *EmbeddedClusterOperator) Outro(ctx context.Context, cli client.Client, 
 	}
 	loading.Closef("Embedded Cluster Operator is ready!")
 
-	if e.airgap {
-		if err := e.createVersionMetadataConfigmap(ctx, cli, releaseMetadata); err != nil {
-			return fmt.Errorf("unable to create version metadata: %w", err)
-		}
+	if err := e.createVersionMetadataConfigmap(ctx, cli, releaseMetadata); err != nil {
+		return fmt.Errorf("unable to create version metadata: %w", err)
 	}
 
 	cfg, err := release.GetEmbeddedClusterConfig()

--- a/pkg/addons/openebs/openebs.go
+++ b/pkg/addons/openebs/openebs.go
@@ -7,7 +7,9 @@ import (
 	_ "embed"
 	"fmt"
 
-	eckinds "github.com/replicatedhq/embedded-cluster-kinds/apis/v1beta1"
+	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+	ecv1beta1 "github.com/replicatedhq/embedded-cluster-kinds/apis/v1beta1"
+	"github.com/replicatedhq/embedded-cluster-kinds/types"
 	"github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"gopkg.in/yaml.v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -70,8 +72,8 @@ func (o *OpenEBS) GetProtectedFields() map[string][]string {
 }
 
 // GenerateHelmConfig generates the helm config for the OpenEBS chart.
-func (o *OpenEBS) GenerateHelmConfig(onlyDefaults bool) ([]eckinds.Chart, []eckinds.Repository, error) {
-	chartConfig := eckinds.Chart{
+func (o *OpenEBS) GenerateHelmConfig(k0sCfg *k0sv1beta1.ClusterConfig, onlyDefaults bool) ([]ecv1beta1.Chart, []ecv1beta1.Repository, error) {
+	chartConfig := ecv1beta1.Chart{
 		Name:      releaseName,
 		ChartName: Metadata.Location,
 		Version:   Metadata.Version,
@@ -85,7 +87,7 @@ func (o *OpenEBS) GenerateHelmConfig(onlyDefaults bool) ([]eckinds.Chart, []ecki
 	}
 	chartConfig.Values = string(valuesStringData)
 
-	return []eckinds.Chart{chartConfig}, nil, nil
+	return []ecv1beta1.Chart{chartConfig}, nil, nil
 }
 
 func (a *OpenEBS) GetImages() []string {
@@ -105,7 +107,7 @@ func (o *OpenEBS) GetAdditionalImages() []string {
 }
 
 // Outro is executed after the cluster deployment.
-func (o *OpenEBS) Outro(ctx context.Context, cli client.Client) error {
+func (o *OpenEBS) Outro(ctx context.Context, cli client.Client, k0sCfg *k0sv1beta1.ClusterConfig, releaseMetadata *types.ReleaseMetadata) error {
 	loading := spinner.Start()
 	loading.Infof("Waiting for Storage to be ready")
 	if err := kubeutils.WaitForDeployment(ctx, cli, namespace, "openebs-localpv-provisioner"); err != nil {

--- a/pkg/addons/options.go
+++ b/pkg/addons/options.go
@@ -4,9 +4,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	embeddedclusterv1beta1 "github.com/replicatedhq/embedded-cluster-kinds/apis/v1beta1"
-	"github.com/replicatedhq/embedded-cluster-kinds/types"
 	"github.com/replicatedhq/embedded-cluster/pkg/defaults"
 )
 
@@ -24,13 +22,6 @@ func WithoutPrompt() Option {
 func Quiet() Option {
 	return func(a *Applier) {
 		a.verbose = false
-	}
-}
-
-// WithConfig sets the helm config for the addons.
-func WithConfig(config v1beta1.ClusterConfig) Option {
-	return func(a *Applier) {
-		a.config = config
 	}
 }
 
@@ -64,13 +55,6 @@ func WithAirgapBundle(airgapBundle string) Option {
 	}
 }
 
-// WithVersionMetadata sets the release version metadata to be used during addons installation.
-func WithVersionMetadata(metadata *types.ReleaseMetadata) Option {
-	return func(a *Applier) {
-		a.releaseMetadata = metadata
-	}
-}
-
 // WithProxyFromEnv sets the proxy environment variables to be used during addons installation.
 func WithProxyFromEnv(podCIDR, serviceCIDR string) Option {
 	return WithProxyFromArgs(os.Getenv("HTTP_PROXY"), os.Getenv("HTTPS_PROXY"), os.Getenv("NO_PROXY"), podCIDR, serviceCIDR)
@@ -93,12 +77,5 @@ func WithProxyFromArgs(httpProxy string, httpsProxy string, noProxy string, podC
 func WithAdminConsolePassword(password string) Option {
 	return func(a *Applier) {
 		a.adminConsolePwd = password
-	}
-}
-
-// WithNetwork sets the network configuration for the cluster
-func WithNetwork(network *embeddedclusterv1beta1.NetworkSpec) Option {
-	return func(a *Applier) {
-		a.network = network
 	}
 }

--- a/pkg/addons/seaweedfs/seaweedfs.go
+++ b/pkg/addons/seaweedfs/seaweedfs.go
@@ -6,8 +6,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
-	eckinds "github.com/replicatedhq/embedded-cluster-kinds/apis/v1beta1"
+	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+	ecv1beta1 "github.com/replicatedhq/embedded-cluster-kinds/apis/v1beta1"
+	"github.com/replicatedhq/embedded-cluster-kinds/types"
 	"github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -44,7 +45,6 @@ func init() {
 // SeaweedFS manages the installation of the SeaweedFS helm chart.
 type SeaweedFS struct {
 	namespace string
-	config    v1beta1.ClusterConfig
 	isAirgap  bool
 }
 
@@ -71,12 +71,12 @@ func (o *SeaweedFS) GetProtectedFields() map[string][]string {
 }
 
 // GenerateHelmConfig generates the helm config for the SeaweedFS chart.
-func (o *SeaweedFS) GenerateHelmConfig(onlyDefaults bool) ([]eckinds.Chart, []eckinds.Repository, error) {
+func (o *SeaweedFS) GenerateHelmConfig(k0sCfg *k0sv1beta1.ClusterConfig, onlyDefaults bool) ([]ecv1beta1.Chart, []ecv1beta1.Repository, error) {
 	if !o.isAirgap {
 		return nil, nil, nil
 	}
 
-	chartConfig := eckinds.Chart{
+	chartConfig := ecv1beta1.Chart{
 		Name:      releaseName,
 		ChartName: Metadata.Location,
 		Version:   Metadata.Version,
@@ -90,7 +90,7 @@ func (o *SeaweedFS) GenerateHelmConfig(onlyDefaults bool) ([]eckinds.Chart, []ec
 	}
 	chartConfig.Values = string(valuesStringData)
 
-	return []eckinds.Chart{chartConfig}, nil, nil
+	return []ecv1beta1.Chart{chartConfig}, nil, nil
 }
 
 func (a *SeaweedFS) GetImages() []string {
@@ -106,14 +106,14 @@ func (o *SeaweedFS) GetAdditionalImages() []string {
 }
 
 // Outro is executed after the cluster deployment.
-func (o *SeaweedFS) Outro(ctx context.Context, cli client.Client) error {
+func (o *SeaweedFS) Outro(ctx context.Context, cli client.Client, k0sCfg *k0sv1beta1.ClusterConfig, releaseMetadata *types.ReleaseMetadata) error {
 	// SeaweedFS is applied by the operator
 	return nil
 }
 
 // New creates a new SeaweedFS addon.
-func New(namespace string, config v1beta1.ClusterConfig, isAirgap bool) (*SeaweedFS, error) {
-	return &SeaweedFS{namespace: namespace, config: config, isAirgap: isAirgap}, nil
+func New(namespace string, isAirgap bool) (*SeaweedFS, error) {
+	return &SeaweedFS{namespace: namespace, isAirgap: isAirgap}, nil
 }
 
 // WaitForReady waits for SeaweedFS to be ready.

--- a/pkg/addons/velero/velero.go
+++ b/pkg/addons/velero/velero.go
@@ -5,7 +5,9 @@ import (
 	_ "embed"
 	"fmt"
 
-	eckinds "github.com/replicatedhq/embedded-cluster-kinds/apis/v1beta1"
+	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+	ecv1beta1 "github.com/replicatedhq/embedded-cluster-kinds/apis/v1beta1"
+	"github.com/replicatedhq/embedded-cluster-kinds/types"
 	"github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
@@ -73,12 +75,12 @@ func (o *Velero) GetProtectedFields() map[string][]string {
 }
 
 // GenerateHelmConfig generates the helm config for the Velero chart.
-func (o *Velero) GenerateHelmConfig(onlyDefaults bool) ([]eckinds.Chart, []eckinds.Repository, error) {
+func (o *Velero) GenerateHelmConfig(k0sCfg *k0sv1beta1.ClusterConfig, onlyDefaults bool) ([]ecv1beta1.Chart, []ecv1beta1.Repository, error) {
 	if !o.isEnabled {
 		return nil, nil, nil
 	}
 
-	chartConfig := eckinds.Chart{
+	chartConfig := ecv1beta1.Chart{
 		Name:      releaseName,
 		ChartName: Metadata.Location,
 		Version:   Metadata.Version,
@@ -102,7 +104,7 @@ func (o *Velero) GenerateHelmConfig(onlyDefaults bool) ([]eckinds.Chart, []eckin
 	}
 	chartConfig.Values = string(valuesStringData)
 
-	return []eckinds.Chart{chartConfig}, nil, nil
+	return []ecv1beta1.Chart{chartConfig}, nil, nil
 }
 
 func (a *Velero) GetImages() []string {
@@ -125,7 +127,7 @@ func (o *Velero) GetAdditionalImages() []string {
 }
 
 // Outro is executed after the cluster deployment.
-func (o *Velero) Outro(ctx context.Context, cli client.Client) error {
+func (o *Velero) Outro(ctx context.Context, cli client.Client, k0sCfg *k0sv1beta1.ClusterConfig, releaseMetadata *types.ReleaseMetadata) error {
 	if !o.isEnabled {
 		return nil
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -54,25 +54,23 @@ func RenderK0sConfig() *k0sconfig.ClusterConfig {
 }
 
 // UpdateHelmConfigs updates the helm config in the provided cluster configuration.
-func UpdateHelmConfigs(cfg *k0sconfig.ClusterConfig, opts ...addons.Option) error {
-	applier := addons.NewApplier(opts...)
+func UpdateHelmConfigs(applier *addons.Applier, k0sCfg *k0sconfig.ClusterConfig) error {
 	chtconfig, repconfig, err := applier.GenerateHelmConfigs(
-		AdditionalCharts(), AdditionalRepositories(),
+		k0sCfg, AdditionalCharts(), AdditionalRepositories(),
 	)
 	if err != nil {
 		return fmt.Errorf("unable to apply addons: %w", err)
 	}
-	return updateHelmConfigs(cfg, chtconfig, repconfig)
+	return updateHelmConfigs(k0sCfg, chtconfig, repconfig)
 }
 
 // UpdateHelmConfigsForRestore updates the helm config in the provided cluster configuration for a restore operation.
-func UpdateHelmConfigsForRestore(cfg *k0sconfig.ClusterConfig, opts ...addons.Option) error {
-	applier := addons.NewApplier(opts...)
-	chtconfig, repconfig, err := applier.GenerateHelmConfigsForRestore()
+func UpdateHelmConfigsForRestore(applier *addons.Applier, k0sCfg *k0sconfig.ClusterConfig) error {
+	chtconfig, repconfig, err := applier.GenerateHelmConfigsForRestore(k0sCfg)
 	if err != nil {
 		return fmt.Errorf("unable to apply addons: %w", err)
 	}
-	return updateHelmConfigs(cfg, chtconfig, repconfig)
+	return updateHelmConfigs(k0sCfg, chtconfig, repconfig)
 }
 
 func updateHelmConfigs(cfg *k0sconfig.ClusterConfig, chtconfig []embeddedclusterv1beta1.Chart, repconfig []embeddedclusterv1beta1.Repository) error {

--- a/pkg/helpers/parse.go
+++ b/pkg/helpers/parse.go
@@ -11,6 +11,9 @@ import (
 
 // ParseEndUserConfig parses the end user configuration from the given file.
 func ParseEndUserConfig(fpath string) (*embeddedclusterv1beta1.Config, error) {
+	if fpath == "" {
+		return nil, nil
+	}
 	data, err := os.ReadFile(fpath)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read overrides file: %w", err)


### PR DESCRIPTION
This sets the computed value of service-node-port-range in the installation object for later use in the join command from the defaults taking into account the unsupported overrides from both the spec and the install flag.

This fixes an issue that could cause node joins to use a different value for the service-node-port-range than on the original node.