### PR TITLE
fix(preflights): panic on preflight warnings

### DIFF
--- a/cmd/embedded-cluster/install.go
+++ b/cmd/embedded-cluster/install.go
@@ -257,6 +257,7 @@ func runHostPreflights(c *cli.Context, provider *defaults.Provider, hpf *v1beta2
 		if !prompts.New().Confirm("Do you want to continue ?", false) {
 			return fmt.Errorf("user aborted")
 		}
+		return nil
 	}
 
 	// No failures or warnings


### PR DESCRIPTION
#### What this PR does / why we need it:
This fixes a panic when a `warn` preflight fails and prompts the customer to proceed. If the customer chooses to proceed we were trying to write to a closed channel we use to write to stdout.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://github.com/replicated-collab/datastax-kots/issues/86

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fix panic when customer gets prompted to act on a warning on preflight checks.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
