### PR TITLE
chore: improvements to support-bundle command

### DIFF
--- a/cmd/embedded-cluster/support_bundle.go
+++ b/cmd/embedded-cluster/support_bundle.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
@@ -72,7 +75,45 @@ func supportBundleCommand() *cli.Command {
 
 			spin.Infof("Support bundle collected!")
 			spin.Close()
+
+			printSupportBundlePath(stdout)
 			return nil
 		},
+	}
+}
+
+// printSupportBundlePath attempts to parse the support bundle command output
+// and find the location where the tgz was written. support bundle output isn't
+// always a json so we can't rely on unmarshaling it. depending on the kinds of
+// errors returned during the collection the output may differ quite a bunch.
+// in order to find where the support bundle was stored we look for a line
+// containing "archivePath", if we find it we attempt to parse it. if we can't
+// find a match or failed to parse it we simply don't print anything. XXX this
+// should be addressed upstream, we should be able to cleanly parse the output
+// as a json (i.e. errors should be printed into stderr).
+func printSupportBundlePath(stdout io.Reader) {
+	pwd, err := os.Getwd()
+	if err != nil {
+		return
+	}
+
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.Contains(line, `"archivePath":`) {
+			continue
+		}
+
+		components := strings.Split(line, `"`)
+		if len(components) < 4 {
+			return
+		}
+
+		fname := components[3]
+		if !strings.HasPrefix(fname, "support-bundle-") {
+			return
+		}
+
+		logrus.Infof("Support bundle written to %s", filepath.Join(pwd, fname))
 	}
 }

--- a/cmd/embedded-cluster/support_bundle.go
+++ b/cmd/embedded-cluster/support_bundle.go
@@ -32,10 +32,16 @@ func supportBundleCommand() *cli.Command {
 				return fmt.Errorf("unable to find support bundle binary")
 			}
 
-			kubeConfig := provider.PathToKubeConfig()
 			hostSupportBundle := provider.PathToEmbeddedClusterSupportFile("host-support-bundle.yaml")
 			if _, err := os.Stat(hostSupportBundle); err != nil {
 				return fmt.Errorf("unable to find host support bundle: %w", err)
+			}
+
+			kubeConfig := provider.PathToKubeConfig()
+			var env map[string]string
+			if _, err := os.Stat(kubeConfig); err == nil {
+				// if we have a kubeconfig, use it.
+				env = map[string]string{"KUBECONFIG": kubeConfig}
 			}
 
 			spin := spinner.Start()
@@ -48,7 +54,7 @@ func supportBundleCommand() *cli.Command {
 					Writer:       stdout,
 					ErrWriter:    stderr,
 					LogOnSuccess: true,
-					Env:          map[string]string{"KUBECONFIG": kubeConfig},
+					Env:          env,
 				},
 				supportBundle,
 				"--interactive=false",

--- a/cmd/embedded-cluster/support_bundle.go
+++ b/cmd/embedded-cluster/support_bundle.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 
 	"github.com/replicatedhq/embedded-cluster/pkg/defaults"
@@ -29,7 +30,8 @@ func supportBundleCommand() *cli.Command {
 
 			supportBundle := provider.PathToEmbeddedClusterBinary("kubectl-support_bundle")
 			if _, err := os.Stat(supportBundle); err != nil {
-				return fmt.Errorf("unable to find support bundle binary")
+				logrus.Errorf("Support bundle binary not found. The support-bundle command can only be run after an 'install' attempt.")
+				return ErrNothingElseToAdd
 			}
 
 			hostSupportBundle := provider.PathToEmbeddedClusterSupportFile("host-support-bundle.yaml")


### PR DESCRIPTION
#### What this PR does / why we need it:

- only sets kubeconfig environment variable if the kubeconfig file exists.
- print a better message if the support-bundle binary does not exist on disk.
- print the support bundle tar.gz file location.