### PR TITLE
fix: cli warn and error should go to stdout like the lower levels

### DIFF
--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -1814,7 +1814,7 @@ func TestMultiNodeHAInstallation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("fail to remove controller node 2: %v: %s: %s", err, stdout, stderr)
 	}
-	if !strings.Contains(stderr, "High-availability clusters must maintain at least three controller nodes") {
+	if !strings.Contains(stdout, "High-availability clusters must maintain at least three controller nodes") {
 		t.Errorf("reset output does not contain the ha warning")
 		t.Logf("stdout: %s\nstderr: %s", stdout, stderr)
 	}
@@ -2035,7 +2035,7 @@ func TestMultiNodeAirgapHAInstallation(t *testing.T) {
 		t.Logf("stdout: %s\nstderr: %s", stdout, stderr)
 		t.Fatalf("fail to remove controller node %s:", err)
 	}
-	if !strings.Contains(stderr, "High-availability clusters must maintain at least three controller nodes") {
+	if !strings.Contains(stdout, "High-availability clusters must maintain at least three controller nodes") {
 		t.Errorf("reset output does not contain the ha warning")
 		t.Logf("stdout: %s\nstderr: %s", stdout, stderr)
 	}

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -11,15 +11,15 @@ import (
 	"time"
 
 	"github.com/fatih/color"
-	"github.com/sirupsen/logrus"
-
 	"github.com/replicatedhq/embedded-cluster/pkg/defaults"
+	"github.com/sirupsen/logrus"
 )
 
 // MaxLogFiles is the maximum number of log files we keep.
 const MaxLogFiles = 100
 
-// StdoutLogger is a Logrus hook for routing Info, Error, and Fatal logs to the screen.
+// StdoutLogger is a Logrus hook for routing Info, Warn and Error logs to stdout and Fatal logs to
+// stderr.
 type StdoutLogger struct{}
 
 // Levels defines on which log levels this hook would trigger.
@@ -36,6 +36,9 @@ func (hook *StdoutLogger) Levels() []logrus.Level {
 func (hook *StdoutLogger) Fire(entry *logrus.Entry) error {
 	message := fmt.Sprintf("%s\n", entry.Message)
 	output := os.Stdout
+	if entry.Level == logrus.FatalLevel {
+		output = os.Stderr
+	}
 	var writer *color.Color
 	switch entry.Level {
 	case logrus.WarnLevel:

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -36,9 +36,6 @@ func (hook *StdoutLogger) Levels() []logrus.Level {
 func (hook *StdoutLogger) Fire(entry *logrus.Entry) error {
 	message := fmt.Sprintf("%s\n", entry.Message)
 	output := os.Stdout
-	if entry.Level != logrus.InfoLevel {
-		output = os.Stderr
-	}
 	var writer *color.Color
 	switch entry.Level {
 	case logrus.WarnLevel:


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Prior to this change log.Warn and log.Error goes to stderr while info goes to stdout.

For example:

<img width="961" alt="Screenshot 2024-11-19 at 10 21 40 AM" src="https://github.com/user-attachments/assets/9f5f0c58-caf0-4b08-afc9-81819c912036">

Vs after the change

<img width="961" alt="Screenshot 2024-11-19 at 10 02 45 AM" src="https://github.com/user-attachments/assets/61d8a1fd-30aa-4b2f-b81b-2f21b7483bfe">

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Error and warning logs from the CLI now go to stdout rather than stderr with the rest of the output.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
