### PR TITLE
feat(troubleshoot): add filesystem latency check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ LD_FLAGS = \
 	-X github.com/replicatedhq/embedded-cluster/pkg/addons/adminconsole.AdminConsoleMigrationsImageOverride=$(ADMIN_CONSOLE_MIGRATIONS_IMAGE_OVERRIDE) \
 	-X github.com/replicatedhq/embedded-cluster/pkg/addons/adminconsole.AdminConsoleKurlProxyImageOverride=$(ADMIN_CONSOLE_KURL_PROXY_IMAGE_OVERRIDE) \
 	-X github.com/replicatedhq/embedded-cluster/pkg/addons/embeddedclusteroperator.EmbeddedOperatorImageOverride=$(EMBEDDED_OPERATOR_IMAGE_OVERRIDE)
+DISABLE_FIO_BUILD ?= 0
 
 export PATH := $(shell pwd)/bin:$(PATH)
 
@@ -76,6 +77,16 @@ pkg/goods/bins/local-artifact-mirror: Makefile
 	$(MAKE) -C local-artifact-mirror build GOOS=linux GOARCH=amd64
 	cp local-artifact-mirror/bin/local-artifact-mirror-$(GOOS)-$(GOARCH) pkg/goods/bins/local-artifact-mirror
 
+pkg/goods/bins/fio: PLATFORM = linux/amd64
+pkg/goods/bins/fio: Makefile
+ifneq ($(DISABLE_FIO_BUILD),1)
+	mkdir -p pkg/goods/bins
+	docker build -t fio --build-arg PLATFORM=$(PLATFORM) fio
+	docker rm -f fio && docker run --name fio fio
+	docker cp fio:/output/fio pkg/goods/bins/fio
+	touch pkg/goods/bins/fio
+endif
+
 pkg/goods/internal/bins/kubectl-kots: Makefile
 	mkdir -p pkg/goods/internal/bins
 	mkdir -p output/tmp/kots
@@ -110,6 +121,7 @@ static: pkg/goods/bins/k0s \
 	pkg/goods/bins/kubectl-preflight \
 	pkg/goods/bins/kubectl-support_bundle \
 	pkg/goods/bins/local-artifact-mirror \
+	pkg/goods/bins/fio \
 	pkg/goods/internal/bins/kubectl-kots
 
 .PHONY: embedded-cluster-linux-amd64

--- a/cmd/embedded-cluster/install.go
+++ b/cmd/embedded-cluster/install.go
@@ -119,10 +119,13 @@ func runHostPreflights(c *cli.Context, hpf *v1beta2.HostPreflightSpec, proxy *ec
 		return nil
 	}
 	pb.Infof("Running host preflights")
-	output, err := preflights.Run(c.Context, hpf, proxy)
+	output, stderr, err := preflights.Run(c.Context, hpf, proxy)
 	if err != nil {
 		pb.CloseWithError()
 		return fmt.Errorf("host preflights failed to run: %w", err)
+	}
+	if stderr != "" {
+		logrus.Debugf("preflight stderr: %s", stderr)
 	}
 
 	err = output.SaveToDisk()
@@ -164,6 +167,9 @@ func runHostPreflights(c *cli.Context, hpf *v1beta2.HostPreflightSpec, proxy *ec
 		}
 		pb.CloseWithError()
 		output.PrintTableWithoutInfo()
+		if stderr != "" {
+			logrus.Debugf("preflight stderr: %s", stderr)
+		}
 		if !prompts.New().Confirm("Do you want to continue ?", false) {
 			return fmt.Errorf("user aborted")
 		}

--- a/cmd/embedded-cluster/install.go
+++ b/cmd/embedded-cluster/install.go
@@ -167,9 +167,6 @@ func runHostPreflights(c *cli.Context, hpf *v1beta2.HostPreflightSpec, proxy *ec
 		}
 		pb.CloseWithError()
 		output.PrintTableWithoutInfo()
