### PR TITLE
chore(gitignore): ignore preflight bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ go.work.sum
 /local-dev/
 *.tmp
 .envrc
+
+# Ignore preflight bundles generated during local dev
+preflightbundle*


### PR DESCRIPTION
#### What this PR does / why we need it:
Maybe this is a me thing but when developing preflights and testing them out locally it's easy to end up with a bunch of `preflightbundle*.tar.gz` files laying around. This just prevents committing them by accident.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
