### PR TITLE
test with a noproxy that doesn't include every private IP

### DIFF
--- a/e2e/cluster/cluster.go
+++ b/e2e/cluster/cluster.go
@@ -252,7 +252,6 @@ func NewTestCluster(in *Input) *Output {
 
 const ProxyImage = "debian/12"
 const HTTPProxy = "http://10.0.0.254:3128"
-const NOProxy = "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
 
 // CreateProxy creates a node that attaches to both networks (external and internal),
 // once this is done we install squid and configure it to be a proxy. We also make

--- a/e2e/cluster/cluster.go
+++ b/e2e/cluster/cluster.go
@@ -740,13 +740,11 @@ func CreateNode(in *Input, i int) (string, string) {
 		}
 	}
 	ip := ""
-	for key, netState := range state.Network {
-		for _, addr := range netState.Addresses {
-			fmt.Printf("key: %s Family: %s IP: %s\n", key, addr.Family, addr.Address)
-			if addr.Family == "inet" {
-				ip = addr.Address
-				break
-			}
+	for _, addr := range state.Network["eth0"].Addresses {
+		fmt.Printf("Family: %s IP: %s\n", addr.Family, addr.Address)
+		if addr.Family == "inet" {
+			ip = addr.Address
+			break
 		}
 	}
 

--- a/e2e/proxy_test.go
+++ b/e2e/proxy_test.go
@@ -34,7 +34,7 @@ func TestProxiedEnvironment(t *testing.T) {
 	line = append(line, "--http-proxy", cluster.HTTPProxy)
 	line = append(line, "--https-proxy", cluster.HTTPProxy)
 	line = append(line, "--no-proxy", strings.Join(tc.IPs, ","))
-	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv()); err != nil {
+	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv(tc.IPs)); err != nil {
 		t.Fatalf("fail to install embedded-cluster on node %s: %v", tc.Nodes[0], err)
 	}
 
@@ -133,7 +133,7 @@ func TestProxiedCustomCIDR(t *testing.T) {
 	line = append(line, "--no-proxy", strings.Join(tc.IPs, ","))
 	line = append(line, "--pod-cidr", "10.128.0.0/20")
 	line = append(line, "--service-cidr", "10.129.0.0/20")
-	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv()); err != nil {
+	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv(tc.IPs)); err != nil {
 		t.Fatalf("fail to install embedded-cluster on node %s: %v", tc.Nodes[0], err)
 	}
 

--- a/e2e/proxy_test.go
+++ b/e2e/proxy_test.go
@@ -33,7 +33,7 @@ func TestProxiedEnvironment(t *testing.T) {
 	line := []string{"single-node-install.sh", "ui"}
 	line = append(line, "--http-proxy", cluster.HTTPProxy)
 	line = append(line, "--https-proxy", cluster.HTTPProxy)
-	line = append(line, "--no-proxy", cluster.NOProxy)
+	line = append(line, "--no-proxy", strings.Join(tc.IPs, ","))
 	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv()); err != nil {
 		t.Fatalf("fail to install embedded-cluster on node %s: %v", tc.Nodes[0], err)
 	}
@@ -130,7 +130,7 @@ func TestProxiedCustomCIDR(t *testing.T) {
 	line := []string{"single-node-install.sh", "ui"}
 	line = append(line, "--http-proxy", cluster.HTTPProxy)
 	line = append(line, "--https-proxy", cluster.HTTPProxy)
-	line = append(line, "--no-proxy", cluster.NOProxy)
+	line = append(line, "--no-proxy", strings.Join(tc.IPs, ","))
 	line = append(line, "--pod-cidr", "10.128.0.0/20")
 	line = append(line, "--service-cidr", "10.129.0.0/20")
 	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv()); err != nil {

--- a/e2e/restore_test.go
+++ b/e2e/restore_test.go
@@ -114,7 +114,7 @@ func TestSingleNodeDisasterRecoveryWithProxy(t *testing.T) {
 	line := []string{"single-node-install.sh", "ui"}
 	line = append(line, "--http-proxy", cluster.HTTPProxy)
 	line = append(line, "--https-proxy", cluster.HTTPProxy)
-	line = append(line, "--no-proxy", cluster.NOProxy)
+	line = append(line, "--no-proxy", strings.Join(tc.IPs, ","))
 	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv()); err != nil {
 		t.Fatalf("fail to install embedded-cluster on node %s: %v", tc.Nodes[0], err)
 	}
@@ -143,7 +143,7 @@ func TestSingleNodeDisasterRecoveryWithProxy(t *testing.T) {
 	line = append([]string{"restore-installation.exp"}, testArgs...)
 	line = append(line, "--http-proxy", cluster.HTTPProxy)
 	line = append(line, "--https-proxy", cluster.HTTPProxy)
-	line = append(line, "--no-proxy", cluster.NOProxy)
+	line = append(line, "--no-proxy", strings.Join(tc.IPs, ","))
 	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv()); err != nil {
 		t.Fatalf("fail to restore the installation: %v", err)
 	}

--- a/e2e/restore_test.go
+++ b/e2e/restore_test.go
@@ -115,7 +115,7 @@ func TestSingleNodeDisasterRecoveryWithProxy(t *testing.T) {
 	line = append(line, "--http-proxy", cluster.HTTPProxy)
 	line = append(line, "--https-proxy", cluster.HTTPProxy)
 	line = append(line, "--no-proxy", strings.Join(tc.IPs, ","))
-	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv()); err != nil {
+	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv(tc.IPs)); err != nil {
 		t.Fatalf("fail to install embedded-cluster on node %s: %v", tc.Nodes[0], err)
 	}
 
@@ -125,7 +125,7 @@ func TestSingleNodeDisasterRecoveryWithProxy(t *testing.T) {
 
 	t.Logf("%s: checking installation state", time.Now().Format(time.RFC3339))
 	line = []string{"check-installation-state.sh", os.Getenv("SHORT_SHA"), k8sVersion()}
-	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv()); err != nil {
+	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv(tc.IPs)); err != nil {
 		t.Fatalf("fail to check installation state: %v", err)
 	}
 
@@ -144,13 +144,13 @@ func TestSingleNodeDisasterRecoveryWithProxy(t *testing.T) {
 	line = append(line, "--http-proxy", cluster.HTTPProxy)
 	line = append(line, "--https-proxy", cluster.HTTPProxy)
 	line = append(line, "--no-proxy", strings.Join(tc.IPs, ","))
-	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv()); err != nil {
+	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv(tc.IPs)); err != nil {
 		t.Fatalf("fail to restore the installation: %v", err)
 	}
 
 	t.Logf("%s: checking installation state", time.Now().Format(time.RFC3339))
 	line = []string{"check-installation-state.sh", os.Getenv("SHORT_SHA"), k8sVersion()}
-	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv()); err != nil {
+	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv(tc.IPs)); err != nil {
 		t.Fatalf("fail to check installation state: %v", err)
 	}
 
@@ -220,7 +220,7 @@ func TestSingleNodeResumeDisasterRecovery(t *testing.T) {
 
 	t.Logf("%s: checking installation state", time.Now().Format(time.RFC3339))
 	line = []string{"check-installation-state.sh", os.Getenv("SHORT_SHA"), k8sVersion()}
-	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv()); err != nil {
+	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv(tc.IPs)); err != nil {
 		t.Fatalf("fail to check installation state: %v", err)
 	}
 
@@ -284,7 +284,7 @@ func TestSingleNodeAirgapDisasterRecovery(t *testing.T) {
 	line = []string{"single-node-airgap-install.sh", "--proxy"}
 	line = append(line, "--pod-cidr", "10.128.0.0/20")
 	line = append(line, "--service-cidr", "10.129.0.0/20")
-	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv()); err != nil {
+	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv(tc.IPs)); err != nil {
 		t.Fatalf("fail to install embedded-cluster on node %s: %v", tc.Nodes[0], err)
 	}
 	if _, _, err := setupPlaywrightAndRunTest(t, tc, "deploy-app"); err != nil {
@@ -316,7 +316,7 @@ func TestSingleNodeAirgapDisasterRecovery(t *testing.T) {
 	t.Logf("%s: restoring the installation", time.Now().Format(time.RFC3339))
 	testArgs = append(testArgs, "--pod-cidr", "10.128.0.0/20", "--service-cidr", "10.129.0.0/20")
 	line = append([]string{"restore-installation-airgap.exp"}, testArgs...)
-	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv()); err != nil {
+	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv(tc.IPs)); err != nil {
 		t.Fatalf("fail to restore the installation: %v", err)
 	}
 	t.Logf("%s: checking installation state after restoring app", time.Now().Format(time.RFC3339))
@@ -594,7 +594,7 @@ func TestMultiNodeAirgapHADisasterRecovery(t *testing.T) {
 
 	t.Logf("%s: installing embedded-cluster on node 0", time.Now().Format(time.RFC3339))
 	line = []string{"single-node-airgap-install.sh", "--proxy"}
-	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv()); err != nil {
+	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv(tc.IPs)); err != nil {
 		t.Fatalf("fail to install embedded-cluster on node %s: %v", tc.Nodes[0], err)
 	}
 
@@ -685,7 +685,7 @@ func TestMultiNodeAirgapHADisasterRecovery(t *testing.T) {
 	// begin restoring the cluster
 	t.Logf("%s: restoring the installation: phase 1", time.Now().Format(time.RFC3339))
 	line = append([]string{"restore-multi-node-airgap-phase1.exp"}, testArgs...)
-	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv()); err != nil {
+	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv(tc.IPs)); err != nil {
 		t.Fatalf("fail to restore phase 1 of the installation: %v", err)
 	}
 
@@ -734,7 +734,7 @@ func TestMultiNodeAirgapHADisasterRecovery(t *testing.T) {
 
 	t.Logf("%s: restoring the installation: phase 2", time.Now().Format(time.RFC3339))
 	line = []string{"restore-multi-node-airgap-phase2.exp"}
-	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv()); err != nil {
+	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv(tc.IPs)); err != nil {
 		t.Fatalf("fail to restore phase 2 of the installation: %v", err)
 	}
 

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -211,10 +211,10 @@ func installTestDependenciesDebian(t *testing.T, tc *cluster.Output, node int, w
 	}
 }
 
-func withProxyEnv() RunCommandOption {
+func withProxyEnv(nodeIPs []string) RunCommandOption {
 	return WithEnv(map[string]string{
 		"HTTP_PROXY":  cluster.HTTPProxy,
 		"HTTPS_PROXY": cluster.HTTPProxy,
-		"NO_PROXY":    cluster.NOProxy,
+		"NO_PROXY":    strings.Join(nodeIPs, ","),
 	})
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

This changes our test code to not use 10.0.0.0/8 etc as our noproxy addresses, and instead only pass the VM IPs there.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
