### PR TITLE
fix(registry): logs missing from support bundle

### DIFF
--- a/operator/charts/embedded-cluster-operator/troubleshoot/cluster-support-bundle.yaml
+++ b/operator/charts/embedded-cluster-operator/troubleshoot/cluster-support-bundle.yaml
@@ -81,7 +81,7 @@ spec:
       name: podlogs/registry
       namespace: registry
       selector:
-      - app=registry
+      - app=docker-registry
       limits:
         maxAge: 720h
   - logs:


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Label is incorrect

```
        "labels": {
          "app": "docker-registry",
          "pod-template-hash": "6b5bc4cc97",
          "release": "docker-registry"
        },
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue that causes registry logs to be missing from the support bundle.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
