### PR TITLE
Fix deploy-upgrade playwright test flakiness

### DIFF
--- a/e2e/playwright/tests/deploy-upgrade/test.spec.ts
+++ b/e2e/playwright/tests/deploy-upgrade/test.spec.ts
@@ -7,7 +7,7 @@ test('deploy upgrade', async ({ page }) => {
   await page.getByRole('link', { name: 'Version history', exact: true }).click();
   await page.locator('.available-update-row', { hasText: process.env.APP_UPGRADE_VERSION }).getByRole('button', { name: 'Deploy', exact: true }).click();
   const iframe = page.frameLocator('#upgrade-service-iframe');
-  await expect(iframe.locator('h3')).toContainText('The First Config Group', { timeout: 20 * 1000 });
+  await expect(iframe.locator('h3')).toContainText('The First Config Group', { timeout: 60 * 1000 }); // can take time to download the kots binary
   await expect(iframe.locator('input[type="text"]')).toHaveValue('initial-hostname.com');
   await iframe.locator('input[type="text"]').click();
   await iframe.locator('input[type="text"]').fill('updated-hostname.com');


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Fixes an issue where the `deploy-upgrade` playwright test can timeout while trying to download the KOTS binary. This PR increases the timeout as it can take longer than 20 seconds depending on the network bandwidth.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE