### PR TITLE
feat: determine network interface / IP on join

### DIFF
--- a/cmd/embedded-cluster/join.go
+++ b/cmd/embedded-cluster/join.go
@@ -28,6 +28,7 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/highavailability"
 	"github.com/replicatedhq/embedded-cluster/pkg/kubeutils"
 	"github.com/replicatedhq/embedded-cluster/pkg/metrics"
+	"github.com/replicatedhq/embedded-cluster/pkg/netutils"
 	"github.com/replicatedhq/embedded-cluster/pkg/prompts"
 	"github.com/replicatedhq/embedded-cluster/pkg/spinner"
 )
@@ -183,6 +184,13 @@ var joinCommand = &cli.Command{
 			return fmt.Errorf("usage: %s join <url> <token>", binName)
 		}
 
+		logrus.Debugf("getting network interface from join command")
+		jcmdAddress := strings.Split(c.Args().Get(0), ":")[0]
+		networkInterface, err := netutils.InterfaceNameForAddress(jcmdAddress)
+		if err != nil {
+			return fmt.Errorf("unable to get network interface for address %s: %w", jcmdAddress, err)
+		}
+
 		logrus.Debugf("fetching join token remotely")
 		jcmd, err := getJoinToken(c.Context, c.Args().Get(0), c.Args().Get(1))
 		if err != nil {
@@ -190,7 +198,7 @@ var joinCommand = &cli.Command{
 		}
 
 		setProxyEnv(jcmd.Proxy)
-		proxyOK, localIP, err := checkProxyConfigForLocalIP(jcmd.Proxy, "") // TODO (@salah): detect network interface from join command
+		proxyOK, localIP, err := checkProxyConfigForLocalIP(jcmd.Proxy, networkInterface)
 		if err != nil {
 			return fmt.Errorf("failed to check proxy config for local IP: %w", err)
 		}
@@ -265,7 +273,7 @@ var joinCommand = &cli.Command{
 		}
 
 		logrus.Debugf("overriding network configuration")
-		if err := applyNetworkConfiguration(c, jcmd); err != nil {
+		if err := applyNetworkConfiguration(jcmd, networkInterface); err != nil {
 			err := fmt.Errorf("unable to apply network configuration: %w", err)
 			metrics.ReportJoinFailed(c.Context, jcmd.MetricsBaseURL, jcmd.ClusterID, err)
 		}
@@ -278,7 +286,7 @@ var joinCommand = &cli.Command{
 		}
 
 		logrus.Debugf("joining node to cluster")
-		if err := runK0sInstallCommand(jcmd.K0sJoinCommand); err != nil {
+		if err := runK0sInstallCommand(jcmd.K0sJoinCommand, networkInterface); err != nil {
 			err := fmt.Errorf("unable to join node to cluster: %w", err)
 			metrics.ReportJoinFailed(c.Context, jcmd.MetricsBaseURL, jcmd.ClusterID, err)
 			return err
@@ -326,9 +334,15 @@ var joinCommand = &cli.Command{
 	},
 }
 
-func applyNetworkConfiguration(c *cli.Context, jcmd *JoinCommandResponse) error {
+func applyNetworkConfiguration(jcmd *JoinCommandResponse, networkInterface string) error {
 	if jcmd.Network != nil {
 		clusterSpec := config.RenderK0sConfig()
+		address, err := netutils.FirstValidAddress(networkInterface)
+		if err != nil {
+			return fmt.Errorf("unable to find first valid address: %w", err)
+		}
+		clusterSpec.Spec.API.Address = address
+		clusterSpec.Spec.Storage.Etcd.PeerAddress = address
 		// NOTE: we should be copying everything from the in cluster config spec and overriding
 		// the node specific config from clusterSpec.GetClusterWideConfig()
 		clusterSpec.Spec.Network.PodCIDR = jcmd.Network.PodCIDR
@@ -468,12 +482,18 @@ func systemdUnitFileName() string {
 
 // runK0sInstallCommand runs the k0s install command as provided by the kots
 // adm api.
-func runK0sInstallCommand(fullcmd string) error {
+func runK0sInstallCommand(fullcmd string, networkInterface string) error {
 	args := strings.Split(fullcmd, " ")
 	args = append(args, "--token-file", "/etc/k0s/join-token")
 	if strings.Contains(fullcmd, "controller") {
 		args = append(args, "--disable-components", "konnectivity-server", "--enable-dynamic-config")
 	}
+
+	nodeIP, err := netutils.FirstValidAddress(networkInterface)
+	if err != nil {
+		return fmt.Errorf("unable to find first valid address: %w", err)
+	}
+	args = append(args, "--kubelet-extra-args", fmt.Sprintf(`"--node-ip=%s"`, nodeIP))
 
 	if _, err := helpers.RunCommand(args[0], args[1:]...); err != nil {
 		return err

--- a/cmd/embedded-cluster/restore.go
+++ b/cmd/embedded-cluster/restore.go
@@ -329,6 +329,7 @@ func ensureK0sConfigForRestore(c *cli.Context, applier *addons.Applier) (*k0sv1b
 		return nil, fmt.Errorf("unable to find first valid address: %w", err)
 	}
 	cfg.Spec.API.Address = address
+	cfg.Spec.Storage.Etcd.PeerAddress = address
 	cfg.Spec.Network.PodCIDR = c.String("pod-cidr")
 	cfg.Spec.Network.ServiceCIDR = c.String("service-cidr")
 	if err := config.UpdateHelmConfigsForRestore(applier, cfg); err != nil {
@@ -863,7 +864,7 @@ func installAndWaitForRestoredK0sNode(c *cli.Context, applier *addons.Applier) (
 		return nil, fmt.Errorf("unable to create systemd unit files: %w", err)
 	}
 	logrus.Debugf("installing k0s")
-	if err := installK0s(); err != nil {
+	if err := installK0s(c); err != nil {
 		return nil, fmt.Errorf("unable update cluster: %w", err)
 	}
 	loading.Infof("Waiting for %s node to be ready", binName)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -170,7 +170,7 @@ func PatchK0sConfig(config *k0sconfig.ClusterConfig, patch string) (*k0sconfig.C
 }
 
 // InstallFlags returns a list of default flags to be used when bootstrapping a k0s cluster.
-func InstallFlags() []string {
+func InstallFlags(nodeIP string) []string {
 	return []string{
 		"install",
 		"controller",
@@ -179,6 +179,7 @@ func InstallFlags() []string {
 		"--enable-worker",
 		"--no-taints",
 		"--enable-dynamic-config",
+		"--kubelet-extra-args", fmt.Sprintf(`"--node-ip=%s"`, nodeIP),
 		"-c", defaults.PathToK0sConfig(),
 	}
 }

--- a/pkg/netutils/ips.go
+++ b/pkg/netutils/ips.go
@@ -41,6 +41,29 @@ func FirstValidIPNet(networkInterface string) (*net.IPNet, error) {
 	return nil, fmt.Errorf("interface %s not found or is not valid. The following interfaces were detected: %s", networkInterface, strings.Join(ifNames, ", "))
 }
 
+func InterfaceNameForAddress(address string) (string, error) {
+	ifs, err := listValidInterfaces()
+	if err != nil {
+		return "", fmt.Errorf("list valid network interfaces: %w", err)
+	}
+	for _, i := range ifs {
+		addrs, err := i.Addrs()
+		if err != nil {
+			return "", fmt.Errorf("get addresses: %w", err)
+		}
+		for _, a := range addrs {
+			ipnet, ok := a.(*net.IPNet)
+			if !ok {
+				continue
+			}
+			if ipnet.Contains(net.ParseIP(address)) {
+				return i.Name, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("could not find interface for address %s", address)
+}
+
 // listValidInterfaces returns a list of valid network interfaces for the node.
 func listValidInterfaces() ([]net.Interface, error) {
 	ifs, err := net.Interfaces()


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

- Automatically determines the network interfaces on join.
- Fixes an issue where the internal node IP wasn't set from the user-specified network interface.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE