### PR TITLE
validate that the registry is still available for pulls after HA migration

### DIFF
--- a/e2e/kots-release-install/deployment-2.yaml
+++ b/e2e/kots-release-install/deployment-2.yaml
@@ -15,6 +15,18 @@ spec:
       labels:
         app: second
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - second
+                topologyKey: "kubernetes.io/hostname"
       containers:
         - name: nginx
           image: proxy.replicated.com/anonymous/nginx:1.24-alpine

--- a/e2e/kots-release-upgrade/deployment-2.yaml
+++ b/e2e/kots-release-upgrade/deployment-2.yaml
@@ -6,7 +6,7 @@ metadata:
     app: second
     replicated.com/disaster-recovery: app
 spec:
-  replicas: 1
+  replicas: 4
   selector:
     matchLabels:
       app: second
@@ -15,6 +15,18 @@ spec:
       labels:
         app: second
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - second
+                topologyKey: "kubernetes.io/hostname"
       containers:
         - name: nginx
           image: proxy.replicated.com/anonymous/nginx:1.25-alpine

--- a/e2e/scripts/check-airgap-post-ha-state.sh
+++ b/e2e/scripts/check-airgap-post-ha-state.sh
@@ -75,7 +75,7 @@ main() {
 
     # scale up the second deployment to ensure that images can still be pulled
     echo "scaling up the 'second' deployment to ensure that images can still be pulled"
-    kubectl scale deployment/second --replicas=4
+    kubectl scale -n kotsadm deployment/second --replicas=4
     sleep 5
     echo "after 5 seconds, pods in the 'kotsadm' namespace:"
     kubectl get pods -n kotsadm -o wide

--- a/e2e/scripts/check-airgap-post-ha-state.sh
+++ b/e2e/scripts/check-airgap-post-ha-state.sh
@@ -73,6 +73,14 @@ main() {
         validate_data_dirs
     fi
 
+    # scale up the second deployment to ensure that images can still be pulled
+    kubectl scale deployment second --replicas=4
+    sleep 1
+    if ! wait_for_pods_running 60; then
+        echo "Failed waiting for the second deployment's nginx pods"
+        exit 1
+    fi
+
     validate_no_pods_in_crashloop
 }
 

--- a/e2e/scripts/check-airgap-post-ha-state.sh
+++ b/e2e/scripts/check-airgap-post-ha-state.sh
@@ -74,8 +74,11 @@ main() {
     fi
 
     # scale up the second deployment to ensure that images can still be pulled
-    kubectl scale deployment second --replicas=4
-    sleep 1
+    echo "scaling up the 'second' deployment to ensure that images can still be pulled"
+    kubectl scale deployment/second --replicas=4
+    sleep 5
+    echo "after 5 seconds, pods in the 'kotsadm' namespace:"
+    kubectl get pods -n kotsadm -o wide
     if ! wait_for_pods_running 60; then
         echo "Failed waiting for the second deployment's nginx pods"
         exit 1

--- a/e2e/scripts/check-airgap-post-ha-state.sh
+++ b/e2e/scripts/check-airgap-post-ha-state.sh
@@ -83,6 +83,8 @@ main() {
         echo "Failed waiting for the second deployment's nginx pods"
         exit 1
     fi
+    # scale the second deployment back down so that they aren't restored in the DR test
+    kubectl scale -n kotsadm deployment/second --replicas=0
 
     validate_no_pods_in_crashloop
 }


### PR DESCRIPTION

#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

This PR adds a change to the airgap HA migration validation. Previously, we did not actually pull images from the registry post-migration before having kots push images to the registry again - which would work if we did not actually migrate registry data. Now, we scale a deployment that has a 'prefer not on the same node' scheduling restriction, and make sure that those pods reach a running state.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
