### PR TITLE
fix(ci): release using ttl.sh image

### DIFF
--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -151,7 +151,9 @@ jobs:
 
       - name: Update embedded-cluster-operator metadata.yaml
         env:
-          IMAGES_REGISTRY_SERVER: ttl.sh
+          IMAGES_REGISTRY_SERVER: index.docker.io
+          IMAGES_REGISTRY_USER: ${{ secrets.DOCKERHUB_USER }}
+          IMAGES_REGISTRY_PASS: ${{ secrets.DOCKERHUB_PASSWORD }}
           OPERATOR_CHART: ${{ needs.publish-operator-chart.outputs.chart }}
           OPERATOR_IMAGE: ${{ needs.publish-operator-image.outputs.image }}
         run: |


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

ttl.sh image is ending up in the release metadata

```
"proxy.replicated.com/anonymous/ttl.sh/replicated/ec-utils@sha256:ce82b0dd0b8816d87d26d4ebec0f95cdca964a5e092739903150943a9621aa47"
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
