### PR TITLE
chore: remove spurious printf

### DIFF
--- a/pkg/kotscli/kotscli.go
+++ b/pkg/kotscli/kotscli.go
@@ -318,7 +318,6 @@ func CreateHostSupportBundle() error {
 	if err != nil {
 		return fmt.Errorf("unable to unmarshal support bundle spec: %w", err)
 	}
-	fmt.Println(hostSupportBundle.APIVersion)
 
 	if err := s.Encode(hostSupportBundle, &b); err != nil {
 		return fmt.Errorf("unable to encode support bundle spec: %w", err)


### PR DESCRIPTION

#### What this PR does / why we need it:

this should not be there.
