### PR TITLE
Fix automated PRs manager detecting E2E CI jobs

### DIFF
--- a/.github/workflows/automated-prs-manager.yaml
+++ b/.github/workflows/automated-prs-manager.yaml
@@ -90,8 +90,8 @@ jobs:
 
           # If more than half of the e2e jobs are successful, re-run the failed jobs.
 
-          num_of_jobs=$(gh run view "$run_id" --json jobs -q '.jobs[] | select(.name | startswith("e2e")) | .name' | wc -l)
-          num_of_successful_jobs=$(gh run view "$run_id" --json jobs -q '.jobs[] | select((.name | startswith("e2e")) and (.conclusion == "success")) | .name' | wc -l)
+          num_of_jobs=$(gh run view "$run_id" --json jobs -q '.jobs[] | select(.name | startswith("E2E")) | .name' | wc -l)
+          num_of_successful_jobs=$(gh run view "$run_id" --json jobs -q '.jobs[] | select((.name | startswith("E2E")) and (.conclusion == "success")) | .name' | wc -l)
 
           if [ "$num_of_successful_jobs" -gt $((num_of_jobs / 2)) ]; then
             echo "More than half of the e2e jobs are successful. Re-running failed jobs."

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -481,7 +481,7 @@ jobs:
 
   # e2e-docker runs the e2e tests inside a docker container rather than a full VM
   e2e-docker:
-    name: E2E docker
+    name: E2E docker # this name is used by .github/workflows/automated-prs-manager.yaml
     runs-on: ubuntu-latest
     needs:
       - git-sha
@@ -570,7 +570,7 @@ jobs:
           test-name: '${{ matrix.test }}'
 
   e2e:
-    name: E2E
+    name: E2E # this name is used by .github/workflows/automated-prs-manager.yaml
     runs-on: ${{ matrix.runner || 'ubuntu-22.04' }}
     needs:
       - build-current


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Fixes an issue where the automated PRs manager workflow could not detect e2e jobs in CI runs because they were renamed to `E2E` instead of `e2e`.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE