### PR TITLE
fix(utils): change module path and update go version

### DIFF
--- a/utils/go.mod
+++ b/utils/go.mod
@@ -1,6 +1,6 @@
-module github.com/replicatedhq/embedded-cluster-utils
+module github.com/replicatedhq/embedded-cluster/utils
 
-go 1.22.5
+go 1.23.0
 
 require github.com/stretchr/testify v1.9.0
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

go get fails with

```
ethan@Ethans-MacBook-Pro-2 replicated-app % go get github.com/replicatedhq/embedded-cluster/utils@main
go: downloading github.com/replicatedhq/embedded-cluster v1.29.5-0.20240904165046-f3364d7f56b7
go: downloading github.com/replicatedhq/embedded-cluster/utils v0.0.0-20240904165046-f3364d7f56b7
go: github.com/replicatedhq/embedded-cluster/utils@main (v0.0.0-20240904165046-f3364d7f56b7) requires github.com/replicatedhq/embedded-cluster/utils@v0.0.0-20240904165046-f3364d7f56b7: parsing go.mod:
        module declares its path as: github.com/replicatedhq/embedded-cluster-utils
                but was required as: github.com/replicatedhq/embedded-cluster/utils
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
