### PR TITLE
hardcode proxy.replicated.com and replicated.app static IPs in troubleshoot output

### DIFF
--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -323,7 +323,8 @@ spec:
           - fail:
               when: error
               message: >
-                Error connecting to {{ .ReplicatedAPIURL }}.
+                Error connecting to {{ .ReplicatedAPIURL }}. The static IP addresses for
+                {{ .ReplicatedAPIURL }} are 162.159.133.41 and 162.159.134.41.
                 Ensure your firewall is properly configured, and use the --http-proxy, --https-proxy,
                 and --no-proxy flags if there is a proxy server.
           - pass:
@@ -331,7 +332,8 @@ spec:
               message: 'Connected to {{ .ReplicatedAPIURL }}'
           - fail:
               message: >
-                Unexpected response from {{ .ReplicatedAPIURL }}.
+                Error connecting to {{ .ReplicatedAPIURL }}. The static IP addresses for
+                {{ .ReplicatedAPIURL }} are 162.159.133.41 and 162.159.134.41.
                 Ensure your firewall is properly configured, and use the --http-proxy, --https-proxy,
                 and --no-proxy flags if there is a proxy server.
     - http:
@@ -342,7 +344,8 @@ spec:
           - fail:
               when: error
               message: >
-                Error connecting to {{ .ProxyRegistryURL }}.
+                Error connecting to {{ .ProxyRegistryURL }}. The static IP addresses for
+                {{ .ProxyRegistryURL }} are 162.159.137.43 and 162.159.138.43.
                 Ensure your firewall is properly configured, and use the --http-proxy, --https-proxy,
                 and --no-proxy flags if there is a proxy server.
           - pass:
@@ -350,7 +353,8 @@ spec:
               message: 'Connected to {{ .ProxyRegistryURL }}'
           - fail:
               message: >
-                Unexpected response from {{ .ProxyRegistryURL }}.
+                Unexpected response from {{ .ProxyRegistryURL }}. The static IP addresses for
+                {{ .ProxyRegistryURL }} are 162.159.137.43 and 162.159.138.43.
                 Ensure your firewall is properly configured, and use the --http-proxy, --https-proxy,
                 and --no-proxy flags if there is a proxy server.
     - textAnalyze:

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -323,19 +323,21 @@ spec:
           - fail:
               when: error
               message: >
-                Error connecting to {{ .ReplicatedAPIURL }}. The static IP addresses for
-                {{ .ReplicatedAPIURL }} are 162.159.133.41 and 162.159.134.41.
+                Error connecting to {{ .ReplicatedAPIURL }}.
                 Ensure your firewall is properly configured, and use the --http-proxy, --https-proxy,
                 and --no-proxy flags if there is a proxy server.
+                The static IP addresses for {{ .ReplicatedAPIURL }} are
+                162.159.133.41 and 162.159.134.41.
           - pass:
               when: 'statusCode == 200'
               message: 'Connected to {{ .ReplicatedAPIURL }}'
           - fail:
               message: >
-                Error connecting to {{ .ReplicatedAPIURL }}. The static IP addresses for
-                {{ .ReplicatedAPIURL }} are 162.159.133.41 and 162.159.134.41.
+                Error connecting to {{ .ReplicatedAPIURL }}.
                 Ensure your firewall is properly configured, and use the --http-proxy, --https-proxy,
                 and --no-proxy flags if there is a proxy server.
+                The static IP addresses for {{ .ReplicatedAPIURL }} are
+                162.159.133.41 and 162.159.134.41.
     - http:
         checkName: Proxy Registry Access
         collectorName: http-proxy-replicated-com
@@ -344,19 +346,21 @@ spec:
           - fail:
               when: error
               message: >
-                Error connecting to {{ .ProxyRegistryURL }}. The static IP addresses for
-                {{ .ProxyRegistryURL }} are 162.159.137.43 and 162.159.138.43.
+                Error connecting to {{ .ProxyRegistryURL }}.
                 Ensure your firewall is properly configured, and use the --http-proxy, --https-proxy,
                 and --no-proxy flags if there is a proxy server.
+                The static IP addresses for {{ .ProxyRegistryURL }} are
+                162.159.137.43 and 162.159.138.43.
           - pass:
               when: 'statusCode == 401'
               message: 'Connected to {{ .ProxyRegistryURL }}'
           - fail:
               message: >
-                Unexpected response from {{ .ProxyRegistryURL }}. The static IP addresses for
-                {{ .ProxyRegistryURL }} are 162.159.137.43 and 162.159.138.43.
+                Unexpected response from {{ .ProxyRegistryURL }}.
                 Ensure your firewall is properly configured, and use the --http-proxy, --https-proxy,
                 and --no-proxy flags if there is a proxy server.
+                The static IP addresses for {{ .ProxyRegistryURL }} are
+                162.159.137.43 and 162.159.138.43.
     - textAnalyze:
         checkName: Resolver Configuration
         fileName: host-collectors/run-host/resolv.conf.txt


### PR DESCRIPTION

#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

This simplifies client debugging by specifying the static IP addresses of proxy.replicated.com and replicated.app when connectivity checks to those domains fail.

We may want to consider adding these as compile time variables, but they really shouldn't be changing on our end either.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
