### PR TITLE
chore(makefile): fix the e2e single test execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,7 @@ e2e-tests: embedded-release
 
 .PHONY: e2e-test
 e2e-test:
-	go test -timeout 60m -ldflags="$(LD_FLAGS)" -v ./e2e -run $(TEST_NAME)$
+	go test -timeout 60m -ldflags="$(LD_FLAGS)" -v ./e2e -run ^$(TEST_NAME)$$
 
 .PHONY: build-ttl.sh
 build-ttl.sh:


### PR DESCRIPTION
#### What this PR does / why we need it:
The current `e2e-test` script uses go's `-run` flag which interprets the provided name as a regex, this means that similar test names will execute. E.g.

```
make e2e-test (...) TEST_NAME=TestResetAndReinstall
go test -timeout 60m -ldflags="(...)" -v ./e2e -run TestResetAndReinstall
=== RUN   TestResetAndReinstall
=== PAUSE TestResetAndReinstall
=== RUN   TestResetAndReinstallAirgap
=== PAUSE TestResetAndReinstallAirgap
```

After the change
```
make e2e-test (...) TEST_NAME=TestResetAndReinstall
go test -timeout 60m -ldflags="(...)" -v ./e2e -run ^TestResetAndReinstall$
=== RUN   TestResetAndReinstall
=== PAUSE TestResetAndReinstall
=== RUN   TestResetAndReinstallAirgap
=== PAUSE TestResetAndReinstallAirgap
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
