### PR TITLE
run the daemonsets to collect k0s controller/worker logs in the embedded-cluster namespace

### DIFF
--- a/operator/charts/embedded-cluster-operator/templates/embedded-cluster-logs-collector.yaml
+++ b/operator/charts/embedded-cluster-operator/templates/embedded-cluster-logs-collector.yaml
@@ -19,7 +19,7 @@ data:
       collectors:
         - runDaemonSet:
             name: "k0scontroller"
-            namespace: default
+            namespace: embedded-cluster
             podSpec:
               containers:
               - image: {{ .Values.utilsImage }}
@@ -47,12 +47,12 @@ data:
                 name: host-root
         - runDaemonSet:
             name: "k0sworker"
-            namespace: default
+            namespace: embedded-cluster
             podSpec:
               containers:
               - image: {{ .Values.utilsImage }}
                 imagePullPolicy: Always
-                args: ["chroot","/host","journalctl","-u","k0scontroller","--no-pager","--since","2 days ago"]
+                args: ["chroot","/host","journalctl","-u","k0sworker","--no-pager","--since","2 days ago"]
                 name: debugger
                 resources: {}
                 terminationMessagePath: /dev/termination-log


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Currently we run daemonsets to collect journalctl logs for k0scontroller and k0sworker in the `default` namespace. This PR changes those to run in `embedded-cluster` instead, and also changes the `k0sworker` collector to collect logs for the worker service instead of controller again.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
