### PR TITLE
Add additional namespaces for collection

### DIFF
--- a/operator/charts/embedded-cluster-operator/troubleshoot/cluster-support-bundle.yaml
+++ b/operator/charts/embedded-cluster-operator/troubleshoot/cluster-support-bundle.yaml
@@ -11,12 +11,15 @@ spec:
   - clusterResources:
       namespaces:
       - kube-system
+      - kube-node-lease
+      - kube-public
       - openebs
       - registry
       - embedded-cluster
       - seaweedfs
       - default
       - velero
+      - k0s-autopilot
   - logs:
       name: podlogs/embedded-cluster-operator
       namespace: embedded-cluster

--- a/operator/charts/embedded-cluster-operator/troubleshoot/cluster-support-bundle.yaml
+++ b/operator/charts/embedded-cluster-operator/troubleshoot/cluster-support-bundle.yaml
@@ -17,6 +17,7 @@ spec:
       - registry
       - embedded-cluster
       - seaweedfs
+      - kotsadm
       - default
       - velero
       - k0s-autopilot


### PR DESCRIPTION
#### What this PR does / why we need it:
The support bundles doesn't include some namespaces that are necessary to debug some failure condistion.
