### PR TITLE
chore(ci): wait for app to deploy after upgrade

### DIFF
--- a/e2e/scripts/check-postupgrade-state.sh
+++ b/e2e/scripts/check-postupgrade-state.sh
@@ -39,7 +39,8 @@ main() {
     fi
 
     # ensure that new app pods exist
-    if ! kubectl get pods -n kotsadm -l app=second | grep -q Running ; then
+    # wait for new app pods to be running
+    if ! retry 5 kubectl get pods -n kotsadm -l app=second | grep -q Running ; then
         echo "no pods found for second app version"
         kubectl get pods -n kotsadm
         exit 1


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

this seems like a transient error to me based on the cluster bundle

```
        kotsadm            second-547bf4b58d-pskcj                         0/1     ImagePullBackOff   0             14s
```

```
        "conditions": [
          {
            "type": "Available",
            "status": "True",
            "lastUpdateTime": "2024-10-22T19:45:07Z",
            "lastTransitionTime": "2024-10-22T19:45:07Z",
            "reason": "MinimumReplicasAvailable",
            "message": "Deployment has minimum availability."
          },
          {
            "type": "Progressing",
            "status": "True",
            "lastUpdateTime": "2024-10-22T19:45:07Z",
            "lastTransitionTime": "2024-10-22T19:28:34Z",
            "reason": "NewReplicaSetAvailable",
            "message": "ReplicaSet \"second-547bf4b58d\" has successfully progressed."
          }
        ]
```

https://github.com/replicatedhq/embedded-cluster/actions/runs/11466739613/job/31908613257?pr=1363

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
