### PR TITLE
Unhide air gap and alphabetize flags

### DIFF
--- a/cmd/embedded-cluster/install.go
+++ b/cmd/embedded-cluster/install.go
@@ -654,17 +654,19 @@ func installCommand() *cli.Command {
 					Usage:  fmt.Sprintf("Password for the Admin Console (minimum %d characters)", minAdminPasswordLength),
 					Hidden: false,
 				},
+				getAdminConsolePortFlag(runtimeConfig),
 				&cli.StringFlag{
-					Name:   "airgap-bundle",
-					Usage:  "Path to the air gap bundle. If set, the installation will complete without internet access.",
-					Hidden: true,
+					Name:  "airgap-bundle",
+					Usage: "Path to the air gap bundle. If set, the installation will complete without internet access.",
 				},
+				getDataDirFlag(runtimeConfig),
 				&cli.StringFlag{
 					Name:    "license",
 					Aliases: []string{"l"},
 					Usage:   "Path to the license file",
 					Hidden:  false,
 				},
+				getLocalArtifactMirrorPortFlag(runtimeConfig),
 				&cli.StringFlag{
 					Name:  "network-interface",
 					Usage: "The network interface to use for the cluster",
@@ -680,18 +682,15 @@ func installCommand() *cli.Command {
 					Usage:  "File with an EmbeddedClusterConfig object to override the default configuration",
 					Hidden: true,
 				},
+				&cli.StringSliceFlag{
+					Name:  "private-ca",
+					Usage: "Path to a trusted private CA certificate file",
+				},
 				&cli.BoolFlag{
 					Name:  "skip-host-preflights",
 					Usage: "Skip host preflight checks. This is not recommended.",
 					Value: false,
 				},
-				&cli.StringSliceFlag{
-					Name:  "private-ca",
-					Usage: "Path to a trusted private CA certificate file",
-				},
-				getDataDirFlag(runtimeConfig),
-				getAdminConsolePortFlag(runtimeConfig),
-				getLocalArtifactMirrorPortFlag(runtimeConfig),
 			},
 		)),
 		Action: func(c *cli.Context) error {

--- a/cmd/embedded-cluster/join.go
+++ b/cmd/embedded-cluster/join.go
@@ -135,9 +135,8 @@ var joinCommand = &cli.Command{
 	},
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:   "airgap-bundle",
-			Usage:  "Path to the air gap bundle. If set, the installation will complete without internet access.",
-			Hidden: true,
+			Name:  "airgap-bundle",
+			Usage: "Path to the air gap bundle. If set, the installation will complete without internet access.",
 		},
 		&cli.BoolFlag{
 			Name:   "enable-ha",

--- a/cmd/embedded-cluster/reset.go
+++ b/cmd/embedded-cluster/reset.go
@@ -342,6 +342,7 @@ func resetCommand() *cli.Command {
 		},
 		Args: false,
 		Flags: []cli.Flag{
+			getDataDirFlag(runtimeConfig),
 			&cli.BoolFlag{
 				Name:    "force",
 				Aliases: []string{"f"},
@@ -353,7 +354,6 @@ func resetCommand() *cli.Command {
 				Usage: "Disable interactive prompts",
 				Value: false,
 			},
-			getDataDirFlag(runtimeConfig),
 		},
 		Usage: fmt.Sprintf("Remove %s from the current node", binName),
 		Action: func(c *cli.Context) error {

--- a/cmd/embedded-cluster/restore.go
+++ b/cmd/embedded-cluster/restore.go
@@ -905,9 +905,15 @@ func restoreCommand() *cli.Command {
 		Flags: withProxyFlags(withSubnetCIDRFlags(
 			[]cli.Flag{
 				&cli.StringFlag{
-					Name:   "airgap-bundle",
-					Usage:  "Path to the air gap bundle. If set, the restore will complete without internet access.",
-					Hidden: true,
+					Name:  "airgap-bundle",
+					Usage: "Path to the air gap bundle. If set, the restore will complete without internet access.",
+				},
+				getDataDirFlag(runtimeConfig),
+				&cli.StringFlag{
+					Name:  "local-artifact-mirror-port",
+					Usage: "Port on which the Local Artifact Mirror will be served. If left empty, the port will be retrieved from the snapshot.",
+					// DefaultText: strconv.Itoa(ecv1beta1.DefaultLocalArtifactMirrorPort),
+					Hidden: false,
 				},
 				&cli.StringFlag{
 					Name:  "network-interface",
@@ -930,13 +936,6 @@ func restoreCommand() *cli.Command {
 					Value:  false,
 					Hidden: true,
 				},
-				&cli.StringFlag{
-					Name:  "local-artifact-mirror-port",
-					Usage: "Port on which the Local Artifact Mirror will be served. If left empty, the port will be retrieved from the snapshot.",
-					// DefaultText: strconv.Itoa(ecv1beta1.DefaultLocalArtifactMirrorPort),
-					Hidden: false,
-				},
-				getDataDirFlag(runtimeConfig),
 			},
 		)),
 		Before: func(c *cli.Context) error {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
I realized the air gap flags are still hidden, so I unhid those. I also alphabetized the CLI flags in the help menus so they're easier to read. The CIDR and proxy flags are from functions, so those didn't get alphabetized. Ultimately I'd like them to be alphabetized, but I didn't bother to rework those functions.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Unhides the `--airgap-bundle` flag for the `install`, `join`, and `restore` commands.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE