### PR TITLE
chore: eco is built at release time and is no longer needed in auto updates

### DIFF
--- a/.github/workflows/image-deps-updater.yaml
+++ b/.github/workflows/image-deps-updater.yaml
@@ -57,7 +57,6 @@ jobs:
           - k0s
           - openebs
           - velero
-          - embeddedclusteroperator
           - seaweedfs
     steps:
     - name: Checkout

--- a/.github/workflows/update-addons.yaml
+++ b/.github/workflows/update-addons.yaml
@@ -46,7 +46,6 @@ jobs:
           - registry
           - seaweedfs
           - velero
-          - embeddedclusteroperator
           - adminconsole
     steps:
       - name: Check out repo


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

We now build ECO at time of release and no longer need to update it periodically.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
