### PR TITLE
fix: unable to upgrade EC when introducing a required config item w/o…

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ Additionally, it includes a Registry when deployed in air gap mode.
 - Replicated CLI
 - Helm CLI
 - AWS CLI
-- jq
 - Dagger
+- shasum
+- jq
 
 ### Running the Development Environment
 

--- a/e2e/playwright/tests/deploy-upgrade/test.spec.ts
+++ b/e2e/playwright/tests/deploy-upgrade/test.spec.ts
@@ -1,34 +1,60 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page, FrameLocator } from '@playwright/test';
 import { login } from '../shared';
 
 test('deploy upgrade', async ({ page }) => {
   test.setTimeout(15 * 60 * 1000); // 15 minutes
   await login(page);
+  await initiateUpgrade(page);
+  const iframe = page.frameLocator('#upgrade-service-iframe');
+  await fillConfigForm(iframe);
+  await handlePreflightChecks(iframe);
+  await deployUpgrade(iframe);
+  await waitForClusterUpdate(page);
+  await verifyUpgradeSuccess(page);
+});
+
+async function initiateUpgrade(page: Page) {
   await page.getByRole('link', { name: 'Version history', exact: true }).click();
   await page.locator('.available-update-row', { hasText: process.env.APP_UPGRADE_VERSION }).getByRole('button', { name: 'Deploy', exact: true }).click();
-  const iframe = page.frameLocator('#upgrade-service-iframe');
+}
+
+async function fillConfigForm(iframe: FrameLocator) {
   await expect(iframe.locator('h3')).toContainText('The First Config Group', { timeout: 60 * 1000 }); // can take time to download the kots binary
-  await expect(iframe.locator('input[type="text"]')).toHaveValue( process.env.APP_INITIAL_HOSTNAME ? process.env.APP_INITIAL_HOSTNAME : 'initial-hostname.com');
-  await iframe.locator('input[type="text"]').click();
-  await iframe.locator('input[type="text"]').fill('updated-hostname.com');
+
+  const hostnameInput = iframe.locator('#hostname-group').locator('input[type="text"]');
+  await expect(hostnameInput).toHaveValue(process.env.APP_INITIAL_HOSTNAME ? process.env.APP_INITIAL_HOSTNAME : 'initial-hostname.com');
+  await hostnameInput.click();
+  await hostnameInput.fill('updated-hostname.com');
+
   await iframe.locator('input[type="password"]').click();
   await iframe.locator('input[type="password"]').fill('updated password');
+
   await iframe.getByRole('button', { name: 'Next', exact: true }).click();
+}
+
+async function handlePreflightChecks(iframe: FrameLocator) {
   await expect(iframe.getByText('Preflight checks', { exact: true })).toBeVisible({ timeout: 10 * 1000 });
   await expect(iframe.getByRole('button', { name: 'Rerun' })).toBeVisible({ timeout: 10 * 1000 });
   await expect(iframe.locator('#app')).toContainText('Embedded Cluster Installation CRD exists');
   await expect(iframe.locator('#app')).toContainText('Embedded Cluster Config CRD exists');
   await expect(iframe.getByRole('button', { name: 'Back: Config' })).toBeVisible();
   await iframe.getByRole('button', { name: 'Next: Confirm and deploy' }).click();
+}
+
+async function deployUpgrade(iframe: FrameLocator) {
   await expect(iframe.locator('#app')).toContainText('All preflight checks passed');
   await expect(iframe.getByRole('button', { name: 'Back: Preflight checks' })).toBeVisible();
   await iframe.getByRole('button', { name: 'Deploy', exact: true }).click();
+}
 
+async function waitForClusterUpdate(page: Page) {
   if (process.env.SKIP_CLUSTER_UPGRADE_CHECK !== 'true') {
     await expect(page.locator('.Modal-body')).toContainText('Cluster update in progress');
     await expect(page.locator('.Modal-body').getByText('Cluster update in progress')).not.toBeVisible({ timeout: 20 * 60 * 1000 });
   }
+}
 
