### PR TITLE
Add centos-9 and debian-bullseye distros

### DIFF
--- a/dev/distros/dockerfiles/centos-9.Dockerfile
+++ b/dev/distros/dockerfiles/centos-9.Dockerfile
@@ -1,0 +1,25 @@
+FROM quay.io/centos/centos:stream9
+
+# Install necessary packages
+RUN dnf install -y \
+  sudo \
+  systemd \
+  openssh-server \
+  ca-certificates \
+  bash \
+  coreutils \
+  curl \
+  procps-ng \
+  ipvsadm \
+  kmod \
+  iproute \
+  chrony \
+  expect \
+  vim \
+  --allowerasing
+
+# Export kube config
+ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf
+
+# Default command to run systemd
+CMD ["/sbin/init"]

--- a/dev/distros/dockerfiles/debian-bullseye.Dockerfile
+++ b/dev/distros/dockerfiles/debian-bullseye.Dockerfile
@@ -1,0 +1,26 @@
+FROM debian:bullseye-slim
+
+# Install necessary packages
+RUN apt-get update && apt-get install -y \
+  sudo \
+  systemd \
+  openssh-server \
+  ca-certificates \
+  bash \
+  coreutils \
+  curl \
+  inotify-tools \
+  ipvsadm \
+  kmod \
+  iproute2 \
+  systemd-timesyncd \
+  expect \
+  vim
+
+# Override timesyncd config to allow it to run in containers
+COPY ./timesyncd-override.conf /etc/systemd/system/systemd-timesyncd.service.d/override.conf
+
+# Export kube config
+ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf
+
+CMD ["/sbin/init"]


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Adds centos-9 and debian-bullseye distros to the dev/test images

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-113140](https://app.shortcut.com/replicated/story/113140)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE