### PR TITLE
feat: warn if online installation is attempted on air gap

### DIFF
--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -769,6 +769,17 @@ func installCommand() *cli.Command {
 				logrus.Infof("\n  sudo ./%s reset\n", binName)
 				return ErrNothingElseToAdd
 			}
+
+			if channelRelease, err := release.GetChannelRelease(); err != nil {
+				return fmt.Errorf("unable to read channel release data: %w", err)
+			} else if channelRelease != nil && channelRelease.Airgap && c.String("airgap-bundle") == "" && !c.Bool("no-prompt") {
+				logrus.Infof("You downloaded an air gap bundle but are performing an online installation.")
+				logrus.Infof("To do an air gap installation, pass the air gap bundle with --airgap-bundle.")
+				if !prompts.New().Confirm("Do you want to proceed with an online installation ?", false) {
+					return ErrNothingElseToAdd
+				}
+			}
+
 			metrics.ReportApplyStarted(c)
 			logrus.Debugf("configuring network manager")
 			if err := configureNetworkManager(c, provider); err != nil {

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -775,7 +775,7 @@ func installCommand() *cli.Command {
 			} else if channelRelease != nil && channelRelease.Airgap && c.String("airgap-bundle") == "" && !c.Bool("no-prompt") {
 				logrus.Infof("You downloaded an air gap bundle but are performing an online installation.")
 				logrus.Infof("To do an air gap installation, pass the air gap bundle with --airgap-bundle.")
-				if !prompts.New().Confirm("Do you want to proceed with an online installation ?", false) {
+				if !prompts.New().Confirm("Do you want to proceed with an online installation?", false) {
 					return ErrNothingElseToAdd
 				}
 			}

--- a/pkg/cmd/join.go
+++ b/pkg/cmd/join.go
@@ -191,7 +191,7 @@ var joinCommand = &cli.Command{
 		} else if channelRelease != nil && channelRelease.Airgap && c.String("airgap-bundle") == "" && !c.Bool("no-prompt") {
 			logrus.Infof("You downloaded an air gap bundle but are performing an online join.")
 			logrus.Infof("To do an air gap join, pass the air gap bundle with --airgap-bundle.")
-			if !prompts.New().Confirm("Do you want to proceed with an online join ?", false) {
+			if !prompts.New().Confirm("Do you want to proceed with an online join?", false) {
 				return ErrNothingElseToAdd
 			}
 		}

--- a/pkg/cmd/restore.go
+++ b/pkg/cmd/restore.go
@@ -959,6 +959,16 @@ func restoreCommand() *cli.Command {
 				return fmt.Errorf("unable to write runtime config: %w", err)
 			}
 
+			if channelRelease, err := release.GetChannelRelease(); err != nil {
+				return fmt.Errorf("unable to read channel release data: %w", err)
+			} else if channelRelease != nil && channelRelease.Airgap && c.String("airgap-bundle") == "" && !c.Bool("no-prompt") {
+				logrus.Infof("You downloaded an air gap bundle but are performing an online restore.")
+				logrus.Infof("To do an air gap restore, pass the air gap bundle with --airgap-bundle.")
+				if !prompts.New().Confirm("Do you want to proceed with an online restore ?", false) {
+					return ErrNothingElseToAdd
+				}
+			}
+
 			proxy, err := getProxySpecFromFlags(c)
 			if err != nil {
 				return fmt.Errorf("unable to get proxy spec from flags: %w", err)

--- a/pkg/cmd/restore.go
+++ b/pkg/cmd/restore.go
@@ -964,7 +964,7 @@ func restoreCommand() *cli.Command {
 			} else if channelRelease != nil && channelRelease.Airgap && c.String("airgap-bundle") == "" && !c.Bool("no-prompt") {
 				logrus.Infof("You downloaded an air gap bundle but are performing an online restore.")
 				logrus.Infof("To do an air gap restore, pass the air gap bundle with --airgap-bundle.")
-				if !prompts.New().Confirm("Do you want to proceed with an online restore ?", false) {
+				if !prompts.New().Confirm("Do you want to proceed with an online restore?", false) {
 					return ErrNothingElseToAdd
 				}
 			}

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -155,6 +155,7 @@ type ChannelRelease struct {
 	ChannelID    string `yaml:"channelID"`
 	ChannelSlug  string `yaml:"channelSlug"`
 	AppSlug      string `yaml:"appSlug"`
+	Airgap       bool   `yaml:"airgap"`
 }
 
 // GetChannelRelease reads the embedded channel release object. If no channel release


### PR DESCRIPTION
#### What this PR does / why we need it:

> [!IMPORTANT]  
> for this to work we need to merge https://github.com/replicatedhq/vandoor/pull/6374 first.

vendor portal informs us (through the embedded channel release struct) if the binary was downloaded with or without an  airgap bundle.

if the binary was downloaded with an airgap bundle, we should warn the user we must warn the users if they attempt to install the binary without passing in the airgap bundle flag.

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Warn users if an online installation is executed with an air gap prepared installer binary.
```