### PR TITLE
fix: fail to discover azure standard sku public ip address

### DIFF
--- a/operator/pkg/artifacts/upgrade_test.go
+++ b/operator/pkg/artifacts/upgrade_test.go
@@ -30,7 +30,7 @@ func TestEnsureArtifactsJobForNodes(t *testing.T) {
 			}
 
 			list := &batchv1.JobList{}
-			err := cli.List(ctx, list, client.InNamespace(ecNamespace))
+			err := cli.List(context.Background(), list, client.InNamespace(ecNamespace))
 			if err != nil {
 				require.NoError(t, err)
 			}
@@ -39,7 +39,7 @@ func TestEnsureArtifactsJobForNodes(t *testing.T) {
 					// there is no job controller in envtest so the finalizer will not be
 					// removed and the job will not be deleted
 					item.SetFinalizers(nil)
-					err := cli.Update(ctx, &item)
+					err := cli.Update(context.Background(), &item)
 					require.NoError(t, err)
 				}
 			}

--- a/pkg/defaults/cloudprovider.go
+++ b/pkg/defaults/cloudprovider.go
@@ -24,31 +24,37 @@ func init() {
 // string is returned.
 func TryDiscoverPublicIP() string {
 	if !shouldUseMetadataService() {
+		logrus.Debug("No cloud provider metadata service found, skipping public IP discovery")
 		return ""
 	}
 
 	publicIP := tryDiscoverPublicIPAWSIMDSv2()
 	if publicIP != "" {
+		logrus.Debugf("Found public IP %s using AWS IMDSv2", publicIP)
 		return publicIP
 	}
 
 	publicIP = tryDiscoverPublicIPAWSIMDSv1()
 	if publicIP != "" {
+		logrus.Debugf("Found public IP %s using AWS IMDSv1", publicIP)
 		return publicIP
 	}
 
 	publicIP = tryDiscoverPublicIPGCE()
 	if publicIP != "" {
+		logrus.Debugf("Found public IP %s using GCE", publicIP)
 		return publicIP
 	}
 
 	publicIP = tryDiscoverPublicIPAzureStandardSKU()
 	if publicIP != "" {
+		logrus.Debugf("Found public IP %s using Azure Standard SKU", publicIP)
 		return publicIP
 	}
 
 	publicIP = tryDiscoverPublicIPAzure()
 	if publicIP != "" {
+		logrus.Debugf("Found public IP %s using Azure", publicIP)
 		return publicIP
 	}
 

--- a/pkg/defaults/cloudprovider.go
+++ b/pkg/defaults/cloudprovider.go
@@ -62,7 +62,7 @@ func TryDiscoverPublicIP() string {
 }
 
 func tryDiscoverPublicIPGCE() string {
-	return makeMetadataRequest(
+	return makeMetadataRequestForIPv4(
 		http.MethodGet,
 		"http://169.254.169.254/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip",
 		map[string]string{"Metadata-Flavor": "Google"},
@@ -70,7 +70,7 @@ func tryDiscoverPublicIPGCE() string {
 }
 
 func tryDiscoverPublicIPAWSIMDSv1() string {
-	return makeMetadataRequest(
+	return makeMetadataRequestForIPv4(
 		http.MethodGet,
 		"http://169.254.169.254/latest/meta-data/public-ipv4",
 		nil,
@@ -86,7 +86,7 @@ func tryDiscoverPublicIPAWSIMDSv2() string {
 	if token == "" {
 		return ""
 	}
-	return makeMetadataRequest(
+	return makeMetadataRequestForIPv4(
 		http.MethodGet,
 		"http://169.254.169.254/latest/meta-data/public-ipv4",
 		map[string]string{"X-aws-ec2-metadata-token": token},
@@ -94,7 +94,7 @@ func tryDiscoverPublicIPAWSIMDSv2() string {
 }
 
 func tryDiscoverPublicIPAzure() string {
-	return makeMetadataRequest(
+	return makeMetadataRequestForIPv4(
 		http.MethodGet,
 		"http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/publicIpAddress?api-version=2017-08-01&format=text",
 		map[string]string{"Metadata": "true"},
@@ -155,6 +155,14 @@ func shouldUseMetadataService() bool {
 	return true
 }
 
+func makeMetadataRequestForIPv4(method string, url string, headers map[string]string) string {
+	body := makeMetadataRequest(method, url, headers)
+	if net.ParseIP(body).To4() != nil {
+		return body
+	}
+	return ""
+}
+
 func makeMetadataRequest(method string, url string, headers map[string]string) string {
 	client := &http.Client{
 		Timeout:   2 * time.Second,
@@ -181,9 +189,5 @@ func makeMetadataRequest(method string, url string, headers map[string]string) s
 	}
 
 	bodyBytes, _ := io.ReadAll(resp.Body)
-	publicIP := string(bodyBytes)
-	if net.ParseIP(publicIP).To4() != nil {
-		return publicIP
-	}
-	return ""
+	return string(bodyBytes)
 }

--- a/pkg/defaults/cloudprovider_test.go
+++ b/pkg/defaults/cloudprovider_test.go
@@ -1,0 +1,36 @@
+package defaults
+
+import "testing"
+
+func Test_parseAzureLoadBalancerMetadataResponse(t *testing.T) {
+	type args struct {
+		resp string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "basic",
+			args: args{
+				resp: `{"loadbalancer":{"publicIpAddresses":[{"frontendIpAddress":"52.249.223.56","privateIpAddress":"10.0.0.4"}],"inboundRules":[],"outboundRules":[]}}`,
+			},
+			want:    "52.249.223.56",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseAzureLoadBalancerMetadataResponse(tt.args.resp)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseAzureLoadBalancerMetadataResponse() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("parseAzureLoadBalancerMetadataResponse() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Cant retrieve standard sku address from instance metadata

https://learn.microsoft.com/en-us/answers/questions/7932/public-ip-not-available-via-metadata

```
azureuser@ethan-1:~$ sudo ./embedded-cluster-smoke-test-staging-app install --license license.yaml --skip-host-preflights
? Set the Admin Console password (minimum 6 characters): ********
? Confirm the Admin Console password: ********
✔  Host files materialized!
✔  Host preflights skipped
✔  Node installation finished!
✔  Storage is ready!
✔  Embedded Cluster Operator is ready!
✔  Admin Console is ready!
✔  Additional components are ready!
Visit the Admin Console to configure and install embedded-cluster-smoke-test-staging-app: http://52.249.223.56:30000
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue when installing in Azure that caused the install command to output the instance private address rather than the public one in the link to the Admin Console.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
