### PR TITLE
fix(ci): operator release fails with "no rule to make target 'build-chart'"

### DIFF
--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -75,7 +75,7 @@ jobs:
           HELM_REGISTRY: registry.replicated.com
           CHART_VERSION: ${{needs.get-tag.outputs.tag-name}}
         run: |
-          make build-chart \
+          make -C operator build-chart \
             PACKAGE_VERSION=${{ needs.get-tag.outputs.tag-name }}
           echo "chart=$(cat operator/build/chart)" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

https://github.com/replicatedhq/embedded-cluster/actions/runs/10605611609/job/29394826595

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
