### PR TITLE
bug: fix fio build so it can be used on other cpus

### DIFF
--- a/fio/Dockerfile
+++ b/fio/Dockerfile
@@ -17,7 +17,7 @@ RUN [ -z "$FIO_VERSION" ] && echo "FIO_VERSION is required" && exit 1 || true
 RUN wget -O fio.tar.gz -q https://api.github.com/repos/axboe/fio/tarball/fio-$FIO_VERSION
 RUN tar -xzf fio.tar.gz --strip-components=1
 
-RUN ./configure --build-static
+RUN ./configure --build-static --disable-native
 RUN make -j$(nproc)
 
 FROM ubuntu:22.04


### PR DESCRIPTION
use the --disable-native option so it does not optmize for the cpu.

#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
