### PR TITLE
chore(preflights): replace run collector with host sysctl for ip_forwarding

### DIFF
--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -148,10 +148,6 @@ spec:
         exclude: '{{ eq .GlobalCIDR.CIDR "" }}'
         CIDRRangeAlloc: '{{ .GlobalCIDR.CIDR }}'
         desiredCIDR: {{.GlobalCIDR.Size}}
-    - run:
-        collectorName: "kernel-parameters"
-        command: "sysctl"
-        args: ["-a"]
     - sysctl: {}
   analyzers:
     - cpu:
@@ -839,17 +835,6 @@ spec:
           - pass:
               when: "a-subnet-is-available"
               message: Specified CIDR is available.
-    - textAnalyze:
-        checkName: IP forwarding
-        fileName: host-collectors/run-host/kernel-parameters.txt
-        regex: 'net.ipv4.ip_forward = 1'
-        outcomes:
-          - pass:
-              when: "true"
-              message: IP forwarding is enabled.
-          - fail:
-              when: "false"
-              message: IP forwarding must be enabled. To enable it, edit /etc/sysctl.conf, add or uncomment the line 'net.ipv4.ip_forward=1', and run 'sudo sysctl -p'.
     - sysctl:
         checkName: "ARP Filter default value for newly created interfaces"
         outcomes:
@@ -886,3 +871,12 @@ spec:
           - pass:
               when: 'net.ipv4.conf.all.arp_ignore == 0'
               message: "ARP ignore is disabled for all interfaces on the host."
+    - sysctl:
+        checkName: "IP forwarding"
+        outcomes:
+          - fail:
+              when: 'net.ipv4.ip_forward == 0'
+              message: "IP forwarding must be enabled. To enable it, edit /etc/sysctl.conf, add or uncomment the line 'net.ipv4.ip_forward=1', and run 'sudo sysctl -p'."
+          - pass:
+              when: 'net.ipv4.ip_forward > 0'
+              message: "IP forwarding is enabled."


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Follow up to https://github.com/replicatedhq/embedded-cluster/pull/1500 we should use the already existing `sysctl` collector for the `ip_forwarding` check

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

I run a manual test locally, however it's hard to reproduce with the recent changes introduced in - https://github.com/replicatedhq/embedded-cluster/pull/1484. Instead I cherry picked the analyzer and collector and run them separately using the preflight binary:

![image](https://github.com/user-attachments/assets/ae1700bf-e691-4567-b363-adbf8328c4f5)

After `sysctl net.ipv4.ip_forward=0`

![image](https://github.com/user-attachments/assets/853d243f-7189-4f20-aefe-b94cabc40a54)


#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
