### PR TITLE
bug: fix wrong link to upstream support bundle url

### DIFF
--- a/operator/charts/embedded-cluster-operator/troubleshoot/cluster-support-bundle.yaml
+++ b/operator/charts/embedded-cluster-operator/troubleshoot/cluster-support-bundle.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     troubleshoot.io/kind: support-bundle
 spec:
-  uri: https://raw.githubusercontent.com/replicatedhq/embedded-cluster-operator/main/charts/embedded-cluster-operator/troubleshoot/cluster-support-bundle.yaml
+  uri: https://raw.githubusercontent.com/replicatedhq/embedded-cluster/main/operator/charts/embedded-cluster-operator/troubleshoot/cluster-support-bundle.yaml
   collectors:
   - logs:
       name: podlogs/embedded-cluster-operator


### PR DESCRIPTION

#### What this PR does / why we need it:

the uri field was pointing to the old repository.

