### PR TITLE
Enable goldpinger collector and analyzer

### DIFF
--- a/operator/charts/embedded-cluster-operator/troubleshoot/cluster-support-bundle.yaml
+++ b/operator/charts/embedded-cluster-operator/troubleshoot/cluster-support-bundle.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   uri: https://raw.githubusercontent.com/replicatedhq/embedded-cluster-operator/main/charts/embedded-cluster-operator/troubleshoot/cluster-support-bundle.yaml
   collectors:
+  - goldpinger: {}
   - logs:
       name: podlogs/embedded-cluster-operator
       namespace: embedded-cluster
@@ -64,6 +65,7 @@ spec:
       limits:
         maxAge: 720h
   analyzers:
+  - goldpinger: {}
   - textAnalyze:
       checkName: Cluster installation status
       fileName: cluster-resources/custom-resources/installations.embeddedcluster.replicated.com.yaml


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Enables the goldpinger collector and analyzer now that the collector is capable of temporarily provisioning goldpinger. 

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Enable goldpinger collector and analyzer
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE