### PR TITLE
Set default value for pod/service CIDRs with flag

### DIFF
--- a/cmd/embedded-cluster/install.go
+++ b/cmd/embedded-cluster/install.go
@@ -548,7 +548,7 @@ var installCommand = &cli.Command{
 			&cli.StringFlag{
 				Name:    "license",
 				Aliases: []string{"l"},
-				Usage:   "Path to the license file.",
+				Usage:   "Path to the license file",
 				Hidden:  false,
 			},
 			&cli.BoolFlag{

--- a/cmd/embedded-cluster/install.go
+++ b/cmd/embedded-cluster/install.go
@@ -324,8 +324,8 @@ func ensureK0sConfig(c *cli.Context, applier *addons.Applier) (*k0sconfig.Cluste
 		return nil, fmt.Errorf("unable to create directory: %w", err)
 	}
 	cfg := config.RenderK0sConfig()
-	cfg.Spec.Network.PodCIDR = getPodCIDR(c)
-	cfg.Spec.Network.ServiceCIDR = getServiceCIDR(c)
+	cfg.Spec.Network.PodCIDR = c.String("pod-cidr")
+	cfg.Spec.Network.ServiceCIDR = c.String("service-cidr")
 	if err := config.UpdateHelmConfigs(applier, cfg); err != nil {
 		return nil, fmt.Errorf("unable to update helm configs: %w", err)
 	}

--- a/cmd/embedded-cluster/network.go
+++ b/cmd/embedded-cluster/network.go
@@ -9,27 +9,15 @@ func withSubnetCIDRFlags(flags []cli.Flag) []cli.Flag {
 	return append(flags,
 		&cli.StringFlag{
 			Name:   "pod-cidr",
-			Usage:  "IP address range for pods",
+			Usage:  "IP address range for Pods",
+			Value:  k0sv1beta1.DefaultNetwork().PodCIDR,
 			Hidden: false,
 		},
 		&cli.StringFlag{
 			Name:   "service-cidr",
-			Usage:  "IP address range for services",
+			Usage:  "IP address range for Services",
+			Value:  k0sv1beta1.DefaultNetwork().ServiceCIDR,
 			Hidden: false,
 		},
 	)
-}
-
-func getPodCIDR(c *cli.Context) string {
-	if c.String("pod-cidr") != "" {
-		return c.String("pod-cidr")
-	}
-	return k0sv1beta1.DefaultNetwork().PodCIDR
-}
-
-func getServiceCIDR(c *cli.Context) string {
-	if c.String("service-cidr") != "" {
-		return c.String("service-cidr")
-	}
-	return k0sv1beta1.DefaultNetwork().ServiceCIDR
 }

--- a/cmd/embedded-cluster/proxy.go
+++ b/cmd/embedded-cluster/proxy.go
@@ -55,7 +55,7 @@ func getProxySpecFromFlags(c *cli.Context) *ecv1beta1.ProxySpec {
 	}
 	if len(noProxy) > 0 || proxy.HTTPProxy != "" || proxy.HTTPSProxy != "" {
 		noProxy = append(defaults.DefaultNoProxy, noProxy...)
-		noProxy = append(noProxy, getPodCIDR(c), getServiceCIDR(c))
+		noProxy = append(noProxy, c.String("pod-cidr"), c.String("service-cidr"))
 		proxy.NoProxy = strings.Join(noProxy, ",")
 	}
 	if proxy.HTTPProxy == "" && proxy.HTTPSProxy == "" && proxy.NoProxy == "" {

--- a/cmd/embedded-cluster/restore.go
+++ b/cmd/embedded-cluster/restore.go
@@ -323,8 +323,8 @@ func ensureK0sConfigForRestore(c *cli.Context, applier *addons.Applier) (*k0sv1b
 		return nil, fmt.Errorf("unable to create directory: %w", err)
 	}
 	cfg := config.RenderK0sConfig()
-	cfg.Spec.Network.PodCIDR = getPodCIDR(c)
-	cfg.Spec.Network.ServiceCIDR = getServiceCIDR(c)
+	cfg.Spec.Network.PodCIDR = c.String("pod-cidr")
+	cfg.Spec.Network.ServiceCIDR = c.String("service-cidr")
 	if err := config.UpdateHelmConfigsForRestore(applier, cfg); err != nil {
 		return nil, fmt.Errorf("unable to update helm configs: %w", err)
 	}


### PR DESCRIPTION
This way the default value shows up in the CLI help menu, making it easier for users to know whether they need to update it.