### PR TITLE
feat(host-preflights): add cidr preflight checks

### DIFF
--- a/cmd/embedded-cluster/install.go
+++ b/cmd/embedded-cluster/install.go
@@ -151,7 +151,7 @@ func RunHostPreflights(c *cli.Context, provider *defaults.Provider, applier *add
 		return fmt.Errorf("unable to read host preflights: %w", err)
 	}
 
-	data := preflights.TemplateData{
+	data, err := preflights.TemplateData{
 		ReplicatedAPIURL:        replicatedAPIURL,
 		ProxyRegistryURL:        proxyRegistryURL,
 		IsAirgap:                isAirgap,
@@ -161,6 +161,10 @@ func RunHostPreflights(c *cli.Context, provider *defaults.Provider, applier *add
 		K0sDataDir:              provider.EmbeddedClusterK0sSubDir(),
 		OpenEBSDataDir:          provider.EmbeddedClusterOpenEBSLocalSubDir(),
 		SystemArchitecture:      runtime.GOARCH,
+	}.WithCIDRData(getCIDRs(c))
+
+	if err != nil {
+		return fmt.Errorf("unable to get host preflights data: %w", err)
 	}
 	chpfs, err := preflights.GetClusterHostPreflights(c.Context, data)
 	if err != nil {

--- a/cmd/embedded-cluster/network.go
+++ b/cmd/embedded-cluster/network.go
@@ -50,3 +50,11 @@ func DeterminePodAndServiceCIDRs(c *cli.Context) (string, string, error) {
 	}
 	return netutils.SplitNetworkCIDR(c.String("cidr"))
 }
+
+// getCIDRs returns the CIDRs in use based on the provided cli flags.
+func getCIDRs(c *cli.Context) (string, string, string) {
+	if c.IsSet("pod-cidr") && c.IsSet("service-cidr") {
+		return c.String("pod-cidr"), c.String("service-cidr"), ""
+	}
+	return "", "", c.String("cidr")
+}

--- a/cmd/embedded-cluster/network.go
+++ b/cmd/embedded-cluster/network.go
@@ -45,7 +45,7 @@ func withSubnetCIDRFlags(flags []cli.Flag) []cli.Flag {
 // --pod-cidr and --service-cidr have been set, they are used. Otherwise,
 // the cidr flag is split into pod and service CIDRs.
 func DeterminePodAndServiceCIDRs(c *cli.Context) (string, string, error) {
-	if c.IsSet("pod-cidr") && c.IsSet("service-cidr") {
+	if c.IsSet("pod-cidr") || c.IsSet("service-cidr") {
 		return c.String("pod-cidr"), c.String("service-cidr"), nil
 	}
 	return netutils.SplitNetworkCIDR(c.String("cidr"))
@@ -53,7 +53,7 @@ func DeterminePodAndServiceCIDRs(c *cli.Context) (string, string, error) {
 
 // getCIDRs returns the CIDRs in use based on the provided cli flags.
 func getCIDRs(c *cli.Context) (string, string, string) {
-	if c.IsSet("pod-cidr") && c.IsSet("service-cidr") {
+	if c.IsSet("pod-cidr") || c.IsSet("service-cidr") {
 		return c.String("pod-cidr"), c.String("service-cidr"), ""
 	}
 	return "", "", c.String("cidr")

--- a/cmd/embedded-cluster/network_test.go
+++ b/cmd/embedded-cluster/network_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+func Test_getCIDRs(t *testing.T) {
+	tests := []struct {
+		name            string
+		buildCliContext func(*flag.FlagSet) *cli.Context
+		expected        []string
+	}{
+		{
+			name: "with pod and service flags",
+			expected: []string{
+				"10.0.0.0/24",
+				"10.1.0.0/24",
+				"",
+			},
+			buildCliContext: func(flagSet *flag.FlagSet) *cli.Context {
+				c := cli.NewContext(cli.NewApp(), flagSet, nil)
+				c.Set("pod-cidr", "10.0.0.0/24")
+				c.Set("service-cidr", "10.1.0.0/24")
+				return c
+			},
+		},
+		{
+			name: "with pod flag",
+			expected: []string{
+				"",
+				"",
+				v1beta1.DefaultNetworkCIDR,
+			},
+			buildCliContext: func(flagSet *flag.FlagSet) *cli.Context {
+				c := cli.NewContext(cli.NewApp(), flagSet, nil)
+				c.Set("pod-cidr", "10.0.0.0/24")
+				return c
+			},
+		},
+		{
+			name: "with pod, service and cidr flags",
+			expected: []string{
+				"",
+				"",
+				"10.2.0.0/24",
+			},
+			buildCliContext: func(flagSet *flag.FlagSet) *cli.Context {
+				c := cli.NewContext(cli.NewApp(), flagSet, nil)
+				c.Set("cidr", "10.2.0.0/24")
+				return c
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := require.New(t)
+
+			flagSet := flag.NewFlagSet(t.Name(), 0)
+			flags := withSubnetCIDRFlags([]cli.Flag{})
+			for _, f := range flags {
+				err := f.Apply(flagSet)
+				req.NoError(err)
+			}
+
+			cc := test.buildCliContext(flagSet)
+			podCIDR, serviceCIDR, CIDR := getCIDRs(cc)
+			req.Equal(test.expected[0], podCIDR)
+			req.Equal(test.expected[1], serviceCIDR)
+			req.Equal(test.expected[2], CIDR)
+		})
+	}
+}

--- a/cmd/embedded-cluster/network_test.go
+++ b/cmd/embedded-cluster/network_test.go
@@ -71,6 +71,19 @@ func Test_getCIDRs(t *testing.T) {
 				return c
 			},
 		},
+		{
+			name: "with cidr flag",
+			expected: []string{
+				"",
+				"",
+				"10.2.0.0/24",
+			},
+			buildCliContext: func(flagSet *flag.FlagSet) *cli.Context {
+				c := cli.NewContext(cli.NewApp(), flagSet, nil)
+				c.Set("cidr", "10.2.0.0/24")
+				return c
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/cmd/embedded-cluster/network_test.go
+++ b/cmd/embedded-cluster/network_test.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"testing"
 
-	"github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
 )
@@ -32,9 +32,9 @@ func Test_getCIDRs(t *testing.T) {
 		{
 			name: "with pod flag",
 			expected: []string{
+				"10.0.0.0/24",
+				v1beta1.DefaultNetwork().ServiceCIDR,
 				"",
-				"",
-				v1beta1.DefaultNetworkCIDR,
 			},
 			buildCliContext: func(flagSet *flag.FlagSet) *cli.Context {
 				c := cli.NewContext(cli.NewApp(), flagSet, nil)
@@ -45,12 +45,28 @@ func Test_getCIDRs(t *testing.T) {
 		{
 			name: "with pod, service and cidr flags",
 			expected: []string{
+				"10.0.0.0/24",
+				"10.1.0.0/24",
 				"",
-				"",
-				"10.2.0.0/24",
 			},
 			buildCliContext: func(flagSet *flag.FlagSet) *cli.Context {
 				c := cli.NewContext(cli.NewApp(), flagSet, nil)
+				c.Set("pod-cidr", "10.0.0.0/24")
+				c.Set("service-cidr", "10.1.0.0/24")
+				c.Set("cidr", "10.2.0.0/24")
+				return c
+			},
+		},
+		{
+			name: "with pod and cidr flags",
+			expected: []string{
+				"10.0.0.0/24",
+				v1beta1.DefaultNetwork().ServiceCIDR,
+				"",
+			},
+			buildCliContext: func(flagSet *flag.FlagSet) *cli.Context {
+				c := cli.NewContext(cli.NewApp(), flagSet, nil)
+				c.Set("pod-cidr", "10.0.0.0/24")
 				c.Set("cidr", "10.2.0.0/24")
 				return c
 			},
@@ -73,6 +89,71 @@ func Test_getCIDRs(t *testing.T) {
 			req.Equal(test.expected[0], podCIDR)
 			req.Equal(test.expected[1], serviceCIDR)
 			req.Equal(test.expected[2], CIDR)
+		})
+	}
+}
+
+func Test_DeterminePodAndServiceCIDRs(t *testing.T) {
+
+	tests := []struct {
+		name            string
+		buildCliContext func(*flag.FlagSet) *cli.Context
+		expected        []string
+	}{
+		{
+			name: "with pod flag",
+			expected: []string{
+				"10.0.0.0/16",
+				v1beta1.DefaultNetwork().ServiceCIDR,
+			},
+			buildCliContext: func(flagSet *flag.FlagSet) *cli.Context {
+				c := cli.NewContext(cli.NewApp(), flagSet, nil)
+				c.Set("pod-cidr", "10.0.0.0/16")
+				return c
+			},
+		},
+		{
+			name: "with service flag",
+			expected: []string{
+				v1beta1.DefaultNetwork().PodCIDR,
+				"10.1.0.0/16",
+			},
+			buildCliContext: func(flagSet *flag.FlagSet) *cli.Context {
+				c := cli.NewContext(cli.NewApp(), flagSet, nil)
+				c.Set("service-cidr", "10.1.0.0/16")
+				return c
+			},
+		},
+		{
+			name: "with cidr flag",
+			expected: []string{
+				"10.0.0.0/16",
+				"10.1.0.0/16",
+			},
+			buildCliContext: func(flagSet *flag.FlagSet) *cli.Context {
+				c := cli.NewContext(cli.NewApp(), flagSet, nil)
+				c.Set("cidr", "10.0.0.0/15")
+				return c
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := require.New(t)
+
+			flagSet := flag.NewFlagSet(t.Name(), 0)
+			flags := withSubnetCIDRFlags([]cli.Flag{})
+			for _, f := range flags {
+				err := f.Apply(flagSet)
+				req.NoError(err)
+			}
+
+			cc := test.buildCliContext(flagSet)
+			podCIDR, serviceCIDR, err := DeterminePodAndServiceCIDRs(cc)
+			req.NoError(err)
+			req.Equal(test.expected[0], podCIDR)
+			req.Equal(test.expected[1], serviceCIDR)
 		})
 	}
 }

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -127,6 +127,21 @@ spec:
         collectorName: 'wildcard-check'
         hostnames:
           - '*'
+    - subnetAvailable:
+        collectorName: Pods Subnet
+        exclude: '{{ or (ne .Global.CIDR "")  (eq .PodsCIDR.CIDR "") }}'
+        CIDRRangeAlloc: '{{ .PodsCIDR.CIDR }}'
+        desiredCIDR: .PodsCIDR.Size
+    - subnetAvailable:
+        collectorName: Services Subnet
+        exclude: '{{ or (ne .Global.CIDR "")  (eq .ServicesCIDR.CIDR "") }}'
+        CIDRRangeAlloc: '{{ .ServicesCIDR.CIDR }}'
+        desiredCIDR: .ServicesCIDR.Size
+    - subnetAvailable:
+        collectorName: Subnet
+        exclude: '{{ eq .GlobalCIDR.CIDR "" }}'
+        CIDRRangeAlloc: '{{ .GlobalCIDR.CIDR }}'
+        desiredCIDR: .GlobalCIDR.Size
   analyzers:
     - cpu:
         checkName: CPU
@@ -780,3 +795,33 @@ spec:
           - pass:
               when: 'true'
               message: No wildcard DNS entry detected.
+    - subnetAvailable:
+        checkName: Pods Subnet Availability
+        collectorName: Pods Subnet
+        outcomes:
+          - fail:
+            when: "no-subnet-available"
+            message: specified pod subnet is not available
+          - pass:
+            when: "a-subnet-is-available"
+            message: specified pod subnet is available
+    - subnetAvailable:
+        checkName: Services Subnet Availability
+        collectorName: Services Subnet
+        outcomes:
+          - fail:
+            when: "no-subnet-available"
+            message: specified services subnet is not available
+          - pass:
+            when: "a-subnet-is-available"
+            message: specified services subnet is available
+    - subnetAvailable:
+        checkName: Subnet Availability
+        collectorName: Subnet
+        outcomes:
+          - fail:
+            when: "no-subnet-available"
+            message: specified subnet is not available
+          - pass:
+            when: "a-subnet-is-available"
+            message: specified subnet is available

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -128,17 +128,17 @@ spec:
         hostnames:
           - '*'
     - subnetAvailable:
-        collectorName: Pods Subnet
+        collectorName: Pod CIDR
         exclude: '{{ eq .PodCIDR.CIDR "" }}'
         CIDRRangeAlloc: '{{ .PodCIDR.CIDR }}'
         desiredCIDR: {{.PodCIDR.Size}}
     - subnetAvailable:
-        collectorName: Services Subnet
+        collectorName: Service CIDR
         exclude: '{{ eq .ServiceCIDR.CIDR "" }}'
         CIDRRangeAlloc: '{{ .ServiceCIDR.CIDR }}'
         desiredCIDR: {{.ServiceCIDR.Size}}
     - subnetAvailable:
-        collectorName: Subnet
+        collectorName: CIDR
         exclude: '{{ eq .GlobalCIDR.CIDR "" }}'
         CIDRRangeAlloc: '{{ .GlobalCIDR.CIDR }}'
         desiredCIDR: {{.GlobalCIDR.Size}}
@@ -778,10 +778,10 @@ spec:
         outcomes:
           - fail:
               when: 'true'
-              message: {{ .DataDir }} cannot be symlinked. Remove the symlink, or use the --data-dir flag to provide an alternate data directory.
+              message: "{{ .DataDir }} cannot be symlinked. Remove the symlink, or use the --data-dir flag to provide an alternate data directory."
           - pass:
               when: 'false'
-              message: {{ .DataDir }} is not a symlink.
+              message: "{{ .DataDir }} is not a symlink."
     - jsonCompare:
         checkName: Wildcard DNS
         fileName: host-collectors/dns/wildcard-check/result.json
@@ -796,35 +796,35 @@ spec:
               when: 'true'
               message: No wildcard DNS entry detected.
     - subnetAvailable:
-        checkName: Pods Subnet Availability
-        collectorName: Pods Subnet
+        checkName: Pod CIDR Availability
+        collectorName: Pod CIDR
         exclude: '{{ eq .PodCIDR.CIDR "" }}'
         outcomes:
           - fail:
             when: "no-subnet-available"
-            message: specified pod subnet is not available
+            message: "{{ .PodCIDR.CIDR }} is not available. Use --pod-cidr to specify an available CIDR block."
           - pass:
             when: "a-subnet-is-available"
             message: specified pod subnet is available
     - subnetAvailable:
-        checkName: Services Subnet Availability
-        collectorName: Services Subnet
+        checkName: Service CIDR Availability
+        collectorName: Service CIDR
         exclude: '{{ eq .ServiceCIDR.CIDR "" }}'
         outcomes:
           - fail:
             when: "no-subnet-available"
-            message: specified services subnet is not available
+            message: "{{ .ServiceCIDR.CIDR }} is not available. Use --service-cidr to specify an available CIDR block."
           - pass:
             when: "a-subnet-is-available"
-            message: specified services subnet is available
+            message: Specified Service CIDR is available.
     - subnetAvailable:
-        checkName: Subnet Availability
-        collectorName: Subnet
+        checkName: CIDR Availability
+        collectorName: CIDR
         exclude: '{{ eq .GlobalCIDR.CIDR "" }}'
         outcomes:
           - fail:
             when: "no-subnet-available"
-            message: specified subnet is not available
+            message:  "{{ .GlobalCIDR.CIDR }} is not available. Use --cidr to specify a CIDR block of available private IP addresses (/16 or larger)."
           - pass:
             when: "a-subnet-is-available"
-            message: specified subnet is available
+            message: Specified CIDR is available.

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -801,30 +801,30 @@ spec:
         exclude: '{{ eq .PodCIDR.CIDR "" }}'
         outcomes:
           - fail:
-            when: "no-subnet-available"
-            message: "{{ .PodCIDR.CIDR }} is not available. Use --pod-cidr to specify an available CIDR block."
+              when: "no-subnet-available"
+              message: "{{ .PodCIDR.CIDR }} is not available. Use --pod-cidr to specify an available CIDR block."
           - pass:
-            when: "a-subnet-is-available"
-            message: specified pod subnet is available
+              when: "a-subnet-is-available"
+              message: Specified Pod CIDR is available.
     - subnetAvailable:
         checkName: Service CIDR Availability
         collectorName: Service CIDR
         exclude: '{{ eq .ServiceCIDR.CIDR "" }}'
         outcomes:
           - fail:
-            when: "no-subnet-available"
-            message: "{{ .ServiceCIDR.CIDR }} is not available. Use --service-cidr to specify an available CIDR block."
+              when: "no-subnet-available"
+              message: "{{ .ServiceCIDR.CIDR }} is not available. Use --service-cidr to specify an available CIDR block."
           - pass:
-            when: "a-subnet-is-available"
-            message: Specified Service CIDR is available.
+              when: "a-subnet-is-available"
+              message: Specified Service CIDR is available.
     - subnetAvailable:
         checkName: CIDR Availability
         collectorName: CIDR
         exclude: '{{ eq .GlobalCIDR.CIDR "" }}'
         outcomes:
           - fail:
-            when: "no-subnet-available"
-            message:  "{{ .GlobalCIDR.CIDR }} is not available. Use --cidr to specify a CIDR block of available private IP addresses (/16 or larger)."
+              when: "no-subnet-available"
+              message:  "{{ .GlobalCIDR.CIDR }} is not available. Use --cidr to specify a CIDR block of available private IP addresses (/16 or larger)."
           - pass:
-            when: "a-subnet-is-available"
-            message: Specified CIDR is available.
+              when: "a-subnet-is-available"
+              message: Specified CIDR is available.

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -798,6 +798,7 @@ spec:
     - subnetAvailable:
         checkName: Pods Subnet Availability
         collectorName: Pods Subnet
+        exclude: '{{ or (ne .GlobalCIDR.CIDR "")  (eq .PodCIDR.CIDR "") }}'
         outcomes:
           - fail:
             when: "no-subnet-available"
@@ -808,6 +809,7 @@ spec:
     - subnetAvailable:
         checkName: Services Subnet Availability
         collectorName: Services Subnet
+        exclude: '{{ or (ne .GlobalCIDR.CIDR "")  (eq .ServiceCIDR.CIDR "") }}'
         outcomes:
           - fail:
             when: "no-subnet-available"
@@ -818,6 +820,7 @@ spec:
     - subnetAvailable:
         checkName: Subnet Availability
         collectorName: Subnet
+        exclude: '{{ eq .GlobalCIDR.CIDR "" }}'
         outcomes:
           - fail:
             when: "no-subnet-available"

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -129,12 +129,12 @@ spec:
           - '*'
     - subnetAvailable:
         collectorName: Pods Subnet
-        exclude: '{{ or (ne .GlobalCIDR.CIDR "")  (eq .PodCIDR.CIDR "") }}'
+        exclude: '{{ eq .PodCIDR.CIDR "" }}'
         CIDRRangeAlloc: '{{ .PodCIDR.CIDR }}'
         desiredCIDR: {{.PodCIDR.Size}}
     - subnetAvailable:
         collectorName: Services Subnet
-        exclude: '{{ or (ne .GlobalCIDR.CIDR "")  (eq .ServiceCIDR.CIDR "") }}'
+        exclude: '{{ eq .ServiceCIDR.CIDR "" }}'
         CIDRRangeAlloc: '{{ .ServiceCIDR.CIDR }}'
         desiredCIDR: {{.ServiceCIDR.Size}}
     - subnetAvailable:
@@ -798,7 +798,7 @@ spec:
     - subnetAvailable:
         checkName: Pods Subnet Availability
         collectorName: Pods Subnet
-        exclude: '{{ or (ne .GlobalCIDR.CIDR "")  (eq .PodCIDR.CIDR "") }}'
+        exclude: '{{ eq .PodCIDR.CIDR "" }}'
         outcomes:
           - fail:
             when: "no-subnet-available"
@@ -809,7 +809,7 @@ spec:
     - subnetAvailable:
         checkName: Services Subnet Availability
         collectorName: Services Subnet
-        exclude: '{{ or (ne .GlobalCIDR.CIDR "")  (eq .ServiceCIDR.CIDR "") }}'
+        exclude: '{{ eq .ServiceCIDR.CIDR "" }}'
         outcomes:
           - fail:
             when: "no-subnet-available"

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -129,19 +129,19 @@ spec:
           - '*'
     - subnetAvailable:
         collectorName: Pods Subnet
-        exclude: '{{ or (ne .Global.CIDR "")  (eq .PodsCIDR.CIDR "") }}'
-        CIDRRangeAlloc: '{{ .PodsCIDR.CIDR }}'
-        desiredCIDR: .PodsCIDR.Size
+        exclude: '{{ or (ne .GlobalCIDR.CIDR "")  (eq .PodCIDR.CIDR "") }}'
+        CIDRRangeAlloc: '{{ .PodCIDR.CIDR }}'
+        desiredCIDR: {{.PodCIDR.Size}}
     - subnetAvailable:
         collectorName: Services Subnet
-        exclude: '{{ or (ne .Global.CIDR "")  (eq .ServicesCIDR.CIDR "") }}'
-        CIDRRangeAlloc: '{{ .ServicesCIDR.CIDR }}'
-        desiredCIDR: .ServicesCIDR.Size
+        exclude: '{{ or (ne .GlobalCIDR.CIDR "")  (eq .ServiceCIDR.CIDR "") }}'
+        CIDRRangeAlloc: '{{ .ServiceCIDR.CIDR }}'
+        desiredCIDR: {{.ServiceCIDR.Size}}
     - subnetAvailable:
         collectorName: Subnet
         exclude: '{{ eq .GlobalCIDR.CIDR "" }}'
         CIDRRangeAlloc: '{{ .GlobalCIDR.CIDR }}'
-        desiredCIDR: .GlobalCIDR.Size
+        desiredCIDR: {{.GlobalCIDR.Size}}
   analyzers:
     - cpu:
         checkName: CPU

--- a/pkg/preflights/template.go
+++ b/pkg/preflights/template.go
@@ -4,8 +4,16 @@ package preflights
 import (
 	"bytes"
 	"fmt"
+	"net"
 	"text/template"
 )
+
+type CIDRData struct {
+	// Should specify the IP Address and size of the network e.g. "10.0.0.0/8"
+	CIDR string
+	// The size of the CIDR network. Should match the CIDR size above.
+	Size int
+}
 
 type TemplateData struct {
 	IsAirgap                bool
@@ -17,6 +25,51 @@ type TemplateData struct {
 	K0sDataDir              string
 	OpenEBSDataDir          string
 	SystemArchitecture      string
+	ServiceCIDR             CIDRData
+	PodCIDR                 CIDRData
+	GlobalCIDR              CIDRData
+}
+
+// WithCIDRData sets the respective CIDR properties in the TemplateData struct based on the provided CIDR strings
+func (t TemplateData) WithCIDRData(podCIDR, serviceCIDR, globalCIDR string) (TemplateData, error) {
+	if globalCIDR != "" {
+		_, cidr, err := net.ParseCIDR(globalCIDR)
+		if err != nil {
+			return t, fmt.Errorf("invalid cidr: %w", err)
+		}
+		size, _ := cidr.Mask.Size()
+		t.GlobalCIDR = CIDRData{
+			CIDR: cidr.String(),
+			Size: size,
+		}
+		return t, nil
+	}
+
+	s := CIDRData{}
+	p := CIDRData{}
+	if serviceCIDR != "" {
+		_, cidr, err := net.ParseCIDR(serviceCIDR)
+		if err != nil {
+			return t, fmt.Errorf("invalid service cidr: %w", err)
+		}
+		size, _ := cidr.Mask.Size()
+		s.CIDR = cidr.String()
+		s.Size = size
+	}
+
+	if podCIDR != "" {
+		_, cidr, err := net.ParseCIDR(podCIDR)
+		if err != nil {
+			return t, fmt.Errorf("invalid pod cidr: %w", err)
+		}
+		size, _ := cidr.Mask.Size()
+		p.CIDR = cidr.String()
+		p.Size = size
+	}
+
+	t.ServiceCIDR = s
+	t.PodCIDR = p
+	return t, nil
 }
 
 func renderTemplate(spec string, data TemplateData) (string, error) {

--- a/pkg/preflights/template_test.go
+++ b/pkg/preflights/template_test.go
@@ -210,53 +210,53 @@ func TestTemplateWithCIDRData(t *testing.T) {
 			wantErr:    true,
 		},
 		{
-			name:        "valid podCIDR, serviceCIDR and CIDR are provided",
+			name:        "valid podCIDR and serviceCIDR are provided",
 			podCIDR:     "10.1.0.0/24",
 			serviceCIDR: "10.2.0.0/24",
-			globalCIDR:  "10.0.0.0/24",
+			globalCIDR:  "",
 			expectCollectors: []v1beta2.SubnetAvailable{
 				{
 					HostCollectorMeta: v1beta2.HostCollectorMeta{
 						CollectorName: "Pods Subnet",
-						Exclude:       multitype.FromString("true"),
+						Exclude:       multitype.FromString("false"),
 					},
-					CIDRRangeAlloc: "",
-					DesiredCIDR:    0,
+					CIDRRangeAlloc: "10.1.0.0/24",
+					DesiredCIDR:    24,
 				},
 				{
 					HostCollectorMeta: v1beta2.HostCollectorMeta{
 						CollectorName: "Services Subnet",
-						Exclude:       multitype.FromString("true"),
+						Exclude:       multitype.FromString("false"),
 					},
-					CIDRRangeAlloc: "",
-					DesiredCIDR:    0,
+					CIDRRangeAlloc: "10.2.0.0/24",
+					DesiredCIDR:    24,
 				},
 				{
 					HostCollectorMeta: v1beta2.HostCollectorMeta{
 						CollectorName: "Subnet",
-						Exclude:       multitype.FromString("false"),
+						Exclude:       multitype.FromString("true"),
 					},
-					CIDRRangeAlloc: "10.0.0.0/24",
-					DesiredCIDR:    24,
+					CIDRRangeAlloc: "",
+					DesiredCIDR:    0,
 				},
 			},
 			expectAnalyzers: []v1beta2.SubnetAvailableAnalyze{
 				{
 					CollectorName: "Pods Subnet",
 					AnalyzeMeta: v1beta2.AnalyzeMeta{
-						Exclude: multitype.FromString("true"),
+						Exclude: multitype.FromString("false"),
 					},
 				},
 				{
 					CollectorName: "Services Subnet",
 					AnalyzeMeta: v1beta2.AnalyzeMeta{
-						Exclude: multitype.FromString("true"),
+						Exclude: multitype.FromString("false"),
 					},
 				},
 				{
 					CollectorName: "Subnet",
 					AnalyzeMeta: v1beta2.AnalyzeMeta{
-						Exclude: multitype.FromString("false"),
+						Exclude: multitype.FromString("true"),
 					},
 				},
 			},

--- a/pkg/preflights/template_test.go
+++ b/pkg/preflights/template_test.go
@@ -1,0 +1,72 @@
+// Package preflights manages running host preflights on remote hosts.
+package preflights
+
+import (
+	"context"
+	"testing"
+
+	"github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
+	"github.com/replicatedhq/troubleshoot/pkg/multitype"
+	"github.com/stretchr/testify/require"
+)
+
+func getSubnetCollectorByName(name string, spec v1beta2.HostPreflightSpec) *v1beta2.SubnetAvailable {
+	for _, c := range spec.Collectors {
+		if c.SubnetAvailable == nil {
+			continue
+		}
+		if c.SubnetAvailable.CollectorName == name {
+			return c.SubnetAvailable
+		}
+	}
+	return nil
+}
+
+func TestTemplateWithCIDRData(t *testing.T) {
+	tests := []struct {
+		name             string
+		podCIDR          string
+		serviceCIDR      string
+		globalCIDR       string
+		wantErr          bool
+		expectCollectors []v1beta2.SubnetAvailable
+		expectAnalyzers  []v1beta2.SubnetAvailableAnalyze
+	}{
+		{
+			name:    "valid podCIDR",
+			podCIDR: "10.0.0.0/24",
+			expectCollectors: []v1beta2.SubnetAvailable{
+				{
+					HostCollectorMeta: v1beta2.HostCollectorMeta{
+						CollectorName: "Pods Subnet",
+						Exclude:       multitype.FromString("false"),
+					},
+					CIDRRangeAlloc: "10.0.0.0/24",
+					DesiredCIDR:    24,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := require.New(t)
+			tl, err := TemplateData{}.WithCIDRData(test.podCIDR, test.serviceCIDR, test.globalCIDR)
+			if test.wantErr {
+				req.Error(err)
+			} else {
+				req.NoError(err)
+			}
+			hpfc, err := GetClusterHostPreflights(context.Background(), tl)
+			req.NoError(err)
+
+			spec := hpfc[0].Spec
+
+			for _, collector := range test.expectCollectors {
+				actual := getSubnetCollectorByName(collector.CollectorName, spec)
+				req.NotNil(actual)
+				req.Equal(collector, *actual)
+			}
+		})
+	}
+}

--- a/pkg/preflights/template_test.go
+++ b/pkg/preflights/template_test.go
@@ -50,7 +50,7 @@ func TestTemplateWithCIDRData(t *testing.T) {
 			expectCollectors: []v1beta2.SubnetAvailable{
 				{
 					HostCollectorMeta: v1beta2.HostCollectorMeta{
-						CollectorName: "Pods Subnet",
+						CollectorName: "Pod CIDR",
 						Exclude:       multitype.FromString("false"),
 					},
 					CIDRRangeAlloc: "10.0.0.0/24",
@@ -58,7 +58,7 @@ func TestTemplateWithCIDRData(t *testing.T) {
 				},
 				{
 					HostCollectorMeta: v1beta2.HostCollectorMeta{
-						CollectorName: "Services Subnet",
+						CollectorName: "Service CIDR",
 						Exclude:       multitype.FromString("true"),
 					},
 					CIDRRangeAlloc: "",
@@ -66,7 +66,7 @@ func TestTemplateWithCIDRData(t *testing.T) {
 				},
 				{
 					HostCollectorMeta: v1beta2.HostCollectorMeta{
-						CollectorName: "Subnet",
+						CollectorName: "CIDR",
 						Exclude:       multitype.FromString("true"),
 					},
 					CIDRRangeAlloc: "",
@@ -75,19 +75,33 @@ func TestTemplateWithCIDRData(t *testing.T) {
 			},
 			expectAnalyzers: []v1beta2.SubnetAvailableAnalyze{
 				{
-					CollectorName: "Pods Subnet",
+					CollectorName: "Pod CIDR",
 					AnalyzeMeta: v1beta2.AnalyzeMeta{
 						Exclude: multitype.FromString("false"),
 					},
+					Outcomes: []*v1beta2.Outcome{
+						{
+							Fail: &v1beta2.SingleOutcome{
+								When:    "no-subnet-available",
+								Message: "10.0.0.0/24 is not available. Use --pod-cidr to specify an available CIDR block.",
+							},
+						},
+						{
+							Pass: &v1beta2.SingleOutcome{
+								When:    "a-subnet-is-available",
+								Message: "Specified Pod CIDR is available.",
+							},
+						},
+					},
 				},
 				{
-					CollectorName: "Services Subnet",
+					CollectorName: "Service CIDR",
 					AnalyzeMeta: v1beta2.AnalyzeMeta{
 						Exclude: multitype.FromString("true"),
 					},
 				},
 				{
-					CollectorName: "Subnet",
+					CollectorName: "CIDR",
 					AnalyzeMeta: v1beta2.AnalyzeMeta{
 						Exclude: multitype.FromString("true"),
 					},
@@ -105,7 +119,7 @@ func TestTemplateWithCIDRData(t *testing.T) {
 			expectCollectors: []v1beta2.SubnetAvailable{
 				{
 					HostCollectorMeta: v1beta2.HostCollectorMeta{
-						CollectorName: "Pods Subnet",
+						CollectorName: "Pod CIDR",
 						Exclude:       multitype.FromString("true"),
 					},
 					CIDRRangeAlloc: "",
@@ -113,7 +127,7 @@ func TestTemplateWithCIDRData(t *testing.T) {
 				},
 				{
 					HostCollectorMeta: v1beta2.HostCollectorMeta{
-						CollectorName: "Services Subnet",
+						CollectorName: "Service CIDR",
 						Exclude:       multitype.FromString("false"),
 					},
 					CIDRRangeAlloc: "10.0.0.0/24",
@@ -121,7 +135,7 @@ func TestTemplateWithCIDRData(t *testing.T) {
 				},
 				{
 					HostCollectorMeta: v1beta2.HostCollectorMeta{
-						CollectorName: "Subnet",
+						CollectorName: "CIDR",
 						Exclude:       multitype.FromString("true"),
 					},
 					CIDRRangeAlloc: "",
@@ -130,19 +144,33 @@ func TestTemplateWithCIDRData(t *testing.T) {
 			},
 			expectAnalyzers: []v1beta2.SubnetAvailableAnalyze{
 				{
-					CollectorName: "Pods Subnet",
+					CollectorName: "Pod CIDR",
 					AnalyzeMeta: v1beta2.AnalyzeMeta{
 						Exclude: multitype.FromString("true"),
 					},
 				},
 				{
-					CollectorName: "Services Subnet",
+					CollectorName: "Service CIDR",
 					AnalyzeMeta: v1beta2.AnalyzeMeta{
 						Exclude: multitype.FromString("false"),
 					},
+					Outcomes: []*v1beta2.Outcome{
+						{
+							Fail: &v1beta2.SingleOutcome{
+								When:    "no-subnet-available",
+								Message: "10.0.0.0/24 is not available. Use --service-cidr to specify an available CIDR block.",
+							},
+						},
+						{
+							Pass: &v1beta2.SingleOutcome{
+								When:    "a-subnet-is-available",
+								Message: "Specified Service CIDR is available.",
+							},
+						},
+					},
 				},
 				{
-					CollectorName: "Subnet",
+					CollectorName: "CIDR",
 					AnalyzeMeta: v1beta2.AnalyzeMeta{
 						Exclude: multitype.FromString("true"),
 					},
@@ -160,7 +188,7 @@ func TestTemplateWithCIDRData(t *testing.T) {
 			expectCollectors: []v1beta2.SubnetAvailable{
 				{
 					HostCollectorMeta: v1beta2.HostCollectorMeta{
-						CollectorName: "Pods Subnet",
+						CollectorName: "Pod CIDR",
 						Exclude:       multitype.FromString("true"),
 					},
 					CIDRRangeAlloc: "",
@@ -168,7 +196,7 @@ func TestTemplateWithCIDRData(t *testing.T) {
 				},
 				{
 					HostCollectorMeta: v1beta2.HostCollectorMeta{
-						CollectorName: "Services Subnet",
+						CollectorName: "Service CIDR",
 						Exclude:       multitype.FromString("true"),
 					},
 					CIDRRangeAlloc: "",
@@ -176,7 +204,7 @@ func TestTemplateWithCIDRData(t *testing.T) {
 				},
 				{
 					HostCollectorMeta: v1beta2.HostCollectorMeta{
-						CollectorName: "Subnet",
+						CollectorName: "CIDR",
 						Exclude:       multitype.FromString("false"),
 					},
 					CIDRRangeAlloc: "10.0.0.0/24",
@@ -185,21 +213,35 @@ func TestTemplateWithCIDRData(t *testing.T) {
 			},
 			expectAnalyzers: []v1beta2.SubnetAvailableAnalyze{
 				{
-					CollectorName: "Pods Subnet",
+					CollectorName: "Pod CIDR",
 					AnalyzeMeta: v1beta2.AnalyzeMeta{
 						Exclude: multitype.FromString("true"),
 					},
 				},
 				{
-					CollectorName: "Services Subnet",
+					CollectorName: "Service CIDR",
 					AnalyzeMeta: v1beta2.AnalyzeMeta{
 						Exclude: multitype.FromString("true"),
 					},
 				},
 				{
-					CollectorName: "Subnet",
+					CollectorName: "CIDR",
 					AnalyzeMeta: v1beta2.AnalyzeMeta{
 						Exclude: multitype.FromString("false"),
+					},
+					Outcomes: []*v1beta2.Outcome{
+						{
+							Fail: &v1beta2.SingleOutcome{
+								When:    "no-subnet-available",
+								Message: "10.0.0.0/24 is not available. Use --cidr to specify a CIDR block of available private IP addresses (/16 or larger).",
+							},
+						},
+						{
+							Pass: &v1beta2.SingleOutcome{
+								When:    "a-subnet-is-available",
+								Message: "Specified CIDR is available.",
+							},
+						},
 					},
 				},
 			},
@@ -217,7 +259,7 @@ func TestTemplateWithCIDRData(t *testing.T) {
 			expectCollectors: []v1beta2.SubnetAvailable{
 				{
 					HostCollectorMeta: v1beta2.HostCollectorMeta{
-						CollectorName: "Pods Subnet",
+						CollectorName: "Pod CIDR",
 						Exclude:       multitype.FromString("false"),
 					},
 					CIDRRangeAlloc: "10.1.0.0/24",
@@ -225,7 +267,7 @@ func TestTemplateWithCIDRData(t *testing.T) {
 				},
 				{
 					HostCollectorMeta: v1beta2.HostCollectorMeta{
-						CollectorName: "Services Subnet",
+						CollectorName: "Service CIDR",
 						Exclude:       multitype.FromString("false"),
 					},
 					CIDRRangeAlloc: "10.2.0.0/24",
@@ -233,7 +275,7 @@ func TestTemplateWithCIDRData(t *testing.T) {
 				},
 				{
 					HostCollectorMeta: v1beta2.HostCollectorMeta{
-						CollectorName: "Subnet",
+						CollectorName: "CIDR",
 						Exclude:       multitype.FromString("true"),
 					},
 					CIDRRangeAlloc: "",
@@ -242,19 +284,19 @@ func TestTemplateWithCIDRData(t *testing.T) {
 			},
 			expectAnalyzers: []v1beta2.SubnetAvailableAnalyze{
 				{
-					CollectorName: "Pods Subnet",
+					CollectorName: "Pod CIDR",
 					AnalyzeMeta: v1beta2.AnalyzeMeta{
 						Exclude: multitype.FromString("false"),
 					},
 				},
 				{
-					CollectorName: "Services Subnet",
+					CollectorName: "Service CIDR",
 					AnalyzeMeta: v1beta2.AnalyzeMeta{
 						Exclude: multitype.FromString("false"),
 					},
 				},
 				{
-					CollectorName: "Subnet",
+					CollectorName: "CIDR",
 					AnalyzeMeta: v1beta2.AnalyzeMeta{
 						Exclude: multitype.FromString("true"),
 					},
@@ -287,6 +329,9 @@ func TestTemplateWithCIDRData(t *testing.T) {
 				actual := getSubnetAnalyzerByName(analyzer.CollectorName, spec)
 				req.NotNil(actual)
 				req.Equal(analyzer.Exclude, actual.Exclude)
+				for _, out := range analyzer.Outcomes {
+					req.Contains(actual.Outcomes, out)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Adds host preflight checks for the pod-cidr, service-cidr and cidr flags. If the `--pod-cidr`or `--service-cidr` checks are provided then those are the preflights that will be put in place, else we're gonna setup a preflight for wtv is provided through the `--cidr` flag.

This also fixes the current behaviour for CIDR flags where both service and a pod CIDR must be provided in order for us to use that VS the default CIDR flag.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/113111/new-preflight-check-to-detect-whether-cluster-network-might-conflict-with-enterprise-s-internal-network

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Added a series of tests.

Plus some manual executions:
```
root@node0:/replicatedhq/embedded-cluster# output/bin/embedded-cluster install run-preflights --license local-dev/Joao.yaml --cidr 172.17.0.0/16
✔  Host files materialized!
✗  2 host preflights failed

 •  NTP is enabled but the system clock is not synchronized. Synchronize the system clock to continue.
 •  172.17.0.0/16 is not available. Use --cidr to specify a CIDR block of available private IP addresses (/16 or larger).

Please address these issues and try again.

root@node0:/replicatedhq/embedded-cluster# output/bin/embedded-cluster install run-preflights --license local-dev/Joao.yaml --cidr 172.17.0.0/16
✔  Host files materialized!
✗  1 host preflight failed

 •  172.17.0.0/16 is not available. Use --cidr to specify a CIDR block of available private IP addresses (/16 or larger).

Please address this issue and try again.

root@node0:/replicatedhq/embedded-cluster# output/bin/embedded-cluster install run-preflights --license local-dev/Joao.yaml --pod-cidr 172.17.0.0/16
✔  Host files materialized!
✗  1 host preflight failed

 •  172.17.0.0/16 is not available. Use --pod-cidr to specify an available CIDR block.

Please address this issue and try again.

root@node0:/replicatedhq/embedded-cluster# output/bin/embedded-cluster install run-preflights --license local-dev/Joao.yaml --service-cidr 172.17.0.0/16
✔  Host files materialized!
✗  2 host preflights failed

 •  NTP is enabled but the system clock is not synchronized. Synchronize the system clock to continue.
 •  172.17.0.0/16 is not available. Use --service-cidr to specify an available CIDR block.

Please address these issues and try again.

```

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds preflight checks for the required subnets.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
