### PR TITLE
bug(seaweedfs): fix data path, add validation in e2e tests

### DIFF
--- a/e2e/cluster/docker/cluster.go
+++ b/e2e/cluster/docker/cluster.go
@@ -82,10 +82,9 @@ func (c *Cluster) WaitForReady() {
 }
 
 func (c *Cluster) Cleanup(envs ...map[string]string) {
-	// if c.t.Failed() {
 	c.generateSupportBundle(envs...)
 	c.copyPlaywrightReport()
-	//}
+
 	for _, node := range c.Nodes {
 		node.Destroy()
 	}

--- a/e2e/cluster/lxd/cluster.go
+++ b/e2e/cluster/lxd/cluster.go
@@ -989,10 +989,8 @@ func (c *Cluster) InstallTestDependenciesDebian(t *testing.T, node int, withProx
 }
 
 func (c *Cluster) Cleanup(envs ...map[string]string) {
-	// if c.T.Failed() {
 	c.generateSupportBundle(envs...)
 	c.copyPlaywrightReport()
-	// }
 }
 
 func (c *Cluster) SetupPlaywrightAndRunTest(testName string, args ...string) (string, string, error) {

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -1157,24 +1157,20 @@ func TestAirgapUpgradeFromEC18(t *testing.T) {
 		t.Fatalf("fail to check postupgrade state: %v", err)
 	}
 
-	// TODO: reset fails with the following error:
-	//   error: could not reset k0s: exit status 1, time="2024-10-17 22:44:52" level=warning msg="To ensure a full reset, a node reboot is recommended."
-	//   Error: errors received during clean-up: [failed to delete /run/k0s. err: unlinkat /run/k0s/containerd/io.containerd.grpc.v1.cri/sandboxes/.../shm: device or resource busy]
+	t.Logf("%s: resetting worker node", time.Now().Format(time.RFC3339))
+	line = []string{"reset-installation.sh"}
+	if stdout, stderr, err := tc.RunCommandOnNode(1, line, withEnv); err != nil {
+		t.Fatalf("fail to reset worker node: %v: %s: %s", err, stdout, stderr)
+	}
 
-	// t.Logf("%s: resetting worker node", time.Now().Format(time.RFC3339))
-	// line = []string{"reset-installation.sh"}
-	// if stdout, stderr, err := tc.RunCommandOnNode(1, line, withEnv); err != nil {
-	// 	t.Fatalf("fail to reset worker node: %v: %s: %s", err, stdout, stderr)
-	// }
+	// use upgrade binary for reset
+	withUpgradeBin := map[string]string{"EMBEDDED_CLUSTER_BIN": "embedded-cluster-upgrade"}
 
-	// // use upgrade binary for reset
-	// withUpgradeBin := map[string]string{"EMBEDDED_CLUSTER_BIN": "embedded-cluster-upgrade"}
-
-	// t.Logf("%s: resetting node 0", time.Now().Format(time.RFC3339))
-	// line = []string{"reset-installation.sh"}
-	// if stdout, stderr, err := tc.RunCommandOnNode(0, line, withEnv, withUpgradeBin); err != nil {
-	// 	t.Fatalf("fail to reset node 0: %v: %s: %s", err, stdout, stderr)
-	// }
+	t.Logf("%s: resetting node 0", time.Now().Format(time.RFC3339))
+	line = []string{"reset-installation.sh"}
+	if stdout, stderr, err := tc.RunCommandOnNode(0, line, withEnv, withUpgradeBin); err != nil {
+		t.Fatalf("fail to reset node 0: %v: %s: %s", err, stdout, stderr)
+	}
 
 	t.Logf("%s: test complete", time.Now().Format(time.RFC3339))
 }

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -1157,20 +1157,24 @@ func TestAirgapUpgradeFromEC18(t *testing.T) {
 		t.Fatalf("fail to check postupgrade state: %v", err)
 	}
 
-	t.Logf("%s: resetting worker node", time.Now().Format(time.RFC3339))
-	line = []string{"reset-installation.sh"}
-	if stdout, stderr, err := tc.RunCommandOnNode(1, line, withEnv); err != nil {
-		t.Fatalf("fail to reset worker node: %v: %s: %s", err, stdout, stderr)
-	}
+	// TODO: reset fails with the following error:
+	//   error: could not reset k0s: exit status 1, time="2024-10-17 22:44:52" level=warning msg="To ensure a full reset, a node reboot is recommended."
+	//   Error: errors received during clean-up: [failed to delete /run/k0s. err: unlinkat /run/k0s/containerd/io.containerd.grpc.v1.cri/sandboxes/.../shm: device or resource busy]
 
-	// use upgrade binary for reset
-	withUpgradeBin := map[string]string{"EMBEDDED_CLUSTER_BIN": "embedded-cluster-upgrade"}
+	// t.Logf("%s: resetting worker node", time.Now().Format(time.RFC3339))
+	// line = []string{"reset-installation.sh"}
+	// if stdout, stderr, err := tc.RunCommandOnNode(1, line, withEnv); err != nil {
+	// 	t.Fatalf("fail to reset worker node: %v: %s: %s", err, stdout, stderr)
+	// }
 
-	t.Logf("%s: resetting node 0", time.Now().Format(time.RFC3339))
-	line = []string{"reset-installation.sh"}
-	if stdout, stderr, err := tc.RunCommandOnNode(0, line, withEnv, withUpgradeBin); err != nil {
-		t.Fatalf("fail to reset node 0: %v: %s: %s", err, stdout, stderr)
-	}
+	// // use upgrade binary for reset
+	// withUpgradeBin := map[string]string{"EMBEDDED_CLUSTER_BIN": "embedded-cluster-upgrade"}
+
+	// t.Logf("%s: resetting node 0", time.Now().Format(time.RFC3339))
+	// line = []string{"reset-installation.sh"}
+	// if stdout, stderr, err := tc.RunCommandOnNode(0, line, withEnv, withUpgradeBin); err != nil {
+	// 	t.Fatalf("fail to reset node 0: %v: %s: %s", err, stdout, stderr)
+	// }
 
 	t.Logf("%s: test complete", time.Now().Format(time.RFC3339))
 }

