### PR TITLE
Clarify air gap bundle warning

### DIFF
--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -774,9 +774,9 @@ func installCommand() *cli.Command {
 			if channelRelease, err := release.GetChannelRelease(); err != nil {
 				return fmt.Errorf("unable to read channel release data: %w", err)
 			} else if channelRelease != nil && channelRelease.Airgap && c.String("airgap-bundle") == "" && !c.Bool("no-prompt") {
-				logrus.Warnf("You downloaded an air gap bundle but are performing an online installation.")
-				logrus.Infof("To do an air gap installation, pass the air gap bundle with --airgap-bundle.")
-				if !prompts.New().Confirm("Do you want to proceed with an online installation?", false) {
+				logrus.Warnf("You downloaded an air gap bundle but didn't provide it with --airgap-bundle.")
+				logrus.Warnf("If you continue, the installation will not use an air gap bundle and will connect to the internet.")
+				if !prompts.New().Confirm("Are you sure you want to install without an air gap bundle?", false) {
 					return ErrNothingElseToAdd
 				}
 			}

--- a/pkg/cmd/restore.go
+++ b/pkg/cmd/restore.go
@@ -945,9 +945,9 @@ func restoreCommand() *cli.Command {
 			if channelRelease, err := release.GetChannelRelease(); err != nil {
 				return fmt.Errorf("unable to read channel release data: %w", err)
 			} else if channelRelease != nil && channelRelease.Airgap && c.String("airgap-bundle") == "" && !c.Bool("no-prompt") {
-				logrus.Infof("You downloaded an air gap bundle but are performing an online restore.")
-				logrus.Infof("To do an air gap restore, pass the air gap bundle with --airgap-bundle.")
-				if !prompts.New().Confirm("Do you want to proceed with an online restore?", false) {
+				logrus.Warnf("You downloaded an air gap bundle but didn't provide it with --airgap-bundle.")
+				logrus.Warnf("If you continue, the restore will not use an air gap bundle and will connect to the internet.")
+				if !prompts.New().Confirm("Are you sure you want to restore without an air gap bundle?", false) {
 					return ErrNothingElseToAdd
 				}
 			}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
After talking with Paige, make the air gap bundle warning messages more clear. Focus on the use of the air gap bundle over calling something an online or air gap install.

Also make it a warning.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE


<img width="1184" alt="Screenshot 2024-11-19 at 3 48 37 PM" src="https://github.com/user-attachments/assets/467deb8d-1235-4a6a-a08d-a66973afbea4">