### PR TITLE
fix: reset fails on worker nodes after an upgrade

### DIFF
--- a/cmd/embedded-cluster/flags.go
+++ b/cmd/embedded-cluster/flags.go
@@ -58,11 +58,27 @@ func getLocalArtifactMirrorPortFlag(runtimeConfig *ecv1beta1.RuntimeConfigSpec) 
 	}
 }
 
-func getDataDirFlag(runtimeConfig *ecv1beta1.RuntimeConfigSpec) cli.Flag {
+func getInstallDataDirFlag(runtimeConfig *ecv1beta1.RuntimeConfigSpec) *cli.StringFlag {
 	return &cli.StringFlag{
 		Name:   "data-dir",
 		Usage:  "Path to the data directory",
 		Value:  ecv1beta1.DefaultDataDir,
+		Hidden: false,
+		Action: func(c *cli.Context, s string) error {
+			if s == "" {
+				return nil
+			}
+			logrus.Debugf("Setting data dir to %s from flag", s)
+			runtimeConfig.DataDir = s
+			return nil
+		},
+	}
+}
+
+func getDataDirFlag(runtimeConfig *ecv1beta1.RuntimeConfigSpec) *cli.StringFlag {
+	return &cli.StringFlag{
+		Name:   "data-dir",
+		Usage:  "Path to the data directory (default discovered from the cluster)",
 		Hidden: false,
 		Action: func(c *cli.Context, s string) error {
 			if s == "" {

--- a/cmd/embedded-cluster/flags.go
+++ b/cmd/embedded-cluster/flags.go
@@ -58,7 +58,7 @@ func getLocalArtifactMirrorPortFlag(runtimeConfig *ecv1beta1.RuntimeConfigSpec) 
 	}
 }
 
-func getInstallDataDirFlag(runtimeConfig *ecv1beta1.RuntimeConfigSpec) *cli.StringFlag {
+func getDataDirFlagWithDefault(runtimeConfig *ecv1beta1.RuntimeConfigSpec) *cli.StringFlag {
 	return &cli.StringFlag{
 		Name:   "data-dir",
 		Usage:  "Path to the data directory",

--- a/cmd/embedded-cluster/install.go
+++ b/cmd/embedded-cluster/install.go
@@ -660,7 +660,7 @@ func installCommand() *cli.Command {
 					Name:  "airgap-bundle",
 					Usage: "Path to the air gap bundle. If set, the installation will complete without internet access.",
 				},
-				getDataDirFlag(runtimeConfig),
+				getInstallDataDirFlag(runtimeConfig),
 				&cli.StringFlag{
 					Name:    "license",
 					Aliases: []string{"l"},

--- a/cmd/embedded-cluster/install.go
+++ b/cmd/embedded-cluster/install.go
@@ -660,7 +660,7 @@ func installCommand() *cli.Command {
 					Name:  "airgap-bundle",
 					Usage: "Path to the air gap bundle. If set, the installation will complete without internet access.",
 				},
-				getInstallDataDirFlag(runtimeConfig),
+				getDataDirFlagWithDefault(runtimeConfig),
 				&cli.StringFlag{
 					Name:    "license",
 					Aliases: []string{"l"},

--- a/cmd/embedded-cluster/materialize.go
+++ b/cmd/embedded-cluster/materialize.go
@@ -19,7 +19,7 @@ func materializeCommand() *cli.Command {
 		Usage:  "Materialize embedded assets into the data directory",
 		Hidden: true,
 		Flags: []cli.Flag{
-			getInstallDataDirFlag(runtimeConfig),
+			getDataDirFlagWithDefault(runtimeConfig),
 		},
 		Before: func(c *cli.Context) error {
 			if os.Getuid() != 0 {

--- a/cmd/embedded-cluster/materialize.go
+++ b/cmd/embedded-cluster/materialize.go
@@ -19,7 +19,7 @@ func materializeCommand() *cli.Command {
 		Usage:  "Materialize embedded assets into the data directory",
 		Hidden: true,
 		Flags: []cli.Flag{
-			getDataDirFlag(runtimeConfig),
+			getInstallDataDirFlag(runtimeConfig),
 		},
 		Before: func(c *cli.Context) error {
 			if os.Getuid() != 0 {

--- a/cmd/embedded-cluster/preflights.go
+++ b/cmd/embedded-cluster/preflights.go
@@ -38,7 +38,7 @@ func installRunPreflightsCommand() *cli.Command {
 					Usage: "Disable interactive prompts.",
 					Value: false,
 				},
-				getInstallDataDirFlag(runtimeConfig),
+				getDataDirFlagWithDefault(runtimeConfig),
 				getAdminConsolePortFlag(runtimeConfig),
 				getLocalArtifactMirrorPortFlag(runtimeConfig),
 			},

--- a/cmd/embedded-cluster/preflights.go
+++ b/cmd/embedded-cluster/preflights.go
@@ -38,7 +38,7 @@ func installRunPreflightsCommand() *cli.Command {
 					Usage: "Disable interactive prompts.",
 					Value: false,
 				},
-				getDataDirFlag(runtimeConfig),
+				getInstallDataDirFlag(runtimeConfig),
 				getAdminConsolePortFlag(runtimeConfig),
 				getLocalArtifactMirrorPortFlag(runtimeConfig),
 			},

--- a/cmd/embedded-cluster/provider.go
+++ b/cmd/embedded-cluster/provider.go
@@ -38,15 +38,15 @@ func discoverKubeconfigPath(ctx context.Context, runtimeConfig *ecv1beta1.Runtim
 // discoverBestProvider discovers the provider from the cluster (if it's up) and will fall back to
 // the flag, the filesystem, or the default.
 func discoverBestProvider(ctx context.Context, runtimeConfig *ecv1beta1.RuntimeConfigSpec) *defaults.Provider {
+	// Use the data dir from the data-dir flag if it's set
+	if runtimeConfig.DataDir != "" {
+		return defaults.NewProviderFromRuntimeConfig(runtimeConfig)
+	}
+
 	// It's possible that the cluster is not up
 	provider, err := getProviderFromCluster(ctx)
 	if err == nil {
 		return provider
-	}
-
-	// Use the data dir from the data-dir flag if it's set
-	if runtimeConfig.DataDir != "" {
-		return defaults.NewProviderFromRuntimeConfig(runtimeConfig)
 	}
 
 	// Otherwise, fall back to the filesystem

--- a/cmd/embedded-cluster/restore.go
+++ b/cmd/embedded-cluster/restore.go
@@ -908,7 +908,7 @@ func restoreCommand() *cli.Command {
 					Name:  "airgap-bundle",
 					Usage: "Path to the air gap bundle. If set, the restore will complete without internet access.",
 				},
-				getInstallDataDirFlag(runtimeConfig),
+				getDataDirFlagWithDefault(runtimeConfig),
 				&cli.StringFlag{
 					Name:  "local-artifact-mirror-port",
 					Usage: "Port on which the Local Artifact Mirror will be served. If left empty, the port will be retrieved from the snapshot.",

--- a/cmd/embedded-cluster/restore.go
+++ b/cmd/embedded-cluster/restore.go
@@ -908,7 +908,7 @@ func restoreCommand() *cli.Command {
 					Name:  "airgap-bundle",
 					Usage: "Path to the air gap bundle. If set, the restore will complete without internet access.",
 				},
-				getDataDirFlag(runtimeConfig),
+				getInstallDataDirFlag(runtimeConfig),
 				&cli.StringFlag{
 					Name:  "local-artifact-mirror-port",
 					Usage: "Port on which the Local Artifact Mirror will be served. If left empty, the port will be retrieved from the snapshot.",


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Reset is failing on worker nodes after an upgrade because the cli is preferring the default data directory over the one discovered from the filesystem.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
