### PR TITLE
Publish dev/test EC distros to dockerhub

### DIFF
--- a/.github/workflows/distros.yaml
+++ b/.github/workflows/distros.yaml
@@ -1,7 +1,9 @@
 name: distros
 
 on:
-  pull_request: {} # TODO NOW: remove this
+  pull_request:
+    paths:
+      - 'dev/distros/**'
   push:
     paths:
       - 'dev/distros/**'

--- a/.github/workflows/distros.yaml
+++ b/.github/workflows/distros.yaml
@@ -3,7 +3,7 @@ name: distros
 on:
   pull_request:
     paths:
-      - 'dev/distros/**'
+      - 'dev/dockerfiles/**'
   push:
     paths:
       - 'dev/distros/**'

--- a/.github/workflows/distros.yaml
+++ b/.github/workflows/distros.yaml
@@ -1,9 +1,6 @@
 name: distros
 
 on:
-  pull_request:
-    paths:
-      - 'dev/dockerfiles/**'
   push:
     paths:
       - 'dev/distros/**'

--- a/.github/workflows/distros.yaml
+++ b/.github/workflows/distros.yaml
@@ -1,0 +1,31 @@
+name: distros
+
+on:
+  pull_request: {} # TODO NOW: remove this
+  push:
+    paths:
+      - 'dev/distros/**'
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build and push
+        run: |
+          cd dev/distros
+          make list | xargs -I {} make build-and-push-{}

--- a/Makefile
+++ b/Makefile
@@ -286,10 +286,6 @@ create-node%: DISTRO = debian-bookworm
 create-node%: NODE_PORT = 30000
 create-node%: K0S_DATA_DIR = /var/lib/k0s
 create-node%:
-	@if ! docker images | grep -q ec-$(DISTRO); then \
-		$(MAKE) -C dev/distros build-$(DISTRO); \
-	fi
-
 	@docker run -d \
 		--name node$* \
 		--hostname node$* \
@@ -299,7 +295,7 @@ create-node%:
 		-v $(shell pwd):/replicatedhq/embedded-cluster \
 		-v $(shell dirname $(shell pwd))/kots:/replicatedhq/kots \
 		$(if $(filter node0,node$*),-p $(NODE_PORT):$(NODE_PORT)) \
-		ec-$(DISTRO)
+		replicated/ec-distro:$(DISTRO)
 
 	@$(MAKE) ssh-node$*
 

--- a/dev/distros/Makefile
+++ b/dev/distros/Makefile
@@ -4,6 +4,11 @@ SHELL := /bin/bash
 list:
 	@ls dockerfiles/*.Dockerfile | sed 's/^dockerfiles\///' | sed 's/\.Dockerfile$$//'
 
+.PHONY: build-and-push-%
+build-and-push-%:
+	@$(MAKE) build-$*
+	docker push replicated/ec-distro:$*
+
 .PHONY: build-%
 build-%:
-	docker build -t ec-$* -f dockerfiles/$*.Dockerfile .
+	docker build -t replicated/ec-distro:$* -f dockerfiles/$*.Dockerfile .

--- a/dev/distros/README.md
+++ b/dev/distros/README.md
@@ -4,3 +4,13 @@ The Dockerfiles in this directory were adapted from the k0s project:
 https://github.com/k0sproject/k0s/blob/2b7adcd574b0f20ccd1a2da515cf8c81d57b2241/inttest/bootloose-alpine/Dockerfile
 
 These Dockerfiles are used to create various distribution images for testing and development purposes.
+
+## Adding / updating distros
+
+1. Create or modify the Dockerfile in the `dockerfiles` directory. For new distros, name it `<distro-name>.Dockerfile`.
+1. Test building the image locally:
+    ```bash
+    make build-<distro-name>
+    ```
+1. Test an installation with the image locally.
+1. Once merged to main, the CI will automatically (re)build and push the image to DockerHub.


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Publishes EC distro images to Dockerhub so they can be used for testing without having to build them in CI to avoid flakiness.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[113140](https://app.shortcut.com/replicated/story/113140)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE