### PR TITLE
chore: revert prevent the use of symlinks

### DIFF
--- a/cmd/embedded-cluster/install.go
+++ b/cmd/embedded-cluster/install.go
@@ -631,9 +631,6 @@ func installCommand() *cli.Command {
 			if c.String("airgap-bundle") != "" {
 				metrics.DisableMetrics()
 			}
-			if err := validateDataDir(c); err != nil {
-				return err
-			}
 			return nil
 		},
 		Flags: withProxyFlags(withSubnetCIDRFlags(

--- a/cmd/embedded-cluster/join.go
+++ b/cmd/embedded-cluster/join.go
@@ -167,9 +167,6 @@ var joinCommand = &cli.Command{
 		if c.String("airgap-bundle") != "" {
 			metrics.DisableMetrics()
 		}
-		if err := validateDataDir(c); err != nil {
-			return err
-		}
 		return nil
 	},
 	Action: func(c *cli.Context) error {

--- a/cmd/embedded-cluster/preflights.go
+++ b/cmd/embedded-cluster/preflights.go
@@ -185,34 +185,3 @@ var joinRunPreflightsCommand = &cli.Command{
 		return nil
 	},
 }
-
-// validateDataDir checks if the data dir is valid before we start to
-// materialize binaries in it. at this point we don't have the preflights
-// binary available yet ( it is also materialized in the data dir ).
-func validateDataDir(c *cli.Context) error {
-	if c.Bool("skip-host-preflights") {
-		return nil
-	}
-
-	dataDir := c.String("data-dir")
-	dinfo, err := os.Lstat(dataDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			// if the data dir doesn't exist that is okay as we
-			// will create it later.
-			return nil
-		}
-		return fmt.Errorf("unable to stat data dir: %v", err)
-	}
-
-	// if it is not a symlink, it is valid.
-	if dinfo.Mode()&os.ModeSymlink == 0 {
-		return nil
-	}
-
-	// we attempt to mimic the behavior of the preflight results here.
-	logrus.Infof("✗ 1 host preflight failed\n")
-	logrus.Infof(" •  %s cannot be symlinked. Remove the symlink, or use the --data-dir flag to provide an alternate data directory.\n", dataDir)
-	logrus.Infof("Please address this issue and try again.")
-	return ErrNothingElseToAdd
-}

--- a/cmd/embedded-cluster/restore.go
+++ b/cmd/embedded-cluster/restore.go
@@ -929,9 +929,6 @@ func restoreCommand() *cli.Command {
 			if os.Getuid() != 0 {
 				return fmt.Errorf("restore command must be run as root")
 			}
-			if err := validateDataDir(c); err != nil {
-				return err
-			}
 			return nil
 		},
 		Action: func(c *cli.Context) error {


### PR DESCRIPTION
#### What this PR does / why we need it:

This reverts commit 8309d3c14126a2c6fb797d411c0db32525de2f10.
