### PR TITLE
fix(proxy): do not pass unnecessary values to no-proxy

### DIFF
--- a/cmd/embedded-cluster/proxy_test.go
+++ b/cmd/embedded-cluster/proxy_test.go
@@ -40,7 +40,7 @@ func Test_getProxySpecFromFlags(t *testing.T) {
 			want: &ecv1beta1.ProxySpec{
 				HTTPProxy:  "http://proxy",
 				HTTPSProxy: "https://proxy",
-				NoProxy:    "localhost,127.0.0.1,.cluster.local.,.cluster.local,.svc,no-proxy-1,no-proxy-2,10.244.0.0/16,10.96.0.0/12",
+				NoProxy:    "localhost,127.0.0.1,.cluster.local,.svc,no-proxy-1,no-proxy-2,10.244.0.0/16,10.96.0.0/12",
 			},
 		},
 		{
@@ -68,7 +68,7 @@ func Test_getProxySpecFromFlags(t *testing.T) {
 			want: &ecv1beta1.ProxySpec{
 				HTTPProxy:  "http://other-proxy",
 				HTTPSProxy: "https://other-proxy",
-				NoProxy:    "localhost,127.0.0.1,.cluster.local.,.cluster.local,.svc,other-no-proxy-1,other-no-proxy-2,10.244.0.0/16,10.96.0.0/12",
+				NoProxy:    "localhost,127.0.0.1,.cluster.local,.svc,other-no-proxy-1,other-no-proxy-2,10.244.0.0/16,10.96.0.0/12",
 			},
 		},
 		{
@@ -86,7 +86,7 @@ func Test_getProxySpecFromFlags(t *testing.T) {
 			want: &ecv1beta1.ProxySpec{
 				HTTPProxy:  "http://other-proxy",
 				HTTPSProxy: "https://other-proxy",
-				NoProxy:    "localhost,127.0.0.1,.cluster.local.,.cluster.local,.svc,no-proxy-1,no-proxy-2,other-no-proxy-1,other-no-proxy-2,10.244.0.0/16,10.96.0.0/12",
+				NoProxy:    "localhost,127.0.0.1,.cluster.local,.svc,no-proxy-1,no-proxy-2,other-no-proxy-1,other-no-proxy-2,10.244.0.0/16,10.96.0.0/12",
 			},
 		},
 		{
@@ -102,7 +102,7 @@ func Test_getProxySpecFromFlags(t *testing.T) {
 			want: &ecv1beta1.ProxySpec{
 				HTTPProxy:  "http://other-proxy",
 				HTTPSProxy: "https://other-proxy",
-				NoProxy:    "localhost,127.0.0.1,.cluster.local.,.cluster.local,.svc,other-no-proxy-1,other-no-proxy-2,1.1.1.1/24,2.2.2.2/24",
+				NoProxy:    "localhost,127.0.0.1,.cluster.local,.svc,other-no-proxy-1,other-no-proxy-2,1.1.1.1/24,2.2.2.2/24",
 			},
 		},
 	}

--- a/cmd/embedded-cluster/proxy_test.go
+++ b/cmd/embedded-cluster/proxy_test.go
@@ -40,7 +40,7 @@ func Test_getProxySpecFromFlags(t *testing.T) {
 			want: &ecv1beta1.ProxySpec{
 				HTTPProxy:  "http://proxy",
 				HTTPSProxy: "https://proxy",
-				NoProxy:    "localhost,127.0.0.1,no-proxy-1,no-proxy-2,10.244.0.0/16,10.96.0.0/12",
+				NoProxy:    "localhost,127.0.0.1,.cluster.local,no-proxy-1,no-proxy-2,10.244.0.0/16,10.96.0.0/12",
 			},
 		},
 		{
@@ -68,7 +68,7 @@ func Test_getProxySpecFromFlags(t *testing.T) {
 			want: &ecv1beta1.ProxySpec{
 				HTTPProxy:  "http://other-proxy",
 				HTTPSProxy: "https://other-proxy",
-				NoProxy:    "localhost,127.0.0.1,other-no-proxy-1,other-no-proxy-2,10.244.0.0/16,10.96.0.0/12",
+				NoProxy:    "localhost,127.0.0.1,.cluster.local,other-no-proxy-1,other-no-proxy-2,10.244.0.0/16,10.96.0.0/12",
 			},
 		},
 		{
@@ -86,7 +86,7 @@ func Test_getProxySpecFromFlags(t *testing.T) {
 			want: &ecv1beta1.ProxySpec{
 				HTTPProxy:  "http://other-proxy",
 				HTTPSProxy: "https://other-proxy",
-				NoProxy:    "localhost,127.0.0.1,no-proxy-1,no-proxy-2,other-no-proxy-1,other-no-proxy-2,10.244.0.0/16,10.96.0.0/12",
+				NoProxy:    "localhost,127.0.0.1,.cluster.local,no-proxy-1,no-proxy-2,other-no-proxy-1,other-no-proxy-2,10.244.0.0/16,10.96.0.0/12",
 			},
 		},
 		{
@@ -102,7 +102,7 @@ func Test_getProxySpecFromFlags(t *testing.T) {
 			want: &ecv1beta1.ProxySpec{
 				HTTPProxy:  "http://other-proxy",
 				HTTPSProxy: "https://other-proxy",
-				NoProxy:    "localhost,127.0.0.1,other-no-proxy-1,other-no-proxy-2,1.1.1.1/24,2.2.2.2/24",
+				NoProxy:    "localhost,127.0.0.1,.cluster.local,other-no-proxy-1,other-no-proxy-2,1.1.1.1/24,2.2.2.2/24",
 			},
 		},
 	}

--- a/cmd/embedded-cluster/proxy_test.go
+++ b/cmd/embedded-cluster/proxy_test.go
@@ -40,7 +40,7 @@ func Test_getProxySpecFromFlags(t *testing.T) {
 			want: &ecv1beta1.ProxySpec{
 				HTTPProxy:  "http://proxy",
 				HTTPSProxy: "https://proxy",
-				NoProxy:    "localhost,127.0.0.1,.default,.local,.svc,kubernetes,kotsadm-rqlite,no-proxy-1,no-proxy-2,10.244.0.0/16,10.96.0.0/12",
+				NoProxy:    "localhost,127.0.0.1,no-proxy-1,no-proxy-2,10.244.0.0/16,10.96.0.0/12",
 			},
 		},
 		{
@@ -68,7 +68,7 @@ func Test_getProxySpecFromFlags(t *testing.T) {
 			want: &ecv1beta1.ProxySpec{
 				HTTPProxy:  "http://other-proxy",
 				HTTPSProxy: "https://other-proxy",
-				NoProxy:    "localhost,127.0.0.1,.default,.local,.svc,kubernetes,kotsadm-rqlite,other-no-proxy-1,other-no-proxy-2,10.244.0.0/16,10.96.0.0/12",
+				NoProxy:    "localhost,127.0.0.1,other-no-proxy-1,other-no-proxy-2,10.244.0.0/16,10.96.0.0/12",
 			},
 		},
 		{
@@ -86,7 +86,7 @@ func Test_getProxySpecFromFlags(t *testing.T) {
 			want: &ecv1beta1.ProxySpec{
 				HTTPProxy:  "http://other-proxy",
 				HTTPSProxy: "https://other-proxy",
-				NoProxy:    "localhost,127.0.0.1,.default,.local,.svc,kubernetes,kotsadm-rqlite,no-proxy-1,no-proxy-2,other-no-proxy-1,other-no-proxy-2,10.244.0.0/16,10.96.0.0/12",
+				NoProxy:    "localhost,127.0.0.1,no-proxy-1,no-proxy-2,other-no-proxy-1,other-no-proxy-2,10.244.0.0/16,10.96.0.0/12",
 			},
 		},
 		{
@@ -102,7 +102,7 @@ func Test_getProxySpecFromFlags(t *testing.T) {
 			want: &ecv1beta1.ProxySpec{
 				HTTPProxy:  "http://other-proxy",
 				HTTPSProxy: "https://other-proxy",
-				NoProxy:    "localhost,127.0.0.1,.default,.local,.svc,kubernetes,kotsadm-rqlite,other-no-proxy-1,other-no-proxy-2,1.1.1.1/24,2.2.2.2/24",
+				NoProxy:    "localhost,127.0.0.1,other-no-proxy-1,other-no-proxy-2,1.1.1.1/24,2.2.2.2/24",
 			},
 		},
 	}

--- a/cmd/embedded-cluster/proxy_test.go
+++ b/cmd/embedded-cluster/proxy_test.go
@@ -40,7 +40,7 @@ func Test_getProxySpecFromFlags(t *testing.T) {
 			want: &ecv1beta1.ProxySpec{
 				HTTPProxy:  "http://proxy",
 				HTTPSProxy: "https://proxy",
-				NoProxy:    "localhost,127.0.0.1,.cluster.local,no-proxy-1,no-proxy-2,10.244.0.0/16,10.96.0.0/12",
+				NoProxy:    "localhost,127.0.0.1,.cluster.local.,.cluster.local,.svc,no-proxy-1,no-proxy-2,10.244.0.0/16,10.96.0.0/12",
 			},
 		},
 		{
@@ -68,7 +68,7 @@ func Test_getProxySpecFromFlags(t *testing.T) {
 			want: &ecv1beta1.ProxySpec{
 				HTTPProxy:  "http://other-proxy",
 				HTTPSProxy: "https://other-proxy",
-				NoProxy:    "localhost,127.0.0.1,.cluster.local,other-no-proxy-1,other-no-proxy-2,10.244.0.0/16,10.96.0.0/12",
+				NoProxy:    "localhost,127.0.0.1,.cluster.local.,.cluster.local,.svc,other-no-proxy-1,other-no-proxy-2,10.244.0.0/16,10.96.0.0/12",
 			},
 		},
 		{
@@ -86,7 +86,7 @@ func Test_getProxySpecFromFlags(t *testing.T) {
 			want: &ecv1beta1.ProxySpec{
 				HTTPProxy:  "http://other-proxy",
 				HTTPSProxy: "https://other-proxy",
-				NoProxy:    "localhost,127.0.0.1,.cluster.local,no-proxy-1,no-proxy-2,other-no-proxy-1,other-no-proxy-2,10.244.0.0/16,10.96.0.0/12",
+				NoProxy:    "localhost,127.0.0.1,.cluster.local.,.cluster.local,.svc,no-proxy-1,no-proxy-2,other-no-proxy-1,other-no-proxy-2,10.244.0.0/16,10.96.0.0/12",
 			},
 		},
 		{
@@ -102,7 +102,7 @@ func Test_getProxySpecFromFlags(t *testing.T) {
 			want: &ecv1beta1.ProxySpec{
 				HTTPProxy:  "http://other-proxy",
 				HTTPSProxy: "https://other-proxy",
-				NoProxy:    "localhost,127.0.0.1,.cluster.local,other-no-proxy-1,other-no-proxy-2,1.1.1.1/24,2.2.2.2/24",
+				NoProxy:    "localhost,127.0.0.1,.cluster.local.,.cluster.local,.svc,other-no-proxy-1,other-no-proxy-2,1.1.1.1/24,2.2.2.2/24",
 			},
 		},
 	}

--- a/e2e/cluster/cluster.go
+++ b/e2e/cluster/cluster.go
@@ -738,6 +738,22 @@ func CreateNode(in *Input, i int) (string, string) {
 			in.T.Fatalf("Failed to get node state %s: %v", name, err)
 		}
 	}
+	ip := getInetIP(state)
+	for j := 0; ip == ""; j++ {
+		if j > 6 {
+			in.T.Fatalf("Failed to get node ip %s: %v", name, err)
+		}
+		time.Sleep(5 * time.Second)
+		if state, _, err = client.GetInstanceState(name); err != nil {
+			in.T.Fatalf("Failed to get node state %s: %v", name, err)
+		}
+		ip = getInetIP(state)
+	}
+
+	return name, ip
+}
+
+func getInetIP(state *api.InstanceState) string {
 	ip := ""
 	for _, addr := range state.Network["eth0"].Addresses {
 		fmt.Printf("Family: %s IP: %s\n", addr.Family, addr.Address)
@@ -747,7 +763,7 @@ func CreateNode(in *Input, i int) (string, string) {
 		}
 	}
 
-	return name, ip
+	return ip
 }
 
 // CreateNetworks create two networks, one of type bridge and inside of it another one of

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -14,7 +14,7 @@ var (
 )
 
 // Holds the default no proxy values.
-var DefaultNoProxy = []string{"localhost", "127.0.0.1", ".default", ".local", ".svc", "kubernetes", "kotsadm-rqlite"}
+var DefaultNoProxy = []string{"localhost", "127.0.0.1"}
 
 const ProxyRegistryAddress = "proxy.replicated.com"
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -14,7 +14,7 @@ var (
 )
 
 // Holds the default no proxy values.
-var DefaultNoProxy = []string{"localhost", "127.0.0.1", ".cluster.local.", ".cluster.local", ".svc"}
+var DefaultNoProxy = []string{"localhost", "127.0.0.1", ".cluster.local", ".svc"}
 
 const ProxyRegistryAddress = "proxy.replicated.com"
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -14,7 +14,7 @@ var (
 )
 
 // Holds the default no proxy values.
-var DefaultNoProxy = []string{"localhost", "127.0.0.1", ".cluster.local"}
+var DefaultNoProxy = []string{"localhost", "127.0.0.1", ".cluster.local.", ".cluster.local", ".svc"}
 
 const ProxyRegistryAddress = "proxy.replicated.com"
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -14,7 +14,7 @@ var (
 )
 
 // Holds the default no proxy values.
-var DefaultNoProxy = []string{"localhost", "127.0.0.1"}
+var DefaultNoProxy = []string{"localhost", "127.0.0.1", ".cluster.local"}
 
 const ProxyRegistryAddress = "proxy.replicated.com"
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

These DNS addresses should not be passed to no_proxy and should have no consequences but are unnecessary.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
