### PR TITLE
rename the kinds CI validate-success task to 'validate-success-kinds'

### DIFF
--- a/.github/workflows/kinds.yaml
+++ b/.github/workflows/kinds.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Unit tests
         run: make -C kinds unit-tests
 
-  validate-success:
+  validate-success-kinds:
     runs-on: ubuntu-latest
     needs:
       - lint


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
This changes the kinds CI final task to `validate-success-kinds`, so as not to fulfill the required check for `validate-success` on the main CI workflow

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
