### PR TITLE
Mention that HA can be enabled on or after 3rd node, not just on 3rd node

### DIFF
--- a/pkg/cmd/join.go
+++ b/pkg/cmd/join.go
@@ -555,7 +555,7 @@ func maybeEnableHA(ctx context.Context, kcli client.Client) error {
 		return nil
 	}
 	logrus.Info("")
-	logrus.Info("When adding a third controller node, you have the option to enable high availability. This will migrate the data so that it is replicated across cluster nodes. Once enabled, you must maintain at least three controller nodes.")
+	logrus.Info("You can enable high availability when adding a third controller node or more. This will migrate data so that it is replicated across cluster nodes. Once enabled, you must maintain at least three controller nodes.")
 	logrus.Info("")
 	shouldEnableHA := prompts.New().Confirm("Do you want to enable high availability?", false)
 	if !shouldEnableHA {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Mention that HA can be enabled on or after 3rd node, not just on 3rd node. Also a slight reword for brevity/clarity.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
<img width="1446" alt="Screenshot 2024-11-14 at 11 39 32 AM" src="https://github.com/user-attachments/assets/19b826e2-ed3c-4a81-a60b-378ebe05bc45">