### PR TITLE
check if chart values parse as yaml before installing application

### DIFF
--- a/cmd/embedded-cluster/install.go
+++ b/cmd/embedded-cluster/install.go
@@ -633,6 +633,10 @@ var installCommand = &cli.Command{
 			metrics.ReportApplyFinished(c, err)
 			return err
 		}
+		if err := preflights.ValidateApp(); err != nil {
+			metrics.ReportApplyFinished(c, err)
+			return err
+		}
 		cfg, err := installAndWaitForK0s(c, applier)
 		if err != nil {
 			return err

--- a/cmd/embedded-cluster/install.go
+++ b/cmd/embedded-cluster/install.go
@@ -608,6 +608,10 @@ var installCommand = &cli.Command{
 				return err // we want the user to see the error message without a prefix
 			}
 		}
+		if err := preflights.ValidateApp(); err != nil {
+			metrics.ReportApplyFinished(c, err)
+			return err
+		}
 		adminConsolePwd, err := maybeAskAdminConsolePassword(c)
 		if err != nil {
 			metrics.ReportApplyFinished(c, err)
@@ -630,10 +634,6 @@ var installCommand = &cli.Command{
 			proxyRegistryURL = fmt.Sprintf("https://%s", defaults.ProxyRegistryAddress)
 		}
 		if err := RunHostPreflights(c, applier, replicatedAPIURL, proxyRegistryURL, isAirgap, proxy); err != nil {
-			metrics.ReportApplyFinished(c, err)
-			return err
-		}
-		if err := preflights.ValidateApp(); err != nil {
 			metrics.ReportApplyFinished(c, err)
 			return err
 		}

--- a/pkg/preflights/app.go
+++ b/pkg/preflights/app.go
@@ -1,0 +1,31 @@
+package preflights
+
+import (
+	"fmt"
+
+	"github.com/replicatedhq/embedded-cluster/pkg/release"
+	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/yaml"
+)
+
+// ValidateApp runs some basic checks on the embedded cluster config.
+func ValidateApp() error {
+	cfg, err := release.GetEmbeddedClusterConfig()
+	if err != nil {
+		return fmt.Errorf("unable to get embedded cluster config: %w", err)
+	}
+	if cfg == nil {
+		return nil
+	}
+
+	// for each addon, check to see if the values file parses as yaml
+	for _, addon := range cfg.Spec.Extensions.Helm.Charts {
+		genericUnmarshal := map[string]interface{}{}
+		err = yaml.Unmarshal([]byte(addon.Values), &genericUnmarshal)
+		if err != nil {
+			logrus.Debugf("failed to parse helm chart values for addon %s as yaml, values were %q: %v", addon.Name, addon.Values, err)
+			return fmt.Errorf("failed to parse helm chart values for addon %s as yaml: %w", addon.Name, err)
+		}
+	}
+	return nil
+}

--- a/pkg/preflights/app.go
+++ b/pkg/preflights/app.go
@@ -14,7 +14,7 @@ func ValidateApp() error {
 	if err != nil {
 		return fmt.Errorf("unable to get embedded cluster config: %w", err)
 	}
-	if cfg == nil {
+	if cfg == nil || cfg.Spec.Extensions.Helm == nil {
 		return nil
 	}
 

--- a/pkg/preflights/app_test.go
+++ b/pkg/preflights/app_test.go
@@ -43,6 +43,46 @@ spec:
 `)},
 			wantErr: "failed to parse helm chart values for addon test as yaml: error converting YAML to JSON: yaml: invalid map key: map[interface {}]interface {}{\"repl RandomString 10\":interface {}(nil)}",
 		},
+		{
+			name: "good extension values",
+			releaseData: map[string][]byte{
+				"embedded-cluster-config.yaml": []byte(`
+apiVersion: embeddedcluster.replicated.com/v1beta1
+kind: Config
+metadata:
+  name: "testconfig"
+spec:
+  extensions:
+    helm:
+      charts:
+      - chartname: test
+        name: test
+        namespace: test
+        version: 1.0.0
+        values: |
+          goodyaml: true
+`)},
+			wantErr: "",
+		},
+		{
+			name: "no extension values",
+			releaseData: map[string][]byte{
+				"embedded-cluster-config.yaml": []byte(`
+apiVersion: embeddedcluster.replicated.com/v1beta1
+kind: Config
+metadata:
+  name: "testconfig"
+spec:
+  extensions:
+    helm:
+      charts:
+      - chartname: test
+        name: test
+        namespace: test
+        version: 1.0.0
+`)},
+			wantErr: "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/preflights/app_test.go
+++ b/pkg/preflights/app_test.go
@@ -1,0 +1,62 @@
+package preflights
+
+import (
+	"github.com/replicatedhq/embedded-cluster/pkg/release"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestValidateApp(t *testing.T) {
+	tests := []struct {
+		name        string
+		releaseData map[string][]byte
+		wantErr     string
+	}{
+		{
+			name: "valid",
+			releaseData: map[string][]byte{
+				"embedded-cluster-config.yaml": []byte(`
+apiVersion: embeddedcluster.replicated.com/v1beta1
+kind: Config
+metadata:
+  name: "testconfig"`)},
+		},
+		{
+			name: "bad extension values",
+			releaseData: map[string][]byte{
+				"embedded-cluster-config.yaml": []byte(`
+apiVersion: embeddedcluster.replicated.com/v1beta1
+kind: Config
+metadata:
+  name: "testconfig"
+spec:
+  extensions:
+    helm:
+      charts:
+      - chartname: test
+        name: test
+        namespace: test
+        version: 1.0.0
+        values: |
+          badyaml: true
+          thisisnotavalidmapping: {{repl RandomString 10}}
+`)},
+			wantErr: "failed to parse helm chart values for addon test as yaml: error converting YAML to JSON: yaml: invalid map key: map[interface {}]interface {}{\"repl RandomString 10\":interface {}(nil)}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+
+			req.NoError(release.SetReleaseDataForTests(tt.releaseData))
+
+			err := ValidateApp()
+			if tt.wantErr != "" {
+				req.Error(err)
+				req.Equal(tt.wantErr, err.Error())
+			} else {
+				req.NoError(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Sometimes additional chart values will be invalid yaml. This will prevent the installation from completing 5+ minutes later with very hard to debug error messages. We should check for this early.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
The 'install' command will check helm extension values for yaml validity before installation.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
