### PR TITLE
fix(ci): retry failure to get latest fio version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ pkg/goods/bins/local-artifact-mirror:
 	touch $@
 
 ifndef FIO_VERSION
-FIO_VERSION = $(shell curl -fsSL https://api.github.com/repos/axboe/fio/releases/latest | jq -r '.tag_name' | cut -d- -f2)
+FIO_VERSION = $(shell curl --retry 5 --retry-all-errors -fsSL https://api.github.com/repos/axboe/fio/releases/latest | jq -r '.tag_name' | cut -d- -f2)
 endif
 
 output/bins/fio-%:


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Hopefully this will fix the following flakiness in ci.

```
make[1]: Leaving directory '/home/runner/work/embedded-cluster/embedded-cluster/local-artifact-mirror'
cp local-artifact-mirror/bin/local-artifact-mirror-linux-amd64 pkg/goods/bins/local-artifact-mirror
touch pkg/goods/bins/local-artifact-mirror
curl: (22) The requested URL returned error: 403
curl: (22) The requested URL returned error: 403
make output/bins/fio--amd64
make[1]: Entering directory '/home/runner/work/embedded-cluster/embedded-cluster'
mkdir -p output/bins
docker build -t fio --build-arg FIO_VERSION=amd64 --build-arg PLATFORM=linux/ fio
```

https://github.com/replicatedhq/embedded-cluster/actions/runs/11150994226/job/30993411700?pr=1238

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
