### PR TITLE
feat: configure firewalld if it is running

### DIFF
--- a/cmd/embedded-cluster/join.go
+++ b/cmd/embedded-cluster/join.go
@@ -254,6 +254,11 @@ var joinCommand = &cli.Command{
 			return fmt.Errorf("unable to configure network manager: %w", err)
 		}
 
+		logrus.Debugf("configuring firewalld")
+		if err := configureFirewalld(c, provider); err != nil {
+			return fmt.Errorf("unable to configure firewalld: %w", err)
+		}
+
 		logrus.Debugf("saving token to disk")
 		if err := saveTokenToDisk(jcmd.K0sToken); err != nil {
 			err := fmt.Errorf("unable to save token to disk: %w", err)

--- a/cmd/embedded-cluster/reset.go
+++ b/cmd/embedded-cluster/reset.go
@@ -489,6 +489,10 @@ func resetCommand() *cli.Command {
 				return fmt.Errorf("failed to remove NetworkManager configuration: %w", err)
 			}
 
+			if err := helpers.RemoveAll("/usr/lib/firewalld/zones/embedded-cluster.xml"); err != nil {
+				return fmt.Errorf("failed to remove firewalld configuration: %w", err)
+			}
+
 			if err := helpers.RemoveAll("/usr/local/bin/k0s"); err != nil {
 				return fmt.Errorf("failed to remove k0s binary: %w", err)
 			}

--- a/cmd/embedded-cluster/restore.go
+++ b/cmd/embedded-cluster/restore.go
@@ -1060,6 +1060,12 @@ func restoreCommand() *cli.Command {
 				if err := configureNetworkManager(c, provider); err != nil {
 					return fmt.Errorf("unable to configure network manager: %w", err)
 				}
+
+				logrus.Debugf("configuring firewalld")
+				if err := configureFirewalld(c, provider); err != nil {
+					return fmt.Errorf("unable to configure firewalld: %w", err)
+				}
+
 				logrus.Debugf("materializing binaries")
 				if err := materializeFiles(c, provider); err != nil {
 					return fmt.Errorf("unable to materialize binaries: %w", err)

--- a/pkg/goods/materializer.go
+++ b/pkg/goods/materializer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"text/template"
 
 	"github.com/replicatedhq/embedded-cluster/pkg/defaults"
 )
@@ -226,5 +227,34 @@ func (m *Materializer) Ourselves() error {
 	if _, err := io.Copy(dst, src); err != nil {
 		return fmt.Errorf("unable to write file: %w", err)
 	}
+	return nil
+}
+
+// FirewalldConfig materializes the firewalld config file. This file creates a
+// zone for the embedded cluster pod and service CIDRs. The zone configuration
+// is read from an embedded template file (systemd/firewalld-config.tpl.xml).
+func (m *Materializer) FirewalldConfig(podCIDR, svcCIDR string) error {
+	content, err := systemdfs.ReadFile("systemd/firewalld-config.tpl.xml")
+	if err != nil {
+		return fmt.Errorf("unable to open firewalld template file: %w", err)
+	}
+
+	tpl, err := template.New("firewalld").Parse(string(content))
+	if err != nil {
+		return fmt.Errorf("unable to parse firewalld config file: %w", err)
+	}
+
+	dst := "/usr/lib/firewalld/zones/embedded-cluster.xml"
+	fp, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return fmt.Errorf("unable to open firewalld config file: %w", err)
+	}
+	defer fp.Close()
+
+	data := map[string]string{"PodCIDR": podCIDR, "ServiceCIDR": svcCIDR}
+	if err := tpl.Execute(fp, data); err != nil {
+		return fmt.Errorf("unable to execute firewalld config template: %w", err)
+	}
+
 	return nil
 }

--- a/pkg/goods/systemd/firewalld-config.tpl.xml
+++ b/pkg/goods/systemd/firewalld-config.tpl.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<zone target="ACCEPT">
+  <short>embedded-cluster</short>
+  <description>Zone for Embedded Cluster communication</description>
+  <source address="{{ .PodCIDR }}"/>
+  <source address="{{ .ServiceCIDR }}"/>
+</zone>


### PR DESCRIPTION
#### What this PR does / why we need it:

starts to configure firewalld if it is running. this pr makes the installer to create a zone with 'accept' target for packets related to the pod cidr and the service cidr.

#### Does this PR require a release note?
```release-note
Added firewalld auto configuration.
```