### PR TITLE
chore: fix message when join node is not included in the no-proxy addresses

### DIFF
--- a/pkg/cmd/join.go
+++ b/pkg/cmd/join.go
@@ -224,7 +224,10 @@ var joinCommand = &cli.Command{
 			return fmt.Errorf("failed to check proxy config for local IP: %w", err)
 		}
 		if !proxyOK {
-			return fmt.Errorf("no-proxy config %q does not allow access to local IP %q", jcmd.InstallationSpec.Proxy.NoProxy, localIP)
+			logrus.Errorf("This node's IP address %s is not included in the no-proxy list (%s).", localIP, jcmd.InstallationSpec.Proxy.NoProxy)
+			logrus.Infof(`The no-proxy list cannot easily be modified after initial installation.`)
+			logrus.Infof(`Recreate the first node and pass all node IP addresses to --no-proxy.`)
+			return ErrNothingElseToAdd
 		}
 
 		isAirgap := c.String("airgap-bundle") != ""


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

![Screenshot 2024-11-13 at 10 00 21 AM](https://github.com/user-attachments/assets/f4e5d648-c125-4e69-b632-82cbb6dc29a5)

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
