### PR TITLE
add additional reporting info

### DIFF
--- a/operator/controllers/installation_controller.go
+++ b/operator/controllers/installation_controller.go
@@ -193,7 +193,12 @@ func (r *InstallationReconciler) ReconcileNodeStatuses(ctx context.Context, in *
 	seen := map[string]bool{}
 	for _, node := range nodes.Items {
 		seen[node.Name] = true
-		event := metrics.NodeEventFromNode(in.Spec.ClusterID, in.Spec.Config.Version, node)
+		ver := ""
+		if in.Spec.Config != nil {
+			ver = in.Spec.Config.Version
+		}
+
+		event := metrics.NodeEventFromNode(in.Spec.ClusterID, ver, node)
 		changed, isnew, err := r.NodeHasChanged(in, event)
 		if err != nil {
 			return nil, fmt.Errorf("failed to check if node has changed: %w", err)
@@ -250,25 +255,32 @@ func (r *InstallationReconciler) ReportInstallationChanges(ctx context.Context, 
 		return
 	}
 	var err error
+	var beforeVer, afterVer string
+	if before.Spec.Config != nil {
+		beforeVer = before.Spec.Config.Version
+	}
+	if after.Spec.Config != nil {
+		afterVer = after.Spec.Config.Version
+	}
 	switch after.Status.State {
 	case v1beta1.InstallationStateInstalling:
 		err = metrics.NotifyUpgradeStarted(ctx, after.Spec.MetricsBaseURL, metrics.UpgradeStartedEvent{
 			ClusterID:      after.Spec.ClusterID,
-			TargetVersion:  after.Spec.Config.Version,
-			InitialVersion: before.Spec.Config.Version,
+			TargetVersion:  afterVer,
+			InitialVersion: beforeVer,
 		})
 	case v1beta1.InstallationStateInstalled:
 		err = metrics.NotifyUpgradeSucceeded(ctx, after.Spec.MetricsBaseURL, metrics.UpgradeSucceededEvent{
 			ClusterID:      after.Spec.ClusterID,
-			TargetVersion:  after.Spec.Config.Version,
-			InitialVersion: before.Spec.Config.Version,
+			TargetVersion:  afterVer,
+			InitialVersion: beforeVer,
 		})
 	case v1beta1.InstallationStateFailed:
 		err = metrics.NotifyUpgradeFailed(ctx, after.Spec.MetricsBaseURL, metrics.UpgradeFailedEvent{
 			ClusterID:      after.Spec.ClusterID,
 			Reason:         after.Status.Reason,
-			TargetVersion:  after.Spec.Config.Version,
-			InitialVersion: before.Spec.Config.Version,
+			TargetVersion:  afterVer,
+			InitialVersion: beforeVer,
 		})
 	}
 	if err != nil {

--- a/operator/pkg/metrics/metrics.go
+++ b/operator/pkg/metrics/metrics.go
@@ -13,7 +13,7 @@ import (
 )
 
 // NodeEventFromNode returns a NodeEvent event from a node.
-func NodeEventFromNode(clusterID string, node corev1.Node) NodeEvent {
+func NodeEventFromNode(clusterID string, installVersion string, node corev1.Node) NodeEvent {
 	return NodeEvent{
 		ClusterID:   clusterID,
 		Labels:      node.Labels,
@@ -22,6 +22,7 @@ func NodeEventFromNode(clusterID string, node corev1.Node) NodeEvent {
 		Capacity:    node.Status.Capacity,
 		Allocatable: node.Status.Allocatable,
 		Role:        node.Labels["node.k0sproject.io/role"],
+		Version:     installVersion,
 	}
 }
 
@@ -35,23 +36,29 @@ type NodeEvent struct {
 	Capacity    corev1.ResourceList   `json:"capacity"`
 	Allocatable corev1.ResourceList   `json:"allocatable"`
 	Role        string                `json:"role"`
+	Version     string                `json:"version"`
 }
 
 // UpgradeStartedEvent is send back home when the upgrade starts.
 type UpgradeStartedEvent struct {
-	ClusterID string `json:"clusterID"`
-	Version   string `json:"version"`
+	ClusterID      string `json:"clusterID"`
+	TargetVersion  string `json:"targetVersion"`
+	InitialVersion string `json:"initialVersion"`
 }
 
 // UpgradeFailedEvent is send back home when the upgrade fails.
 type UpgradeFailedEvent struct {
-	ClusterID string `json:"clusterID"`
-	Reason    string `json:"reason"`
+	ClusterID      string `json:"clusterID"`
+	TargetVersion  string `json:"targetVersion"`
+	InitialVersion string `json:"initialVersion"`
+	Reason         string `json:"reason"`
 }
 
 // UpgradeSucceededEvent event is send back home when the upgrade succeeds.
 type UpgradeSucceededEvent struct {
-	ClusterID string `json:"clusterID"`
+	ClusterID      string `json:"clusterID"`
+	TargetVersion  string `json:"targetVersion"`
+	InitialVersion string `json:"initialVersion"`
 }
 
 // Hash returns the hash of the node.
@@ -65,8 +72,9 @@ func (n NodeEvent) Hash() (string, error) {
 
 // NodeRemovedEvent is the event generated when a node is removed from the cluster.
 type NodeRemovedEvent struct {
-	ClusterID string `json:"clusterID"`
-	NodeName  string `json:"nodeName"`
+	ClusterID       string `json:"clusterID"`
+	OperatorVersion string `json:"operatorVersion"`
+	NodeName        string `json:"nodeName"`
 }
 
 // sendEvent sends the received event to the metrics server through a post request.

--- a/operator/pkg/metrics/metrics.go
+++ b/operator/pkg/metrics/metrics.go
@@ -23,6 +23,7 @@ func NodeEventFromNode(clusterID string, installVersion string, node corev1.Node
 		Allocatable: node.Status.Allocatable,
 		Role:        node.Labels["node.k0sproject.io/role"],
 		Version:     installVersion,
+		NodeID:      string(node.UID),
 	}
 }
 
@@ -37,6 +38,7 @@ type NodeEvent struct {
 	Allocatable corev1.ResourceList   `json:"allocatable"`
 	Role        string                `json:"role"`
 	Version     string                `json:"version"`
+	NodeID      string                `json:"nodeID"`
 }
 
 // UpgradeStartedEvent is send back home when the upgrade starts.

--- a/operator/pkg/metrics/metrics.go
+++ b/operator/pkg/metrics/metrics.go
@@ -23,7 +23,6 @@ func NodeEventFromNode(clusterID string, installVersion string, node corev1.Node
 		Allocatable: node.Status.Allocatable,
 		Role:        node.Labels["node.k0sproject.io/role"],
 		Version:     installVersion,
-		NodeID:      string(node.UID),
 	}
 }
 
@@ -38,7 +37,6 @@ type NodeEvent struct {
 	Allocatable corev1.ResourceList   `json:"allocatable"`
 	Role        string                `json:"role"`
 	Version     string                `json:"version"`
-	NodeID      string                `json:"nodeID"`
 }
 
 // UpgradeStartedEvent is send back home when the upgrade starts.

--- a/pkg/metrics/events.go
+++ b/pkg/metrics/events.go
@@ -28,6 +28,7 @@ func (e InstallationStarted) Title() string {
 // InstallationSucceeded event is send back home when the installation finishes.
 type InstallationSucceeded struct {
 	ClusterID uuid.UUID `json:"clusterID"`
+	Version   string    `json:"version"`
 }
 
 // Title returns the name of the event.
@@ -38,6 +39,7 @@ func (e InstallationSucceeded) Title() string {
 // InstallationFailed event is send back home when the installation fails.
 type InstallationFailed struct {
 	ClusterID uuid.UUID `json:"clusterID"`
+	Version   string    `json:"version"`
 	Reason    string    `json:"reason"`
 }
 
@@ -49,6 +51,7 @@ func (e InstallationFailed) Title() string {
 // JoinStarted event is send back home when a node join starts.
 type JoinStarted struct {
 	ClusterID uuid.UUID `json:"clusterID"`
+	Version   string    `json:"version"`
 	NodeName  string    `json:"nodeName"`
 }
 
@@ -68,6 +71,7 @@ func (e JoinSucceeded) Title() string {
 // JoinFailed event is send back home when a node join fails.
 type JoinFailed struct {
 	ClusterID uuid.UUID `json:"clusterID"`
+	Version   string    `json:"version"`
 	NodeName  string    `json:"nodeName"`
 	Reason    string    `json:"reason"`
 }

--- a/pkg/metrics/events.go
+++ b/pkg/metrics/events.go
@@ -12,12 +12,14 @@ type Event interface {
 
 // InstallationStarted event is send back home when the installation starts.
 type InstallationStarted struct {
-	ClusterID  uuid.UUID `json:"clusterID"`
-	Version    string    `json:"version"`
-	Flags      string    `json:"flags"`
-	BinaryName string    `json:"binaryName"`
-	Type       string    `json:"type"`
-	LicenseID  string    `json:"licenseID"`
+	ClusterID    uuid.UUID `json:"clusterID"`
+	Version      string    `json:"version"`
+	Flags        string    `json:"flags"`
+	BinaryName   string    `json:"binaryName"`
+	Type         string    `json:"type"`
+	LicenseID    string    `json:"licenseID"`
+	AppChannelID string    `json:"appChannelID"`
+	AppVersion   string    `json:"appVersion"`
 }
 
 // Title returns the name of the event.

--- a/pkg/metrics/reporter.go
+++ b/pkg/metrics/reporter.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/replicatedhq/embedded-cluster/pkg/defaults"
 	"github.com/replicatedhq/embedded-cluster/pkg/helpers"
+	"github.com/replicatedhq/embedded-cluster/pkg/release"
 	"github.com/replicatedhq/embedded-cluster/pkg/versions"
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 )
@@ -59,13 +60,22 @@ func ClusterID() uuid.UUID {
 
 // ReportInstallationStarted reports that the installation has started.
 func ReportInstallationStarted(ctx context.Context, license *kotsv1beta1.License) {
+	rel, _ := release.GetChannelRelease()
+	appChannel, appVersion := "", ""
+	if rel != nil {
+		appChannel = rel.ChannelID
+		appVersion = rel.VersionLabel
+	}
+
 	Send(ctx, BaseURL(license), InstallationStarted{
-		ClusterID:  ClusterID(),
-		Version:    versions.Version,
-		Flags:      strings.Join(os.Args[1:], " "),
-		BinaryName: defaults.BinaryName(),
-		Type:       "centralized",
-		LicenseID:  LicenseID(license),
+		ClusterID:    ClusterID(),
+		Version:      versions.Version,
+		Flags:        strings.Join(os.Args[1:], " "),
+		BinaryName:   defaults.BinaryName(),
+		Type:         "centralized",
+		LicenseID:    LicenseID(license),
+		AppChannelID: appChannel,
+		AppVersion:   appVersion,
 	})
 }
 

--- a/pkg/metrics/reporter.go
+++ b/pkg/metrics/reporter.go
@@ -71,12 +71,12 @@ func ReportInstallationStarted(ctx context.Context, license *kotsv1beta1.License
 
 // ReportInstallationSucceeded reports that the installation has succeeded.
 func ReportInstallationSucceeded(ctx context.Context, license *kotsv1beta1.License) {
-	Send(ctx, BaseURL(license), InstallationSucceeded{ClusterID: ClusterID()})
+	Send(ctx, BaseURL(license), InstallationSucceeded{ClusterID: ClusterID(), Version: versions.Version})
 }
 
 // ReportInstallationFailed reports that the installation has failed.
 func ReportInstallationFailed(ctx context.Context, license *kotsv1beta1.License, err error) {
-	Send(ctx, BaseURL(license), InstallationFailed{ClusterID(), err.Error()})
+	Send(ctx, BaseURL(license), InstallationFailed{ClusterID(), versions.Version, err.Error()})
 }
 
 // ReportJoinStarted reports that a join has started.
@@ -86,7 +86,7 @@ func ReportJoinStarted(ctx context.Context, baseURL string, clusterID uuid.UUID)
 		logrus.Warnf("unable to get hostname: %s", err)
 		hostname = "unknown"
 	}
-	Send(ctx, baseURL, JoinStarted{clusterID, hostname})
+	Send(ctx, baseURL, JoinStarted{clusterID, versions.Version, hostname})
 }
 
 // ReportJoinSucceeded reports that a join has finished successfully.
@@ -96,7 +96,7 @@ func ReportJoinSucceeded(ctx context.Context, baseURL string, clusterID uuid.UUI
 		logrus.Warnf("unable to get hostname: %s", err)
 		hostname = "unknown"
 	}
-	Send(ctx, baseURL, JoinSucceeded{clusterID, hostname})
+	Send(ctx, baseURL, JoinSucceeded{clusterID, versions.Version, hostname})
 }
 
 // ReportJoinFailed reports that a join has failed.
@@ -106,7 +106,7 @@ func ReportJoinFailed(ctx context.Context, baseURL string, clusterID uuid.UUID, 
 		logrus.Warnf("unable to get hostname: %s", err)
 		hostname = "unknown"
 	}
-	Send(ctx, baseURL, JoinFailed{clusterID, hostname, exterr.Error()})
+	Send(ctx, baseURL, JoinFailed{clusterID, versions.Version, hostname, exterr.Error()})
 }
 
 // ReportApplyStarted reports an InstallationStarted event.


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

This adds the following items to reporting:
1. all cli-level 'event' items now include the embedded cluster version generating the event.
2. node events sent from the operator now include the embedded cluster version.
3. upgrade events sent from the operator now include the initial and target embedded cluster versions.
4. initial installation events include the app channel ID and app version string (when relevant)

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
