### PR TITLE
chore: disable appamor setup

### DIFF
--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -85,12 +85,6 @@ runs:
       sudo rm -rf /opt/ghc
       sudo rm -rf /usr/local/share/boost
       df -h
-  - name: Set AppArmor mode to complain
-    shell: bash
-    run: |
-      sudo apt-get update -y
-      sudo apt install apparmor-utils -y
-      sudo aa-complain /etc/apparmor.d/*
   - name: Setup Go
     uses: actions/setup-go@v5
     with:


### PR DESCRIPTION
#### What this PR does / why we need it:

iirc this is a left over from when we were having problems installing embedded cluster on the github runners. in the end the problem was related to the network manager service stomping over the calico interfaces. if you are seeing this commit then it means that these step was not necessary and got removed from the e2e action.
