### PR TITLE
retry setting installation state on conflict

### DIFF
--- a/operator/pkg/upgrade/installation.go
+++ b/operator/pkg/upgrade/installation.go
@@ -3,9 +3,11 @@ package upgrade
 import (
 	"context"
 	"fmt"
+	"time"
 
 	clusterv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg/kubeutils"
+	"k8s.io/apimachinery/pkg/api/errors"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -39,17 +41,24 @@ func CreateInstallation(ctx context.Context, cli client.Client, original *cluste
 
 // setInstallationState gets the installation object of the given name and sets the state to the given state.
 func setInstallationState(ctx context.Context, cli client.Client, name string, state string, reason string, pendingCharts ...string) error {
-	existingInstallation := &clusterv1beta1.Installation{}
-	err := cli.Get(ctx, client.ObjectKey{Name: name}, existingInstallation)
-	if err != nil {
-		return fmt.Errorf("get installation: %w", err)
+	var err error
+	for i := 0; i < 5; i++ {
+		existingInstallation := &clusterv1beta1.Installation{}
+		err = cli.Get(ctx, client.ObjectKey{Name: name}, existingInstallation)
+		if err != nil {
+			return fmt.Errorf("get installation: %w", err)
+		}
+		existingInstallation.Status.SetState(state, reason, pendingCharts)
+		err = cli.Status().Update(ctx, existingInstallation)
+		if errors.IsConflict(err) {
+			time.Sleep(time.Second)
+			continue
+		} else if err != nil {
+			return fmt.Errorf("update installation status: %w", err)
+		}
+		return nil
 	}
-	existingInstallation.Status.SetState(state, reason, pendingCharts)
-	err = cli.Status().Update(ctx, existingInstallation)
-	if err != nil {
-		return fmt.Errorf("update installation status: %w", err)
-	}
-	return nil
+	return fmt.Errorf("failed to set installation state after 5 attempts %w", err)
 }
 
 // reApplyInstallation updates the installation spec to match what's in the configmap used by the upgrade job.

--- a/operator/pkg/upgrade/installation.go
+++ b/operator/pkg/upgrade/installation.go
@@ -7,7 +7,6 @@ import (
 
 	clusterv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg/kubeutils"
-	"k8s.io/apimachinery/pkg/api/errors"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -50,11 +49,9 @@ func setInstallationState(ctx context.Context, cli client.Client, name string, s
 		}
 		existingInstallation.Status.SetState(state, reason, pendingCharts)
 		err = cli.Status().Update(ctx, existingInstallation)
-		if errors.IsConflict(err) {
+		if err != nil {
 			time.Sleep(time.Second)
 			continue
-		} else if err != nil {
-			return fmt.Errorf("update installation status: %w", err)
 		}
 		return nil
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

in the kots logs:
```
2024/10/23 20:56:19 Running upgrade command...
2024/10/23 20:56:19 Upgrade command output:
2024/10/23 20:56:19   Upgrade job creation started
2024/10/23 20:56:19   Preparing upgrade to installation 20241023205617 (k0s version 1.16.0+k8s-1.30)
2024/10/23 20:56:19   time="2024-10-23T20:56:19Z" level=info msg="Creating installation 20241023205617"
2024/10/23 20:56:19   Error: apply installation: update installation status: update installation status: Operation cannot be fulfilled on installations.embeddedcluster.replicated.com "20241023205617": the object has been modified; please apply your changes to the latest version and try again
```

This was when upgrading the app but leaving the version of embedded cluster constant - a new installation object was created, updated with nodes and HA transitions status, and then we attempted to set the state to k8sinstalled at the same time that this was ongoing:

```
Status:
  Conditions:
    Last Transition Time:  2024-10-23T20:56:19Z
    Message:
    Observed Generation:   1
    Reason:                HANotEnabled
    Status:                False
    Type:                  HighAvailability
  Nodes Status:
    Hash:  3a19c36ff4b50f860566f24a404777ede397e1778e0d742afde84a9247addc4c
    Name:  laverya-ec-upgrade
Events:
  Type    Reason       Age   From                     Message
  ----    ------       ----  ----                     -------
  Normal  NodeUpdated  71s   installation-controller  Node laverya-ec-upgrade has been updated
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
