### PR TITLE
fix(ci): do not override digest for wrong architecture

### DIFF
--- a/cmd/buildtools/utils.go
+++ b/cmd/buildtools/utils.go
@@ -377,7 +377,10 @@ func GetImageDigest(ctx context.Context, img string, arch string) (string, error
 		if info.Architecture != arch {
 			return "", &DockerManifestNotFoundError{image: img, arch: arch, err: err}
 		}
-		digest := i.ConfigInfo().Digest
+		digest, err := manifest.Digest(manifraw)
+		if err != nil {
+			return "", fmt.Errorf("get manifest digest: %w", err)
+		}
 		return digest.String(), nil
 	}
 

--- a/cmd/buildtools/utils.go
+++ b/cmd/buildtools/utils.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/containers/image/v5/docker"
+	"github.com/containers/image/v5/image"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
 	"github.com/distribution/reference"
@@ -364,10 +365,19 @@ func GetImageDigest(ctx context.Context, img string, arch string) (string, error
 	}
 
 	if !manifest.MIMETypeIsMultiImage(maniftype) {
-		digest, err := manifest.Digest(manifraw)
+		i, err := image.FromSource(ctx, sysctx, src)
 		if err != nil {
-			return "", fmt.Errorf("get manifest digest: %w", err)
+			return "", fmt.Errorf("image from source: %w", err)
 		}
+		defer i.Close()
+		info, err := i.Inspect(ctx)
+		if err != nil {
+			return "", fmt.Errorf("inspect image: %w", err)
+		}
+		if info.Architecture != arch {
+			return "", &DockerManifestNotFoundError{image: img, arch: arch, err: err}
+		}
+		digest := i.ConfigInfo().Digest
 		return digest.String(), nil
 	}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Prior to this change, for non list type manifests we were ignoring architecture.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
