### PR TITLE
fix(reset): fix panic

### DIFF
--- a/cmd/embedded-cluster/uninstall.go
+++ b/cmd/embedded-cluster/uninstall.go
@@ -400,7 +400,10 @@ var resetCommand = &cli.Command{
 			}
 		}
 
-		numControllerNodes, _ := kubeutils.NumOfControlPlaneNodes(c.Context, currentHost.Kclient)
+		var numControllerNodes int
+		if currentHost.KclientError == nil {
+			numControllerNodes, _ = kubeutils.NumOfControlPlaneNodes(c.Context, currentHost.Kclient)
+		}
 		// do not drain node if this is the only controller node in the cluster
 		// if there is an error (numControllerNodes == 0), drain anyway to be safe
 		if currentHost.Status.Role != "controller" || numControllerNodes != 1 {


### PR DESCRIPTION
```
$ sudo ./embedded-cluster-smoke-test-staging-app reset
This will remove this node from the cluster and completely reset it, removing all data stored on the node.
Do not reset another node until this is complete.
? Do you want to continue? Yes
error: fork/exec /usr/local/bin/k0s: no such file or directory
An error occurred while trying to reset this node.
Continuing may leave the cluster in an unexpected state.
? Do you want to continue anyway? Yes
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x15ac69c]

goroutine 1 [running]:
github.com/replicatedhq/embedded-cluster/pkg/kubeutils.NumOfControlPlaneNodes({0x25733168, 0xc000068080}, {0x0, 0x0})
	/home/runner/work/embedded-cluster/embedded-cluster/pkg/kubeutils/kubeutils.go:408 +0x17c
main.init.func14(0xc000a026c0)
	/home/runner/work/embedded-cluster/embedded-cluster/cmd/embedded-cluster/uninstall.go:403 +0x412
github.com/urfave/cli/v2.(*Command).Run(0x26790360, 0xc000a026c0, {0xc0006a04c0, 0x1, 0x1})
	/home/runner/go/pkg/mod/github.com/urfave/cli/v2@v2.27.3/command.go:276 +0x97d
github.com/urfave/cli/v2.(*Command).Run(0xc000b1c160, 0xc000a02600, {0xc000050040, 0x2, 0x2})
	/home/runner/go/pkg/mod/github.com/urfave/cli/v2@v2.27.3/command.go:269 +0xbb7
github.com/urfave/cli/v2.(*App).RunContext(0xc000195000, {0x25733168, 0xc000068080}, {0xc000050040, 0x2, 0x2})
	/home/runner/go/pkg/mod/github.com/urfave/cli/v2@v2.27.3/app.go:333 +0x5a5
main.main()
	/home/runner/work/embedded-cluster/embedded-cluster/cmd/embedded-cluster/main.go:42 +0x2e7
```