### PR TITLE
chore: simplify regex on e2e test

### DIFF
--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -995,8 +995,8 @@ func TestSingleNodeAirgapUpgradeCustomCIDR(t *testing.T) {
 	// we have used --cidr 172.16.0.0/15 during install time so pods are
 	// expected to be in the 172.16.0.0/16 range while services are in the
 	// 172.17.0.0/16 range.
-	podregex := `172\.16\.`
-	svcregex := `172\.17\.`
+	podregex := `172\.16\.[0-9]+\.[0-9]+`
+	svcregex := `172\.17\.[0-9]+\.[0-9]+`
 
 	if stdout, stderr, err := tc.RunCommandOnNode(0, []string{"check-cidr-ranges.sh", podregex, svcregex}); err != nil {
 		t.Log(stdout)

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -944,7 +944,7 @@ func TestSingleNodeAirgapUpgradeCustomCIDR(t *testing.T) {
 
 	t.Logf("%s: installing embedded-cluster on node 0", time.Now().Format(time.RFC3339))
 	line = []string{"single-node-airgap-install.sh"}
-	line = append(line, "--cidr", "192.168.0.0/16")
+	line = append(line, "--cidr", "172.16.0.0/15")
 	if _, _, err := tc.RunCommandOnNode(0, line); err != nil {
 		t.Fatalf("fail to install embedded-cluster on node %s: %v", tc.Nodes[0], err)
 	}
@@ -992,12 +992,11 @@ func TestSingleNodeAirgapUpgradeCustomCIDR(t *testing.T) {
 	// ensure that the cluster is using the right IP ranges.
 	t.Logf("%s: checking service and pod IP addresses", time.Now().Format(time.RFC3339))
 
-	// we have used --cidr 192.168.0.0/16 during install time so pods are
-	// expected to be in the 192.168.0.0/17 range while services are in the
-	// 192.168.128.0/17 range. i.e. pods are in 192.168.0-127.* while
-	// services in 192.168.128-254.*.
-	podregex := `192\.168\.\([0-9]\|[1-9][0-9]\|12[0-7]\|1[0-1][0-9]\)\.`
-	svcregex := `192\.168\.\(12[8-9]\|1[3-9][0-9]\|[2-5][0-9][0-9]\)\.`
+	// we have used --cidr 172.16.0.0/15 during install time so pods are
+	// expected to be in the 172.16.0.0/16 range while services are in the
+	// 172.17.0.0/16 range.
+	podregex := `172\.16\.`
+	svcregex := `172\.17\.`
 
 	if stdout, stderr, err := tc.RunCommandOnNode(0, []string{"check-cidr-ranges.sh", podregex, svcregex}); err != nil {
 		t.Log(stdout)

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -995,8 +995,8 @@ func TestSingleNodeAirgapUpgradeCustomCIDR(t *testing.T) {
 	// we have used --cidr 172.16.0.0/15 during install time so pods are
 	// expected to be in the 172.16.0.0/16 range while services are in the
 	// 172.17.0.0/16 range.
-	podregex := `172\.16\.[0-9]+\.[0-9]+`
-	svcregex := `172\.17\.[0-9]+\.[0-9]+`
+	podregex := `172\.16\.[0-9]\+\.[0-9]\+`
+	svcregex := `172\.17\.[0-9]\+\.[0-9]\+`
 
 	if stdout, stderr, err := tc.RunCommandOnNode(0, []string{"check-cidr-ranges.sh", podregex, svcregex}); err != nil {
 		t.Log(stdout)


### PR DESCRIPTION

#### What this PR does / why we need it:

simplify the regex matching on the e2e test.


#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
