### PR TITLE
Use warn function when doing online install after downloading air gap

### DIFF
--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -773,7 +773,7 @@ func installCommand() *cli.Command {
 			if channelRelease, err := release.GetChannelRelease(); err != nil {
 				return fmt.Errorf("unable to read channel release data: %w", err)
 			} else if channelRelease != nil && channelRelease.Airgap && c.String("airgap-bundle") == "" && !c.Bool("no-prompt") {
-				logrus.Infof("You downloaded an air gap bundle but are performing an online installation.")
+				logrus.Warnf("You downloaded an air gap bundle but are performing an online installation.")
 				logrus.Infof("To do an air gap installation, pass the air gap bundle with --airgap-bundle.")
 				if !prompts.New().Confirm("Do you want to proceed with an online installation?", false) {
 					return ErrNothingElseToAdd


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Use the warn function so the text is yellow and makes the warning more clear to users.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE

<img width="1079" alt="Screenshot 2024-11-14 at 6 44 00 AM" src="https://github.com/user-attachments/assets/c9fe0745-8aab-4312-879b-321b78536898">
