### PR TITLE
chore: bump troubleshoot to allow optional cluster specs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ K0S_GO_VERSION = v1.30.5+k0s.0
 PREVIOUS_K0S_VERSION ?= v1.29.9+k0s.0-ec.0
 PREVIOUS_K0S_GO_VERSION ?= v1.29.9+k0s.0
 K0S_BINARY_SOURCE_OVERRIDE =
-TROUBLESHOOT_VERSION = v0.105.2
+TROUBLESHOOT_VERSION = v0.107.3
 KOTS_VERSION = v$(shell awk '/^version/{print $$2}' pkg/addons/adminconsole/static/metadata.yaml | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
 # When updating KOTS_BINARY_URL_OVERRIDE, also update the KOTS_VERSION above or
 # scripts/ci-upload-binaries.sh may find the version in the cache and not upload the overridden binary.

--- a/cmd/embedded-cluster/support_bundle.go
+++ b/cmd/embedded-cluster/support_bundle.go
@@ -34,6 +34,9 @@ func supportBundleCommand() *cli.Command {
 
 			kubeConfig := provider.PathToKubeConfig()
 			hostSupportBundle := provider.PathToEmbeddedClusterSupportFile("host-support-bundle.yaml")
+			if _, err := os.Stat(hostSupportBundle); err != nil {
+				return fmt.Errorf("unable to find host support bundle: %w", err)
+			}
 
 			spin := spinner.Start()
 			spin.Infof("Collecting support bundle (this may take a while)")
@@ -45,10 +48,10 @@ func supportBundleCommand() *cli.Command {
 					Writer:       stdout,
 					ErrWriter:    stderr,
 					LogOnSuccess: true,
+					Env:          map[string]string{"KUBECONFIG": kubeConfig},
 				},
 				supportBundle,
 				"--interactive=false",
-				fmt.Sprintf("--kubeconfig=%s", kubeConfig),
 				"--load-cluster-specs",
 				hostSupportBundle,
 			); err != nil {

--- a/e2e/scripts/validate-support-bundle.sh
+++ b/e2e/scripts/validate-support-bundle.sh
@@ -19,7 +19,7 @@ main() {
     tar -zxvf support-bundle-*.tar.gz
     rm -rf support-bundle-*.tar.gz
 
-    if ! ls support-bundle-*/host-collectors/run-host/k0s-sysinfo.txt; then
+    if ! ls support-bundle-*/host-collectors/run-host/*/k0s-sysinfo.txt; then
         echo "Failed to find 'k0s sysinfo' inside the support bundle generated with the embedded cluster binary"
         return 1
     fi

--- a/e2e/scripts/validate-support-bundle.sh
+++ b/e2e/scripts/validate-support-bundle.sh
@@ -19,7 +19,7 @@ main() {
     tar -zxvf support-bundle-*.tar.gz
     rm -rf support-bundle-*.tar.gz
 
-    if ! ls support-bundle-*/host-collectors/run-host/*/k0s-sysinfo.txt; then
+    if ! ls support-bundle-*/host-collectors/run-host/k0s-sysinfo.txt; then
         echo "Failed to find 'k0s sysinfo' inside the support bundle generated with the embedded cluster binary"
         return 1
     fi

--- a/pkg/goods/support/host-support-bundle-remote.yaml
+++ b/pkg/goods/support/host-support-bundle-remote.yaml
@@ -3,7 +3,6 @@ kind: SupportBundle
 metadata:
   name: embedded-cluster-host-support-bundle
 spec:
-  runHostCollectorsInPod: true  # default is false 
   hostCollectors:
   - hostOS: {}
   - cpu: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

latest version of troubleshoot now supports bypassing errors when reading support bundle specs from the cluster (https://github.com/replicatedhq/troubleshoot/pull/1660). in the previous version it used to fail.

this pr also makes the `embedded-cluster support-bundle` command use the kubeconfig as an environment variable.


#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
