### PR TITLE
feat: ability to override admin console and lam host ports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ include common.mk
 
 APP_NAME = embedded-cluster
 ADMIN_CONSOLE_CHART_REPO_OVERRIDE =
-ADMIN_CONSOLE_IMAGE_OVERRIDE =
+ADMIN_CONSOLE_IMAGE_OVERRIDE = ttl.sh/ethan/kotsadm:24h
 ADMIN_CONSOLE_MIGRATIONS_IMAGE_OVERRIDE =
 ADMIN_CONSOLE_KURL_PROXY_IMAGE_OVERRIDE =
 K0S_VERSION = v1.29.8+k0s.0
@@ -13,10 +13,10 @@ PREVIOUS_K0S_VERSION ?= v1.28.10+k0s.0
 K0S_BINARY_SOURCE_OVERRIDE =
 PREVIOUS_K0S_BINARY_SOURCE_OVERRIDE =
 TROUBLESHOOT_VERSION = v0.102.0
-KOTS_VERSION = v$(shell awk '/^version/{print $$2}' pkg/addons/adminconsole/static/metadata.yaml | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+KOTS_VERSION = v0.0.1-ethan-20240919-1
 # When updating KOTS_BINARY_URL_OVERRIDE, also update the KOTS_VERSION above or
 # scripts/ci-upload-binaries.sh may find the version in the cache and not upload the overridden binary.
-KOTS_BINARY_URL_OVERRIDE =
+KOTS_BINARY_URL_OVERRIDE = https://repldev-ethan-test.s3.amazonaws.com/kots.tar.gz
 # TODO: move this to a manifest file
 LOCAL_ARTIFACT_MIRROR_IMAGE ?= proxy.replicated.com/anonymous/replicated/embedded-cluster-local-artifact-mirror:$(VERSION)
 # These are used to override the binary urls in dev and e2e tests

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ include common.mk
 
 APP_NAME = embedded-cluster
 ADMIN_CONSOLE_CHART_REPO_OVERRIDE =
-ADMIN_CONSOLE_IMAGE_OVERRIDE = ttl.sh/ethan/kotsadm:24h
+ADMIN_CONSOLE_IMAGE_OVERRIDE =
 ADMIN_CONSOLE_MIGRATIONS_IMAGE_OVERRIDE =
 ADMIN_CONSOLE_KURL_PROXY_IMAGE_OVERRIDE =
 K0S_VERSION = v1.29.8+k0s.0
@@ -13,10 +13,10 @@ PREVIOUS_K0S_VERSION ?= v1.28.10+k0s.0
 K0S_BINARY_SOURCE_OVERRIDE =
 PREVIOUS_K0S_BINARY_SOURCE_OVERRIDE =
 TROUBLESHOOT_VERSION = v0.102.0
-KOTS_VERSION = v0.0.1-ethan-20240919-1
+KOTS_VERSION = v$(shell awk '/^version/{print $$2}' pkg/addons/adminconsole/static/metadata.yaml | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
 # When updating KOTS_BINARY_URL_OVERRIDE, also update the KOTS_VERSION above or
 # scripts/ci-upload-binaries.sh may find the version in the cache and not upload the overridden binary.
-KOTS_BINARY_URL_OVERRIDE = https://repldev-ethan-test.s3.amazonaws.com/kots.tar.gz
+KOTS_BINARY_URL_OVERRIDE =
 # TODO: move this to a manifest file
 LOCAL_ARTIFACT_MIRROR_IMAGE ?= proxy.replicated.com/anonymous/replicated/embedded-cluster-local-artifact-mirror:$(VERSION)
 # These are used to override the binary urls in dev and e2e tests

--- a/Makefile
+++ b/Makefile
@@ -269,6 +269,7 @@ list-distros:
 
 .PHONY: create-node%
 create-node%: DISTRO = debian-bookworm
+create-node%: NODE_PORT = 30000
 create-node%:
 	@if ! docker images | grep -q ec-$(DISTRO); then \
 		$(MAKE) -C dev/distros build-$(DISTRO); \
@@ -282,7 +283,7 @@ create-node%:
 		-v /var/lib/k0s \
 		-v $(shell pwd):/replicatedhq/embedded-cluster \
 		-v $(shell dirname $(shell pwd))/kots:/replicatedhq/kots \
-		$(if $(filter node0,node$*),-p 30000:30000) \
+		$(if $(filter node0,node$*),-p $(NODE_PORT):$(NODE_PORT)) \
 		ec-$(DISTRO)
 
 	@$(MAKE) ssh-node$*

--- a/cmd/embedded-cluster/flags.go
+++ b/cmd/embedded-cluster/flags.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/replicatedhq/embedded-cluster/pkg/defaults"
+	"github.com/urfave/cli/v2"
+	k8snet "k8s.io/utils/net"
+)
+
+func getAdminColsolePortFlag() cli.Flag {
+	return &cli.StringFlag{
+		Name:   "admin-console-port",
+		Usage:  "Port on which the Admin Console will be served",
+		Value:  strconv.Itoa(defaults.AdminConsolePort),
+		Hidden: false,
+	}
+}
+
+func getAdminConsolePortFromFlag(c *cli.Context) (int, error) {
+	portStr := c.String("admin-console-port")
+	if portStr == "" {
+		return defaults.AdminConsolePort, nil
+	}
+	// TODO: add first class support for service node port range and validate the port
+	port, err := k8snet.ParsePort(portStr, false)
+	if err != nil {
+		return 0, fmt.Errorf("invalid admin console port: %w", err)
+	}
+	return port, nil
+}
+
+func getLocalArtifactMirrorPortFlag() cli.Flag {
+	return &cli.StringFlag{
+		Name:   "local-artifact-mirror-port",
+		Usage:  "Port on which the Local Artifact Mirror will be served",
+		Value:  strconv.Itoa(defaults.LocalArtifactMirrorPort),
+		Hidden: false,
+	}
+}
+
+func getLocalArtifactMirrorPortFromFlag(c *cli.Context) (int, error) {
+	portStr := c.String("local-artifact-mirror-port")
+	if portStr == "" {
+		return defaults.LocalArtifactMirrorPort, nil
+	}
+	// TODO: add first class support for service node port range and validate the port does not
+	// conflict with this range
+	port, err := k8snet.ParsePort(portStr, false)
+	if err != nil {
+		return 0, fmt.Errorf("invalid local artifact mirror port: %w", err)
+	}
+	if portStr == c.String("admin-console-port") {
+		return 0, fmt.Errorf("local artifact mirror port cannot be the same as admin console port")
+	}
+	return port, nil
+}

--- a/cmd/embedded-cluster/install.go
+++ b/cmd/embedded-cluster/install.go
@@ -37,9 +37,12 @@ var ErrNothingElseToAdd = fmt.Errorf("")
 // installAndEnableLocalArtifactMirror installs and enables the local artifact mirror. This
 // service is responsible for serving on localhost, through http, all files that are used
 // during a cluster upgrade.
-func installAndEnableLocalArtifactMirror() error {
+func installAndEnableLocalArtifactMirror(port int) error {
 	if err := goods.MaterializeLocalArtifactMirrorUnitFile(); err != nil {
 		return fmt.Errorf("failed to materialize artifact mirror unit: %w", err)
+	}
+	if err := writeLocalArtifactMirrorEnvironmentFile(port); err != nil {
+		return fmt.Errorf("failed to write local artifact mirror environment file: %w", err)
 	}
 	if _, err := helpers.RunCommand("systemctl", "daemon-reload"); err != nil {
 		return fmt.Errorf("unable to get reload systemctl daemon: %w", err)
@@ -48,7 +51,41 @@ func installAndEnableLocalArtifactMirror() error {
 		return fmt.Errorf("unable to start the local artifact mirror: %w", err)
 	}
 	if _, err := helpers.RunCommand("systemctl", "enable", "local-artifact-mirror"); err != nil {
-		return fmt.Errorf("unable to start the local artifact mirror: %w", err)
+		return fmt.Errorf("unable to start the local artifact mirror service: %w", err)
+	}
+	return nil
+}
+
+// updateLocalArtifactMirrorService updates the port on which the local artifact mirror is served.
+func updateLocalArtifactMirrorService(port int) error {
+	if err := writeLocalArtifactMirrorEnvironmentFile(port); err != nil {
+		return fmt.Errorf("failed to write local artifact mirror environment file: %w", err)
+	}
+	if _, err := helpers.RunCommand("systemctl", "daemon-reload"); err != nil {
+		return fmt.Errorf("unable to get reload systemctl daemon: %w", err)
+	}
+	if _, err := helpers.RunCommand("systemctl", "restart", "local-artifact-mirror"); err != nil {
+		return fmt.Errorf("unable to restart the local artifact mirror service: %w", err)
+	}
+	return nil
+}
+
+const (
+	localArtifactMirrorSystemdConfFile         = "/etc/systemd/system/local-artifact-mirror.service.d/embedded-cluster.conf"
+	localArtifactMirrorEnvironmentFileContents = `[Service]
+Environment="LOCAL_ARTIFACT_MIRROR_PORT=%d"`
+)
+
+func writeLocalArtifactMirrorEnvironmentFile(port int) error {
+	dir := filepath.Dir(localArtifactMirrorSystemdConfFile)
+	err := os.MkdirAll(dir, 0755)
+	if err != nil {
+		return fmt.Errorf("create directory: %w", err)
+	}
+	contents := fmt.Sprintf(localArtifactMirrorEnvironmentFileContents, port)
+	err = os.WriteFile(localArtifactMirrorSystemdConfFile, []byte(contents), 0644)
+	if err != nil {
+		return fmt.Errorf("write file: %w", err)
 	}
 	return nil
 }
@@ -458,7 +495,7 @@ func installAndWaitForK0s(c *cli.Context, applier *addons.Applier, proxy *ecv1be
 		return nil, err
 	}
 	logrus.Debugf("creating systemd unit files")
-	if err := createSystemdUnitFiles(false, proxy); err != nil {
+	if err := createSystemdUnitFiles(false, proxy, applier.GetLocalArtifactMirrorPort()); err != nil {
 		err := fmt.Errorf("unable to create systemd unit files: %w", err)
 		metrics.ReportApplyFinished(c, err)
 		return nil, err
@@ -586,6 +623,8 @@ var installCommand = &cli.Command{
 				Name:  "private-ca",
 				Usage: "Path to a trusted private CA certificate file",
 			},
+			getAdminColsolePortFlag(),
+			getLocalArtifactMirrorPortFlag(),
 		},
 	)),
 	Action: func(c *cli.Context) error {
@@ -704,6 +743,19 @@ func getAddonsApplier(c *cli.Context, adminConsolePwd string, proxy *ecv1beta1.P
 		}
 		opts = append(opts, addons.WithPrivateCAs(privateCAs))
 	}
+
+	adminConsolePort, err := getAdminConsolePortFromFlag(c)
+	if err != nil {
+		return nil, err
+	}
+	opts = append(opts, addons.WithAdminConsolePort(adminConsolePort))
+
+	localArtifactMirrorPort, err := getLocalArtifactMirrorPortFromFlag(c)
+	if err != nil {
+		return nil, err
+	}
+	opts = append(opts, addons.WithLocalArtifactMirrorPort(localArtifactMirrorPort))
+
 	if adminConsolePwd != "" {
 		opts = append(opts, addons.WithAdminConsolePassword(adminConsolePwd))
 	}

--- a/cmd/embedded-cluster/util.go
+++ b/cmd/embedded-cluster/util.go
@@ -12,7 +12,7 @@ import (
 
 // createSystemdUnitFiles links the k0s systemd unit file. this also creates a new
 // systemd unit file for the local artifact mirror service.
-func createSystemdUnitFiles(isWorker bool, proxy *ecv1beta1.ProxySpec) error {
+func createSystemdUnitFiles(isWorker bool, proxy *ecv1beta1.ProxySpec, localArtifactMirrorPort int) error {
 	dst := systemdUnitFileName()
 	if _, err := os.Lstat(dst); err == nil {
 		if err := os.Remove(dst); err != nil {
@@ -36,7 +36,10 @@ func createSystemdUnitFiles(isWorker bool, proxy *ecv1beta1.ProxySpec) error {
 	if _, err := helpers.RunCommand("systemctl", "daemon-reload"); err != nil {
 		return fmt.Errorf("unable to get reload systemctl daemon: %w", err)
 	}
-	return installAndEnableLocalArtifactMirror()
+	if err := installAndEnableLocalArtifactMirror(localArtifactMirrorPort); err != nil {
+		return fmt.Errorf("unable to install and enable local artifact mirror: %w", err)
+	}
+	return nil
 }
 
 // ensureProxyConfig creates a new http-proxy.conf configuration file. The file is saved in the

--- a/dev/dockerfiles/operator/Dockerfile.ttlsh
+++ b/dev/dockerfiles/operator/Dockerfile.ttlsh
@@ -9,6 +9,7 @@ RUN --mount=type=cache,target="/go/pkg/mod" go mod download
 
 COPY common.mk common.mk
 COPY operator/ operator/
+COPY pkg/ pkg/
 COPY kinds/ kinds/
 COPY utils/ utils/
 

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -31,7 +31,7 @@ func TestSingleNodeInstallation(t *testing.T) {
 	defer cleanupCluster(t, tc)
 
 	t.Logf("%s: installing embedded-cluster on node 0", time.Now().Format(time.RFC3339))
-	line := []string{"single-node-install.sh", "ui"}
+	line := []string{"single-node-install.sh", "ui", "--admin-console-port", "30002"}
 	if _, _, err := RunCommandOnNode(t, tc, 0, line); err != nil {
 		t.Fatalf("fail to install embedded-cluster on node %s: %v", tc.Nodes[0], err)
 	}
@@ -806,7 +806,7 @@ func TestSingleNodeAirgapUpgrade(t *testing.T) {
 	}
 
 	t.Logf("%s: installing embedded-cluster on node 0", time.Now().Format(time.RFC3339))
-	line = []string{"single-node-airgap-install.sh"}
+	line = []string{"single-node-airgap-install.sh", "--local-artifact-mirror-port", "50001"} // choose an alternate lam port
 	if _, _, err := RunCommandOnNode(t, tc, 0, line); err != nil {
 		t.Fatalf("fail to install embedded-cluster on node %s: %v", tc.Nodes[0], err)
 	}
@@ -1257,7 +1257,7 @@ func TestMultiNodeAirgapUpgrade(t *testing.T) {
 	}
 
 	t.Logf("%s: installing embedded-cluster on node 0", time.Now().Format(time.RFC3339))
-	line = []string{"single-node-airgap-install.sh"}
+	line = []string{"single-node-airgap-install.sh", "--local-artifact-mirror-port", "50001"} // choose an alternate lam port
 	if _, _, err := RunCommandOnNode(t, tc, 0, line); err != nil {
 		t.Fatalf("fail to install embedded-cluster on node %s: %v", tc.Nodes[0], err)
 	}

--- a/e2e/local-artifact-mirror_test.go
+++ b/e2e/local-artifact-mirror_test.go
@@ -23,7 +23,7 @@ func TestLocalArtifactMirror(t *testing.T) {
 	defer cleanupCluster(t, tc)
 
 	t.Logf("%s: installing embedded-cluster on node 0", time.Now().Format(time.RFC3339))
-	line := []string{"default-install.sh"}
+	line := []string{"default-install.sh", "--local-artifact-mirror-port", "50001"}
 	if _, _, err := RunCommandOnNode(t, tc, 0, line); err != nil {
 		t.Fatalf("fail to install embedded-cluster on node %s: %v", tc.Nodes[0], err)
 	}
@@ -34,7 +34,7 @@ func TestLocalArtifactMirror(t *testing.T) {
 		{"systemctl", "stop", "local-artifact-mirror"},
 		{"systemctl", "start", "local-artifact-mirror"},
 		{"systemctl", "status", "local-artifact-mirror"},
-		{"curl", "-o", "/tmp/kubectl-test", "127.0.0.1:50000/bin/kubectl"},
+		{"curl", "-o", "/tmp/kubectl-test", "127.0.0.1:50001/bin/kubectl"},
 		{"chmod", "755", "/tmp/kubectl-test"},
 		{"/tmp/kubectl-test", "version", "--client"},
 	}
@@ -47,13 +47,13 @@ func TestLocalArtifactMirror(t *testing.T) {
 		t.Fatalf("fail to copy file: %v", err)
 	}
 
-	command = []string{"curl", "-O", "--fail", "127.0.0.1:50000/logs/passwd"}
+	command = []string{"curl", "-O", "--fail", "127.0.0.1:50001/logs/passwd"}
 	t.Logf("running %v", command)
 	if _, _, err := RunCommandOnNode(t, tc, 0, command); err == nil {
 		t.Fatalf("we should not be able to fetch logs from local artifact mirror")
 	}
 
-	command = []string{"curl", "-O", "--fail", "127.0.0.1:50000/../../../etc/passwd"}
+	command = []string{"curl", "-O", "--fail", "127.0.0.1:50001/../../../etc/passwd"}
 	t.Logf("running %v", command)
 	if _, _, err := RunCommandOnNode(t, tc, 0, command); err == nil {
 		t.Fatalf("we should not be able to fetch paths with ../")

--- a/e2e/scripts/default-install.sh
+++ b/e2e/scripts/default-install.sh
@@ -14,12 +14,18 @@ check_openebs_storage_class() {
 }
 
 main() {
-    if embedded-cluster install --no-prompt --skip-host-preflights --license /assets/license.yaml 2>&1 | tee /tmp/log ; then
+    local additional_args=
+    if [ -n "${1:-}" ]; then
+        additional_args="$*"
+        echo "Running install with additional args: $additional_args"
+    fi
+
+    if embedded-cluster install --no-prompt --skip-host-preflights --license /assets/license.yaml $additional_args 2>&1 | tee /tmp/log ; then
         echo "Expected installation to fail with a license provided"
         exit 1
     fi
 
-    if ! embedded-cluster install --no-prompt --skip-host-preflights 2>&1 | tee /tmp/log ; then
+    if ! embedded-cluster install --no-prompt --skip-host-preflights $additional_args 2>&1 | tee /tmp/log ; then
         cat /etc/os-release
         echo "Failed to install embedded-cluster"
         exit 1
@@ -49,4 +55,4 @@ main() {
 export EMBEDDED_CLUSTER_METRICS_BASEURL="https://staging.replicated.app"
 export KUBECONFIG=/var/lib/k0s/pki/admin.conf
 export PATH=$PATH:/var/lib/embedded-cluster/bin
-main
+main "$@"

--- a/e2e/scripts/restore-multi-node-airgap-phase1.exp
+++ b/e2e/scripts/restore-multi-node-airgap-phase1.exp
@@ -12,7 +12,7 @@ set dr_aws_s3_prefix [lindex $argv 3]
 set dr_aws_access_key_id [lindex $argv 4]
 set dr_aws_secret_access_key [lindex $argv 5]
 
-spawn embedded-cluster restore --airgap-bundle /assets/release.airgap --proxy
+spawn embedded-cluster restore --airgap-bundle /assets/release.airgap --proxy --local-artifact-mirror-port 50001
 
 expect {
     "Enter information to configure access to your backup storage location." {}

--- a/operator/controllers/installation_controller.go
+++ b/operator/controllers/installation_controller.go
@@ -31,6 +31,7 @@ import (
 	apcore "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
 	"github.com/k0sproject/version"
 	ectypes "github.com/replicatedhq/embedded-cluster/kinds/types"
+	"github.com/replicatedhq/embedded-cluster/pkg/defaults"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -753,7 +754,11 @@ func (r *InstallationReconciler) StartAutopilotUpgrade(ctx context.Context, in *
 		// if we are running in an airgap environment all assets are already present in the
 		// node and are served by the local-artifact-mirror binary listening on localhost
 		// port 50000. we just need to get autopilot to fetch the k0s binary from there.
-		k0surl = "http://127.0.0.1:50000/bin/k0s-upgrade"
+		port := defaults.LocalArtifactMirrorPort
+		if in.Spec.LocalArtifactMirror != nil && in.Spec.LocalArtifactMirror.Port > 0 {
+			port = in.Spec.LocalArtifactMirror.Port
+		}
+		k0surl = fmt.Sprintf("http://127.0.0.1:%d/bin/k0s-upgrade", port)
 	} else {
 		artifact := meta.Artifacts["k0s"]
 		if strings.HasPrefix(artifact, "https://") || strings.HasPrefix(artifact, "http://") {

--- a/operator/pkg/artifacts/upgrade.go
+++ b/operator/pkg/artifacts/upgrade.go
@@ -12,6 +12,7 @@ import (
 	"github.com/replicatedhq/embedded-cluster/operator/pkg/k8sutil"
 	"github.com/replicatedhq/embedded-cluster/operator/pkg/release"
 	"github.com/replicatedhq/embedded-cluster/operator/pkg/util"
+	"github.com/replicatedhq/embedded-cluster/pkg/defaults"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -252,7 +253,11 @@ func CreateAutopilotAirgapPlanCommand(ctx context.Context, cli client.Client, in
 		allNodes = append(allNodes, node.Name)
 	}
 
-	imageURL := fmt.Sprintf("http://127.0.0.1:50000/images/images-amd64-%s.tar", in.Name)
+	port := defaults.LocalArtifactMirrorPort
+	if in.Spec.LocalArtifactMirror != nil && in.Spec.LocalArtifactMirror.Port > 0 {
+		port = in.Spec.LocalArtifactMirror.Port
+	}
+	imageURL := fmt.Sprintf("http://127.0.0.1:%d/images/images-amd64-%s.tar", port, in.Name)
 
 	return &autopilotv1beta2.PlanCommand{
 		AirgapUpdate: &autopilotv1beta2.PlanCommandAirgapUpdate{

--- a/pkg/addons/adminconsole/adminconsole.go
+++ b/pkg/addons/adminconsole/adminconsole.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/registry"
 	"github.com/replicatedhq/embedded-cluster/pkg/defaults"
+	"github.com/replicatedhq/embedded-cluster/pkg/helm"
 	"github.com/replicatedhq/embedded-cluster/pkg/helpers"
 	"github.com/replicatedhq/embedded-cluster/pkg/kotscli"
 	"github.com/replicatedhq/embedded-cluster/pkg/kubeutils"
@@ -34,8 +35,7 @@ import (
 )
 
 const (
-	ReleaseName                 = "admin-console"
-	DefaultAdminConsoleNodePort = 30000
+	ReleaseName = "admin-console"
 )
 
 var (
@@ -89,6 +89,7 @@ type AdminConsole struct {
 	airgapBundle string
 	proxyEnv     map[string]string
 	privateCAs   map[string]string
+	port         int
 }
 
 // Version returns the embedded admin console version.
@@ -132,7 +133,14 @@ func (a *AdminConsole) GenerateHelmConfig(k0sCfg *k0sv1beta1.ClusterConfig, only
 			helmValues["extraEnv"] = extraEnv
 		}
 	}
-	values, err := yaml.Marshal(helmValues)
+
+	var err error
+	helmValues, err = helm.SetValue(helmValues, "kurlProxy.nodePort", a.port)
+	if err != nil {
+		return nil, nil, fmt.Errorf("set helm values admin-console.kurlProxy.nodePort: %w", err)
+	}
+
+	values, err := helm.MarshalValues(helmValues)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to marshal helm values: %w", err)
 	}
@@ -212,14 +220,23 @@ func (a *AdminConsole) Outro(ctx context.Context, cli client.Client, k0sCfg *k0s
 }
 
 // New creates a new AdminConsole object.
-func New(ns, password string, licenseFile string, airgapBundle string, proxyEnv map[string]string, privateCAs map[string]string) (*AdminConsole, error) {
+func New(
+	namespace string,
+	password string,
+	licenseFile string,
+	airgapBundle string,
+	proxyEnv map[string]string,
+	privateCAs map[string]string,
+	port int,
+) (*AdminConsole, error) {
 	return &AdminConsole{
-		namespace:    ns,
+		namespace:    namespace,
 		password:     password,
 		licenseFile:  licenseFile,
 		airgapBundle: airgapBundle,
 		proxyEnv:     proxyEnv,
 		privateCAs:   privateCAs,
+		port:         GetPort(port),
 	}, nil
 }
 
@@ -259,7 +276,7 @@ func WaitForReady(ctx context.Context, cli client.Client, ns string, writer *spi
 }
 
 // GetURL returns the URL to the admin console.
-func GetURL(networkInterface string) string {
+func GetURL(networkInterface string, port int) string {
 	ipaddr := defaults.TryDiscoverPublicIP()
 	if ipaddr == "" {
 		var err error
@@ -269,7 +286,15 @@ func GetURL(networkInterface string) string {
 			ipaddr = "NODE-IP-ADDRESS"
 		}
 	}
-	return fmt.Sprintf("http://%s:%v", ipaddr, DefaultAdminConsoleNodePort)
+	return fmt.Sprintf("http://%s:%v", ipaddr, GetPort(port))
+}
+
+// GetURL returns the URL to the admin console.
+func GetPort(port int) int {
+	if port <= 0 {
+		return defaults.AdminConsolePort
+	}
+	return port
 }
 
 func createRegistrySecret(ctx context.Context, cli client.Client, namespace string) error {

--- a/pkg/addons/adminconsole/static/metadata.yaml
+++ b/pkg/addons/adminconsole/static/metadata.yaml
@@ -5,24 +5,24 @@
 # $ make buildtools
 # $ output/bin/buildtools update addon <addon name>
 #
-version: 1.117.1
+version: 1.117.2
 location: oci://proxy.replicated.com/anonymous/registry.replicated.com/library/admin-console
 images:
     kotsadm:
         repo: proxy.replicated.com/anonymous/kotsadm/kotsadm
         tag:
-            amd64: v1.117.1-amd64@sha256:cf22f8f8ad9358035d8d5d5e4d9d3adeb4686b77483f5e319fc7246160f075f8
-            arm64: v1.117.1-arm64@sha256:b4d473b08c25d17c22e0d2795950feae86e723c19eda44407bc0d6e33e377bd5
+            amd64: v1.117.2-amd64@sha256:eb36a5a9af101164598f1e2f7f0745aad59bdb8d8870e09e2702d8c75c753380
+            arm64: v1.117.2-arm64@sha256:a60cf01f935a785b1a5e693d65a18bd6f4e8d7aac7be30a3311c4c17f3b8222f
     kotsadm-migrations:
         repo: proxy.replicated.com/anonymous/kotsadm/kotsadm-migrations
         tag:
-            amd64: v1.117.1-amd64@sha256:10dd44ba52da9cd8dc89eac92ec6a6dc310c63acb9350d34359aff365c624ea6
-            arm64: v1.117.1-arm64@sha256:fbde81bd9a08de901013fafb70f783ed6e17d3e741ff4aae92bb87ef6cf3a8d5
+            amd64: v1.117.2-amd64@sha256:afb070977dfc16d3b85d2ae9e3cf68fc317e17e3ab05e6ad08d353201f1682ef
+            arm64: v1.117.2-arm64@sha256:cff8c43da1094d7969ef689eca3fd11c17aae936f45d1584fd00e25085a6112b
     kurl-proxy:
         repo: proxy.replicated.com/anonymous/kotsadm/kurl-proxy
         tag:
-            amd64: v1.117.1-amd64@sha256:d70f3ef0ee64984e5a9b08c7a0f997f1ed3a732854315a1c4f6709980fb65a2a
-            arm64: v1.117.1-arm64@sha256:866f343f2c5a71d0817339605d94754209ac002126e40e302b3714544b809c25
+            amd64: v1.117.2-amd64@sha256:b2e4a7ee3ca4cedd1028fbac0678fcab091b1e0a81fd39d6b8d5d20f509b2304
+            arm64: v1.117.2-arm64@sha256:056b640c03ff824553adb2fc95fb4930e4cdea18c89b656ed81c1937d8ab3c73
     rqlite:
         repo: proxy.replicated.com/anonymous/kotsadm/rqlite
         tag:

--- a/pkg/addons/applier.go
+++ b/pkg/addons/applier.go
@@ -41,15 +41,17 @@ type AddOn interface {
 
 // Applier is an entity that applies (installs and updates) addons in the cluster.
 type Applier struct {
-	prompt          bool
-	verbose         bool
-	adminConsolePwd string // admin console password
-	licenseFile     string
-	onlyDefaults    bool
-	endUserConfig   *ecv1beta1.Config
-	airgapBundle    string
-	proxyEnv        map[string]string
-	privateCAs      map[string]string
+	prompt                  bool
+	verbose                 bool
+	adminConsolePwd         string // admin console password
+	licenseFile             string
+	onlyDefaults            bool
+	endUserConfig           *ecv1beta1.Config
+	airgapBundle            string
+	proxyEnv                map[string]string
+	privateCAs              map[string]string
+	adminConsolePort        int
+	localArtifactMirrorPort int
 }
 
 // Outro runs the outro in all enabled add-ons.
@@ -79,7 +81,7 @@ func (a *Applier) Outro(ctx context.Context, k0sCfg *k0sv1beta1.ClusterConfig, e
 	if err := spinForInstallation(ctx, kcli); err != nil {
 		return err
 	}
-	if err := printKotsadmLinkMessage(a.licenseFile, networkInterface); err != nil {
+	if err := printKotsadmLinkMessage(a.licenseFile, networkInterface, a.GetAdminConsolePort()); err != nil {
 		return fmt.Errorf("unable to print success message: %w", err)
 	}
 	return nil
@@ -250,6 +252,20 @@ func (a *Applier) HostPreflightsForRestore() (*v1beta2.HostPreflightSpec, error)
 	return a.hostPreflights(addons)
 }
 
+func (a *Applier) GetAdminConsolePort() int {
+	if a.adminConsolePort <= 0 {
+		return defaults.AdminConsolePort
+	}
+	return a.adminConsolePort
+}
+
+func (a *Applier) GetLocalArtifactMirrorPort() int {
+	if a.localArtifactMirrorPort <= 0 {
+		return defaults.LocalArtifactMirrorPort
+	}
+	return a.localArtifactMirrorPort
+}
+
 func (a *Applier) hostPreflights(addons []AddOn) (*v1beta2.HostPreflightSpec, error) {
 	allpf := &v1beta2.HostPreflightSpec{}
 	for _, addon := range addons {
@@ -280,7 +296,15 @@ func (a *Applier) load() ([]AddOn, error) {
 	}
 	addons = append(addons, reg)
 
-	embedoperator, err := embeddedclusteroperator.New(a.endUserConfig, a.licenseFile, a.airgapBundle != "", a.proxyEnv, a.privateCAs)
+	embedoperator, err := embeddedclusteroperator.New(
+		a.endUserConfig,
+		a.licenseFile,
+		a.airgapBundle != "",
+		a.proxyEnv,
+		a.privateCAs,
+		a.GetAdminConsolePort(),
+		a.GetLocalArtifactMirrorPort(),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create embedded cluster operator addon: %w", err)
 	}
@@ -296,7 +320,15 @@ func (a *Applier) load() ([]AddOn, error) {
 	}
 	addons = append(addons, vel)
 
-	aconsole, err := adminconsole.New(defaults.KotsadmNamespace, a.adminConsolePwd, a.licenseFile, a.airgapBundle, a.proxyEnv, a.privateCAs)
+	aconsole, err := adminconsole.New(
+		defaults.KotsadmNamespace,
+		a.adminConsolePwd,
+		a.licenseFile,
+		a.airgapBundle,
+		a.proxyEnv,
+		a.privateCAs,
+		a.GetAdminConsolePort(),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create admin console addon: %w", err)
 	}
@@ -391,7 +423,7 @@ func spinForInstallation(ctx context.Context, cli client.Client) error {
 }
 
 // printKotsadmLinkMessage prints the success message when the admin console is online.
-func printKotsadmLinkMessage(licenseFile string, networkInterface string) error {
+func printKotsadmLinkMessage(licenseFile string, networkInterface string, adminConsolePort int) error {
 	var err error
 	license := &kotsv1beta1.License{}
 	if licenseFile != "" {
@@ -401,16 +433,18 @@ func printKotsadmLinkMessage(licenseFile string, networkInterface string) error 
 		}
 	}
 
+	adminConsoleURL := adminconsole.GetURL(networkInterface, adminConsolePort)
+
 	successColor := "\033[32m"
 	colorReset := "\033[0m"
 	var successMessage string
 	if license != nil {
 		successMessage = fmt.Sprintf("Visit the Admin Console to configure and install %s: %s%s%s",
-			license.Spec.AppSlug, successColor, adminconsole.GetURL(networkInterface), colorReset,
+			license.Spec.AppSlug, successColor, adminConsoleURL, colorReset,
 		)
 	} else {
 		successMessage = fmt.Sprintf("Visit the Admin Console to configure and install your application: %s%s%s",
-			successColor, adminconsole.GetURL(networkInterface), colorReset,
+			successColor, adminConsoleURL, colorReset,
 		)
 	}
 	logrus.Info(successMessage)

--- a/pkg/addons/embeddedclusteroperator/embeddedclusteroperator.go
+++ b/pkg/addons/embeddedclusteroperator/embeddedclusteroperator.go
@@ -62,13 +62,15 @@ func init() {
 // EmbeddedClusterOperator manages the installation of the embedded cluster operator
 // helm chart.
 type EmbeddedClusterOperator struct {
-	namespace     string
-	deployName    string
-	endUserConfig *ecv1beta1.Config
-	licenseFile   string
-	airgap        bool
-	proxyEnv      map[string]string
-	privateCAs    map[string]string
+	namespace               string
+	deployName              string
+	endUserConfig           *ecv1beta1.Config
+	licenseFile             string
+	airgap                  bool
+	proxyEnv                map[string]string
+	privateCAs              map[string]string
+	adminConsolePort        int
+	localArtifactMirrorPort int
 }
 
 // Version returns the version of the embedded cluster operator chart.
@@ -259,11 +261,17 @@ func (e *EmbeddedClusterOperator) Outro(ctx context.Context, cli client.Client, 
 			},
 		},
 		Spec: ecv1beta1.InstallationSpec{
-			ClusterID:                 metrics.ClusterID().String(),
-			MetricsBaseURL:            metrics.BaseURL(license),
-			AirGap:                    e.airgap,
-			Proxy:                     proxySpec,
-			Network:                   k0sConfigToNetworkSpec(k0sCfg),
+			ClusterID:      metrics.ClusterID().String(),
+			MetricsBaseURL: metrics.BaseURL(license),
+			AirGap:         e.airgap,
+			Proxy:          proxySpec,
+			Network:        k0sConfigToNetworkSpec(k0sCfg),
+			AdminConsole: &ecv1beta1.AdminConsoleSpec{
+				Port: e.adminConsolePort,
+			},
+			LocalArtifactMirror: &ecv1beta1.LocalArtifactMirrorSpec{
+				Port: e.localArtifactMirrorPort,
+			},
 			Config:                    cfgspec,
 			EndUserK0sConfigOverrides: euOverrides,
 			BinaryName:                defaults.BinaryName(),
@@ -279,15 +287,25 @@ func (e *EmbeddedClusterOperator) Outro(ctx context.Context, cli client.Client, 
 }
 
 // New creates a new EmbeddedClusterOperator addon.
-func New(endUserConfig *ecv1beta1.Config, licenseFile string, airgapEnabled bool, proxyEnv map[string]string, privateCAs map[string]string) (*EmbeddedClusterOperator, error) {
+func New(
+	endUserConfig *ecv1beta1.Config,
+	licenseFile string,
+	airgapEnabled bool,
+	proxyEnv map[string]string,
+	privateCAs map[string]string,
+	adminConsolePort int,
+	localArtifactMirrorPort int,
+) (*EmbeddedClusterOperator, error) {
 	return &EmbeddedClusterOperator{
-		namespace:     "embedded-cluster",
-		deployName:    "embedded-cluster-operator",
-		endUserConfig: endUserConfig,
-		licenseFile:   licenseFile,
-		airgap:        airgapEnabled,
-		proxyEnv:      proxyEnv,
-		privateCAs:    privateCAs,
+		namespace:               "embedded-cluster",
+		deployName:              "embedded-cluster-operator",
+		endUserConfig:           endUserConfig,
+		licenseFile:             licenseFile,
+		airgap:                  airgapEnabled,
+		proxyEnv:                proxyEnv,
+		privateCAs:              privateCAs,
+		adminConsolePort:        adminConsolePort,
+		localArtifactMirrorPort: localArtifactMirrorPort,
 	}, nil
 }
 

--- a/pkg/addons/options.go
+++ b/pkg/addons/options.go
@@ -21,6 +21,20 @@ func WithPrivateCAs(privateCAs map[string]string) Option {
 	}
 }
 
+// WithAdminConsolePort sets the port on which the admin console will be served.
+func WithAdminConsolePort(port int) Option {
+	return func(a *Applier) {
+		a.adminConsolePort = port
+	}
+}
+
+// WithLocalArtifactMirrorPort sets the port on which the local artifact mirror will be served.
+func WithLocalArtifactMirrorPort(port int) Option {
+	return func(a *Applier) {
+		a.localArtifactMirrorPort = port
+	}
+}
+
 // Quiet disables logging for addons.
 func Quiet() Option {
 	return func(a *Applier) {

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -8,11 +8,6 @@ var (
 	DefaultProvider = NewProvider("")
 )
 
-var (
-	// provider holds a global reference to the default provider.
-	provider *Provider
-)
-
 // Holds the default no proxy values.
 var DefaultNoProxy = []string{"localhost", "127.0.0.1", ".cluster.local", ".svc"}
 
@@ -22,6 +17,9 @@ const KotsadmNamespace = "kotsadm"
 const SeaweedFSNamespace = "seaweedfs"
 const RegistryNamespace = "registry"
 const VeleroNamespace = "velero"
+
+const AdminConsolePort = 30000
+const LocalArtifactMirrorPort = 50000
 
 // BinaryName calls BinaryName on the default provider.
 func BinaryName() string {

--- a/pkg/helm/values.go
+++ b/pkg/helm/values.go
@@ -1,0 +1,41 @@
+package helm
+
+import (
+	"fmt"
+
+	"github.com/k0sproject/dig"
+	"github.com/ohler55/ojg/jp"
+	"gopkg.in/yaml.v2"
+)
+
+func UnmarshalValues(valuesYaml string) (map[string]interface{}, error) {
+	newValuesMap := map[string]interface{}{}
+	if err := yaml.Unmarshal([]byte(valuesYaml), &newValuesMap); err != nil {
+		return nil, fmt.Errorf("yaml unmarshal: %w", err)
+	}
+	return newValuesMap, nil
+}
+
+func MarshalValues(values map[string]interface{}) (string, error) {
+	newValuesYaml, err := yaml.Marshal(values)
+	if err != nil {
+		return "", fmt.Errorf("yaml marshal: %w", err)
+	}
+	return string(newValuesYaml), nil
+}
+
+func SetValue(values map[string]interface{}, path string, newValue interface{}) (map[string]interface{}, error) {
+	newValuesMap := dig.Mapping(values)
+
+	x, err := jp.ParseString(path)
+	if err != nil {
+		return nil, fmt.Errorf("parse json path %q: %w", path, err)
+	}
+
+	err = x.Set(newValuesMap, newValue)
+	if err != nil {
+		return nil, fmt.Errorf("set json path %q to %q: %w", path, newValue, err)
+	}
+
+	return newValuesMap, nil
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

- Adds the ability to override the Admin Console port (default 30000) on installation using the flag `--admin-console-port`
- Adds the ability to override the Local Artifact Mirror port (default 50000) on installation using the flag `--local-artifact-mirror-port`
- Adds the ability to override the Local Artifact Mirror port (default 50000) on restore using the flag `--local-artifact-mirror-port`

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- Adds the ability to override the Admin Console port (default 30000) on installation using the flag `--admin-console-port`
- Adds the ability to override the Local Artifact Mirror port (default 50000) on installation using the flag `--local-artifact-mirror-port`
- Adds the ability to override the Local Artifact Mirror port (default 50000) on restore using the flag `--local-artifact-mirror-port`
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