-		if stderr != "" {
-			logrus.Debugf("preflight stderr: %s", stderr)
-		}
 		if !prompts.New().Confirm("Do you want to continue ?", false) {
 			return fmt.Errorf("user aborted")
 		}

--- a/e2e/materialize_test.go
+++ b/e2e/materialize_test.go
@@ -21,10 +21,12 @@ func TestMaterialize(t *testing.T) {
 		{"rm", "-rf", "/var/lib/embedded-cluster/bin/kubectl"},
 		{"rm", "-rf", "/var/lib/embedded-cluster/bin/kubectl-preflight"},
 		{"rm", "-rf", "/var/lib/embedded-cluster/bin/kubectl-support_bundle"},
+		{"rm", "-rf", "/var/lib/embedded-cluster/bin/fio"},
 		{"embedded-cluster", "materialize"},
 		{"ls", "-la", "/var/lib/embedded-cluster/bin/kubectl"},
 		{"ls", "-la", "/var/lib/embedded-cluster/bin/kubectl-preflight"},
 		{"ls", "-la", "/var/lib/embedded-cluster/bin/kubectl-support_bundle"},
+		{"ls", "-la", "/var/lib/embedded-cluster/bin/fio"},
 	}
 	if err := RunCommandsOnNode(t, tc, 0, commands); err != nil {
 		t.Fatalf("fail testing materialize assets: %v", err)

--- a/fio/Dockerfile
+++ b/fio/Dockerfile
@@ -1,0 +1,27 @@
+ARG PLATFORM=linux/amd64
+
+FROM --platform=$PLATFORM ubuntu:22.04 AS build
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG TZ=Etc/UTC
+
+RUN apt-get update \
+    && apt-get install -y \
+    build-essential cmake libstdc++6 pkg-config unzip wget
+
+RUN mkdir -p /fio
+WORKDIR /fio
+
+RUN wget -O- https://api.github.com/repos/axboe/fio/releases/latest \
+    | grep "tarball_url" \
+    | cut -d : -f 2,3 \
+    | tr -d '", ' \
+    | xargs -n1 wget -O fio.tar.gz -q
+RUN tar -xzf fio.tar.gz --strip-components=1
+
+RUN ./configure --build-static
+RUN make -j$(nproc)
+
+FROM ubuntu:22.04
+COPY --from=build /fio/fio /output/fio
+CMD [ "echo", "Done" ]

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -4,6 +4,11 @@
 package defaults
 
 var (
+	// DefaultProvider holds the default provider and is used by the exported functions.
+	DefaultProvider = NewProvider("")
+)
+
+var (
 	// provider holds a global reference to the default provider.
 	provider *Provider
 )
@@ -11,97 +16,88 @@ var (
 // Holds the default no proxy values.
 var DefaultNoProxy = []string{"localhost", "127.0.0.1", ".default", ".local", ".svc", "kubernetes", "kotsadm-rqlite"}
 
-var ProxyRegistryAddress = "proxy.replicated.com"
+const ProxyRegistryAddress = "proxy.replicated.com"
 
 const KotsadmNamespace = "kotsadm"
 const SeaweedFSNamespace = "seaweedfs"
 const RegistryNamespace = "registry"
 const VeleroNamespace = "velero"
 
-// def returns a global reference to the default provider. creates one if not
-// already created.
-func def() *Provider {
-	if provider == nil {
-		provider = NewProvider("")
-	}
-	return provider
-}
-
 // BinaryName calls BinaryName on the default provider.
 func BinaryName() string {
-	return def().BinaryName()
+	return DefaultProvider.BinaryName()
 }
 
 // EmbeddedClusterBinsSubDir calls EmbeddedClusterBinsSubDir on the default provider.
 func EmbeddedClusterBinsSubDir() string {
-	return def().EmbeddedClusterBinsSubDir()
+	return DefaultProvider.EmbeddedClusterBinsSubDir()
 }
 
 // EmbeddedClusterChartsSubDir calls EmbeddedClusterChartsSubDir on the default provider.
 func EmbeddedClusterChartsSubDir() string {
-	return def().EmbeddedClusterChartsSubDir()
+	return DefaultProvider.EmbeddedClusterChartsSubDir()
 }
 
 // EmbeddedClusterImagesSubDir calls EmbeddedClusterImagesSubDir on the default provider.
 func EmbeddedClusterImagesSubDir() string {
-	return def().EmbeddedClusterImagesSubDir()
+	return DefaultProvider.EmbeddedClusterImagesSubDir()
 }
 
 // EmbeddedClusterLogsSubDir calls EmbeddedClusterLogsSubDir on the default provider.
 func EmbeddedClusterLogsSubDir() string {
-	return def().EmbeddedClusterLogsSubDir()
+	return DefaultProvider.EmbeddedClusterLogsSubDir()
 }
 
 // K0sBinaryPath calls K0sBinaryPath on the default provider.
 func K0sBinaryPath() string {
-	return def().K0sBinaryPath()
+	return DefaultProvider.K0sBinaryPath()
 }
 
 // PathToEmbeddedClusterBinary calls PathToEmbeddedClusterBinary on the default provider.
 func PathToEmbeddedClusterBinary(name string) string {
-	return def().PathToEmbeddedClusterBinary(name)
+	return DefaultProvider.PathToEmbeddedClusterBinary(name)
 }
 
 // PathToLog calls PathToLog on the default provider.
 func PathToLog(name string) string {
-	return def().PathToLog(name)
+	return DefaultProvider.PathToLog(name)
 }
 
 // PathToKubeConfig calls PathToKubeConfig on the default provider.
 func PathToKubeConfig() string {
-	return def().PathToKubeConfig()
+	return DefaultProvider.PathToKubeConfig()
 }
 
 // PreferredNodeIPAddress calls PreferredNodeIPAddress on the default provider.
 func PreferredNodeIPAddress() (string, error) {
-	return def().PreferredNodeIPAddress()
+	return DefaultProvider.PreferredNodeIPAddress()
 }
 
 // TryDiscoverPublicIP calls TryDiscoverPublicIP on the default provider.
 func TryDiscoverPublicIP() string {
-	return def().TryDiscoverPublicIP()
+	return DefaultProvider.TryDiscoverPublicIP()
 }
 
 // PathToK0sConfig calls PathToK0sConfig on the default provider.
 func PathToK0sConfig() string {
-	return def().PathToK0sConfig()
+	return DefaultProvider.PathToK0sConfig()
 }
 
 // PathToK0sStatusSocket calls PathToK0sStatusSocket on the default provider.
 func PathToK0sStatusSocket() string {
-	return def().PathToK0sStatusSocket()
+	return DefaultProvider.PathToK0sStatusSocket()
 }
 
 func PathToK0sContainerdConfig() string {
-	return def().PathToK0sContainerdConfig()
+	return DefaultProvider.PathToK0sContainerdConfig()
 }
 
 // EmbeddedClusterHomeDirectory calls EmbeddedClusterHomeDirectory on the default provider.
 func EmbeddedClusterHomeDirectory() string {
-	return def().EmbeddedClusterHomeDirectory()
+	return DefaultProvider.EmbeddedClusterHomeDirectory()
 }
 
 // PathToEmbeddedClusterSupportFile calls PathToEmbeddedClusterSupportFile on the default provider.
 func PathToEmbeddedClusterSupportFile(name string) string {
-	return def().PathToEmbeddedClusterSupportFile(name)
+	return DefaultProvider.PathToEmbeddedClusterSupportFile(name)
 }

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -64,7 +64,7 @@ spec:
         command: 'sh'
         args: ['-c', 'cat /etc/resolv.conf']
     - filesystemPerformance:
-        collectorName: filesystem-latency-etcd
+        collectorName: filesystem-write-latency-etcd
         timeout: 2m
         directory: /var/lib/k0s/etcd
         fileSize: 22Mi
@@ -381,11 +381,11 @@ spec:
               when: "false"
               message: "resolv.conf does not reference '127.0.0.1'"
     - filesystemPerformance:
-        checkName: Filesystem Latency
-        collectorName: filesystem-latency-etcd
+        checkName: Filesystem Write Latency
+        collectorName: filesystem-write-latency-etcd
         outcomes:
           - pass:
               when: "p99 < 10ms"
               message: 'Write latency is ok (p99 target < 10ms, actual: {{ "{{" }} .P99 {{ "}}" }})'
           - fail:
-              message: 'Write latency is high. p99 target < 10ms, actual:{{ "{{" }} .String {{ "}}" }}'
+              message: 'Write latency is high (p99 target < 10ms, actual: {{ "{{" }} .String {{ "}}" }})'

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -63,6 +63,19 @@ spec:
         collectorName: resolv.conf
         command: 'sh'
         args: ['-c', 'cat /etc/resolv.conf']
+    - filesystemPerformance:
+        collectorName: filesystem-latency-etcd
+        timeout: 2m
+        directory: /var/lib/k0s/etcd
+        fileSize: 22Mi
+        operationSizeBytes: 2300
+        datasync: true
+        enableBackgroundIOPS: true
+        backgroundIOPSWarmupSeconds: 10
+        backgroundWriteIOPS: 300
+        backgroundWriteIOPSJobs: 6
+        backgroundReadIOPS: 50
+        backgroundReadIOPSJobs: 1
   analyzers:
     - cpu:
         checkName: CPU
@@ -367,3 +380,12 @@ spec:
           - pass:
               when: "false"
               message: "resolv.conf does not reference '127.0.0.1'"
+    - filesystemPerformance:
+        checkName: Filesystem Latency
+        collectorName: filesystem-latency-etcd
+        outcomes:
+          - pass:
+              when: "p99 < 10ms"
+              message: "Write latency is ok (p99 target < 10ms, actual: {{ .P99 }})"
+          - fail:
+              message: "Write latency is high. p99 target < 10ms, actual:{{ .String }}"

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -386,6 +386,6 @@ spec:
         outcomes:
           - pass:
               when: "p99 < 10ms"
-              message: "Write latency is ok (p99 target < 10ms, actual: {{ .P99 }})"
+              message: 'Write latency is ok (p99 target < 10ms, actual: {{ "{{" }} .P99 {{ "}}" }})'
           - fail:
-              message: "Write latency is high. p99 target < 10ms, actual:{{ .String }}"
+              message: 'Write latency is high. p99 target < 10ms, actual:{{ "{{" }} .String {{ "}}" }}'

--- a/pkg/preflights/preflights.go
+++ b/pkg/preflights/preflights.go
@@ -106,7 +106,7 @@ func proxyEnv(env []string, proxy *ecv1beta1.ProxySpec) []string {
 	for _, e := range env {
 		switch strings.SplitN(e, "=", 2)[0] {
 		// Unset proxy environment variables
-		case "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy", "PATH":
+		case "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy":
 		default:
 			next = append(next, e)
 		}

--- a/pkg/preflights/preflights.go
+++ b/pkg/preflights/preflights.go
@@ -45,7 +45,9 @@ func Run(ctx context.Context, spec *troubleshootv1beta2.HostPreflightSpec, proxy
 	binpath := defaults.PathToEmbeddedClusterBinary("kubectl-preflight")
 	stdout := bytes.NewBuffer(nil)
 	cmd := exec.Command(binpath, "--interactive=false", "--format=json", fpath)
-	cmd.Env = proxyEnv(proxy)
+	cmd.Env = os.Environ()
+	cmd.Env = proxyEnv(cmd.Env, proxy)
+	cmd.Env = pathEnv(cmd.Env)
 	cmd.Stdout, cmd.Stderr = stdout, io.Discard
 	if err = cmd.Run(); err == nil {
 		return OutputFromReader(stdout)
@@ -97,20 +99,40 @@ func dedup[T any](objs []T) []T {
 	return out
 }
 
-func proxyEnv(proxy *ecv1beta1.ProxySpec) []string {
-	env := []string{}
-	for _, e := range os.Environ() {
+func proxyEnv(env []string, proxy *ecv1beta1.ProxySpec) []string {
+	next := []string{}
+	for _, e := range env {
 		switch strings.SplitN(e, "=", 2)[0] {
 		// Unset proxy environment variables
-		case "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy":
-			continue
+		case "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy", "PATH":
+		default:
+			next = append(next, e)
 		}
-		env = append(env, e)
 	}
 	if proxy != nil {
-		env = append(env, fmt.Sprintf("HTTP_PROXY=%s", proxy.HTTPProxy))
-		env = append(env, fmt.Sprintf("HTTPS_PROXY=%s", proxy.HTTPSProxy))
-		env = append(env, fmt.Sprintf("NO_PROXY=%s", proxy.NoProxy))
+		next = append(next, fmt.Sprintf("HTTP_PROXY=%s", proxy.HTTPProxy))
+		next = append(next, fmt.Sprintf("HTTPS_PROXY=%s", proxy.HTTPSProxy))
+		next = append(next, fmt.Sprintf("NO_PROXY=%s", proxy.NoProxy))
 	}
-	return env
+	return next
+}
+
+func pathEnv(env []string) []string {
+	path := ""
+	next := []string{}
+	for _, e := range env {
+		switch strings.SplitN(e, "=", 2)[0] {
+		// Unset PATH environment variable
+		case "PATH":
+			path = strings.SplitN(e, "=", 2)[1]
+		default:
+			next = append(next, e)
+		}
+	}
+	if path != "" {
+		next = append(next, fmt.Sprintf("PATH=%s,%s", path, defaults.EmbeddedClusterBinsSubDir()))
+	} else {
+		next = append(next, fmt.Sprintf("PATH=%s", defaults.EmbeddedClusterBinsSubDir()))
+	}
+	return next
 }

--- a/pkg/preflights/preflights_test.go
+++ b/pkg/preflights/preflights_test.go
@@ -2,116 +2,188 @@
 package preflights
 
 import (
+	"os"
 	"strings"
 	"testing"
 
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster-kinds/apis/v1beta1"
+	"github.com/replicatedhq/embedded-cluster/pkg/defaults"
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_proxyEnv(t *testing.T) {
 	type args struct {
+		env   []string
 		proxy *ecv1beta1.ProxySpec
 	}
 	tests := []struct {
-		name           string
-		env            map[string]string
-		args           args
-		wantHTTPProxy  string
-		wantHTTPSProxy string
-		wantNoProxy    string
+		name string
+		args args
+		want []string
 	}{
 		{
 			name: "no proxy nil",
 			args: args{
+				env: []string{
+					"TEST=test",
+				},
 				proxy: nil,
 			},
-			wantHTTPProxy:  "",
-			wantHTTPSProxy: "",
-			wantNoProxy:    "",
+			want: []string{
+				"TEST=test",
+			},
 		},
 		{
-			name: "no proxy nil",
+			name: "no proxy empty",
 			args: args{
+				env: []string{
+					"TEST=test",
+				},
 				proxy: &ecv1beta1.ProxySpec{},
 			},
-			wantHTTPProxy:  "",
-			wantHTTPSProxy: "",
-			wantNoProxy:    "",
+			want: []string{
+				"TEST=test",
+				"HTTP_PROXY=",
+				"HTTPS_PROXY=",
+				"NO_PROXY=",
+			},
 		},
 		{
 			name: "no proxy unset env",
-			env: map[string]string{
-				"HTTP_PROXY":  "http://proxy:8080",
-				"HTTPS_PROXY": "https://proxy:8080",
-				"NO_PROXY":    "localhost",
-				"http_proxy":  "http://proxy:8080",
-				"https_proxy": "https://proxy:8080",
-				"no_proxy":    "localhost",
-			},
 			args: args{
+				env: []string{
+					"TEST=test",
+					"HTTP_PROXY=http://proxy:8080",
+					"HTTPS_PROXY=https://proxy:8080",
+					"NO_PROXY=localhost",
+					"http_proxy=http://proxy:8080",
+					"https_proxy=https://proxy:8080",
+					"no_proxy=localhost",
+				},
 				proxy: &ecv1beta1.ProxySpec{},
 			},
-			wantHTTPProxy:  "",
-			wantHTTPSProxy: "",
-			wantNoProxy:    "",
+			want: []string{
+				"TEST=test",
+				"HTTP_PROXY=",
+				"HTTPS_PROXY=",
+				"NO_PROXY=",
+			},
 		},
 		{
 			name: "no proxy set env",
 			args: args{
+				env: []string{
+					"TEST=test",
+				},
 				proxy: &ecv1beta1.ProxySpec{
 					HTTPProxy:  "http://proxy:8080",
 					HTTPSProxy: "https://proxy:8080",
 					NoProxy:    "localhost",
 				},
 			},
-			wantHTTPProxy:  "http://proxy:8080",
-			wantHTTPSProxy: "https://proxy:8080",
-			wantNoProxy:    "localhost",
+			want: []string{
+				"TEST=test",
+				"HTTP_PROXY=http://proxy:8080",
+				"HTTPS_PROXY=https://proxy:8080",
+				"NO_PROXY=localhost",
+			},
 		},
 		{
 			name: "proxy override env",
-			env: map[string]string{
-				"HTTP_PROXY":  "http://proxy:8080",
-				"HTTPS_PROXY": "https://proxy:8080",
-				"NO_PROXY":    "localhost",
-				"http_proxy":  "http://proxy:8080",
-				"https_proxy": "https://proxy:8080",
-				"no_proxy":    "localhost",
-			},
 			args: args{
+				env: []string{
+					"TEST=test",
+					"HTTP_PROXY=http://proxy:8080",
+					"HTTPS_PROXY=https://proxy:8080",
+					"NO_PROXY=localhost",
+					"http_proxy=http://proxy:8080",
+					"https_proxy=https://proxy:8080",
+					"no_proxy=localhost",
+				},
 				proxy: &ecv1beta1.ProxySpec{
 					HTTPProxy:  "http://proxy2:8080",
 					HTTPSProxy: "https://proxy2:8080",
 					NoProxy:    "localhost2",
 				},
 			},
-			wantHTTPProxy:  "http://proxy2:8080",
-			wantHTTPSProxy: "https://proxy2:8080",
-			wantNoProxy:    "localhost2",
+			want: []string{
+				"TEST=test",
+				"HTTP_PROXY=http://proxy2:8080",
+				"HTTPS_PROXY=https://proxy2:8080",
+				"NO_PROXY=localhost2",
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Unset proxy environment variables
-			for _, k := range []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy"} {
-				t.Setenv(k, "")
-			}
-			for k, v := range tt.env {
-				t.Setenv(k, v)
-			}
-			got := proxyEnv(tt.args.proxy)
+			got := proxyEnv(tt.args.env, tt.args.proxy)
 			gotMap := make(map[string]string)
 			for _, e := range got {
 				parts := strings.SplitN(e, "=", 2)
 				gotMap[parts[0]] = parts[1]
 			}
-			assert.Equal(t, tt.wantHTTPProxy, gotMap["HTTP_PROXY"])
-			assert.Equal(t, tt.wantHTTPSProxy, gotMap["HTTPS_PROXY"])
-			assert.Equal(t, tt.wantNoProxy, gotMap["NO_PROXY"])
-			assert.Empty(t, gotMap["http_proxy"])
-			assert.Empty(t, gotMap["https_proxy"])
-			assert.Empty(t, gotMap["no_proxy"])
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_pathEnv(t *testing.T) {
+	dir, err := os.MkdirTemp("", "embedded-cluster")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	oDefaultProvider := defaults.DefaultProvider
+	defaults.DefaultProvider = defaults.NewProvider(dir)
+	t.Cleanup(func() {
+		defaults.DefaultProvider = oDefaultProvider
+	})
+
+	binDir := defaults.DefaultProvider.EmbeddedClusterBinsSubDir()
+
+	type args struct {
+		env []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "path empty",
+			args: args{
+				env: []string{
+					"TEST=test",
+				},
+			},
+			want: []string{
+				"TEST=test",
+				"PATH=" + binDir,
+			},
+		},
+		{
+			name: "path override",
+			args: args{
+				env: []string{
+					"TEST=test",
+					"PATH=/usr/bin,/usr/local/bin",
+				},
+			},
+			want: []string{
+				"TEST=test",
+				"PATH=/usr/bin,/usr/local/bin," + binDir,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pathEnv(tt.args.env)
+			gotMap := make(map[string]string)
+			for _, e := range got {
+				parts := strings.SplitN(e, "=", 2)
+				gotMap[parts[0]] = parts[1]
+			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/preflights/preflights_test.go
+++ b/pkg/preflights/preflights_test.go
@@ -166,12 +166,12 @@ func Test_pathEnv(t *testing.T) {
 			args: args{
 				env: []string{
 					"TEST=test",
-					"PATH=/usr/bin,/usr/local/bin",
+					"PATH=/usr/bin:/usr/local/bin",
 				},
 			},
 			want: []string{
 				"TEST=test",
-				"PATH=/usr/bin,/usr/local/bin," + binDir,
+				"PATH=/usr/bin:/usr/local/bin:" + binDir,
 			},
 		},
 	}


### PR DESCRIPTION
Includes statically linked fio in the binary.

Runs fio preflight on installation.

Adds about 30 seconds to the installation time.

Will fail if disk does not meet threshold.

tested in bookwork-slim image

```
root@ethanm-ec-1:/home/ethan# docker run --rm -it -v `pwd`:/wrk -w /wrk debian:bookworm-slim bash
root@e9dd75129439:/wrk# ./embedded-cluster-smoke-test-staging-app install run-preflights --license license.yaml
✔  Host files materialized!
✗  6 host preflights failed
+--------+-----------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| STATUS | TITLE                       | MESSAGE                                                                                                                                                                                                        |
+--------+-----------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| FAIL   | Default Route               | Analyzer Failed: analyze: failed to read collected file name: host-collectors/run-host/ip-route-table.txt: File not found: host-collectors/run-host/ip-route-table.txt                                         |
| FAIL   | System Clock                | Analyzer Failed: analyze: failed to get collected file: file host-collectors/system/time.json was not collected                                                                                                |
| FAIL   | 'freezer' Cgroup Controller | 'freezer' cgroup controller is not enabled                                                                                                                                                                     |
| FAIL   | 'modprobe' Command          | 'modprobe' command does not exist in PATH                                                                                                                                                                      |
| FAIL   | API Access                  | Error connecting to https://ec-e2e-replicated-app.testcluster.net. Ensure your firewall is properly configured, or use the `--http-proxy`, `--https-proxy`, and `--no-proxy` flags if there is a proxy server. |
|        |                             |                                                                                                                                                                                                                |
| FAIL   | Proxy Registry Access       | Error connecting to https://proxy.replicated.com. Ensure your firewall is properly configured, or use the `--http-proxy`, `--https-proxy`, and `--no-proxy` flags if there is a proxy server.                  |
|        |                             |                                                                                                                                                                                                                |
+--------+-----------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

host preflight failures detected
root@e9dd75129439:/wrk# cat /var/lib/embedded-cluster/support/host-preflight-results.json | grep 'Filesystem Write' -A 1
      "title": "Filesystem Write Latency",
      "message": "Write latency is ok (p99 target \u003c 10ms, actual: 1.548288ms)"
```