### PR TITLE
fix(ci): operator release fails with "buildtools: No such file or directory"

### DIFF
--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -28,6 +28,25 @@ jobs:
           # store the tag name in an output for later steps
           echo "tag-name=${V_TAG}" >> $GITHUB_OUTPUT
 
+  buildtools:
+    name: Build Buildtools
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Compile buildtools
+        run: |
+          make buildtools
+      - name: Upload buildtools artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: buildtools
+          path: output/bin/buildtools
+
   publish-operator-image:
     runs-on: ubuntu-latest
     needs: [get-tag]
@@ -111,15 +130,21 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [get-tag, publish-images, publish-operator-image, publish-operator-chart]
+    needs: [get-tag, buildtools, publish-images, publish-operator-image, publish-operator-chart]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Go
+      - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+
+      - name: Download buildtools artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: buildtools
+          path: output/bin
 
       - name: Update embedded-cluster-operator metadata.yaml
         env:


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

https://github.com/replicatedhq/embedded-cluster/actions/runs/10605907954/job/29395716361

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