--- a/e2e/scripts/check-airgap-installation-state.sh
+++ b/e2e/scripts/check-airgap-installation-state.sh
@@ -43,7 +43,10 @@ main() {
         exit 1
     fi
 
-    validate_data_dirs
+    # if this is the current version
+    if echo "$version" | grep -E "^(dev|appver)-" ; then
+        validate_data_dirs
+    fi
 }
 
 main "$@"

--- a/e2e/scripts/check-airgap-installation-state.sh
+++ b/e2e/scripts/check-airgap-installation-state.sh
@@ -42,6 +42,8 @@ main() {
         kubectl get cm -n kotsadm kotsadm-application-metadata -o yaml
         exit 1
     fi
+
+    validate_data_dirs
 }
 
 main "$@"

--- a/e2e/scripts/check-airgap-post-ha-state.sh
+++ b/e2e/scripts/check-airgap-post-ha-state.sh
@@ -67,6 +67,8 @@ main() {
         kubectl get cm -n kotsadm kotsadm-application-metadata -o yaml
         exit 1
     fi
+
+    validate_data_dirs
 }
 
 main "$@"

--- a/e2e/scripts/check-airgap-post-ha-state.sh
+++ b/e2e/scripts/check-airgap-post-ha-state.sh
@@ -68,7 +68,10 @@ main() {
         exit 1
     fi
 
-    validate_data_dirs
+    # if this is the current version
+    if echo "$version" | grep -E "^(dev|appver)-" ; then
+        validate_data_dirs
+    fi
 }
 
 main "$@"

--- a/e2e/scripts/check-installation-state.sh
+++ b/e2e/scripts/check-installation-state.sh
@@ -47,6 +47,8 @@ main() {
         kubectl get cm -n kotsadm kotsadm-application-metadata -o yaml
         exit 1
     fi
+
+    validate_data_dirs
 }
 
 main "$@"

--- a/e2e/scripts/check-installation-state.sh
+++ b/e2e/scripts/check-installation-state.sh
@@ -48,7 +48,10 @@ main() {
         exit 1
     fi
 
-    validate_data_dirs
+    # if this is the current version
+    if echo "$version" | grep -E "^(dev|appver)-" ; then
+        validate_data_dirs
+    fi
 }
 
 main "$@"

--- a/e2e/scripts/check-post-ha-state.sh
+++ b/e2e/scripts/check-post-ha-state.sh
@@ -61,7 +61,10 @@ main() {
         exit 1
     fi
 
-    validate_data_dirs
+    # if this is the current version
+    if echo "$version" | grep -E "^(dev|appver)-" ; then
+        validate_data_dirs
+    fi
 }
 
 main "$@"

--- a/e2e/scripts/check-post-ha-state.sh
+++ b/e2e/scripts/check-post-ha-state.sh
@@ -60,6 +60,8 @@ main() {
         kubectl get cm -n kotsadm kotsadm-application-metadata -o yaml
         exit 1
     fi
+
+    validate_data_dirs
 }
 
 main "$@"

--- a/e2e/scripts/check-postupgrade-state.sh
+++ b/e2e/scripts/check-postupgrade-state.sh
@@ -108,6 +108,8 @@ main() {
         echo "not all nodes are running k8s $k8s_version"
         exit 1
     fi
+
+    validate_data_dirs
 }
 
 main "$@"

--- a/e2e/scripts/common.sh
+++ b/e2e/scripts/common.sh
@@ -345,6 +345,7 @@ maybe_install_curl() {
 }
 
 validate_data_dirs() {
+    local expected_datadir="$EMBEDDED_CLUSTER_BASE_DIR"
     local expected_k0sdatadir="$EMBEDDED_CLUSTER_BASE_DIR/k0s"
     local expected_openebsdatadir="$EMBEDDED_CLUSTER_BASE_DIR/openebs-local"
     if [ "$KUBECONFIG" = "/var/lib/k0s/pki/admin.conf" ]; then
@@ -373,8 +374,8 @@ validate_data_dirs() {
         echo "found seaweedfs chart"
 
         seaweefdatadir=$(kubectl -n kube-system get charts k0s-addon-chart-seaweedfs -oyaml| grep -v apiVersion | grep -m 1 "hostPathPrefix:" | awk '{print $2}') 
-        if [ "$seaweefdatadir" != "$expected_openebsdatadir" ]; then
-            echo "got unexpected seaweefdatadir $seaweefdatadir, want $expected_openebsdatadir"
+        if ! echo "$seaweefdatadir" | grep -qE "^$expected_datadir/seaweedfs/(ssd|storage)$" ; then
+            echo "got unexpected seaweefdatadir $seaweefdatadir, want $expected_datadir/seaweedfs/(ssd|storage)"
             kubectl -n kube-system get charts k0s-addon-chart-seaweedfs -oyaml| grep -v apiVersion | grep -m 1 "hostPathPrefix:" -A5 -B5
             fail=1
         else

--- a/e2e/scripts/common.sh
+++ b/e2e/scripts/common.sh
@@ -343,3 +343,66 @@ maybe_install_curl() {
         apt-get install -y curl
     fi
 }
+
+validate_data_dirs() {
+    local expected_k0sdatadir="$EMBEDDED_CLUSTER_BASE_DIR/k0s"
+    local expected_openebsdatadir="$EMBEDDED_CLUSTER_BASE_DIR/openebs-local"
+    if [ "$KUBECONFIG" = "/var/lib/k0s/pki/admin.conf" ]; then
+        expected_k0sdatadir=/var/lib/k0s
+        expected_openebsdatadir=/var/openebs
+    fi
+
+    local fail=0
+
+    if kubectl -n kube-system get charts k0s-addon-chart-openebs -oyaml >/dev/null 2>&1 ; then
+        echo "found openebs chart"
+
+        openebsdatadir=$(kubectl -n kube-system get charts k0s-addon-chart-openebs -oyaml | grep -v apiVersion | grep "basePath:" | awk '{print $2}') 
+        if [ "$openebsdatadir" != "$expected_openebsdatadir" ]; then
+            echo "got unexpected openebsdatadir $openebsdatadir, want $expected_openebsdatadir"
+            kubectl -n kube-system get charts k0s-addon-chart-openebs -oyaml | grep -v apiVersion | grep "basePath:" -A5 -B5
+            fail=1
+        else
+            echo "validated openebsdatadir $openebsdatadir"
+        fi
+    else
+        echo "did not find openebs chart"
+    fi
+
+    if kubectl -n kube-system get charts k0s-addon-chart-seaweedfs -oyaml >/dev/null 2>&1 ; then
+        echo "found seaweedfs chart"
+
+        seaweefdatadir=$(kubectl -n kube-system get charts k0s-addon-chart-seaweedfs -oyaml| grep -v apiVersion | grep -m 1 "hostPathPrefix:" | awk '{print $2}') 
+        if [ "$seaweefdatadir" != "$expected_openebsdatadir" ]; then
+            echo "got unexpected seaweefdatadir $seaweefdatadir, want $expected_openebsdatadir"
+            kubectl -n kube-system get charts k0s-addon-chart-seaweedfs -oyaml| grep -v apiVersion | grep -m 1 "hostPathPrefix:" -A5 -B5
+            fail=1
+        else
+            echo "validated seaweefdatadir $seaweefdatadir"
+        fi
+    else
+        echo "did not find seaweedfs chart"
+    fi
+
+    if kubectl -n kube-system get charts k0s-addon-chart-velero -oyaml >/dev/null 2>&1 ; then
+        echo "found velero chart"
+
+        velerodatadir=$(kubectl -n kube-system get charts k0s-addon-chart-velero -oyaml | grep -v apiVersion | grep "podVolumePath:" | awk '{print $2}') 
+        if [ "$velerodatadir" != "$expected_k0sdatadir/kubelet/pods" ]; then
+            echo "got unexpected velerodatadir $velerodatadir, want $expected_openebsdatadir/kubelet/pods"
+            kubectl -n kube-system get charts k0s-addon-chart-velero -oyaml | grep -v apiVersion | grep "podVolumePath:" -A5 -B5
+            fail=1
+        else
+            echo "validated velerodatadir $velerodatadir"
+        fi
+    else
+        echo "did not find velero chart"
+    fi
+
+    if [ "$fail" -eq 1 ]; then
+        echo "data dir validation failed"
+        exit 1
+    else
+        echo "data dir validation succeeded"
+    fi
+}

--- a/operator/pkg/charts/charts.go
+++ b/operator/pkg/charts/charts.go
@@ -281,14 +281,14 @@ func updateInfraChartsFromInstall(in *v1beta1.Installation, clusterConfig *k0sv1
 			}
 
 			dataPath := filepath.Join(provider.EmbeddedClusterSeaweedfsSubDir(), "ssd")
-			newVals, err = helm.SetValue(newVals, "global.data.hostPathPrefix", dataPath)
+			newVals, err = helm.SetValue(newVals, "master.data.hostPathPrefix", dataPath)
 			if err != nil {
-				return nil, fmt.Errorf("set helm values seaweedfs.global.data.hostPathPrefix: %w", err)
+				return nil, fmt.Errorf("set helm values seaweedfs.master.data.hostPathPrefix: %w", err)
 			}
 			logsPath := filepath.Join(provider.EmbeddedClusterSeaweedfsSubDir(), "storage")
-			newVals, err = helm.SetValue(newVals, "global.logs.hostPathPrefix", logsPath)
+			newVals, err = helm.SetValue(newVals, "master.logs.hostPathPrefix", logsPath)
 			if err != nil {
-				return nil, fmt.Errorf("set helm values seaweedfs.global.logs.hostPathPrefix: %w", err)
+				return nil, fmt.Errorf("set helm values seaweedfs.master.logs.hostPathPrefix: %w", err)
 			}
 
 			charts[i].Values, err = helm.MarshalValues(newVals)

--- a/pkg/kubeutils/kubeutils.go
+++ b/pkg/kubeutils/kubeutils.go
@@ -3,6 +3,7 @@ package kubeutils
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"sort"
 	"time"
 
@@ -263,11 +264,15 @@ func GetPreviousInstallation(ctx context.Context, cli client.Client, in *embedde
 }
 
 var (
-	Version115 = semver.MustParse("1.15.0")
+	version115            = semver.MustParse("1.15.0")
+	oldVersionSchemeRegex = regexp.MustCompile(`.*\+ec\.[0-9]+`)
 )
 
 func lessThanK0s115(ver *semver.Version) bool {
-	return ver.LessThan(Version115)
+	if oldVersionSchemeRegex.MatchString(ver.Original()) {
+		return true
+	}
+	return ver.LessThan(version115)
 }
 
 // MaybeOverrideInstallationDataDirs checks if the previous installation is less than 1.15.0 that

--- a/pkg/kubeutils/kubeutils_test.go
+++ b/pkg/kubeutils/kubeutils_test.go
@@ -206,6 +206,13 @@ func Test_lessThanK0s115(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "old version scheme",
+			args: args{
+				ver: semver.MustParse("1.28.7+ec.0"),
+			},
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

The seaweedfs data paths are incorrect because the values are set wrong (global.data.hostPathPrefix vs master.data.hostPathPrefix).

Additionally, fixes an issue that prevents data paths from being set correctly for upgrades from the pre-minio version.

Adds validation to e2e tests for data paths.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue that causes the data paths to be set incorrectly for seaweedfs when cluster is converted to HA.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
