### PR TITLE
Include binutils in distro images to avoid network flakiness

### DIFF
--- a/.github/workflows/distros.yaml
+++ b/.github/workflows/distros.yaml
@@ -6,7 +6,7 @@ on:
       - 'dev/distros/**'
     branches:
       - main
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/distros.yaml
+++ b/.github/workflows/distros.yaml
@@ -6,6 +6,7 @@ on:
       - 'dev/distros/**'
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/dev/distros/dockerfiles/almalinux-8.Dockerfile
+++ b/dev/distros/dockerfiles/almalinux-8.Dockerfile
@@ -11,6 +11,7 @@ RUN dnf install -y \
   ca-certificates \
   bash \
   coreutils \
+  binutils \
   curl \
   procps-ng \
   ipvsadm \

--- a/dev/distros/dockerfiles/centos-9.Dockerfile
+++ b/dev/distros/dockerfiles/centos-9.Dockerfile
@@ -11,6 +11,7 @@ RUN dnf install -y \
   ca-certificates \
   bash \
   coreutils \
+  binutils \
   curl \
   procps-ng \
   ipvsadm \

--- a/dev/distros/dockerfiles/debian-bookworm.Dockerfile
+++ b/dev/distros/dockerfiles/debian-bookworm.Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
   ca-certificates \
   bash \
   coreutils \
+  binutils \
   curl \
   inotify-tools \
   ipvsadm \

--- a/dev/distros/dockerfiles/debian-bullseye.Dockerfile
+++ b/dev/distros/dockerfiles/debian-bullseye.Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
   ca-certificates \
   bash \
   coreutils \
+  binutils \
   curl \
   inotify-tools \
   ipvsadm \

--- a/dev/distros/dockerfiles/ubuntu-jammy.Dockerfile
+++ b/dev/distros/dockerfiles/ubuntu-jammy.Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
   ca-certificates \
   bash \
   coreutils \
+  binutils \
   curl \
   inotify-tools \
   ipvsadm \

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -291,7 +291,7 @@ func TestHostPreflightCustomSpec(t *testing.T) {
 	defer tc.Cleanup()
 
 	t.Logf("%s: installing test dependencies on node 0", time.Now().Format(time.RFC3339))
-	line := []string{"yum", "install", "-y", "binutils", "fio"}
+	line := []string{"yum", "install", "-y", "fio"}
 	if stdout, stderr, err := tc.RunCommandOnNode(0, line); err != nil {
 		t.Fatalf("fail to install dependencies on node 0: %v: %s: %s", err, stdout, stderr)
 	}

--- a/e2e/unsupported-overrides_test.go
+++ b/e2e/unsupported-overrides_test.go
@@ -20,17 +20,6 @@ func TestUnsupportedOverrides(t *testing.T) {
 	})
 	defer tc.Cleanup()
 
-	t.Logf("%s: installing dependencies on node 0", time.Now().Format(time.RFC3339))
-	commands := [][]string{
-		{"apt-get", "update", "-y"},
-		{"apt-get", "install", "binutils", "-y"},
-	}
-	for _, cmd := range commands {
-		if stdout, stderr, err := tc.RunCommandOnNode(0, cmd); err != nil {
-			t.Fatalf("fail to run command %q: %v: %s: %s", cmd, err, stdout, stderr)
-		}
-	}
-
 	t.Logf("%s: installing embedded-cluster with unsupported overrides on node 0", time.Now().Format(time.RFC3339))
 	line := []string{"unsupported-overrides.sh"}
 	if stdout, stderr, err := tc.RunCommandOnNode(0, line); err != nil {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Includes `binutils` in EC distro images to avoid network flakiness

Example flakiness: https://github.com/replicatedhq/embedded-cluster/actions/runs/11843290988/job/33004470938?pr=1487#step:8:56

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE