### PR TITLE
automatically detect node ip during install for noproxy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -519,56 +519,56 @@ jobs:
       matrix:
         test:
           - TestSingleNodeInstallation
-#          - TestSingleNodeInstallationAlmaLinux8
-#          - TestSingleNodeInstallationDebian11
-#          - TestSingleNodeInstallationDebian12
-#          - TestSingleNodeInstallationCentos9Stream
-#          - TestVersion
-#          - TestHostPreflightCustomSpec
-#          - TestHostPreflightInBuiltSpec
-#          - TestUnsupportedOverrides
-#          - TestMultiNodeInstallation
-#          - TestMultiNodeReset
-#          - TestCommandsRequireSudo
-#          - TestInstallWithoutEmbed
-#          - TestInstallFromReplicatedApp
-#          - TestUpgradeFromReplicatedApp
-#          - TestUpgradeEC18FromReplicatedApp
-#          - TestResetAndReinstall
-#          - TestResetAndReinstallAirgap
-#          - TestCollectSupportBundle
-#          - TestOldVersionUpgrade
-#          - TestMaterialize
-#          - TestLocalArtifactMirror
-#          - TestSingleNodeAirgapUpgrade
-#          - TestSingleNodeAirgapUpgradeFromEC18
-#          - TestSingleNodeAirgapUpgradeCustomCIDR
-#          - TestInstallSnapshotFromReplicatedApp
-#          - TestMultiNodeAirgapUpgrade
-#          - TestSingleNodeDisasterRecovery
-#          - TestSingleNodeDisasterRecoveryWithProxy
-#          - TestSingleNodeResumeDisasterRecovery
+          - TestSingleNodeInstallationAlmaLinux8
+          - TestSingleNodeInstallationDebian11
+          - TestSingleNodeInstallationDebian12
+          - TestSingleNodeInstallationCentos9Stream
+          - TestVersion
+          - TestHostPreflightCustomSpec
+          - TestHostPreflightInBuiltSpec
+          - TestUnsupportedOverrides
+          - TestMultiNodeInstallation
+          - TestMultiNodeReset
+          - TestCommandsRequireSudo
+          - TestInstallWithoutEmbed
+          - TestInstallFromReplicatedApp
+          - TestUpgradeFromReplicatedApp
+          - TestUpgradeEC18FromReplicatedApp
+          - TestResetAndReinstall
+          - TestResetAndReinstallAirgap
+          - TestCollectSupportBundle
+          - TestOldVersionUpgrade
+          - TestMaterialize
+          - TestLocalArtifactMirror
+          - TestSingleNodeAirgapUpgrade
+          - TestSingleNodeAirgapUpgradeFromEC18
+          - TestSingleNodeAirgapUpgradeCustomCIDR
+          - TestInstallSnapshotFromReplicatedApp
+          - TestMultiNodeAirgapUpgrade
+          - TestSingleNodeDisasterRecovery
+          - TestSingleNodeDisasterRecoveryWithProxy
+          - TestSingleNodeResumeDisasterRecovery
           - TestProxiedEnvironment
-#          - TestMultiNodeHAInstallation
-#          - TestMultiNodeHADisasterRecovery
-#          - TestCustomCIDR
+          - TestMultiNodeHAInstallation
+          - TestMultiNodeHADisasterRecovery
+          - TestCustomCIDR
           - TestProxiedCustomCIDR
-#          - TestSingleNodeInstallationNoopUpgrade
-#          - TestInstallWithPrivateCAs
-#          - TestInstallWithMITMProxy
-#        include:
-#          - test: TestMultiNodeAirgapUpgrade
-#            runner: embedded-cluster
-#          - test: TestMultiNodeAirgapUpgradeSameK0s
-#            runner: embedded-cluster
-#          - test: TestSingleNodeAirgapDisasterRecovery
-#            runner: embedded-cluster
-#          - test: TestMultiNodeAirgapHAInstallation
-#            runner: embedded-cluster
-#          - test: TestMultiNodeAirgapHADisasterRecovery
-#            runner: embedded-cluster
-#          - test: TestFiveNodesAirgapUpgrade
-#            runner: embedded-cluster
+          - TestSingleNodeInstallationNoopUpgrade
+          - TestInstallWithPrivateCAs
+          - TestInstallWithMITMProxy
+        include:
+          - test: TestMultiNodeAirgapUpgrade
+            runner: embedded-cluster
+          - test: TestMultiNodeAirgapUpgradeSameK0s
+            runner: embedded-cluster
+          - test: TestSingleNodeAirgapDisasterRecovery
+            runner: embedded-cluster
+          - test: TestMultiNodeAirgapHAInstallation
+            runner: embedded-cluster
+          - test: TestMultiNodeAirgapHADisasterRecovery
+            runner: embedded-cluster
+          - test: TestFiveNodesAirgapUpgrade
+            runner: embedded-cluster
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -519,56 +519,56 @@ jobs:
       matrix:
         test:
           - TestSingleNodeInstallation
-#          - TestSingleNodeInstallationAlmaLinux8
-#          - TestSingleNodeInstallationDebian11
-#          - TestSingleNodeInstallationDebian12
-#          - TestSingleNodeInstallationCentos9Stream
-#          - TestVersion
-#          - TestHostPreflightCustomSpec
-#          - TestHostPreflightInBuiltSpec
-#          - TestUnsupportedOverrides
-#          - TestMultiNodeInstallation
-#          - TestMultiNodeReset
-#          - TestCommandsRequireSudo
-#          - TestInstallWithoutEmbed
-#          - TestInstallFromReplicatedApp
-#          - TestUpgradeFromReplicatedApp
-#          - TestUpgradeEC18FromReplicatedApp
-#          - TestResetAndReinstall
-#          - TestResetAndReinstallAirgap
-#          - TestCollectSupportBundle
-#          - TestOldVersionUpgrade
-#          - TestMaterialize
-#          - TestLocalArtifactMirror
-#          - TestSingleNodeAirgapUpgrade
-#          - TestSingleNodeAirgapUpgradeFromEC18
-#          - TestSingleNodeAirgapUpgradeCustomCIDR
-#          - TestInstallSnapshotFromReplicatedApp
-#          - TestMultiNodeAirgapUpgrade
-#          - TestSingleNodeDisasterRecovery
-#          - TestSingleNodeDisasterRecoveryWithProxy
-#          - TestSingleNodeResumeDisasterRecovery
+          - TestSingleNodeInstallationAlmaLinux8
+          - TestSingleNodeInstallationDebian11
+          - TestSingleNodeInstallationDebian12
+          - TestSingleNodeInstallationCentos9Stream
+          - TestVersion
+          - TestHostPreflightCustomSpec
+          - TestHostPreflightInBuiltSpec
+          - TestUnsupportedOverrides
+          - TestMultiNodeInstallation
+          - TestMultiNodeReset
+          - TestCommandsRequireSudo
+          - TestInstallWithoutEmbed
+          - TestInstallFromReplicatedApp
+          - TestUpgradeFromReplicatedApp
+          - TestUpgradeEC18FromReplicatedApp
+          - TestResetAndReinstall
+          - TestResetAndReinstallAirgap
+          - TestCollectSupportBundle
+          - TestOldVersionUpgrade
+          - TestMaterialize
+          - TestLocalArtifactMirror
+          - TestSingleNodeAirgapUpgrade
+          - TestSingleNodeAirgapUpgradeFromEC18
+          - TestSingleNodeAirgapUpgradeCustomCIDR
+          - TestInstallSnapshotFromReplicatedApp
+          - TestMultiNodeAirgapUpgrade
+          - TestSingleNodeDisasterRecovery
+          - TestSingleNodeDisasterRecoveryWithProxy
+          - TestSingleNodeResumeDisasterRecovery
           - TestProxiedEnvironment
-#          - TestMultiNodeHAInstallation
-#          - TestMultiNodeHADisasterRecovery
-#          - TestCustomCIDR
+          - TestMultiNodeHAInstallation
+          - TestMultiNodeHADisasterRecovery
+          - TestCustomCIDR
           - TestProxiedCustomCIDR
-#          - TestSingleNodeInstallationNoopUpgrade
-#          - TestInstallWithPrivateCAs
+          - TestSingleNodeInstallationNoopUpgrade
+          - TestInstallWithPrivateCAs
           - TestInstallWithMITMProxy
-#        include:
-#          - test: TestMultiNodeAirgapUpgrade
-#            runner: embedded-cluster
-#          - test: TestMultiNodeAirgapUpgradeSameK0s
-#            runner: embedded-cluster
-#          - test: TestSingleNodeAirgapDisasterRecovery
-#            runner: embedded-cluster
-#          - test: TestMultiNodeAirgapHAInstallation
-#            runner: embedded-cluster
-#          - test: TestMultiNodeAirgapHADisasterRecovery
-#            runner: embedded-cluster
-#          - test: TestFiveNodesAirgapUpgrade
-#            runner: embedded-cluster
+        include:
+          - test: TestMultiNodeAirgapUpgrade
+            runner: embedded-cluster
+          - test: TestMultiNodeAirgapUpgradeSameK0s
+            runner: embedded-cluster
+          - test: TestSingleNodeAirgapDisasterRecovery
+            runner: embedded-cluster
+          - test: TestMultiNodeAirgapHAInstallation
+            runner: embedded-cluster
+          - test: TestMultiNodeAirgapHADisasterRecovery
+            runner: embedded-cluster
+          - test: TestFiveNodesAirgapUpgrade
+            runner: embedded-cluster
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -519,56 +519,56 @@ jobs:
       matrix:
         test:
           - TestSingleNodeInstallation
-          - TestSingleNodeInstallationAlmaLinux8
-          - TestSingleNodeInstallationDebian11
-          - TestSingleNodeInstallationDebian12
-          - TestSingleNodeInstallationCentos9Stream
-          - TestVersion
-          - TestHostPreflightCustomSpec
-          - TestHostPreflightInBuiltSpec
-          - TestUnsupportedOverrides
-          - TestMultiNodeInstallation
-          - TestMultiNodeReset
-          - TestCommandsRequireSudo
-          - TestInstallWithoutEmbed
-          - TestInstallFromReplicatedApp
-          - TestUpgradeFromReplicatedApp
-          - TestUpgradeEC18FromReplicatedApp
-          - TestResetAndReinstall
-          - TestResetAndReinstallAirgap
-          - TestCollectSupportBundle
-          - TestOldVersionUpgrade
-          - TestMaterialize
-          - TestLocalArtifactMirror
-          - TestSingleNodeAirgapUpgrade
-          - TestSingleNodeAirgapUpgradeFromEC18
-          - TestSingleNodeAirgapUpgradeCustomCIDR
-          - TestInstallSnapshotFromReplicatedApp
-          - TestMultiNodeAirgapUpgrade
-          - TestSingleNodeDisasterRecovery
-          - TestSingleNodeDisasterRecoveryWithProxy
-          - TestSingleNodeResumeDisasterRecovery
+#          - TestSingleNodeInstallationAlmaLinux8
+#          - TestSingleNodeInstallationDebian11
+#          - TestSingleNodeInstallationDebian12
+#          - TestSingleNodeInstallationCentos9Stream
+#          - TestVersion
+#          - TestHostPreflightCustomSpec
+#          - TestHostPreflightInBuiltSpec
+#          - TestUnsupportedOverrides
+#          - TestMultiNodeInstallation
+#          - TestMultiNodeReset
+#          - TestCommandsRequireSudo
+#          - TestInstallWithoutEmbed
+#          - TestInstallFromReplicatedApp
+#          - TestUpgradeFromReplicatedApp
+#          - TestUpgradeEC18FromReplicatedApp
+#          - TestResetAndReinstall
+#          - TestResetAndReinstallAirgap
+#          - TestCollectSupportBundle
+#          - TestOldVersionUpgrade
+#          - TestMaterialize
+#          - TestLocalArtifactMirror
+#          - TestSingleNodeAirgapUpgrade
+#          - TestSingleNodeAirgapUpgradeFromEC18
+#          - TestSingleNodeAirgapUpgradeCustomCIDR
+#          - TestInstallSnapshotFromReplicatedApp
+#          - TestMultiNodeAirgapUpgrade
+#          - TestSingleNodeDisasterRecovery
+#          - TestSingleNodeDisasterRecoveryWithProxy
+#          - TestSingleNodeResumeDisasterRecovery
           - TestProxiedEnvironment
-          - TestMultiNodeHAInstallation
-          - TestMultiNodeHADisasterRecovery
-          - TestCustomCIDR
+#          - TestMultiNodeHAInstallation
+#          - TestMultiNodeHADisasterRecovery
+#          - TestCustomCIDR
           - TestProxiedCustomCIDR
-          - TestSingleNodeInstallationNoopUpgrade
-          - TestInstallWithPrivateCAs
+#          - TestSingleNodeInstallationNoopUpgrade
+#          - TestInstallWithPrivateCAs
           - TestInstallWithMITMProxy
-        include:
-          - test: TestMultiNodeAirgapUpgrade
-            runner: embedded-cluster
-          - test: TestMultiNodeAirgapUpgradeSameK0s
-            runner: embedded-cluster
-          - test: TestSingleNodeAirgapDisasterRecovery
-            runner: embedded-cluster
-          - test: TestMultiNodeAirgapHAInstallation
-            runner: embedded-cluster
-          - test: TestMultiNodeAirgapHADisasterRecovery
-            runner: embedded-cluster
-          - test: TestFiveNodesAirgapUpgrade
-            runner: embedded-cluster
+#        include:
+#          - test: TestMultiNodeAirgapUpgrade
+#            runner: embedded-cluster
+#          - test: TestMultiNodeAirgapUpgradeSameK0s
+#            runner: embedded-cluster
+#          - test: TestSingleNodeAirgapDisasterRecovery
+#            runner: embedded-cluster
+#          - test: TestMultiNodeAirgapHAInstallation
+#            runner: embedded-cluster
+#          - test: TestMultiNodeAirgapHADisasterRecovery
+#            runner: embedded-cluster
+#          - test: TestFiveNodesAirgapUpgrade
+#            runner: embedded-cluster
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -519,56 +519,56 @@ jobs:
       matrix:
         test:
           - TestSingleNodeInstallation
-          - TestSingleNodeInstallationAlmaLinux8
-          - TestSingleNodeInstallationDebian11
-          - TestSingleNodeInstallationDebian12
-          - TestSingleNodeInstallationCentos9Stream
-          - TestVersion
-          - TestHostPreflightCustomSpec
-          - TestHostPreflightInBuiltSpec
-          - TestUnsupportedOverrides
-          - TestMultiNodeInstallation
-          - TestMultiNodeReset
-          - TestCommandsRequireSudo
-          - TestInstallWithoutEmbed
-          - TestInstallFromReplicatedApp
-          - TestUpgradeFromReplicatedApp
-          - TestUpgradeEC18FromReplicatedApp
-          - TestResetAndReinstall
-          - TestResetAndReinstallAirgap
-          - TestCollectSupportBundle
-          - TestOldVersionUpgrade
-          - TestMaterialize
-          - TestLocalArtifactMirror
-          - TestSingleNodeAirgapUpgrade
-          - TestSingleNodeAirgapUpgradeFromEC18
-          - TestSingleNodeAirgapUpgradeCustomCIDR
-          - TestInstallSnapshotFromReplicatedApp
-          - TestMultiNodeAirgapUpgrade
-          - TestSingleNodeDisasterRecovery
-          - TestSingleNodeDisasterRecoveryWithProxy
-          - TestSingleNodeResumeDisasterRecovery
+#          - TestSingleNodeInstallationAlmaLinux8
+#          - TestSingleNodeInstallationDebian11
+#          - TestSingleNodeInstallationDebian12
+#          - TestSingleNodeInstallationCentos9Stream
+#          - TestVersion
+#          - TestHostPreflightCustomSpec
+#          - TestHostPreflightInBuiltSpec
+#          - TestUnsupportedOverrides
+#          - TestMultiNodeInstallation
+#          - TestMultiNodeReset
+#          - TestCommandsRequireSudo
+#          - TestInstallWithoutEmbed
+#          - TestInstallFromReplicatedApp
+#          - TestUpgradeFromReplicatedApp
+#          - TestUpgradeEC18FromReplicatedApp
+#          - TestResetAndReinstall
+#          - TestResetAndReinstallAirgap
+#          - TestCollectSupportBundle
+#          - TestOldVersionUpgrade
+#          - TestMaterialize
+#          - TestLocalArtifactMirror
+#          - TestSingleNodeAirgapUpgrade
+#          - TestSingleNodeAirgapUpgradeFromEC18
+#          - TestSingleNodeAirgapUpgradeCustomCIDR
+#          - TestInstallSnapshotFromReplicatedApp
+#          - TestMultiNodeAirgapUpgrade
+#          - TestSingleNodeDisasterRecovery
+#          - TestSingleNodeDisasterRecoveryWithProxy
+#          - TestSingleNodeResumeDisasterRecovery
           - TestProxiedEnvironment
-          - TestMultiNodeHAInstallation
-          - TestMultiNodeHADisasterRecovery
-          - TestCustomCIDR
+#          - TestMultiNodeHAInstallation
+#          - TestMultiNodeHADisasterRecovery
+#          - TestCustomCIDR
           - TestProxiedCustomCIDR
-          - TestSingleNodeInstallationNoopUpgrade
-          - TestInstallWithPrivateCAs
-          - TestInstallWithMITMProxy
-        include:
-          - test: TestMultiNodeAirgapUpgrade
-            runner: embedded-cluster
-          - test: TestMultiNodeAirgapUpgradeSameK0s
-            runner: embedded-cluster
-          - test: TestSingleNodeAirgapDisasterRecovery
-            runner: embedded-cluster
-          - test: TestMultiNodeAirgapHAInstallation
-            runner: embedded-cluster
-          - test: TestMultiNodeAirgapHADisasterRecovery
-            runner: embedded-cluster
-          - test: TestFiveNodesAirgapUpgrade
-            runner: embedded-cluster
+#          - TestSingleNodeInstallationNoopUpgrade
+#          - TestInstallWithPrivateCAs
+#          - TestInstallWithMITMProxy
+#        include:
+#          - test: TestMultiNodeAirgapUpgrade
+#            runner: embedded-cluster
+#          - test: TestMultiNodeAirgapUpgradeSameK0s
+#            runner: embedded-cluster
+#          - test: TestSingleNodeAirgapDisasterRecovery
+#            runner: embedded-cluster
+#          - test: TestMultiNodeAirgapHAInstallation
+#            runner: embedded-cluster
+#          - test: TestMultiNodeAirgapHADisasterRecovery
+#            runner: embedded-cluster
+#          - test: TestFiveNodesAirgapUpgrade
+#            runner: embedded-cluster
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Additionally, it includes a Registry when deployed in air gap mode.
     ```
 
 1. In the Vendor Portal, create and download a license that is assigned to the channel.
+We recommend storing this license in the `local-dev/` directory, as it is gitignored and not otherwise used by the CI.
 
 1. Install Embedded Cluster:
     ```bash

--- a/cmd/embedded-cluster/install.go
+++ b/cmd/embedded-cluster/install.go
@@ -613,6 +613,11 @@ var installCommand = &cli.Command{
 			metrics.ReportApplyFinished(c, err)
 			return err
 		}
