### PR TITLE
Fix automated PRs manager detecting validate success branch protection job

### DIFF
--- a/.github/workflows/automated-prs-manager.yaml
+++ b/.github/workflows/automated-prs-manager.yaml
@@ -74,7 +74,7 @@ jobs:
 
           # If all tests and required checks passed, approve and merge.
 
-          if gh run view "$run_id" --json jobs -q '.jobs[] | select(.name == "validate-success") | .conclusion' | grep -q "success"; then
+          if gh run view "$run_id" --json jobs -q '.jobs[] | select(.name == "Validate success") | .conclusion' | grep -q "success"; then
             if gh pr checks "${{ matrix.pr.url }}" --required; then
               echo "All tests and required checks passed. Approving and merging."
               echo -e "LGTM :thumbsup: \n\nThis PR was automatically approved and merged by the [automated-prs-manager](https://github.com/replicatedhq/embedded-cluster/blob/main/.github/workflows/automated-prs-manager.yaml) GitHub action" > body.txt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -635,7 +635,7 @@ jobs:
   # this job will validate that all the tests passed
   # it is used for the github branch protection rule
   validate-success:
-    name: Validate success
+    name: Validate success # this name is used by .github/workflows/automated-prs-manager.yaml
     runs-on: ubuntu-20.04
     needs:
       - e2e


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Fixes an issue where the automated PRs manager workflow could not detect e2e jobs in CI runs because they were renamed to `Validate success` instead of `validate-success`.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE