### PR TITLE
chore: unit test returned supernet

### DIFF
--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -996,7 +996,7 @@ func TestSingleNodeAirgapUpgradeCustomCIDR(t *testing.T) {
 	// expected to be in the 192.168.0.0/17 range while services are in the
 	// 192.168.128.0/17 range. i.e. pods are in 192.168.0-127.* while
 	// services in 192.168.128-254.*.
-	podregex := `192\.168\.\([0-9]\|[1-9][0-9]\|12[0-7]\)\.`
+	podregex := `192\.168\.\([0-9]\|[1-9][0-9]\|12[0-7]\|1[0-1][0-9]\)\.`
 	svcregex := `192\.168\.\(12[8-9]\|1[3-9][0-9]\|[2-5][0-9][0-9]\)\.`
 
 	if stdout, stderr, err := tc.RunCommandOnNode(0, []string{"check-cidr-ranges.sh", podregex, svcregex}); err != nil {

--- a/pkg/netutils/nets_test.go
+++ b/pkg/netutils/nets_test.go
@@ -97,23 +97,26 @@ func TestValidateCIDR(t *testing.T) {
 
 func TestNetworksAreAdjacentAndSameSize(t *testing.T) {
 	for _, tt := range []struct {
-		name    string
-		a       string
-		b       string
-		want    bool
-		wantErr bool
+		name     string
+		a        string
+		b        string
+		expected string
+		want     bool
+		wantErr  bool
 	}{
 		{
-			name: "two adjacent networks",
-			a:    "10.96.0.0/16",
-			b:    "10.97.0.0/16",
-			want: true,
+			name:     "two adjacent networks",
+			a:        "10.96.0.0/16",
+			b:        "10.97.0.0/16",
+			expected: "10.96.0.0/15",
+			want:     true,
 		},
 		{
-			name: "another two adjacent networks",
-			a:    "10.1.0.0/17",
-			b:    "10.1.128.0/17",
-			want: true,
+			name:     "another two adjacent networks",
+			a:        "10.1.0.0/17",
+			b:        "10.1.128.0/17",
+			expected: "10.1.0.0/16",
+			want:     true,
 		},
 		{
 			name: "not adjacent networks",
@@ -129,9 +132,12 @@ func TestNetworksAreAdjacentAndSameSize(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			got, _, err := NetworksAreAdjacentAndSameSize(tt.a, tt.b)
+			got, supernet, err := NetworksAreAdjacentAndSameSize(tt.a, tt.b)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, got)
+			if tt.want {
+				assert.Equal(t, tt.expected, supernet)
+			}
 		})
 	}
 }


### PR DESCRIPTION

#### What this PR does / why we need it:

as per pr comment this makes sure we are also validating the returned supernet.

ref: https://github.com/replicatedhq/embedded-cluster/pull/1324#discussion_r1806661271

