### PR TITLE
chore: skip proxy tests on k0s < 1.29

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,11 +219,11 @@ vet: static
 
 .PHONY: e2e-tests
 e2e-tests: embedded-release
-	go test -timeout 60m -parallel 1 -failfast -v ./e2e
+	go test -timeout 60m -ldflags="$(LD_FLAGS)" -parallel 1 -failfast -v ./e2e
 
 .PHONY: e2e-test
 e2e-test:
-	go test -timeout 60m -v ./e2e -run $(TEST_NAME)$
+	go test -timeout 60m -ldflags="$(LD_FLAGS)" -v ./e2e -run $(TEST_NAME)$
 
 .PHONY: build-ttl.sh
 build-ttl.sh:

--- a/e2e/proxy_test.go
+++ b/e2e/proxy_test.go
@@ -7,13 +7,26 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/replicatedhq/embedded-cluster/e2e/cluster"
+	"github.com/replicatedhq/embedded-cluster/pkg/versions"
 	"github.com/stretchr/testify/require"
 )
+
+// SkipProxyTest returns true if the k0s version in use does not support
+// proxied environments.
+func SkipProxyTest() bool {
+	supportedVersion := semver.MustParse("1.29.0")
+	currentVersion := semver.MustParse(versions.K0sVersion)
+	return currentVersion.LessThan(supportedVersion)
+}
 
 // TestProxiedEnvironment tests the installation behind a proxy server
 func TestProxiedEnvironment(t *testing.T) {
 	t.Parallel()
+	if SkipProxyTest() {
+		t.Skip("skipping test for k0s versions < 1.29.0")
+	}
 
 	tc := cluster.NewTestCluster(&cluster.Input{
 		T:                   t,
@@ -125,6 +138,9 @@ func TestProxiedEnvironment(t *testing.T) {
 // TestProxiedCustomCIDR tests the installation behind a proxy server while using a custom pod and service CIDR
 func TestProxiedCustomCIDR(t *testing.T) {
 	t.Parallel()
+	if SkipProxyTest() {
+		t.Skip("skipping test for k0s versions < 1.29.0")
+	}
 
 	tc := cluster.NewTestCluster(&cluster.Input{
 		T:                   t,
@@ -244,6 +260,10 @@ func TestProxiedCustomCIDR(t *testing.T) {
 }
 
 func TestInstallWithMITMProxy(t *testing.T) {
+	if SkipProxyTest() {
+		t.Skip("skipping test for k0s versions < 1.29.0")
+	}
+
 	tc := cluster.NewTestCluster(&cluster.Input{
 		T:                   t,
 		Nodes:               4,

--- a/e2e/restore_test.go
+++ b/e2e/restore_test.go
@@ -96,6 +96,9 @@ func TestSingleNodeDisasterRecovery(t *testing.T) {
 
 func TestSingleNodeDisasterRecoveryWithProxy(t *testing.T) {
 	t.Parallel()
+	if SkipProxyTest() {
+		t.Skip("skipping test for k0s versions < 1.29.0")
+	}
 
 	requiredEnvVars := []string{
 		"DR_AWS_S3_ENDPOINT",


### PR DESCRIPTION
#### What this PR does / why we need it:

proxy installations are not supported on k0s < 1.29.