### PR TITLE
fix(ci): buildtools handle helm chart app version change

### DIFF
--- a/cmd/buildtools/main.go
+++ b/cmd/buildtools/main.go
@@ -15,9 +15,6 @@ This script uses the following environment variables:
 - CHARTS_REGISTRY_SERVER: the registry server to push the chart to (e.g. index.docker.io)
 - CHARTS_REGISTRY_USER: the username to authenticate with.
 - CHARTS_REGISTRY_PASS: the password to authenticate with.
-- IMAGES_REGISTRY_SERVER: the registry server to push the images to (e.g. index.docker.io)
-- IMAGES_REGISTRY_USER: the username to authenticate with.
-- IMAGES_REGISTRY_PASS: the password to authenticate with.
 - CHARTS_DESTINATION: the destination repository to push the chart to (e.g. ttl.sh/embedded-cluster-charts)
 `
 

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"gopkg.in/yaml.v2"
 	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/downloader"
@@ -212,6 +213,15 @@ func (h *Helm) Push(path, dst string) error {
 		Options: []pusher.Option{pusher.WithRegistryClient(h.regcli)},
 	}
 	return up.UploadTo(path, dst)
+}
+
+func (h *Helm) GetChartMetadata(chartPath string) (*chart.Metadata, error) {
+	chartRequested, err := loader.Load(chartPath)
+	if err != nil {
+		return nil, fmt.Errorf("load chart: %w", err)
+	}
+
+	return chartRequested.Metadata, nil
 }
 
 func (h *Helm) Render(chartName string, chartPath string, vals map[string]interface{}, namespace string) ([][]byte, error) {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

[Seaweedfs](https://artifacthub.io/packages/helm/seaweedfs/seaweedfs) changed their app version in the helm chart without changing the helm chart version. This does not play well with our shrinkwrapped releases and now we have cves in the seaweed image.

https://github.com/replicatedhq/embedded-cluster/actions/runs/11060070387/job/30733862137

Right now im just warning but i think we need to handle this somehow.

```
WARN[0004] dst tag exists but app versions do not match (src: 3.73, dst: 3.71) 
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
