### PR TITLE
clarify that kots should be in the same parent directory, not a subdirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,9 @@ make delete-node1
 
 ### Developing KOTS components
 
-1. Clone the KOTS repo to the same directory as Embedded Cluster:
+1. Clone the KOTS repo to the same parent directory as Embedded Cluster:
     ```bash
+    cd ..
     git clone https://github.com/replicatedhq/kots.git
     cd kots
     ```


### PR DESCRIPTION

#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
