### PR TITLE
fix: validate admin console password length

### DIFF
--- a/cmd/embedded-cluster/install.go
+++ b/cmd/embedded-cluster/install.go
@@ -567,14 +567,14 @@ func maybeAskAdminConsolePassword(c *cli.Context) (string, error) {
 		promptA := prompts.New().Password("Set the Admin Console password:")
 		promptB := prompts.New().Password("Confirm the Admin Console password:")
 
-		if validatePassword(promptA, promptB) {
+		if validateAdminConsolePassword(promptA, promptB) {
 			return promptA, nil
 		}
 	}
 	return "", fmt.Errorf("unable to set the Admin Console password after %d tries", maxTries)
 }
 
-func validatePassword(password, passwordCheck string) bool {
+func validateAdminConsolePassword(password, passwordCheck string) bool {
 	if len(password) < 6 {
 		logrus.Info("Passwords must have more than 6 characters. Please try again.")
 		return false

--- a/cmd/embedded-cluster/install.go
+++ b/cmd/embedded-cluster/install.go
@@ -567,13 +567,23 @@ func maybeAskAdminConsolePassword(c *cli.Context) (string, error) {
 		promptA := prompts.New().Password("Set the Admin Console password:")
 		promptB := prompts.New().Password("Confirm the Admin Console password:")
 
-		if promptA == promptB {
-			// TODO: Should we add extra password validation here? e.g length, complexity etc
+		if validatePassword(promptA, promptB) {
 			return promptA, nil
 		}
-		logrus.Info("Passwords don't match. Please try again.")
 	}
 	return "", fmt.Errorf("unable to set the Admin Console password after %d tries", maxTries)
+}
+
+func validatePassword(password, passwordCheck string) bool {
+	if len(password) < 6 {
+		logrus.Info("Passwords must have more than 6 characters. Please try again.")
+		return false
+	}
+	if password != passwordCheck {
+		logrus.Info("Passwords don't match. Please try again.")
+		return false
+	}
+	return true
 }
 
 // installCommands executes the "install" command. This will ensure that a k0s.yaml file exists

--- a/cmd/embedded-cluster/install.go
+++ b/cmd/embedded-cluster/install.go
@@ -29,6 +29,9 @@ import (
 	"github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 )
 
+// Minimum character length for the Admin Console password
+const minAdminPasswordLength = 6
+
 // ErrNothingElseToAdd is an error returned when there is nothing else to add to the
 // screen. This is useful when we want to exit an error from a function here but
 // don't want to print anything else (possibly because we have already printed the
@@ -565,7 +568,7 @@ func maybeAskAdminConsolePassword(c *cli.Context) (string, error) {
 	}
 	maxTries := 3
 	for i := 0; i < maxTries; i++ {
-		promptA := prompts.New().Password("Set the Admin Console password:")
+		promptA := prompts.New().Password(fmt.Sprintf("Set the Admin Console password (minimum %d characters):", minAdminPasswordLength))
 		promptB := prompts.New().Password("Confirm the Admin Console password:")
 
 		if validateAdminConsolePassword(promptA, promptB, true) {
@@ -580,8 +583,8 @@ func validateAdminConsolePassword(password, passwordCheck string, mustMatch bool
 		logrus.Info("Passwords don't match. Please try again.")
 		return false
 	}
-	if len(password) < 6 {
-		logrus.Info("Passwords must have more than 6 characters. Please try again.")
+	if len(password) < minAdminPasswordLength {
+		logrus.Infof("Passwords must have more than %d characters. Please try again.", minAdminPasswordLength)
 		return false
 	}
 	return true
@@ -609,7 +612,7 @@ var installCommand = &cli.Command{
 		[]cli.Flag{
 			&cli.StringFlag{
 				Name:   "admin-console-password",
-				Usage:  "Password for the Admin Console",
+				Usage:  fmt.Sprintf("Password for the Admin Console (minimum %d characters)", minAdminPasswordLength),
 				Hidden: false,
 			},
 			&cli.StringFlag{

--- a/cmd/embedded-cluster/install.go
+++ b/cmd/embedded-cluster/install.go
@@ -556,7 +556,8 @@ func maybeAskAdminConsolePassword(c *cli.Context) (string, error) {
 	userProvidedPassword := c.String("admin-console-password")
 	// If there's a user provided password we'll try that first
 	if userProvidedPassword != "" {
-		if !validateAdminConsolePassword(userProvidedPassword, "", false) {
+		// Password isn't retyped so we provided it twice
+		if !validateAdminConsolePassword(userProvidedPassword, userProvidedPassword) {
 			return "", fmt.Errorf("unable to set the Admin Console password")
 		}
 		return userProvidedPassword, nil
@@ -571,15 +572,15 @@ func maybeAskAdminConsolePassword(c *cli.Context) (string, error) {
 		promptA := prompts.New().Password(fmt.Sprintf("Set the Admin Console password (minimum %d characters):", minAdminPasswordLength))
 		promptB := prompts.New().Password("Confirm the Admin Console password:")
 
-		if validateAdminConsolePassword(promptA, promptB, true) {
+		if validateAdminConsolePassword(promptA, promptB) {
 			return promptA, nil
 		}
 	}
 	return "", fmt.Errorf("unable to set the Admin Console password after %d tries", maxTries)
 }
 
-func validateAdminConsolePassword(password, passwordCheck string, mustMatch bool) bool {
-	if mustMatch && password != passwordCheck {
+func validateAdminConsolePassword(password, passwordCheck string) bool {
+	if password != passwordCheck {
 		logrus.Info("Passwords don't match. Please try again.")
 		return false
 	}

--- a/cmd/embedded-cluster/install_test.go
+++ b/cmd/embedded-cluster/install_test.go
@@ -200,3 +200,51 @@ versionLabel: testversion
 		})
 	}
 }
+
+func Test_validateAdminConsolePassword(t *testing.T) {
+
+	tests := []struct {
+		name          string
+		password      string
+		passwordCheck string
+		wantSuccess   bool
+	}{
+		{
+			name:          "passwords match, with 3 characters length",
+			password:      "123",
+			passwordCheck: "123",
+			wantSuccess:   false,
+		},
+		{
+			name:          "passwords don't match, with 3 characters length",
+			password:      "123",
+			passwordCheck: "nop",
+			wantSuccess:   false,
+		},
+		{
+			name:          "passwords don't match, with 7 characters length",
+			password:      "1234567",
+			passwordCheck: "nomatch",
+			wantSuccess:   false,
+		},
+		{
+			name:          "passwords match, with 7 characters length",
+			password:      "1234567",
+			passwordCheck: "1234567",
+			wantSuccess:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+
+			success := validateAdminConsolePassword(tt.password, tt.passwordCheck)
+			if tt.wantSuccess {
+				req.True(success)
+			} else {
+				req.False(success)
+			}
+		})
+	}
+}

--- a/cmd/embedded-cluster/install_test.go
+++ b/cmd/embedded-cluster/install_test.go
@@ -1,12 +1,15 @@
 package main
 
 import (
+	"flag"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/replicatedhq/embedded-cluster/pkg/release"
 	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
 )
 
 func Test_getLicenseFromFilepath(t *testing.T) {
@@ -263,6 +266,68 @@ func Test_validateAdminConsolePassword(t *testing.T) {
 				req.True(success)
 			} else {
 				req.False(success)
+			}
+		})
+	}
+}
+
+func Test_maybeAskAdminConsolePassword(t *testing.T) {
+
+	tests := []struct {
+		name         string
+		userPassword string
+		noPrompt     bool
+		wantPassword string
+		wantError    bool
+	}{
+		{
+			name:         "no user provided password, no-prompt true",
+			userPassword: "",
+			noPrompt:     true,
+			wantPassword: "password",
+			wantError:    false,
+		},
+		{
+			name:         "invalid user provided password, no-prompt false",
+			userPassword: "123",
+			noPrompt:     false,
+			wantPassword: "",
+			wantError:    true,
+		},
+		{
+			name:         "user provided password, no-prompt true",
+			userPassword: "123456",
+			noPrompt:     true,
+			wantPassword: "123456",
+			wantError:    false,
+		},
+		{
+			name:         "user provided password, no-prompt false",
+			userPassword: "123456",
+			noPrompt:     false,
+			wantPassword: "123456",
+			wantError:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+
+			flags := installCommand.Flags
+			flagSet := flag.NewFlagSet("test", 0)
+			for _, flag := range flags {
+				flag.Apply(flagSet)
+			}
+			flagSet.Set("no-prompt", strconv.FormatBool(tt.noPrompt))
+			flagSet.Set("admin-console-password", tt.userPassword)
+			c := cli.NewContext(cli.NewApp(), flagSet, nil)
+			passwordSet, err := maybeAskAdminConsolePassword(c)
+
+			if tt.wantError {
+				req.Error(err)
+			} else {
+				req.Equal(tt.wantPassword, passwordSet)
 			}
 		})
 	}

--- a/cmd/embedded-cluster/install_test.go
+++ b/cmd/embedded-cluster/install_test.go
@@ -210,49 +210,30 @@ func Test_validateAdminConsolePassword(t *testing.T) {
 		name          string
 		password      string
 		passwordCheck string
-		mustMatch     bool
 		wantSuccess   bool
 	}{
 		{
-			name:          "passwords match, with 3 characters length, must match is required",
+			name:          "passwords match, with 3 characters length",
 			password:      "123",
 			passwordCheck: "123",
-			mustMatch:     true,
 			wantSuccess:   false,
 		},
 		{
-			name:          "passwords don't match, with 3 characters length, must match is required",
+			name:          "passwords don't match, with 3 characters length",
 			password:      "123",
 			passwordCheck: "nop",
-			mustMatch:     true,
 			wantSuccess:   false,
 		},
 		{
-			name:          "passwords don't match, with 6 characters length, must match is required",
+			name:          "passwords don't match, with 6 characters length",
 			password:      "123456",
 			passwordCheck: "nmatch",
-			mustMatch:     true,
 			wantSuccess:   false,
 		},
 		{
-			name:          "passwords match, with 6 characters length, must match is required",
+			name:          "passwords match, with 6 characters length",
 			password:      "123456",
 			passwordCheck: "123456",
-			mustMatch:     true,
-			wantSuccess:   true,
-		},
-		{
-			name:          "password with 3 characters length, must match is not required",
-			password:      "123",
-			passwordCheck: "",
-			mustMatch:     false,
-			wantSuccess:   false,
-		},
-		{
-			name:          "password with 6 characters length, must match is not required",
-			password:      "123456",
-			passwordCheck: "",
-			mustMatch:     false,
 			wantSuccess:   true,
 		},
 	}
@@ -261,7 +242,7 @@ func Test_validateAdminConsolePassword(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := require.New(t)
 
-			success := validateAdminConsolePassword(tt.password, tt.passwordCheck, tt.mustMatch)
+			success := validateAdminConsolePassword(tt.password, tt.passwordCheck)
 			if tt.wantSuccess {
 				req.True(success)
 			} else {

--- a/cmd/embedded-cluster/install_test.go
+++ b/cmd/embedded-cluster/install_test.go
@@ -207,30 +207,49 @@ func Test_validateAdminConsolePassword(t *testing.T) {
 		name          string
 		password      string
 		passwordCheck string
+		mustMatch     bool
 		wantSuccess   bool
 	}{
 		{
-			name:          "passwords match, with 3 characters length",
+			name:          "passwords match, with 3 characters length, must match is required",
 			password:      "123",
 			passwordCheck: "123",
+			mustMatch:     true,
 			wantSuccess:   false,
 		},
 		{
-			name:          "passwords don't match, with 3 characters length",
+			name:          "passwords don't match, with 3 characters length, must match is required",
 			password:      "123",
 			passwordCheck: "nop",
+			mustMatch:     true,
 			wantSuccess:   false,
 		},
 		{
-			name:          "passwords don't match, with 7 characters length",
-			password:      "1234567",
-			passwordCheck: "nomatch",
+			name:          "passwords don't match, with 6 characters length, must match is required",
+			password:      "123456",
+			passwordCheck: "nmatch",
+			mustMatch:     true,
 			wantSuccess:   false,
 		},
 		{
-			name:          "passwords match, with 7 characters length",
-			password:      "1234567",
-			passwordCheck: "1234567",
+			name:          "passwords match, with 6 characters length, must match is required",
+			password:      "123456",
+			passwordCheck: "123456",
+			mustMatch:     true,
+			wantSuccess:   true,
+		},
+		{
+			name:          "password with 3 characters length, must match is not required",
+			password:      "123",
+			passwordCheck: "",
+			mustMatch:     false,
+			wantSuccess:   false,
+		},
+		{
+			name:          "password with 6 characters length, must match is not required",
+			password:      "123456",
+			passwordCheck: "",
+			mustMatch:     false,
 			wantSuccess:   true,
 		},
 	}
@@ -239,7 +258,7 @@ func Test_validateAdminConsolePassword(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := require.New(t)
 
-			success := validateAdminConsolePassword(tt.password, tt.passwordCheck)
+			success := validateAdminConsolePassword(tt.password, tt.passwordCheck, tt.mustMatch)
 			if tt.wantSuccess {
 				req.True(success)
 			} else {


### PR DESCRIPTION
#### What this PR does / why we need it:
Make sure we validate the admin console password length requiring it to be at least 6 characters, similar to what already [happens in KOTS](https://github.com/replicatedhq/kots/blob/dab9434bb24c13ffb5f37b528c515121b31db089/pkg/util/password_prompt.go#L22-L25)

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/104936/admin-console-minimum-password-length-inconsistent

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
I've added a test to the password validation function and was trying to see if there's a way that we could test the `maybeAskAdminConsolePassword` method, but since it relies on input prompts I'm unsure what would be the best mechanism to do so 🤔 open to suggestions.

Meanwhile I've also run a couple of manual tests in the local dev env:
```
root@node0:/replicatedhq/embedded-cluster# output/bin/embedded-cluster install --license local-dev/Joao.yaml
? Set the Admin Console password: ***
? Confirm the Admin Console password: ***
Passwords must have more than 6 characters. Please try again.
? Set the Admin Console password: ******
? Confirm the Admin Console password: ******
Passwords don't match. Please try again.
? Set the Admin Console password: ******
? Confirm the Admin Console password: ******
✔  Host files materialized!
(...)
```

```
root@node0:/replicatedhq/embedded-cluster# output/bin/embedded-cluster install --license local-dev/Joao.yaml --no-prompt
The Admin Console password is set to password
(...)
```

```
root@node0:/replicatedhq/embedded-cluster# output/bin/embedded-cluster install --license local-dev/Joao.yaml --admin-console-password 123
Passwords must have more than 6 characters. Please try again.
unable to set the Admin Console password
root@node0:/replicatedhq/embedded-cluster# output/bin/embedded-cluster install --license local-dev/Joao.yaml --admin-console-password 123456
✔  Host files materialized!
(...)
```

```
root@node0:/replicatedhq/embedded-cluster# output/bin/embedded-cluster install help
NAME:
   embedded-cluster install - Install embedded-cluster

USAGE:
   embedded-cluster install command [command options]

COMMANDS:
   help, h  Shows a list of commands or help for one command

OPTIONS:
   --admin-console-password value             Password for the Admin Console (minimum 6 characters)
   (...)
```

```
root@node0:/replicatedhq/embedded-cluster# output/bin/embedded-cluster install --license local-dev/Joao.yaml
? Set the Admin Console password (minimum 6 characters):
unable to ask for input: interrupt
```

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
