### PR TITLE
Dev / testing: ensure a unique machine ID for each node

### DIFF
--- a/dev/distros/dockerfiles/almalinux-8.Dockerfile
+++ b/dev/distros/dockerfiles/almalinux-8.Dockerfile
@@ -18,11 +18,9 @@ RUN dnf install -y \
   vim \
   --allowerasing
 
-# Disable getty service as it's flaky and doesn't apply in containers
-RUN systemctl mask getty@tty1.service
-
 # Export kube config
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf
 
-# Default command to run systemd
-CMD ["/sbin/init"]
+# Entrypoint for runtime configurations
+COPY ./entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/dev/distros/dockerfiles/centos-9.Dockerfile
+++ b/dev/distros/dockerfiles/centos-9.Dockerfile
@@ -18,11 +18,9 @@ RUN dnf install -y \
   vim \
   --allowerasing
 
-# Disable getty service as it's flaky and doesn't apply in containers
-RUN systemctl mask getty@tty1.service
-
 # Export kube config
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf
 
-# Default command to run systemd
-CMD ["/sbin/init"]
+# Entrypoint for runtime configurations
+COPY ./entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/dev/distros/dockerfiles/debian-bookworm.Dockerfile
+++ b/dev/distros/dockerfiles/debian-bookworm.Dockerfile
@@ -13,17 +13,13 @@ RUN apt-get update && apt-get install -y \
   ipvsadm \
   kmod \
   iproute2 \
-  systemd-timesyncd \
+  chrony \
   expect \
   vim
-
-# Override timesyncd config to allow it to run in containers
-COPY ./timesyncd-override.conf /etc/systemd/system/systemd-timesyncd.service.d/override.conf
-
-# Disable getty service as it's flaky and doesn't apply in containers
-RUN systemctl mask getty@tty1.service
 
 # Export kube config
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf
 
-CMD ["/sbin/init"]
+# Entrypoint for runtime configurations
+COPY ./entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/dev/distros/dockerfiles/debian-bullseye.Dockerfile
+++ b/dev/distros/dockerfiles/debian-bullseye.Dockerfile
@@ -13,17 +13,13 @@ RUN apt-get update && apt-get install -y \
   ipvsadm \
   kmod \
   iproute2 \
-  systemd-timesyncd \
+  chrony \
   expect \
   vim
-
-# Override timesyncd config to allow it to run in containers
-COPY ./timesyncd-override.conf /etc/systemd/system/systemd-timesyncd.service.d/override.conf
-
-# Disable getty service as it's flaky and doesn't apply in containers
-RUN systemctl mask getty@tty1.service
 
 # Export kube config
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf
 
-CMD ["/sbin/init"]
+# Entrypoint for runtime configurations
+COPY ./entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/dev/distros/dockerfiles/ubuntu-jammy.Dockerfile
+++ b/dev/distros/dockerfiles/ubuntu-jammy.Dockerfile
@@ -13,17 +13,13 @@ RUN apt-get update && apt-get install -y \
   ipvsadm \
   kmod \
   iproute2 \
-  systemd-timesyncd \
+  chrony \
   expect \
   vim
-
-# Override timesyncd config to allow it to run in containers
-COPY ./timesyncd-override.conf /etc/systemd/system/systemd-timesyncd.service.d/override.conf
-
-# Disable getty service as it's flaky and doesn't apply in containers
-RUN systemctl mask getty@tty1.service
 
 # Export kube config
 ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf
 
-CMD ["/sbin/init"]
+# Entrypoint for runtime configurations
+COPY ./entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/dev/distros/entrypoint.sh
+++ b/dev/distros/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Disable getty service as it's flaky and doesn't apply in containers
+systemctl mask getty@tty1.service
+
+# A unique machine ID is required for multi-node clusters in k0s <= v1.29
+# https://github.com/k0sproject/k0s/blob/443e28b75d216e120764136b4513e6237cea7cc5/docs/external-runtime-deps.md#a-unique-machine-id-for-multi-node-setups
+if [ ! -f "/etc/machine-id.persistent" ]; then
+    dbus-uuidgen --ensure=/etc/machine-id.persistent
+fi
+ln -sf /etc/machine-id.persistent /etc/machine-id
+ln -sf /etc/machine-id.persistent /var/lib/dbus/machine-id
+
+# Launch the system
+exec /sbin/init

--- a/dev/distros/timesyncd-override.conf
+++ b/dev/distros/timesyncd-override.conf
@@ -1,3 +1,0 @@
-# allow timesyncd to run in containers
-[Unit]
-ConditionVirtualization=


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

A unique machine ID is required for multi-node clusters in k0s <= v1.29. This PR addresses that problem in order to fix multi-node HA upgrades in the dev and new testing env.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-113140](https://app.shortcut.com/replicated/story/113140)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE