### PR TITLE
chore: Collect LAM service config in support bundle

### DIFF
--- a/operator/charts/embedded-cluster-operator/templates/embedded-cluster-lam-service-config.yaml
+++ b/operator/charts/embedded-cluster-operator/templates/embedded-cluster-lam-service-config.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: embedded-cluster-lam-service-config
+  labels:
+    troubleshoot.sh/kind: support-bundle
+    {{- with (include "embedded-cluster-operator.labels" $ | fromYaml) }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+data:
+  support-bundle-spec: |
+    apiVersion: troubleshoot.sh/v1beta2
+    kind: SupportBundle
+    metadata:
+      name: embedded-cluster-lam-service-config
+      labels:
+        troubleshoot.sh/kind: support-bundle
+    spec:
+      collectors:
+        - runDaemonSet:
+            name: "local-artifact-mirror-service-config"
+            namespace: embedded-cluster
+            podSpec:
+              containers:
+              - image: {{ .Values.utilsImage }}
+                imagePullPolicy: Always
+                args: ["chroot","/host","cat","/etc/systemd/system/local-artifact-mirror.service.d/embedded-cluster.conf"]
+                name: debugger
+                resources: {}
+                terminationMessagePath: /dev/termination-log
+                terminationMessagePolicy: File
+                volumeMounts:
+                - mountPath: /host
+                  name: host-root
+              dnsPolicy: ClusterFirst
+              enableServiceLinks: true
+              hostIPC: true
+              hostNetwork: true
+              hostPID: true
+              securityContext:
+                runAsUser: 0
+              tolerations:
+              - operator: Exists
+              volumes:
+              - hostPath:
+                  path: /
+                  type: ""
+                name: host-root

--- a/pkg/goods/support/host-support-bundle.tmpl.yaml
+++ b/pkg/goods/support/host-support-bundle.tmpl.yaml
@@ -155,7 +155,7 @@ spec:
       args: ['-c', 'command -v umount']
   - copy:
       collectorName: installer/lam-service-config
-      path: /etc/systemd/system/local-artifact-mirror.service.d/embedded-cluster.conf
+      path: /etc/systemd/system/local-artifact-mirror.service.d/*
   hostAnalyzers:
   - ipv4Interfaces:
       outcomes:

--- a/pkg/goods/support/host-support-bundle.tmpl.yaml
+++ b/pkg/goods/support/host-support-bundle.tmpl.yaml
@@ -153,6 +153,9 @@ spec:
       collectorName: 'check-umount'
       command: 'sh'
       args: ['-c', 'command -v umount']
+  - copy:
+      collectorName: installer/lam-service-config
+      path: /etc/systemd/system/local-artifact-mirror.service.d/embedded-cluster.conf
   hostAnalyzers:
   - ipv4Interfaces:
       outcomes:


### PR DESCRIPTION
#### What this PR does / why we need it:

Collect Local Artefact Mirror systemd service config in support bundle

#### Which issue(s) this PR fixes:

#### Does this PR require a test?
NONE

#### Does this PR require a release note?
```release-note
Collect local artefact mirror service config in support bundle
```

#### Does this PR require documentation?
NONE