### PR TITLE
chore(local-dev): fixes the metadata generation file for the operator version

### DIFF
--- a/scripts/ci-build-deps.sh
+++ b/scripts/ci-build-deps.sh
@@ -23,7 +23,8 @@ function local_artifact_mirror() {
 
 function operator() {
     make -C operator build-ttl.sh build-chart-ttl.sh \
-        PACKAGE_VERSION="$EC_VERSION"
+        PACKAGE_VERSION="$EC_VERSION" \
+        VERSION="$EC_VERSION"
     cp operator/build/image "operator/build/image-$EC_VERSION"
     cp operator/build/chart "operator/build/chart-$EC_VERSION"
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

Was facing some local dev issues when creating an installation:
> unable to wait for installation to be ready: error waiting for installation: helm chart installation failed: failed to update helm charts:
embedded-cluster-operator: can't locate chart `oci://proxy.replicated.com/anonymous/ttl.sh/jgantunes/embedded-cluster-operator-1.18.0+k8s-1.30-11-g088bf8d5`: proxy.replicated.com/anonymous/ttl.sh/jgantunes/embedded-cluster-operator:1.18.0_k8s-1.30-11-g088bf8d5: not found

Seems like the metadata file generated for the operator was missing the `-<username>` suffix for the chart version. This should fix it.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE