### PR TITLE
Remove KUBECONFIG env var in distro images

### DIFF
--- a/dev/distros/dockerfiles/almalinux-8.Dockerfile
+++ b/dev/distros/dockerfiles/almalinux-8.Dockerfile
@@ -18,9 +18,6 @@ RUN dnf install -y \
   vim \
   --allowerasing
 
-# Export kube config
-ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf
-
 # Entrypoint for runtime configurations
 COPY ./entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/dev/distros/dockerfiles/centos-9.Dockerfile
+++ b/dev/distros/dockerfiles/centos-9.Dockerfile
@@ -18,9 +18,6 @@ RUN dnf install -y \
   vim \
   --allowerasing
 
-# Export kube config
-ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf
-
 # Entrypoint for runtime configurations
 COPY ./entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/dev/distros/dockerfiles/debian-bookworm.Dockerfile
+++ b/dev/distros/dockerfiles/debian-bookworm.Dockerfile
@@ -17,9 +17,6 @@ RUN apt-get update && apt-get install -y \
   expect \
   vim
 
-# Export kube config
-ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf
-
 # Entrypoint for runtime configurations
 COPY ./entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/dev/distros/dockerfiles/debian-bullseye.Dockerfile
+++ b/dev/distros/dockerfiles/debian-bullseye.Dockerfile
@@ -17,9 +17,6 @@ RUN apt-get update && apt-get install -y \
   expect \
   vim
 
-# Export kube config
-ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf
-
 # Entrypoint for runtime configurations
 COPY ./entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/dev/distros/dockerfiles/ubuntu-jammy.Dockerfile
+++ b/dev/distros/dockerfiles/ubuntu-jammy.Dockerfile
@@ -17,9 +17,6 @@ RUN apt-get update && apt-get install -y \
   expect \
   vim
 
-# Export kube config
-ENV KUBECONFIG=/var/lib/k0s/pki/admin.conf
-
 # Entrypoint for runtime configurations
 COPY ./entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Removes KUBECONFIG env var in distro images as it's not necessary.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-113140](https://app.shortcut.com/replicated/story/113140)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE