### PR TITLE
feat: check if data-dir is a symlink

### DIFF
--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -116,6 +116,13 @@ spec:
     - udpPortStatus:
         collectorName: Calico Communication Port
         port: 4789
+    - run:
+        collectorName: check-data-dir-symlink
+        command: sh
+        args:
+          - -c
+          - |
+            [ -d "{{ .DataDir }}" ] && [ -L "{{ .DataDir }}" ] && echo "{{ .DataDir }} is a symlink" || echo "{{ .DataDir }} is not a symlink"
   analyzers:
     - cpu:
         checkName: CPU
@@ -745,3 +752,14 @@ spec:
               message: Port 4789/UDP is available.
           - error:
               message: Port 4789/UDP is required, but an unexpected error occurred when trying to connect to it. Ensure port 4789/UDP is available.
+    - textAnalyze:
+        checkName: Data Dir Symlink Check
+        fileName: host-collectors/run-host/check-data-dir-symlink.txt
+        regex: 'is a symlink'
+        outcomes:
+          - fail:
+              when: 'true'
+              message: {{ .DataDir }} cannot be symlinked. Remove the symlink, or use the --data-dir flag to provide an alternate data directory.
+          - pass:
+              when: 'false'
+              message: {{ .DataDir }} is not a symlink.


### PR DESCRIPTION
#### What this PR does / why we need it:

data directory can't be a symlink, we have decided to fail if this is the case. this pr adds a preflight check for that.
