### PR TITLE
feat: preflight for x86-64 v2 CPU support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ K0S_GO_VERSION = v1.29.8+k0s.0
 PREVIOUS_K0S_VERSION ?= v1.28.10+k0s.0
 K0S_BINARY_SOURCE_OVERRIDE =
 PREVIOUS_K0S_BINARY_SOURCE_OVERRIDE =
-TROUBLESHOOT_VERSION = v0.104.0
+TROUBLESHOOT_VERSION = v0.105.0
 KOTS_VERSION = v$(shell awk '/^version/{print $$2}' pkg/addons/adminconsole/static/metadata.yaml | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
 # When updating KOTS_BINARY_URL_OVERRIDE, also update the KOTS_VERSION above or
 # scripts/ci-upload-binaries.sh may find the version in the cache and not upload the overridden binary.

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -134,6 +134,14 @@ spec:
               message: At least 2 CPU cores are required, but fewer are present
           - pass:
               message: At least 2 CPU cores are present
+    - cpu:
+        checkName: CPU Features
+        outcomes:
+          - pass:
+              when: 'supports x86-64-v2'
+              message: Host CPU supports x86-64-v2 features
+          - fail:
+              message: Required x86-64-v2 CPU features are missing. If using a hypervisor, ensure it is configured to expose the necessary CPU features.
     - memory:
         checkName: Memory
         outcomes:


### PR DESCRIPTION

#### What this PR does / why we need it:

preflight for x86-64 v2 CPU support.
