### PR TITLE
feat: verify network system configuration during preflight

### DIFF
--- a/e2e/cluster/cluster.go
+++ b/e2e/cluster/cluster.go
@@ -845,6 +845,11 @@ func CreateProfile(in *Input) {
 					"network": "lxdbr0",
 					"type":    "nic",
 				},
+				"kernel-modules": {
+					"source": "/usr/lib/modules",
+					"path":   "/usr/lib/modules",
+					"type":   "disk",
+				},
 				"root": {
 					"path": "/",
 					"pool": "default",

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -71,6 +71,10 @@ spec:
         operationSize: 2300
         datasync: true
         runTime: "0" # let it run to completion
+    - run:
+        collectorName: "sysctl"
+        command: "sysctl"
+        args: ["-a"]
   analyzers:
     - cpu:
         checkName: CPU
@@ -373,3 +377,58 @@ spec:
               message: 'P99 write latency for the disk at /var/lib/k0s/etcd is {{ "{{" }} .P99 {{ "}}" }}, which is better than the 10 ms requirement.'
           - fail:
               message: 'P99 write latency for the disk at /var/lib/k0s/etcd is {{ "{{" }} .P99 {{ "}}" }}, but it must be less than 10 ms. A higher-performance disk is required.'
+    - textAnalyze:
+        checkName: IPv4 Forwarding Status Check
+        fileName: host-collectors/run-host/sysctl.txt
+        regex: net.ipv4.conf.all.forwarding = 1
+        outcomes:
+        - pass:
+            when: "true"
+            message: IPv4 Forwarding Enabled
+        - fail:
+            when: "false"
+            message: IPv4 forwarding must be enabled. To enable it, edit /etc/sysctl.conf, add or uncomment the line 'net.ipv4.conf.all.forwarding = 1', and run 'sudo sysctl -p'.
+    - textAnalyze:
+        checkName: IPv6 Forwarding Status Check
+        fileName: host-collectors/run-host/sysctl.txt
+        regex: net.ipv6.conf.all.forwarding = 1
+        outcomes:
+        - pass:
+            when: "true"
+            message: IPv6 Forwarding Enabled
+        - fail:
+            when: "false"
+            message: IPv6 forwarding must be enabled. To enable it, edit /etc/sysctl.conf, add or uncomment the line 'net.ipv6.conf.all.forwarding = 1', and run 'sudo sysctl -p'.
+    - textAnalyze:
+        checkName: New Interface Default IPv4 Forwarding Check
+        fileName: host-collectors/run-host/sysctl.txt
+        regex: net.ipv4.conf.default.forwarding = 1
+        outcomes:
+        - pass:
+            when: "true"
+            message: New Interface Default IPv4 Forwarding Enabled
+        - fail:
+            when: "false"
+            message: New Interface Default IPv4 Forwarding must be enabled. To enable it, edit /etc/sysctl.conf, add or uncomment the line 'net.ipv4.conf.default.forwarding = 1', and run 'sudo sysctl -p'.
+    - textAnalyze:
+        checkName: New Interface Default IPv6 Forwarding Check
+        fileName: host-collectors/run-host/sysctl.txt
+        regex: net.ipv6.conf.default.forwarding = 1
+        outcomes:
+        - pass:
+            when: "true"
+            message: New Interface Default IPv6 Forwarding Enabled
+        - fail:
+            when: "false"
+            message: New Interface Default IPv6 Forwarding must be enabled. To enable it, edit /etc/sysctl.conf, add or uncomment the line 'net.ipv6.conf.default.forwarding = 1', and run 'sudo sysctl -p'.
+    - textAnalyze:
+        checkName: Bridge IP Tables IPv6 Call Check
+        fileName: host-collectors/run-host/sysctl.txt
+        regex: net.bridge.bridge-nf-call-ip6tables = 1
+        outcomes:
+        - pass:
+            when: "true"
+            message: Bridge IP Tables IPv6 Call Enabled
+        - fail:
+            when: "false"
+            message: Bridge IP Tables IPv6 Call must be enabled. To enable it, edit /etc/sysctl.conf, add or uncomment the line 'net.bridge.bridge-nf-call-ip6tables = 1', and run 'sudo sysctl -p'.

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -75,6 +75,12 @@ spec:
         collectorName: "sysctl"
         command: "sysctl"
         args: ["-a"]
+    - run:
+        collectorName: 'available-kernel-modules'
+        command: 'sh'
+        args:
+          - -c
+          - find /lib/modules/$(uname -r) -type f -name '*.ko*'
   analyzers:
     - cpu:
         checkName: CPU
@@ -432,3 +438,25 @@ spec:
         - fail:
             when: "false"
             message: Bridge IP Tables IPv6 Call must be enabled. To enable it, edit /etc/sysctl.conf, add or uncomment the line 'net.bridge.bridge-nf-call-ip6tables = 1', and run 'sudo sysctl -p'.
+    - textAnalyze:
+        checkName: Bridge IP Tables Call Check
+        fileName: host-collectors/run-host/sysctl.txt
+        regex: net.bridge.bridge-nf-call-iptables = 1
+        outcomes:
+        - pass:
+            when: "true"
+            message: Bridge IP Tables Call Enabled
+        - fail:
+            when: "false"
+            message: Bridge IP Tables Call must be enabled. To enable it, edit /etc/sysctl.conf, add or uncomment the line 'net.bridge.bridge-nf-call-iptables = 1', and run 'sudo sysctl -p'.
+    - textAnalyze:
+        checkName: Kernel br_netfilter module available
+        fileName: host-collectors/run-host/available-kernel-modules.txt
+        regex: br_netfilter
+        outcomes:
+          - pass:
+              when: 'true'
+              message: Kernel module br_netfilter available for use.
+          - fail:
+              when: 'false'
+              message: Kernel module br_netfilter isn't available for dynamic loading. You may need to install the Kernel modules package. Please refer to your distribution documentation.


### PR DESCRIPTION
#### What this PR does / why we need it:

Make sure the user deliberately sets up a few `sysctl` parameters. K0s sets these automatically but we want to make users deliberately enable them anyways. The goal is to let users aware that these configurations are necessary. These parameters were copied from k0s [source code](https://github.com/k0sproject/k0s/blob/391cfd1b9fc1c6b6221398e5bcef4034ba248149/pkg/component/worker/kernelsetup_linux.go#L62).

#### Which issue(s) this PR fixes:

https://app.shortcut.com/replicated/story/110749/preflight-for-ip-forwarding

#### Does this PR require a test?

TO BE IMPLEMENTED

#### Does this PR require a release note?
```release-note
Start to verify more sysctl configuration prior to installation.
```
