### PR TITLE
Ignore .envrc for dev environment setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ go.work.sum
 .gomodcache
 /local-dev/
 *.tmp
+.envrc


### PR DESCRIPTION
I use direnv for setting environment variables, this ignores it's config file in the root folder to prevent me from checking in the tokens it sets for the dev environment.