### PR TITLE
fix(e2e): collect cluster support bundle if ec install fails

### DIFF
--- a/e2e/scripts/collect-support-bundle-cluster.sh
+++ b/e2e/scripts/collect-support-bundle-cluster.sh
@@ -2,7 +2,8 @@
 set -euox pipefail
 
 main() {
-    if ! kubectl support-bundle --output cluster.tar.gz --interactive=false --load-cluster-specs; then
+    local url="https://raw.githubusercontent.com/replicatedhq/embedded-cluster-operator/main/charts/embedded-cluster-operator/troubleshoot/cluster-support-bundle.yaml"
+    if ! kubectl support-bundle --output cluster.tar.gz --interactive=false --load-cluster-specs "$url" ; then
         echo "Failed to collect cluster support bundle"
         return 1
     fi


### PR DESCRIPTION
If the operator install fails the support bundle spec is not available in the cluster and collection fails. This change includes the url as well for debugging purposes.