+		proxy, err = maybePromptForNoProxy(c, proxy)
+		if err != nil {
+			metrics.ReportApplyFinished(c, err)
+			return err
+		}
 		logrus.Debugf("materializing binaries")
 		if err := materializeFiles(c); err != nil {
 			metrics.ReportApplyFinished(c, err)

--- a/cmd/embedded-cluster/install.go
+++ b/cmd/embedded-cluster/install.go
@@ -575,7 +575,13 @@ var installCommand = &cli.Command{
 		},
 	)),
 	Action: func(c *cli.Context) error {
+		var err error
 		proxy := getProxySpecFromFlags(c)
+		proxy, err = includeLocalIPInNoProxy(c, proxy)
+		if err != nil {
+			metrics.ReportApplyFinished(c, err)
+			return err
+		}
 		setProxyEnv(proxy)
 
 		logrus.Debugf("checking if %s is already installed", binName)
@@ -612,12 +618,6 @@ var installCommand = &cli.Command{
 			metrics.ReportApplyFinished(c, err)
 			return err
 		}
-		proxy, err = maybePromptForNoProxy(c, proxy)
-		if err != nil {
-			metrics.ReportApplyFinished(c, err)
-			return err
-		}
-		setProxyEnv(proxy)
 
 		logrus.Debugf("materializing binaries")
 		if err := materializeFiles(c); err != nil {

--- a/cmd/embedded-cluster/join.go
+++ b/cmd/embedded-cluster/join.go
@@ -190,6 +190,13 @@ var joinCommand = &cli.Command{
 		}
 
 		setProxyEnv(jcmd.Proxy)
+		proxyOK, localIP, err := checkProxyConfigForLocalIP(jcmd.Proxy)
+		if err != nil {
+			return fmt.Errorf("failed to check proxy config for local IP: %w", err)
+		}
+		if !proxyOK {
+			return fmt.Errorf("no-proxy config %q does not allow access to local IP %q", jcmd.Proxy.NoProxy, localIP)
+		}
 
 		isAirgap := c.String("airgap-bundle") != ""
 

--- a/cmd/embedded-cluster/join.go
+++ b/cmd/embedded-cluster/join.go
@@ -207,7 +207,7 @@ var joinCommand = &cli.Command{
 			return err
 		}
 
-		applier, err := getAddonsApplier(c, "")
+		applier, err := getAddonsApplier(c, "", jcmd.Proxy)
 		if err != nil {
 			metrics.ReportJoinFailed(c.Context, jcmd.MetricsBaseURL, jcmd.ClusterID, err)
 			return err

--- a/cmd/embedded-cluster/preflights.go
+++ b/cmd/embedded-cluster/preflights.go
@@ -118,6 +118,13 @@ var joinRunPreflightsCommand = &cli.Command{
 		}
 
 		setProxyEnv(jcmd.Proxy)
+		proxyOK, localIP, err := checkProxyConfigForLocalIP(jcmd.Proxy)
+		if err != nil {
+			return fmt.Errorf("failed to check proxy config for local IP: %w", err)
+		}
+		if !proxyOK {
+			return fmt.Errorf("no-proxy config %q does not allow access to local IP %q", jcmd.Proxy.NoProxy, localIP)
+		}
 
 		isAirgap := c.String("airgap-bundle") != ""
 

--- a/cmd/embedded-cluster/preflights.go
+++ b/cmd/embedded-cluster/preflights.go
@@ -41,7 +41,12 @@ var installRunPreflightsCommand = &cli.Command{
 		return nil
 	},
 	Action: func(c *cli.Context) error {
+		var err error
 		proxy := getProxySpecFromFlags(c)
+		proxy, err = includeLocalIPInNoProxy(c, proxy)
+		if err != nil {
+			return err
+		}
 		setProxyEnv(proxy)
 
 		license, err := getLicenseFromFilepath(c.String("license"))

--- a/cmd/embedded-cluster/preflights.go
+++ b/cmd/embedded-cluster/preflights.go
@@ -56,7 +56,7 @@ var installRunPreflightsCommand = &cli.Command{
 			return err
 		}
 
-		applier, err := getAddonsApplier(c, "")
+		applier, err := getAddonsApplier(c, "", proxy)
 		if err != nil {
 			return err
 		}
@@ -121,7 +121,7 @@ var joinRunPreflightsCommand = &cli.Command{
 			return err
 		}
 
-		applier, err := getAddonsApplier(c, "")
+		applier, err := getAddonsApplier(c, "", jcmd.Proxy)
 		if err != nil {
 			return err
 		}

--- a/cmd/embedded-cluster/proxy.go
+++ b/cmd/embedded-cluster/proxy.go
@@ -154,3 +154,20 @@ func validateNoProxy(newNoProxy string, localIP string) (bool, error) {
 
 	return foundLocal, nil
 }
+
+func checkProxyConfigForLocalIP(proxy *ecv1beta1.ProxySpec) (bool, string, error) {
+	if proxy == nil {
+		return true, "", nil // no proxy is fine
+	}
+	if proxy.HTTPProxy == "" && proxy.HTTPSProxy == "" {
+		return true, "", nil // no proxy is fine
+	}
+
+	defaultIPNet, err := netutils.GetDefaultIPNet()
+	if err != nil {
+		return false, "", fmt.Errorf("failed to get default IPNet: %w", err)
+	}
+
+	ok, err := validateNoProxy(proxy.NoProxy, defaultIPNet.IP.String())
+	return ok, defaultIPNet.IP.String(), err
+}

--- a/cmd/embedded-cluster/proxy.go
+++ b/cmd/embedded-cluster/proxy.go
@@ -94,7 +94,7 @@ func setProxyEnv(proxy *ecv1beta1.ProxySpec) {
 	}
 }
 
-func maybePromptForNoProxy(c *cli.Context, proxy *ecv1beta1.ProxySpec) (*ecv1beta1.ProxySpec, error) {
+func includeLocalIPInNoProxy(c *cli.Context, proxy *ecv1beta1.ProxySpec) (*ecv1beta1.ProxySpec, error) {
 	if proxy != nil && (proxy.HTTPProxy != "" || proxy.HTTPSProxy != "") {
 		// if there is a proxy set, then there needs to be a no proxy set
 		// if it is not set, prompt with a default (the local IP or subnet)

--- a/cmd/embedded-cluster/proxy.go
+++ b/cmd/embedded-cluster/proxy.go
@@ -59,14 +59,14 @@ func getProxySpecFromFlags(c *cli.Context) *ecv1beta1.ProxySpec {
 		providedNoProxy = append(providedNoProxy, c.String("no-proxy"))
 	}
 	proxy.ProvidedNoProxy = strings.Join(providedNoProxy, ",")
-	regenerateNoProxy(c, proxy)
+	combineNoProxySuppliedValuesAndDefaults(c, proxy)
 	if proxy.HTTPProxy == "" && proxy.HTTPSProxy == "" && proxy.NoProxy == "" {
 		return nil
 	}
 	return proxy
 }
 
-func regenerateNoProxy(c *cli.Context, proxy *ecv1beta1.ProxySpec) {
+func combineNoProxySuppliedValuesAndDefaults(c *cli.Context, proxy *ecv1beta1.ProxySpec) {
 	if proxy.ProvidedNoProxy == "" {
 		return
 	}
@@ -112,8 +112,7 @@ func maybePromptForNoProxy(c *cli.Context, proxy *ecv1beta1.ProxySpec) (*ecv1bet
 			if c.Bool("no-prompt") {
 				logrus.Infof("no-proxy was not set, using default no proxy %s", cleanDefaultIPNet)
 				proxy.ProvidedNoProxy = cleanDefaultIPNet
-				regenerateNoProxy(c, proxy)
-				logrus.Infof("final (default) no-proxy is %q", proxy.NoProxy)
+				combineNoProxySuppliedValuesAndDefaults(c, proxy)
 				return proxy, nil
 			} else {
 				return promptForNoProxy(c, proxy, cleanDefaultIPNet, defaultIPNet.IP.String())
@@ -156,8 +155,7 @@ func promptForNoProxy(c *cli.Context, proxy *ecv1beta1.ProxySpec, subnet, IP str
 		return nil, fmt.Errorf("provided no-proxy %q does not cover the local IP %q", newProxy, IP)
 	}
 	proxy.ProvidedNoProxy = newProxy
-	regenerateNoProxy(c, proxy)
-	fmt.Printf("final (provided) no-proxy is %q\n", proxy.NoProxy)
+	combineNoProxySuppliedValuesAndDefaults(c, proxy)
 	return proxy, nil
 }
 

--- a/cmd/embedded-cluster/proxy.go
+++ b/cmd/embedded-cluster/proxy.go
@@ -113,7 +113,7 @@ func maybePromptForNoProxy(c *cli.Context, proxy *ecv1beta1.ProxySpec) (*ecv1bet
 				logrus.Infof("no-proxy was not set, using default no proxy %s", cleanDefaultIPNet)
 				proxy.ProvidedNoProxy = cleanDefaultIPNet
 				regenerateNoProxy(c, proxy)
-				logrus.Infof("final no-proxy is %q", proxy.ProvidedNoProxy)
+				logrus.Infof("final no-proxy is %q", proxy.NoProxy)
 				return proxy, nil
 			} else {
 				return promptForNoProxy(c, proxy, cleanDefaultIPNet, defaultIPNet.IP.String())

--- a/cmd/embedded-cluster/proxy.go
+++ b/cmd/embedded-cluster/proxy.go
@@ -67,6 +67,9 @@ func getProxySpecFromFlags(c *cli.Context) *ecv1beta1.ProxySpec {
 }
 
 func regenerateNoProxy(c *cli.Context, proxy *ecv1beta1.ProxySpec) {
+	if proxy.ProvidedNoProxy == "" {
+		return
+	}
 	noProxy := strings.Split(proxy.ProvidedNoProxy, ",")
 	if len(noProxy) > 0 || proxy.HTTPProxy != "" || proxy.HTTPSProxy != "" {
 		noProxy = append(defaults.DefaultNoProxy, noProxy...)

--- a/cmd/embedded-cluster/proxy.go
+++ b/cmd/embedded-cluster/proxy.go
@@ -111,7 +111,8 @@ func maybePromptForNoProxy(c *cli.Context, proxy *ecv1beta1.ProxySpec) (*ecv1bet
 		if proxy.ProvidedNoProxy == "" {
 			if c.Bool("no-prompt") {
 				logrus.Infof("no-proxy was not set, using default no proxy %s", cleanDefaultIPNet)
-				proxy.NoProxy = cleanDefaultIPNet
+				proxy.ProvidedNoProxy = cleanDefaultIPNet
+				regenerateNoProxy(c, proxy)
 				return proxy, nil
 			} else {
 				return promptForNoProxy(c, proxy, cleanDefaultIPNet, defaultIPNet.IP.String())
@@ -144,7 +145,7 @@ func cleanCIDR(defaultIPNet *net.IPNet) (string, error) {
 }
 
 func promptForNoProxy(c *cli.Context, proxy *ecv1beta1.ProxySpec, subnet, IP string) (*ecv1beta1.ProxySpec, error) {
-	logrus.Infof("A noproxy is required when a proxy is set. We suggest either the node subnet %q or the addresses of every node that will be a member of the cluster. The current node's IP address is %q.", subnet, IP)
+	logrus.Infof("A no-proxy address is required when a proxy is set. We suggest either the node subnet %q or the addresses of every node that will be a member of the cluster. The current node's IP address is %q.", subnet, IP)
 	newProxy := prompts.New().Input("No proxy:", "", true)
 	isValid, err := validateNoProxy(newProxy, IP)
 	if err != nil {

--- a/cmd/embedded-cluster/proxy.go
+++ b/cmd/embedded-cluster/proxy.go
@@ -113,7 +113,7 @@ func maybePromptForNoProxy(c *cli.Context, proxy *ecv1beta1.ProxySpec) (*ecv1bet
 				logrus.Infof("no-proxy was not set, using default no proxy %s", cleanDefaultIPNet)
 				proxy.ProvidedNoProxy = cleanDefaultIPNet
 				regenerateNoProxy(c, proxy)
-				logrus.Infof("final no-proxy is %q", proxy.NoProxy)
+				logrus.Infof("final (default) no-proxy is %q", proxy.NoProxy)
 				return proxy, nil
 			} else {
 				return promptForNoProxy(c, proxy, cleanDefaultIPNet, defaultIPNet.IP.String())
@@ -157,6 +157,7 @@ func promptForNoProxy(c *cli.Context, proxy *ecv1beta1.ProxySpec, subnet, IP str
 	}
 	proxy.ProvidedNoProxy = newProxy
 	regenerateNoProxy(c, proxy)
+	fmt.Printf("final (provided) no-proxy is %q\n", proxy.NoProxy)
 	return proxy, nil
 }
 

--- a/cmd/embedded-cluster/proxy.go
+++ b/cmd/embedded-cluster/proxy.go
@@ -117,7 +117,7 @@ func includeLocalIPInNoProxy(c *cli.Context, proxy *ecv1beta1.ProxySpec) (*ecv1b
 			if err != nil {
 				return nil, fmt.Errorf("failed to validate no-proxy: %w", err)
 			} else if !isValid {
-				logrus.Infof("The provided no-proxy %q does not cover the local IP %q, adding the default interface's subnet %q to the no-proxy we will use", proxy.NoProxy, defaultIPNet.IP.String(), cleanDefaultIPNet)
+				logrus.Infof("The provided no-proxy %q does not cover the local IP %q, adding the default interface's subnet %q to the no-proxy we will use", proxy.ProvidedNoProxy, defaultIPNet.IP.String(), cleanDefaultIPNet)
 				proxy.ProvidedNoProxy = cleanDefaultIPNet
 				combineNoProxySuppliedValuesAndDefaults(c, proxy)
 				return proxy, nil

--- a/cmd/embedded-cluster/proxy.go
+++ b/cmd/embedded-cluster/proxy.go
@@ -2,15 +2,15 @@ package main
 
 import (
 	"fmt"
-	"github.com/replicatedhq/embedded-cluster/pkg/netutils"
-	"github.com/replicatedhq/embedded-cluster/pkg/prompts"
-	"github.com/sirupsen/logrus"
 	"net"
 	"os"
 	"strings"
 
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg/defaults"
+	"github.com/replicatedhq/embedded-cluster/pkg/netutils"
+	"github.com/replicatedhq/embedded-cluster/pkg/prompts"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
 

--- a/cmd/embedded-cluster/proxy.go
+++ b/cmd/embedded-cluster/proxy.go
@@ -41,12 +41,12 @@ func withProxyFlags(flags []cli.Flag) []cli.Flag {
 
 func getProxySpecFromFlags(c *cli.Context) *ecv1beta1.ProxySpec {
 	proxy := &ecv1beta1.ProxySpec{}
-	var providatedNoProxy []string
+	var providedNoProxy []string
 	if c.Bool("proxy") {
 		proxy.HTTPProxy = os.Getenv("HTTP_PROXY")
 		proxy.HTTPSProxy = os.Getenv("HTTPS_PROXY")
 		if os.Getenv("NO_PROXY") != "" {
-			providatedNoProxy = append(providatedNoProxy, os.Getenv("NO_PROXY"))
+			providedNoProxy = append(providedNoProxy, os.Getenv("NO_PROXY"))
 		}
 	}
 	if c.IsSet("http-proxy") {
@@ -56,9 +56,9 @@ func getProxySpecFromFlags(c *cli.Context) *ecv1beta1.ProxySpec {
 		proxy.HTTPSProxy = c.String("https-proxy")
 	}
 	if c.String("no-proxy") != "" {
-		providatedNoProxy = append(providatedNoProxy, c.String("no-proxy"))
+		providedNoProxy = append(providedNoProxy, c.String("no-proxy"))
 	}
-	proxy.ProvidedNoProxy = strings.Join(providatedNoProxy, ",")
+	proxy.ProvidedNoProxy = strings.Join(providedNoProxy, ",")
 	regenerateNoProxy(c, proxy)
 	if proxy.HTTPProxy == "" && proxy.HTTPSProxy == "" && proxy.NoProxy == "" {
 		return nil

--- a/cmd/embedded-cluster/proxy.go
+++ b/cmd/embedded-cluster/proxy.go
@@ -59,11 +59,7 @@ func getProxySpecFromFlags(c *cli.Context) *ecv1beta1.ProxySpec {
 		providatedNoProxy = append(providatedNoProxy, c.String("no-proxy"))
 	}
 	proxy.ProvidedNoProxy = strings.Join(providatedNoProxy, ",")
-	if len(providatedNoProxy) > 0 || proxy.HTTPProxy != "" || proxy.HTTPSProxy != "" {
-		noProxy := append(defaults.DefaultNoProxy, providatedNoProxy...)
-		noProxy = append(noProxy, c.String("pod-cidr"), c.String("service-cidr"))
-		proxy.NoProxy = strings.Join(noProxy, ",")
-	}
+	regenerateNoProxy(c, proxy)
 	if proxy.HTTPProxy == "" && proxy.HTTPSProxy == "" && proxy.NoProxy == "" {
 		return nil
 	}

--- a/cmd/embedded-cluster/proxy.go
+++ b/cmd/embedded-cluster/proxy.go
@@ -108,7 +108,7 @@ func includeLocalIPInNoProxy(c *cli.Context, proxy *ecv1beta1.ProxySpec) (*ecv1b
 			return nil, fmt.Errorf("failed to clean subnet: %w", err)
 		}
 		if proxy.ProvidedNoProxy == "" {
-			logrus.Infof("no-proxy was not set, adding the default interface's subnet %q to the no-proxy", cleanDefaultIPNet)
+			logrus.Infof("--no-proxy was not set. Adding the default interface's subnet (%q) to the no-proxy list.", cleanDefaultIPNet)
 			proxy.ProvidedNoProxy = cleanDefaultIPNet
 			combineNoProxySuppliedValuesAndDefaults(c, proxy)
 			return proxy, nil
@@ -117,7 +117,7 @@ func includeLocalIPInNoProxy(c *cli.Context, proxy *ecv1beta1.ProxySpec) (*ecv1b
 			if err != nil {
 				return nil, fmt.Errorf("failed to validate no-proxy: %w", err)
 			} else if !isValid {
-				logrus.Infof("The provided no-proxy %q does not cover the local IP %q, adding the default interface's subnet %q to the no-proxy we will use", proxy.ProvidedNoProxy, defaultIPNet.IP.String(), cleanDefaultIPNet)
+				logrus.Infof("The node IP (%q) is not included in the provided no-proxy list (%q). Adding the default interface's subnet (%q) to the no-proxy list.", defaultIPNet.IP.String(), proxy.ProvidedNoProxy, cleanDefaultIPNet)
 				proxy.ProvidedNoProxy = cleanDefaultIPNet
 				combineNoProxySuppliedValuesAndDefaults(c, proxy)
 				return proxy, nil

--- a/cmd/embedded-cluster/proxy.go
+++ b/cmd/embedded-cluster/proxy.go
@@ -113,6 +113,7 @@ func maybePromptForNoProxy(c *cli.Context, proxy *ecv1beta1.ProxySpec) (*ecv1bet
 				logrus.Infof("no-proxy was not set, using default no proxy %s", cleanDefaultIPNet)
 				proxy.ProvidedNoProxy = cleanDefaultIPNet
 				regenerateNoProxy(c, proxy)
+				logrus.Infof("final no-proxy is %q", proxy.ProvidedNoProxy)
 				return proxy, nil
 			} else {
 				return promptForNoProxy(c, proxy, cleanDefaultIPNet, defaultIPNet.IP.String())

--- a/cmd/embedded-cluster/proxy_test.go
+++ b/cmd/embedded-cluster/proxy_test.go
@@ -38,9 +38,10 @@ func Test_getProxySpecFromFlags(t *testing.T) {
 				flagSet.Set("proxy", "true")
 			},
 			want: &ecv1beta1.ProxySpec{
-				HTTPProxy:  "http://proxy",
-				HTTPSProxy: "https://proxy",
-				NoProxy:    "localhost,127.0.0.1,.cluster.local,.svc,no-proxy-1,no-proxy-2,10.244.0.0/16,10.96.0.0/12",
+				HTTPProxy:       "http://proxy",
+				HTTPSProxy:      "https://proxy",
+				ProvidedNoProxy: "no-proxy-1,no-proxy-2",
+				NoProxy:         "localhost,127.0.0.1,.cluster.local,.svc,no-proxy-1,no-proxy-2,10.244.0.0/16,10.96.0.0/12",
 			},
 		},
 		{
@@ -66,13 +67,14 @@ func Test_getProxySpecFromFlags(t *testing.T) {
 				flagSet.Set("no-proxy", "other-no-proxy-1,other-no-proxy-2")
 			},
 			want: &ecv1beta1.ProxySpec{
-				HTTPProxy:  "http://other-proxy",
-				HTTPSProxy: "https://other-proxy",
-				NoProxy:    "localhost,127.0.0.1,.cluster.local,.svc,other-no-proxy-1,other-no-proxy-2,10.244.0.0/16,10.96.0.0/12",
+				HTTPProxy:       "http://other-proxy",
+				HTTPSProxy:      "https://other-proxy",
+				ProvidedNoProxy: "other-no-proxy-1,other-no-proxy-2",
+				NoProxy:         "localhost,127.0.0.1,.cluster.local,.svc,other-no-proxy-1,other-no-proxy-2,10.244.0.0/16,10.96.0.0/12",
 			},
 		},
 		{
-			name: "proxy flags should override proxy from env",
+			name: "proxy flags should override proxy from env, but merge no-proxy",
 			init: func(t *testing.T, flagSet *flag.FlagSet) {
 				t.Setenv("HTTP_PROXY", "http://proxy")
 				t.Setenv("HTTPS_PROXY", "https://proxy")
@@ -84,9 +86,10 @@ func Test_getProxySpecFromFlags(t *testing.T) {
 				flagSet.Set("no-proxy", "other-no-proxy-1,other-no-proxy-2")
 			},
 			want: &ecv1beta1.ProxySpec{
-				HTTPProxy:  "http://other-proxy",
-				HTTPSProxy: "https://other-proxy",
-				NoProxy:    "localhost,127.0.0.1,.cluster.local,.svc,no-proxy-1,no-proxy-2,other-no-proxy-1,other-no-proxy-2,10.244.0.0/16,10.96.0.0/12",
+				HTTPProxy:       "http://other-proxy",
+				HTTPSProxy:      "https://other-proxy",
+				ProvidedNoProxy: "no-proxy-1,no-proxy-2,other-no-proxy-1,other-no-proxy-2",
+				NoProxy:         "localhost,127.0.0.1,.cluster.local,.svc,no-proxy-1,no-proxy-2,other-no-proxy-1,other-no-proxy-2,10.244.0.0/16,10.96.0.0/12",
 			},
 		},
 		{
@@ -100,9 +103,10 @@ func Test_getProxySpecFromFlags(t *testing.T) {
 				flagSet.Set("service-cidr", "2.2.2.2/24")
 			},
 			want: &ecv1beta1.ProxySpec{
-				HTTPProxy:  "http://other-proxy",
-				HTTPSProxy: "https://other-proxy",
-				NoProxy:    "localhost,127.0.0.1,.cluster.local,.svc,other-no-proxy-1,other-no-proxy-2,1.1.1.1/24,2.2.2.2/24",
+				HTTPProxy:       "http://other-proxy",
+				HTTPSProxy:      "https://other-proxy",
+				ProvidedNoProxy: "other-no-proxy-1,other-no-proxy-2",
+				NoProxy:         "localhost,127.0.0.1,.cluster.local,.svc,other-no-proxy-1,other-no-proxy-2,1.1.1.1/24,2.2.2.2/24",
 			},
 		},
 	}

--- a/cmd/embedded-cluster/restore.go
+++ b/cmd/embedded-cluster/restore.go
@@ -942,7 +942,7 @@ var restoreCommand = &cli.Command{
 			}
 		}
 
-		applier, err := getAddonsApplier(c, "")
+		applier, err := getAddonsApplier(c, "", proxy)
 		if err != nil {
 			return err
 		}

--- a/e2e/proxy_test.go
+++ b/e2e/proxy_test.go
@@ -35,7 +35,6 @@ func TestProxiedEnvironment(t *testing.T) {
 	line := []string{"single-node-install.sh", "ui"}
 	line = append(line, "--http-proxy", cluster.HTTPProxy)
 	line = append(line, "--https-proxy", cluster.HTTPProxy)
-	line = append(line, "--no-proxy", strings.Join(tc.IPs, ","))
 	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv(tc.IPs)); err != nil {
 		t.Fatalf("fail to install embedded-cluster on node %s: %v", tc.Nodes[0], err)
 	}

--- a/e2e/proxy_test.go
+++ b/e2e/proxy_test.go
@@ -35,7 +35,7 @@ func TestProxiedEnvironment(t *testing.T) {
 	line := []string{"single-node-install.sh", "ui"}
 	line = append(line, "--http-proxy", cluster.HTTPProxy)
 	line = append(line, "--https-proxy", cluster.HTTPProxy)
-	line = append(line, "--no-proxy", "10.0.0.0/25") // test with half the default subnet, because the proxy is within the subnet otherwise
+	line = append(line, "--no-proxy", "10.0.0.0/24") // test with the default subnet, to see if the issue is with the autoset code or the noproxy itself
 	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv(tc.IPs)); err != nil {
 		t.Fatalf("fail to install embedded-cluster on node %s: %v", tc.Nodes[0], err)
 	}

--- a/e2e/proxy_test.go
+++ b/e2e/proxy_test.go
@@ -35,6 +35,7 @@ func TestProxiedEnvironment(t *testing.T) {
 	line := []string{"single-node-install.sh", "ui"}
 	line = append(line, "--http-proxy", cluster.HTTPProxy)
 	line = append(line, "--https-proxy", cluster.HTTPProxy)
+	line = append(line, "--no-proxy", "10.0.0.0/25") // test with half the default subnet, because the proxy is within the subnet otherwise
 	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv(tc.IPs)); err != nil {
 		t.Fatalf("fail to install embedded-cluster on node %s: %v", tc.Nodes[0], err)
 	}

--- a/e2e/proxy_test.go
+++ b/e2e/proxy_test.go
@@ -262,7 +262,6 @@ func TestInstallWithMITMProxy(t *testing.T) {
 	line := []string{"single-node-install.sh", "ui"}
 	line = append(line, "--http-proxy", cluster.HTTPMITMProxy)
 	line = append(line, "--https-proxy", cluster.HTTPMITMProxy)
-	line = append(line, "--no-proxy", strings.Join(tc.IPs[0:1], ",")) // testing, some nodes will not be in the noproxy list
 	line = append(line, "--private-ca", "/usr/local/share/ca-certificates/proxy/ca.crt")
 	_, _, err := RunCommandOnNode(t, tc, 0, line, withMITMProxyEnv(tc.IPs))
 	require.NoError(t, err, "failed to install embedded-cluster on node 0")

--- a/e2e/proxy_test.go
+++ b/e2e/proxy_test.go
@@ -35,7 +35,6 @@ func TestProxiedEnvironment(t *testing.T) {
 	line := []string{"single-node-install.sh", "ui"}
 	line = append(line, "--http-proxy", cluster.HTTPProxy)
 	line = append(line, "--https-proxy", cluster.HTTPProxy)
-	line = append(line, "--no-proxy", "10.0.0.0/24") // test with the default subnet, to see if the issue is with the autoset code or the noproxy itself
 	if _, _, err := RunCommandOnNode(t, tc, 0, line, withProxyEnv(tc.IPs)); err != nil {
 		t.Fatalf("fail to install embedded-cluster on node %s: %v", tc.Nodes[0], err)
 	}

--- a/e2e/proxy_test.go
+++ b/e2e/proxy_test.go
@@ -262,7 +262,7 @@ func TestInstallWithMITMProxy(t *testing.T) {
 	line := []string{"single-node-install.sh", "ui"}
 	line = append(line, "--http-proxy", cluster.HTTPMITMProxy)
 	line = append(line, "--https-proxy", cluster.HTTPMITMProxy)
-	line = append(line, "--no-proxy", strings.Join(tc.IPs, ","))
+	line = append(line, "--no-proxy", strings.Join(tc.IPs[0:1], ",")) // testing, some nodes will not be in the noproxy list
 	line = append(line, "--private-ca", "/usr/local/share/ca-certificates/proxy/ca.crt")
 	_, _, err := RunCommandOnNode(t, tc, 0, line, withMITMProxyEnv(tc.IPs))
 	require.NoError(t, err, "failed to install embedded-cluster on node 0")

--- a/kinds/apis/v1beta1/installation_types.go
+++ b/kinds/apis/v1beta1/installation_types.go
@@ -68,9 +68,10 @@ type ArtifactsLocation struct {
 
 // ProxySpec holds the proxy configuration.
 type ProxySpec struct {
-	HTTPProxy  string `json:"httpProxy,omitempty"`
-	HTTPSProxy string `json:"httpsProxy,omitempty"`
-	NoProxy    string `json:"noProxy,omitempty"`
+	HTTPProxy       string `json:"httpProxy,omitempty"`
+	HTTPSProxy      string `json:"httpsProxy,omitempty"`
+	ProvidedNoProxy string `json:"providedNoProxy,omitempty"`
+	NoProxy         string `json:"noProxy,omitempty"`
 }
 
 // NetworkSpec holds the network configuration.

--- a/operator/charts/embedded-cluster-operator/charts/crds/templates/resources.yaml
+++ b/operator/charts/embedded-cluster-operator/charts/crds/templates/resources.yaml
@@ -526,6 +526,8 @@ spec:
                     type: string
                   noProxy:
                     type: string
+                  providedNoProxy:
+                    type: string
                 type: object
             type: object
           status:

--- a/operator/config/crd/bases/embeddedcluster.replicated.com_installations.yaml
+++ b/operator/config/crd/bases/embeddedcluster.replicated.com_installations.yaml
@@ -315,6 +315,8 @@ spec:
                     type: string
                   noProxy:
                     type: string
+                  providedNoProxy:
+                    type: string
                 type: object
             type: object
           status:

--- a/pkg/netutils/ips.go
+++ b/pkg/netutils/ips.go
@@ -1,0 +1,53 @@
+package netutils
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// GetDefaultIPAndMask returns the default interface for the node, and the subnet mask for that node, using the same logic as k0s
+func GetDefaultIPAndMask() (*net.IPNet, error) {
+	ifs, err := net.Interfaces()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list network interfaces: %w", err)
+	}
+	for _, i := range ifs {
+		if isPodnetworkInterface(i.Name) {
+			continue
+		}
+		addresses, err := i.Addrs()
+		if err != nil {
+			logrus.Debugf("failed to get addresses for interface %s: %s", i.Name, err.Error())
+			continue
+		}
+		for _, a := range addresses {
+			// check the address type and skip if loopback
+			if ipnet, ok := a.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
+				if ipnet.IP.To4() != nil {
+					return ipnet, nil
+				}
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("failed to find any non-local, non podnetwork ipv4 addresses on host")
+}
+
+func isPodnetworkInterface(name string) bool {
+	switch {
+	case name == "vxlan.calico":
+		return true
+	case name == "kube-bridge":
+		return true
+	case name == "dummyvip0":
+		return true
+	case strings.HasPrefix(name, "veth"):
+		return true
+	case strings.HasPrefix(name, "cali"):
+		return true
+	}
+	return false
+}

--- a/pkg/netutils/ips.go
+++ b/pkg/netutils/ips.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// GetDefaultIPAndMask returns the default interface for the node, and the subnet mask for that node, using the same logic as k0s
-func GetDefaultIPAndMask() (*net.IPNet, error) {
+// GetDefaultIPNet returns the default interface for the node, and the subnet mask for that node, using the same logic as k0s
+func GetDefaultIPNet() (*net.IPNet, error) {
 	ifs, err := net.Interfaces()
 	if err != nil {
 		return nil, fmt.Errorf("failed to list network interfaces: %w", err)

--- a/pkg/netutils/ips.go
+++ b/pkg/netutils/ips.go
@@ -8,7 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// GetDefaultIPNet returns the default interface for the node, and the subnet mask for that node, using the same logic as k0s
+// GetDefaultIPNet returns the default interface for the node, and the subnet mask for that node, using the same logic
+// as k0s in https://github.com/k0sproject/k0s/blob/v1.30.4%2Bk0s.0/internal/pkg/iface/iface.go#L61
 func GetDefaultIPNet() (*net.IPNet, error) {
 	ifs, err := net.Interfaces()
 	if err != nil {

--- a/pkg/netutils/ips_test.go
+++ b/pkg/netutils/ips_test.go
@@ -1,0 +1,15 @@
+package netutils
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestGetDefaultIPAndMask(t *testing.T) {
+	req := require.New(t)
+	got, err := GetDefaultIPAndMask()
+	req.NoError(err)
+	fmt.Printf("got network: %s, got ip: %s\n", got.String(), got.IP.String())
+	req.NotNil(got)
+}

--- a/pkg/netutils/ips_test.go
+++ b/pkg/netutils/ips_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestGetDefaultIPAndMask(t *testing.T) {
 	req := require.New(t)
-	got, err := GetDefaultIPAndMask()
+	got, err := GetDefaultIPNet()
 	req.NoError(err)
 	fmt.Printf("got network: %s, got ip: %s\n", got.String(), got.IP.String())
 	req.NotNil(got)

--- a/pkg/netutils/ips_test.go
+++ b/pkg/netutils/ips_test.go
@@ -2,8 +2,9 @@ package netutils
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetDefaultIPAndMask(t *testing.T) {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

With no no-proxy set:
```
no-proxy was not set, adding the default interface's subnet "172.17.0.0/16" to the no-proxy
? Set the Admin Console password:
```
With an insufficient no-proxy set:
```
The provided no-proxy "10.0.0.0/24" does not cover the local IP "172.17.0.2", adding the default interface's subnet "172.17.0.0/16" to the no-proxy we will use
? Set the Admin Console password:
```
When joining a node that is not included in the cluster's no-proxy:
```
no-proxy config "localhost,127.0.0.1,.cluster.local,.svc,10.0.0.2,10.244.0.0/16,10.96.0.0/12" does not allow access to local IP "10.0.0.3"
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Installations using a proxy will automatically have the default interface's subnet supplied as a no-proxy if the provided no-proxy does not cover the instance IP address.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
