### PR TITLE
fix: unable to get network interface for address when joining nodes

### DIFF
--- a/cmd/embedded-cluster/join.go
+++ b/cmd/embedded-cluster/join.go
@@ -144,6 +144,11 @@ var joinCommand = &cli.Command{
 			Usage:  "Enable high availability.",
 			Hidden: true,
 		},
+		&cli.StringFlag{
+			Name:  "network-interface",
+			Usage: "The network interface to use for the cluster",
+			Value: "",
+		},
 		&cli.BoolFlag{
 			Name:  "no-prompt",
 			Usage: "Disable interactive prompts.",
@@ -181,13 +186,6 @@ var joinCommand = &cli.Command{
 			return fmt.Errorf("usage: %s join <url> <token>", binName)
 		}
 
-		logrus.Debugf("getting network interface from join command")
-		jcmdAddress := strings.Split(c.Args().Get(0), ":")[0]
-		networkInterface, err := netutils.InterfaceNameForAddress(jcmdAddress)
-		if err != nil {
-			return fmt.Errorf("unable to get network interface for address %s: %w", jcmdAddress, err)
-		}
-
 		logrus.Debugf("fetching join token remotely")
 		jcmd, err := getJoinToken(c.Context, c.Args().Get(0), c.Args().Get(1))
 		if err != nil {
@@ -200,7 +198,7 @@ var joinCommand = &cli.Command{
 		}
 
 		setProxyEnv(jcmd.InstallationSpec.Proxy)
-		proxyOK, localIP, err := checkProxyConfigForLocalIP(jcmd.InstallationSpec.Proxy, networkInterface)
+		proxyOK, localIP, err := checkProxyConfigForLocalIP(jcmd.InstallationSpec.Proxy, c.String("network-interface"))
 		if err != nil {
 			return fmt.Errorf("failed to check proxy config for local IP: %w", err)
 		}
@@ -279,7 +277,7 @@ var joinCommand = &cli.Command{
 		}
 
 		logrus.Debugf("overriding network configuration")
-		if err := applyNetworkConfiguration(jcmd, networkInterface); err != nil {
+		if err := applyNetworkConfiguration(c, jcmd); err != nil {
 			err := fmt.Errorf("unable to apply network configuration: %w", err)
 			metrics.ReportJoinFailed(c.Context, jcmd.InstallationSpec.MetricsBaseURL, jcmd.ClusterID, err)
 		}
@@ -292,7 +290,7 @@ var joinCommand = &cli.Command{
 		}
 
 		logrus.Debugf("joining node to cluster")
-		if err := runK0sInstallCommand(jcmd.K0sJoinCommand, networkInterface); err != nil {
+		if err := runK0sInstallCommand(c, jcmd.K0sJoinCommand); err != nil {
 			err := fmt.Errorf("unable to join node to cluster: %w", err)
 			metrics.ReportJoinFailed(c.Context, jcmd.InstallationSpec.MetricsBaseURL, jcmd.ClusterID, err)
 			return err
@@ -340,10 +338,10 @@ var joinCommand = &cli.Command{
 	},
 }
 
-func applyNetworkConfiguration(jcmd *JoinCommandResponse, networkInterface string) error {
+func applyNetworkConfiguration(c *cli.Context, jcmd *JoinCommandResponse) error {
 	if jcmd.InstallationSpec.Network != nil {
 		clusterSpec := config.RenderK0sConfig()
-		address, err := netutils.FirstValidAddress(networkInterface)
+		address, err := netutils.FirstValidAddress(c.String("network-interface"))
 		if err != nil {
 			return fmt.Errorf("unable to find first valid address: %w", err)
 		}
@@ -488,14 +486,14 @@ func systemdUnitFileName() string {
 
 // runK0sInstallCommand runs the k0s install command as provided by the kots
 // adm api.
-func runK0sInstallCommand(fullcmd string, networkInterface string) error {
+func runK0sInstallCommand(c *cli.Context, fullcmd string) error {
 	args := strings.Split(fullcmd, " ")
 	args = append(args, "--token-file", "/etc/k0s/join-token")
 	if strings.Contains(fullcmd, "controller") {
 		args = append(args, "--disable-components", "konnectivity-server", "--enable-dynamic-config")
 	}
 
-	nodeIP, err := netutils.FirstValidAddress(networkInterface)
+	nodeIP, err := netutils.FirstValidAddress(c.String("network-interface"))
 	if err != nil {
 		return fmt.Errorf("unable to find first valid address: %w", err)
 	}

--- a/pkg/netutils/ips.go
+++ b/pkg/netutils/ips.go
@@ -41,29 +41,6 @@ func FirstValidIPNet(networkInterface string) (*net.IPNet, error) {
 	return nil, fmt.Errorf("interface %s not found or is not valid. The following interfaces were detected: %s", networkInterface, strings.Join(ifNames, ", "))
 }
 
-func InterfaceNameForAddress(address string) (string, error) {
-	ifs, err := listValidInterfaces()
-	if err != nil {
-		return "", fmt.Errorf("list valid network interfaces: %w", err)
-	}
-	for _, i := range ifs {
-		addrs, err := i.Addrs()
-		if err != nil {
-			return "", fmt.Errorf("get addresses: %w", err)
-		}
-		for _, a := range addrs {
-			ipnet, ok := a.(*net.IPNet)
-			if !ok {
-				continue
-			}
-			if ipnet.Contains(net.ParseIP(address)) {
-				return i.Name, nil
-			}
-		}
-	}
-	return "", fmt.Errorf("could not find interface for address %s", address)
-}
-
 // listValidInterfaces returns a list of valid network interfaces for the node.
 func listValidInterfaces() ([]net.Interface, error) {
 	ifs, err := net.Interfaces()


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Fixes an issue where joining nodes failed with `unable to get network interface for address`.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-112735](https://app.shortcut.com/replicated/story/112735)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes an issue where joining nodes failed with `unable to get network interface for address`.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE