### PR TITLE
fix(ci): image-scan workflow missing buildtools

### DIFF
--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -10,7 +10,6 @@ on:
     #   - '**/metadata.yaml'
     branches:
       - main
-      - emosbaugh/20240913/fix-image-scan
 
 permissions:
   security-events: write

--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -10,6 +10,7 @@ on:
     #   - '**/metadata.yaml'
     branches:
       - main
+      - emosbaugh/20240913/fix-image-scan
 
 permissions:
   security-events: write
@@ -52,9 +53,31 @@ jobs:
           echo "image=$(cat operator/build/image)" >> $GITHUB_OUTPUT
           echo "chart=$(cat operator/build/chart)" >> $GITHUB_OUTPUT
 
+  buildtools:
+    name: Build buildtools
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: "**/*.sum"
+      - name: Compile buildtools
+        run: |
+          make buildtools
+      - name: Upload buildtools artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: buildtools
+          path: output/bin/buildtools
+
   output-matrix:
     runs-on: ubuntu-latest
-    needs: [build-deps]
+    needs:
+      - build-deps
+      - buildtools
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
     steps:
@@ -66,6 +89,16 @@ jobs:
         with:
           go-version-file: go.mod
           cache-dependency-path: "**/*.sum"
+
+      - name: Download buildtools artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: buildtools
+          path: output/bin
+
+      - name: Compile buildtools
+        run: |
+          make buildtools
 
       - name: Update embedded-cluster-operator metadata.yaml
         env:


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

CI is failing 

```
chmod: cannot access './output/bin/buildtools': No such file or directory
```

https://github.com/replicatedhq/embedded-cluster/actions/runs/10852115430/job/30117607691

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
