### PR TITLE
feat: add preflight for ip forwarding

### DIFF
--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -148,6 +148,10 @@ spec:
         exclude: '{{ eq .GlobalCIDR.CIDR "" }}'
         CIDRRangeAlloc: '{{ .GlobalCIDR.CIDR }}'
         desiredCIDR: {{.GlobalCIDR.Size}}
+    - run:
+        collectorName: "kernel-parameters"
+        command: "sysctl"
+        args: ["-a"]
   analyzers:
     - cpu:
         checkName: CPU
@@ -834,3 +838,14 @@ spec:
           - pass:
               when: "a-subnet-is-available"
               message: Specified CIDR is available.
+    - textAnalyze:
+        checkName: IP forwarding
+        fileName: host-collectors/run-host/kernel-parameters.txt
+        regex: 'net.ipv4.ip_forward = 1'
+        outcomes:
+          - pass:
+              when: "true"
+              message: IP forwarding is enabled.
+          - fail:
+              when: "false"
+              message: IP forwarding must be enabled. To enable it, edit /etc/sysctl.conf, add or uncomment the line 'net.ipv4.ip_forward=1', and run 'sudo sysctl -p'.


### PR DESCRIPTION
#### What this PR does / why we need it:

we require users to manually enable ip forwarding on their nodes before installing. this preflight checks if ip forwarding is enabled and fails if it is not.

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Added preflight for IP forwarding.
```