### PR TITLE
report embedded cluster and k8s versions with metrics object

### DIFF
--- a/pkg/metrics/sender.go
+++ b/pkg/metrics/sender.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/replicatedhq/embedded-cluster/pkg/versions"
 	"github.com/sirupsen/logrus"
 )
 
@@ -56,6 +57,10 @@ func (s *Sender) Send(ctx context.Context, ev Event) {
 
 // payload returns the payload to be sent to the metrics endpoint.
 func (s *Sender) payload(ev Event) ([]byte, error) {
-	payload := map[string]Event{"event": ev}
+	vmap := map[string]string{
+		"EmbeddedCluster": versions.Version,
+		"Kubernetes":      versions.K0sVersion,
+	}
+	payload := map[string]interface{}{"event": ev, "versions": vmap}
 	return json.Marshal(payload)
 }

--- a/pkg/metrics/sender_test.go
+++ b/pkg/metrics/sender_test.go
@@ -67,7 +67,7 @@ func TestSend(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			payload := map[string]Event{"event": tt.event}
+			payload := map[string]interface{}{"event": tt.event, "versions": map[string]string{"EmbeddedCluster": "v0.0.0", "Kubernetes": "0.0.0"}}
 			expected, err := json.Marshal(payload)
 			assert.NoError(t, err)
 			server := httptest.NewServer(


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

This makes it dramatically easier to figure out what version of embedded cluster is throwing errors.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
