### PR TITLE
fix: install flake waiting for k0s

### DIFF
--- a/cmd/embedded-cluster/install.go
+++ b/cmd/embedded-cluster/install.go
@@ -519,7 +519,7 @@ func waitForK0s() error {
 		_, err := helpers.RunCommand(defaults.K0sBinaryPath(), "status")
 		if err == nil {
 			return nil
-		} else if i == 5 {
+		} else if i == 30 {
 			return fmt.Errorf("unable to get status: %w", err)
 		}
 		time.Sleep(2 * time.Second)

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -1981,25 +1981,25 @@ func TestFiveNodesAirgapUpgrade(t *testing.T) {
 		func(t *testing.T) error {
 			err := tc.RunCommandsOnNode(1, joinCommandsSequence)
 			if err != nil {
-				return fmt.Errorf("unable to run commands on node 1: %w", err)
+				return fmt.Errorf("unable to join node 1: %w", err)
 			}
 			return nil
 		}, func(t *testing.T) error {
 			err := tc.RunCommandsOnNode(2, joinCommandsSequence)
 			if err != nil {
-				return fmt.Errorf("unable to run commands on node 2: %w", err)
+				return fmt.Errorf("unable to join node 2: %w", err)
 			}
 			return nil
 		}, func(t *testing.T) error {
 			err := tc.RunCommandsOnNode(3, joinCommandsSequence)
 			if err != nil {
-				return fmt.Errorf("unable to run commands on node 3: %w", err)
+				return fmt.Errorf("unable to join node 3: %w", err)
 			}
 			return nil
 		}, func(t *testing.T) error {
 			err := tc.RunCommandsOnNode(4, joinCommandsSequence)
 			if err != nil {
-				return fmt.Errorf("unable to run commands on node 4: %w", err)
+				return fmt.Errorf("unable to join node 4: %w", err)
 			}
 			return nil
 		},

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -1979,13 +1979,29 @@ func TestFiveNodesAirgapUpgrade(t *testing.T) {
 	}
 	runInParallel(t,
 		func(t *testing.T) error {
-			return tc.RunCommandsOnNode(1, joinCommandsSequence)
+			err := tc.RunCommandsOnNode(1, joinCommandsSequence)
+			if err != nil {
+				return fmt.Errorf("unable to run commands on node 1: %w", err)
+			}
+			return nil
 		}, func(t *testing.T) error {
-			return tc.RunCommandsOnNode(2, joinCommandsSequence)
+			err := tc.RunCommandsOnNode(2, joinCommandsSequence)
+			if err != nil {
+				return fmt.Errorf("unable to run commands on node 2: %w", err)
+			}
+			return nil
 		}, func(t *testing.T) error {
-			return tc.RunCommandsOnNode(3, joinCommandsSequence)
+			err := tc.RunCommandsOnNode(3, joinCommandsSequence)
+			if err != nil {
+				return fmt.Errorf("unable to run commands on node 3: %w", err)
+			}
+			return nil
 		}, func(t *testing.T) error {
-			return tc.RunCommandsOnNode(4, joinCommandsSequence)
+			err := tc.RunCommandsOnNode(4, joinCommandsSequence)
+			if err != nil {
+				return fmt.Errorf("unable to run commands on node 4: %w", err)
+			}
+			return nil
 		},
 	)
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Related https://github.com/replicatedhq/embedded-cluster/pull/1327

This is still happening here https://github.com/replicatedhq/embedded-cluster/actions/runs/11350327808/job/31568962727

The test fails 4 seconds after k0s api starts. Perhaps we are just not waiting long enough?

```
Oct 15 17:24:44 node-dc4d1-03 k0s[3487]: time="2024-10-15 17:24:44" level=info msg="Started successfully, go nuts pid 3532" component=k0s-control-api
```

```
Tue, 15 Oct 2024 17:24:48 GMT
        unable to wait for node: unable to get status: exit status 1: Error: status: can't get "status" via "/run/k0s/status.sock": Get "http://localhost/status": dial unix /run/k0s/status.sock: connect: connection refused
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
