### PR TITLE
Mask systemd getty@tty1.service as it's flaky and doesn't apply in containers

### DIFF
--- a/dev/distros/dockerfiles/almalinux-8.Dockerfile
+++ b/dev/distros/dockerfiles/almalinux-8.Dockerfile
@@ -18,6 +18,9 @@ RUN dnf install -y \
   vim \
   --allowerasing
 
+# Disable getty service as it's flaky and doesn't apply in containers
+RUN systemctl mask getty@tty1.service
+
 # Export kube config
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf
 

--- a/dev/distros/dockerfiles/centos-9.Dockerfile
+++ b/dev/distros/dockerfiles/centos-9.Dockerfile
@@ -18,6 +18,9 @@ RUN dnf install -y \
   vim \
   --allowerasing
 
+# Disable getty service as it's flaky and doesn't apply in containers
+RUN systemctl mask getty@tty1.service
+
 # Export kube config
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf
 

--- a/dev/distros/dockerfiles/debian-bookworm.Dockerfile
+++ b/dev/distros/dockerfiles/debian-bookworm.Dockerfile
@@ -20,6 +20,9 @@ RUN apt-get update && apt-get install -y \
 # Override timesyncd config to allow it to run in containers
 COPY ./timesyncd-override.conf /etc/systemd/system/systemd-timesyncd.service.d/override.conf
 
+# Disable getty service as it's flaky and doesn't apply in containers
+RUN systemctl mask getty@tty1.service
+
 # Export kube config
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf
 

--- a/dev/distros/dockerfiles/debian-bullseye.Dockerfile
+++ b/dev/distros/dockerfiles/debian-bullseye.Dockerfile
@@ -20,6 +20,9 @@ RUN apt-get update && apt-get install -y \
 # Override timesyncd config to allow it to run in containers
 COPY ./timesyncd-override.conf /etc/systemd/system/systemd-timesyncd.service.d/override.conf
 
+# Disable getty service as it's flaky and doesn't apply in containers
+RUN systemctl mask getty@tty1.service
+
 # Export kube config
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf
 

--- a/dev/distros/dockerfiles/ubuntu-jammy.Dockerfile
+++ b/dev/distros/dockerfiles/ubuntu-jammy.Dockerfile
@@ -20,6 +20,9 @@ RUN apt-get update && apt-get install -y \
 # Override timesyncd config to allow it to run in containers
 COPY ./timesyncd-override.conf /etc/systemd/system/systemd-timesyncd.service.d/override.conf
 
+# Disable getty service as it's flaky and doesn't apply in containers
+RUN systemctl mask getty@tty1.service
+
 # Export kube config
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Masks systemd getty@tty1.service as it's flaky in CI and doesn't apply in containers

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-113140](https://app.shortcut.com/replicated/story/113140)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE