### PR TITLE
chore: make preflight pass on arm64

### DIFF
--- a/cmd/embedded-cluster/install.go
+++ b/cmd/embedded-cluster/install.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -140,6 +141,7 @@ func RunHostPreflights(c *cli.Context, applier *addons.Applier, replicatedAPIURL
 		IsAirgap:                isAirgap,
 		AdminConsolePort:        adminConsolePort,
 		LocalArtifactMirrorPort: localArtifactMirrorPort,
+		SystemArchitecture:      runtime.GOARCH,
 	}
 	chpfs, err := preflights.GetClusterHostPreflights(c.Context, data)
 	if err != nil {

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -134,6 +134,7 @@ spec:
               message: At least 2 CPU cores are required, but fewer are present
           - pass:
               message: At least 2 CPU cores are present
+{{- if eq .SystemArchitecture "amd64" }}
     - cpu:
         checkName: CPU Features
         outcomes:
@@ -142,6 +143,7 @@ spec:
               message: Host CPU supports x86-64-v2 features
           - fail:
               message: Required x86-64-v2 CPU features are missing. If using a hypervisor, ensure it is configured to expose the necessary CPU features.
+{{- end }}
     - memory:
         checkName: Memory
         outcomes:

--- a/pkg/preflights/template.go
+++ b/pkg/preflights/template.go
@@ -13,6 +13,7 @@ type TemplateData struct {
 	ProxyRegistryURL        string
 	AdminConsolePort        int
 	LocalArtifactMirrorPort int
+	SystemArchitecture      string
 }
 
 func renderTemplate(spec string, data TemplateData) (string, error) {


### PR DESCRIPTION

#### What this PR does / why we need it:

when on arm64 we don't want to run the x84-64-v2 preflight.


#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