+async function verifyUpgradeSuccess(page: Page) {
   await expect(page.locator('.available-update-row', { hasText: process.env.APP_UPGRADE_VERSION })).not.toBeVisible({ timeout: 10 * 1000 });
   await expect(page.locator('.VersionHistoryRow', { hasText: process.env.APP_UPGRADE_VERSION })).toContainText('Currently deployed version', { timeout: 90 * 1000 });
   await page.getByRole('link', { name: 'Dashboard', exact: true }).click();
@@ -36,4 +62,4 @@ test('deploy upgrade', async ({ page }) => {
   await expect(page.locator('#app')).toContainText('Currently deployed version');
   await expect(page.locator('#app')).toContainText('Ready', { timeout: 30 * 1000 });
   await expect(page.locator('#app')).toContainText('Up to date');
-});
+}

--- a/e2e/playwright/tests/shared/deploy-app.ts
+++ b/e2e/playwright/tests/shared/deploy-app.ts
@@ -1,4 +1,6 @@
-export const deployApp = async (page, expect) => {
+import { Page, Expect } from '@playwright/test';
+
+export const deployApp = async (page: Page, expect: Expect) => {
   await expect(page.getByText('Optionally add nodes to the cluster'),).toBeVisible();
   await expect(page.locator('.react-prism.language-bash')).toBeVisible();
   const joinCommand = await page.locator('.react-prism.language-bash').first().textContent();

--- a/e2e/playwright/tests/shared/deploy-ec18-app-version.ts
+++ b/e2e/playwright/tests/shared/deploy-ec18-app-version.ts
@@ -1,4 +1,6 @@
-export const deployEC18AppVersion = async (page, expect) => {
+import { Page, Expect } from '@playwright/test';
+
+export const deployEC18AppVersion = async (page: Page, expect: Expect) => {
     await expect(page.getByRole('button', { name: 'Add node', exact: true })).toBeVisible();
     await page.getByRole('button', { name: 'Continue' }).click();
     await expect(page.locator('h3')).toContainText('The First Config Group');

--- a/e2e/playwright/tests/shared/login.ts
+++ b/e2e/playwright/tests/shared/login.ts
@@ -1,4 +1,6 @@
-export const login = async (page, password = 'password') => {
+import { Page } from '@playwright/test';
+
+export const login = async (page: Page, password = 'password') => {
   await page.goto('/');
   await page.getByPlaceholder('password').click();
   await page.getByPlaceholder('password').fill(password);

--- a/scripts/ci-upload-binaries.sh
+++ b/scripts/ci-upload-binaries.sh
@@ -96,8 +96,11 @@ function kotsbin() {
     local kots_version=
     kots_version=$(make print-KOTS_VERSION)
 
-    local kots_override=
-    kots_override=$(make print-KOTS_BINARY_URL_OVERRIDE)
+    local kots_url_override=
+    kots_url_override=$(make print-KOTS_BINARY_URL_OVERRIDE)
+
+    local kots_file_override=
+    kots_file_override=$(make print-KOTS_BINARY_FILE_OVERRIDE)
 
     # check if the binary already exists in the bucket
     local kots_binary_exists=
@@ -109,9 +112,12 @@ function kotsbin() {
         return 0
     fi
 
-    if [ -n "${kots_override}" ] && [ "${kots_override}" != '' ]; then
-        echo "KOTS_BINARY_URL_OVERRIDE is set to '${kots_override}', using that source"
-        curl --retry 5 --retry-all-errors -fL -o "build/kots_linux_${ARCH}.tar.gz" "${kots_override}"
+    if [ -n "${kots_url_override}" ]; then
+        echo "KOTS_BINARY_URL_OVERRIDE is set to '${kots_url_override}', using that source"
+        curl --retry 5 --retry-all-errors -fL -o "build/kots_linux_${ARCH}.tar.gz" "${kots_url_override}"
+    elif [ -n "${kots_file_override}" ]; then
+        echo "KOTS_BINARY_FILE_OVERRIDE is set to '${kots_file_override}', using that source"
+        tar -czvf "build/kots_linux_${ARCH}.tar.gz" -C $(dirname "${kots_file_override}") $(basename "${kots_file_override}")
     else
         # download the kots binary from github
         echo "downloading kots binary from https://github.com/replicatedhq/kots/releases/download/${kots_version}/kots_linux_${ARCH}.tar.gz"


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Fixes an issue where updating the app failed if the new app version contained a required config item without a default or value.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-111215](https://app.shortcut.com/replicated/story/111215)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Yes

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes an issue where updating the app failed if the new app version contained a required config item without a default or value.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE