### PR TITLE
feat: add support-bundle command

### DIFF
--- a/cmd/embedded-cluster/main.go
+++ b/cmd/embedded-cluster/main.go
@@ -38,6 +38,7 @@ func main() {
 			updateCommand(),
 			restoreCommand(),
 			adminConsoleCommand(),
+			supportBundleCommand(),
 		},
 	}
 	if err := app.RunContext(ctx, os.Args); err != nil {

--- a/cmd/embedded-cluster/support_bundle.go
+++ b/cmd/embedded-cluster/support_bundle.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+
+	"github.com/creack/pty"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/term"
+
+	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"github.com/replicatedhq/embedded-cluster/pkg/defaults"
+)
+
+func supportBundleCommand() *cli.Command {
+	runtimeConfig := ecv1beta1.GetDefaultRuntimeConfig()
+
+	return &cli.Command{
+		Name:  "support-bundle",
+		Usage: fmt.Sprintf("Generate a %s support bundle", defaults.BinaryName()),
+		Flags: []cli.Flag{
+			getDataDirFlag(runtimeConfig),
+		},
+		Before: func(c *cli.Context) error {
+			if os.Getuid() != 0 {
+				return fmt.Errorf("support-bundle command must be run as root")
+			}
+			return nil
+		},
+		Action: func(c *cli.Context) error {
+			provider := discoverBestProvider(c.Context, runtimeConfig)
+			os.Setenv("TMPDIR", provider.EmbeddedClusterTmpSubDir())
+
+			supportBundle := provider.PathToEmbeddedClusterBinary("kubectl-support_bundle")
+			if _, err := os.Stat(supportBundle); err != nil {
+				return fmt.Errorf("unable to find support bundle binary")
+			}
+
+			kubeConfig := provider.PathToKubeConfig()
+			hostSupportBundle := provider.PathToEmbeddedClusterSupportFile("host-support-bundle.yaml")
+			command := exec.Command(supportBundle, "--load-cluster-specs", hostSupportBundle)
+			command.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeConfig))
+
+			// get the current working directory
+			var err error
+			command.Dir, err = os.Getwd()
+			if err != nil {
+				return fmt.Errorf("unable to get current working directory: %w", err)
+			}
+
+			commandPTY, err := pty.Start(command)
+			if err != nil {
+				return fmt.Errorf("unable to start shell: %w", err)
+			}
+
+			sigch := make(chan os.Signal, 1)
+			signal.Notify(sigch, syscall.SIGWINCH)
+			go handleResize(sigch, commandPTY)
+			sigch <- syscall.SIGWINCH
+			state, err := term.MakeRaw(int(os.Stdin.Fd()))
+			if err != nil {
+				return fmt.Errorf("unable to make raw terminal: %w", err)
+			}
+
+			defer func() {
+				signal.Stop(sigch)
+				close(sigch)
+				fd := int(os.Stdin.Fd())
+				_ = term.Restore(fd, state)
+			}()
+
+			go func() { _, _ = io.Copy(commandPTY, os.Stdin) }()
+			go func() { _, _ = io.Copy(os.Stdout, commandPTY) }()
+			return command.Wait()
+		},
+	}
+}

--- a/cmd/embedded-cluster/support_bundle.go
+++ b/cmd/embedded-cluster/support_bundle.go
@@ -1,30 +1,28 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
-	"os/signal"
-	"syscall"
 
-	"github.com/creack/pty"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
-	"golang.org/x/term"
 
-	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg/defaults"
+	"github.com/replicatedhq/embedded-cluster/pkg/helpers"
+	"github.com/replicatedhq/embedded-cluster/pkg/spinner"
 )
 
-func supportBundleCommand() *cli.Command {
-	runtimeConfig := ecv1beta1.GetDefaultRuntimeConfig()
+type collectOutput struct {
+	ArchivePath string `json:"archivePath"`
+}
 
+func supportBundleCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "support-bundle",
 		Usage: fmt.Sprintf("Generate a %s support bundle", defaults.BinaryName()),
-		Flags: []cli.Flag{
-			getDataDirFlag(runtimeConfig),
-		},
 		Before: func(c *cli.Context) error {
 			if os.Getuid() != 0 {
 				return fmt.Errorf("support-bundle command must be run as root")
@@ -32,7 +30,7 @@ func supportBundleCommand() *cli.Command {
 			return nil
 		},
 		Action: func(c *cli.Context) error {
-			provider := discoverBestProvider(c.Context, runtimeConfig)
+			provider := discoverBestProvider(c.Context)
 			os.Setenv("TMPDIR", provider.EmbeddedClusterTmpSubDir())
 
 			supportBundle := provider.PathToEmbeddedClusterBinary("kubectl-support_bundle")
@@ -40,42 +38,37 @@ func supportBundleCommand() *cli.Command {
 				return fmt.Errorf("unable to find support bundle binary")
 			}
 
+			output := bytes.NewBuffer(nil)
 			kubeConfig := provider.PathToKubeConfig()
 			hostSupportBundle := provider.PathToEmbeddedClusterSupportFile("host-support-bundle.yaml")
-			command := exec.Command(supportBundle, "--load-cluster-specs", hostSupportBundle)
-			command.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeConfig))
 
-			// get the current working directory
-			var err error
-			command.Dir, err = os.Getwd()
-			if err != nil {
-				return fmt.Errorf("unable to get current working directory: %w", err)
+			spin := spinner.Start()
+			spin.Infof("Collecting support bundle (this may take a while)")
+
+			if err := helpers.RunCommandWithOptions(
+				helpers.RunCommandOptions{Writer: output, ErrWriter: output},
+				supportBundle,
+				"--interactive=false",
+				fmt.Sprintf("--kubeconfig=%s", kubeConfig),
+				"--load-cluster-specs",
+				hostSupportBundle,
+			); err != nil {
+				spin.Infof("Failed to collect support bundle")
+				spin.CloseWithError()
+				io.Copy(os.Stderr, output)
+				return ErrNothingElseToAdd
 			}
 
-			commandPTY, err := pty.Start(command)
-			if err != nil {
-				return fmt.Errorf("unable to start shell: %w", err)
+			spin.Infof("Support bundle collected!")
+			spin.Close()
+
+			var parsedOutput collectOutput
+			if err := json.Unmarshal(output.Bytes(), &parsedOutput); err != nil {
+				return fmt.Errorf("unable to parse support bundle output: %w", err)
 			}
 
-			sigch := make(chan os.Signal, 1)
-			signal.Notify(sigch, syscall.SIGWINCH)
-			go handleResize(sigch, commandPTY)
-			sigch <- syscall.SIGWINCH
-			state, err := term.MakeRaw(int(os.Stdin.Fd()))
-			if err != nil {
-				return fmt.Errorf("unable to make raw terminal: %w", err)
-			}
-
-			defer func() {
-				signal.Stop(sigch)
-				close(sigch)
-				fd := int(os.Stdin.Fd())
-				_ = term.Restore(fd, state)
-			}()
-
-			go func() { _, _ = io.Copy(commandPTY, os.Stdin) }()
-			go func() { _, _ = io.Copy(os.Stdout, commandPTY) }()
-			return command.Wait()
+			logrus.Infof("Support bundle saved to %s", parsedOutput.ArchivePath)
+			return nil
 		},
 	}
 }

--- a/e2e/scripts/validate-support-bundle.sh
+++ b/e2e/scripts/validate-support-bundle.sh
@@ -7,12 +7,28 @@ main() {
         echo "Failed to find 'k0s sysinfo' inside the host support bundle"
         return 1
     fi
+    rm -rf host.tar.gz
 
     tar -zxvf cluster.tar.gz
     if ! ls cluster/podlogs/embedded-cluster-operator; then
         echo "Failed to find operator logs inside the cluster support bundle"
         return 1
     fi
+    rm -rf cluster.tar.gz
+
+    tar -zxvf support-bundle-*.tar.gz
+    rm -rf support-bundle-*.tar.gz
+
+    if ! ls support-bundle-*/host-collectors/run-host/k0s-sysinfo.txt; then
+        echo "Failed to find 'k0s sysinfo' inside the support bundle generated with the embedded cluster binary"
+        return 1
+    fi
+
+    if ! ls support-bundle-*/podlogs/embedded-cluster-operator; then
+        echo "Failed to find operator logs inside the support bundle generated with the embedded cluster binary"
+        return 1
+    fi
+
 }
 
 main "$@"

--- a/e2e/support-bundle_test.go
+++ b/e2e/support-bundle_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/replicatedhq/embedded-cluster/e2e/cluster/docker"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCollectSupportBundle(t *testing.T) {
@@ -23,27 +24,25 @@ func TestCollectSupportBundle(t *testing.T) {
 
 	t.Logf("%s: installing embedded-cluster on node 0", time.Now().Format(time.RFC3339))
 	line := []string{"single-node-install.sh", "cli"}
-	if stdout, stderr, err := tc.RunCommandOnNode(0, line); err != nil {
-		t.Fatalf("fail to install embedded-cluster: %v: %s: %s", err, stdout, stderr)
-	}
+	stdout, stderr, err := tc.RunCommandOnNode(0, line)
+	assert.NoErrorf(t, err, "fail to install embedded-cluster: %v: %s: %s", err, stdout, stderr)
 
 	line = []string{"collect-support-bundle-host.sh"}
-	stdout, stderr, err := tc.RunCommandOnNode(0, line)
-	if err != nil {
-		t.Fatalf("fail to collect host support bundle: %v: %s: %s", err, stdout, stderr)
-	}
+	stdout, stderr, err = tc.RunCommandOnNode(0, line)
+	assert.NoErrorf(t, err, "fail to collect host support bundle: %v: %s: %s", err, stdout, stderr)
 
 	line = []string{"collect-support-bundle-cluster.sh"}
 	stdout, stderr, err = tc.RunCommandOnNode(0, line)
-	if err != nil {
-		t.Fatalf("fail to collect cluster support bundle: %v: %s: %s", err, stdout, stderr)
-	}
+	assert.NoErrorf(t, err, "fail to collect cluster support bundle: %v: %s: %s", err, stdout, stderr)
+
+	t.Logf("%s: collecting support bundle with the embedded-cluster binary", time.Now().Format(time.RFC3339))
+	line = []string{"embedded-cluster", "support-bundle"}
+	stdout, stderr, err = tc.RunCommandOnNode(0, line)
+	assert.NoErrorf(t, err, "fail to collect support bundle using embedded-cluster binary: %v: %s: %s", err, stdout, stderr)
 
 	line = []string{"validate-support-bundle.sh"}
 	stdout, stderr, err = tc.RunCommandOnNode(0, line)
-	if err != nil {
-		t.Fatalf("fail to validate support bundle: %v: %s: %s", err, stdout, stderr)
-	}
+	assert.NoErrorf(t, err, "fail to validate support bundle: %v: %s: %s", err, stdout, stderr)
 
 	t.Logf("%s: test complete", time.Now().Format(time.RFC3339))
 }

--- a/pkg/helpers/command.go
+++ b/pkg/helpers/command.go
@@ -18,6 +18,8 @@ type RunCommandOptions struct {
 	Env map[string]string
 	// Stdin is the standard input to be used when running the command.
 	Stdin io.Reader
+	// LogOnSuccess makes the command output to be logged even when it succeeds.
+	LogOnSuccess bool
 }
 
 // RunCommandWithOptions runs a the provided command with the options specified.
@@ -53,6 +55,14 @@ func RunCommandWithOptions(opts RunCommandOptions, bin string, args ...string) e
 		}
 		return err
 	}
+
+	if !opts.LogOnSuccess {
+		return nil
+	}
+
+	logrus.Debugf("command succeeded:")
+	logrus.Debugf("stdout: %s", stdout.String())
+	logrus.Debugf("stderr: %s", stderr.String())
 	return nil
 }
 

--- a/pkg/helpers/command.go
+++ b/pkg/helpers/command.go
@@ -12,6 +12,8 @@ import (
 type RunCommandOptions struct {
 	// Writer is an additional io.Writer to write the stdout of the command to.
 	Writer io.Writer
+	// ErrWriter is an additional io.Writer to write the stderr of the command to.
+	ErrWriter io.Writer
 	// Env is a map of additional environment variables to set for the command.
 	Env map[string]string
 	// Stdin is the standard input to be used when running the command.
@@ -34,6 +36,9 @@ func RunCommandWithOptions(opts RunCommandOptions, bin string, args ...string) e
 		cmd.Stdin = opts.Stdin
 	}
 	cmd.Stderr = stderr
+	if opts.ErrWriter != nil {
+		cmd.Stderr = io.MultiWriter(opts.ErrWriter, stderr)
+	}
 	cmdEnv := cmd.Environ()
 	for k, v := range opts.Env {
 		cmdEnv = append(cmdEnv, fmt.Sprintf("%s=%s", k, v))


### PR DESCRIPTION

#### What this PR does / why we need it:

add support-bundle command. this command generates a support bundle using the in-cluster support bundle definitions and the local host support bundle definitions.

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Added the support-bundle command.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
