### PR TITLE
fix: install flake waiting for k0s

### DIFF
--- a/cmd/embedded-cluster/install.go
+++ b/cmd/embedded-cluster/install.go
@@ -514,10 +514,16 @@ func waitForK0s() error {
 	if !success {
 		return fmt.Errorf("timeout waiting for %s", defaults.BinaryName())
 	}
-	if _, err := helpers.RunCommand(defaults.K0sBinaryPath(), "status"); err != nil {
-		return fmt.Errorf("unable to get status: %w", err)
+
+	for i := 1; ; i++ {
+		_, err := helpers.RunCommand(defaults.K0sBinaryPath(), "status")
+		if err == nil {
+			return nil
+		} else if i == 5 {
+			return fmt.Errorf("unable to get status: %w", err)
+		}
+		time.Sleep(2 * time.Second)
 	}
-	return nil
 }
 
 // installAndWaitForK0s installs the k0s binary and waits for it to be ready


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->


https://github.com/replicatedhq/embedded-cluster/actions/runs/11346836104/job/31557511853?pr=1320

```
◒  Waiting for embedded-cluster node to be ready
✔  Waiting for embedded-cluster node to be ready
	cluster.go:941: stderr:
		unable to wait for node: unable to get status: exit status 1: Error: status: can't get "status" via "/run/k0s/status.sock": Get "http://localhost/status": read unix @->/run/k0s/status.sock: read: connection reset by peer
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue that could cause installs to fail with error "unable to wait for node... connection reset by peer"
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
