### PR TITLE
Bug: Don't check absolute paths for mount binaries

### DIFF
--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -264,7 +264,7 @@ spec:
     - textAnalyze:
         checkName: "'mount' Command"
         fileName: host-collectors/run-host/check-mount.txt
-        regex: 'mount'
+        regex: '/mount$'
         outcomes:
           - pass:
               when: "true"

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -275,7 +275,7 @@ spec:
     - textAnalyze:
         checkName: "'umount' Command"
         fileName: host-collectors/run-host/check-umount.txt
-        regex: 'umount'
+        regex: '/umount$'
         outcomes:
           - pass:
               when: "true"

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -253,7 +253,7 @@ spec:
     - textAnalyze:
         checkName: "'modprobe' Command"
         fileName: host-collectors/run-host/check-modprobe.txt
-        regex: '/usr/sbin/modprobe'
+        regex: 'modprobe'
         outcomes:
           - pass:
               when: "true"
@@ -264,7 +264,7 @@ spec:
     - textAnalyze:
         checkName: "'mount' Command"
         fileName: host-collectors/run-host/check-mount.txt
-        regex: '/usr/bin/mount'
+        regex: 'mount'
         outcomes:
           - pass:
               when: "true"
@@ -275,7 +275,7 @@ spec:
     - textAnalyze:
         checkName: "'umount' Command"
         fileName: host-collectors/run-host/check-umount.txt
-        regex: '/usr/bin/umount'
+        regex: 'umount'
         outcomes:
           - pass:
               when: "true"

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -253,7 +253,7 @@ spec:
     - textAnalyze:
         checkName: "'modprobe' Command"
         fileName: host-collectors/run-host/check-modprobe.txt
-        regex: '/modprobe$'
+        regex: 'modprobe'
         outcomes:
           - pass:
               when: "true"
@@ -264,7 +264,7 @@ spec:
     - textAnalyze:
         checkName: "'mount' Command"
         fileName: host-collectors/run-host/check-mount.txt
-        regex: '/mount$'
+        regex: 'mount'
         outcomes:
           - pass:
               when: "true"
@@ -275,7 +275,7 @@ spec:
     - textAnalyze:
         checkName: "'umount' Command"
         fileName: host-collectors/run-host/check-umount.txt
-        regex: '/umount$'
+        regex: 'umount'
         outcomes:
           - pass:
               when: "true"

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -253,7 +253,7 @@ spec:
     - textAnalyze:
         checkName: "'modprobe' Command"
         fileName: host-collectors/run-host/check-modprobe.txt
-        regex: 'modprobe'
+        regex: '/modprobe$'
         outcomes:
           - pass:
               when: "true"


### PR DESCRIPTION
Checking for absolute paths breaks these host preflights on systems that don't conform to Ubuntu's binary locations. 

i.e: Alpine and RHEL don't keep `mount` and `umount` in `/usr/bin`