### PR TITLE
do not overwrite existing custom k0s builds

### DIFF
--- a/.github/workflows/release-k0s-patch.yaml
+++ b/.github/workflows/release-k0s-patch.yaml
@@ -46,7 +46,7 @@ jobs:
         run: |
           object_key="custom-k0s-binaries/k0s-${{ github.event.inputs.tag }}-${{ matrix.runner.arch }}"
           # check if the file already exists
-          if aws s3 ls "k0s s3://${S3_BUCKET}/${object_key}" > /dev/null; then
+          if aws s3api head-object --bucket="${S3_BUCKET}" --key="${object_key}" > /dev/null 2>&1; then
             echo "::notice ::Binary already exists in https://${S3_BUCKET}.s3.amazonaws.com/${object_key}"
             exit 1
           fi

--- a/.github/workflows/release-k0s-patch.yaml
+++ b/.github/workflows/release-k0s-patch.yaml
@@ -45,5 +45,11 @@ jobs:
           AWS_REGION: us-east-1
         run: |
           object_key="custom-k0s-binaries/k0s-${{ github.event.inputs.tag }}-${{ matrix.runner.arch }}"
+          # check if the file already exists
+          if aws s3 ls "k0s s3://${S3_BUCKET}/${object_key}" > /dev/null; then
+            echo "::notice ::Binary already exists in https://${S3_BUCKET}.s3.amazonaws.com/${object_key}"
+            exit 1
+          fi
+          # upload the file
           aws s3 cp "k0s s3://${S3_BUCKET}/${object_key}"
           echo "::notice ::Binary uploaded to https://${S3_BUCKET}.s3.amazonaws.com/${object_key}"


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

If we overwrite the existing k0s binary, sha256sums will not match. We should not do this.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
