### PR TITLE
fix(metrics): redact specific flags which might hold secrets

### DIFF
--- a/pkg/metrics/reporter.go
+++ b/pkg/metrics/reporter.go
@@ -76,7 +76,7 @@ func ReportInstallationStarted(ctx context.Context, license *kotsv1beta1.License
 	Send(ctx, BaseURL(license), types.InstallationStarted{
 		ClusterID:    ClusterID(),
 		Version:      versions.Version,
-		Flags:        strings.Join(os.Args[1:], " "),
+		Flags:        strings.Join(redactFlags(os.Args[1:]), " "),
 		BinaryName:   defaults.BinaryName(),
 		Type:         "centralized",
 		LicenseID:    LicenseID(license),

--- a/pkg/metrics/reporter_test.go
+++ b/pkg/metrics/reporter_test.go
@@ -22,7 +22,7 @@ func TestReportInstallationStarted(t *testing.T) {
 	}{
 		{
 			name:   "redact secret flags",
-			OSArgs: []string{"secret-command", "--license", "./path", "--admin-console-password", "123", "--some-key", "some-value", "--another-secret", "secret", "--admin-console-password=123", "--also-a-secret", "-password123notaflag"},
+			OSArgs: []string{"install", "-l", "./license.yaml", "--admin-console-password", "some-password", "--skip-host-preflights", "--http-proxy", "http://user:password@my-proxy.test", "--https-proxy=https://user:password@my-https-proxy.test", "--admin-console-port", "8080"},
 			validateRequest: func(t *testing.T, r *http.Request) {
 				req := require.New(t)
 				body, err := io.ReadAll(r.Body)
@@ -33,7 +33,7 @@ func TestReportInstallationStarted(t *testing.T) {
 				req.NoError(err)
 				err = json.Unmarshal(decoded["event"], &event)
 				req.NoError(err)
-				req.Equal("secret-command --license ./path --admin-console-password ***** --some-key ***** --another-secret ***** --admin-console-password=***** --also-a-secret *****", event.Flags)
+				req.Equal("install -l ./license.yaml --admin-console-password ***** --skip-host-preflights --http-proxy ***** --https-proxy=***** --admin-console-port 8080", event.Flags)
 			},
 		},
 	} {

--- a/pkg/metrics/reporter_test.go
+++ b/pkg/metrics/reporter_test.go
@@ -22,7 +22,7 @@ func TestReportInstallationStarted(t *testing.T) {
 	}{
 		{
 			name:   "redact secret flags",
-			OSArgs: []string{"secret-command", "--license", "./path", "--admin-console-password", "123", "--some-key", "some-value", "--another-secret", "secret"},
+			OSArgs: []string{"secret-command", "--license", "./path", "--admin-console-password", "123", "--some-key", "some-value", "--another-secret", "secret", "--admin-console-password=123", "--also-a-secret", "-password123notaflag"},
 			validateRequest: func(t *testing.T, r *http.Request) {
 				req := require.New(t)
 				body, err := io.ReadAll(r.Body)
@@ -33,7 +33,7 @@ func TestReportInstallationStarted(t *testing.T) {
 				req.NoError(err)
 				err = json.Unmarshal(decoded["event"], &event)
 				req.NoError(err)
-				req.Equal("secret-command --license ./path --admin-console-password ***** --some-key ***** --another-secret *****", event.Flags)
+				req.Equal("secret-command --license ./path --admin-console-password ***** --some-key ***** --another-secret ***** --admin-console-password=***** --also-a-secret *****", event.Flags)
 			},
 		},
 	} {

--- a/pkg/metrics/reporter_test.go
+++ b/pkg/metrics/reporter_test.go
@@ -1,0 +1,65 @@
+package metrics
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/replicatedhq/embedded-cluster/pkg/metrics/types"
+	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReportInstallationStarted(t *testing.T) {
+	for _, test := range []struct {
+		name            string
+		OSArgs          []string
+		validateRequest func(*testing.T, *http.Request)
+	}{
+		{
+			name:   "redact secret flags",
+			OSArgs: []string{"secret-command", "--license", "./path", "--password", "123", "--some-key", "some-value", "--another-secret", "secret"},
+			validateRequest: func(t *testing.T, r *http.Request) {
+				req := require.New(t)
+				body, err := io.ReadAll(r.Body)
+				req.NoError(err)
+				var decoded map[string]json.RawMessage
+				var event types.InstallationStarted
+				err = json.Unmarshal(body, &decoded)
+				req.NoError(err)
+				err = json.Unmarshal(decoded["event"], &event)
+				req.NoError(err)
+				req.Equal("secret-command --license ./path --password ***** --some-key ***** --another-secret *****", event.Flags)
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(
+				http.HandlerFunc(
+					func(rw http.ResponseWriter, req *http.Request) {
+						test.validateRequest(t, req)
+						rw.Write([]byte(`OK`))
+					},
+				),
+			)
+			defer server.Close()
+			license := &kotsv1beta1.License{
+				Spec: kotsv1beta1.LicenseSpec{
+					LicenseID: "license-id",
+					AppSlug:   "app-slug",
+					Endpoint:  server.URL,
+				},
+			}
+			// Report call relies on os.Args to get the command and flags used so we nee to mock it
+			originalArgs := os.Args
+			defer func() { os.Args = originalArgs }()
+			os.Args = append([]string{os.Args[0]}, test.OSArgs...)
+
+			ReportInstallationStarted(context.Background(), license)
+		})
+	}
+}

--- a/pkg/metrics/reporter_test.go
+++ b/pkg/metrics/reporter_test.go
@@ -22,7 +22,7 @@ func TestReportInstallationStarted(t *testing.T) {
 	}{
 		{
 			name:   "redact secret flags",
-			OSArgs: []string{"secret-command", "--license", "./path", "--password", "123", "--some-key", "some-value", "--another-secret", "secret"},
+			OSArgs: []string{"secret-command", "--license", "./path", "--admin-console-password", "123", "--some-key", "some-value", "--another-secret", "secret"},
 			validateRequest: func(t *testing.T, r *http.Request) {
 				req := require.New(t)
 				body, err := io.ReadAll(r.Body)
@@ -33,7 +33,7 @@ func TestReportInstallationStarted(t *testing.T) {
 				req.NoError(err)
 				err = json.Unmarshal(decoded["event"], &event)
 				req.NoError(err)
-				req.Equal("secret-command --license ./path --password ***** --some-key ***** --another-secret *****", event.Flags)
+				req.Equal("secret-command --license ./path --admin-console-password ***** --some-key ***** --another-secret *****", event.Flags)
 			},
 		},
 	} {

--- a/pkg/metrics/util.go
+++ b/pkg/metrics/util.go
@@ -46,7 +46,7 @@ func redactFlags(flags []string) []string {
 		if isFlagKey && strings.Contains(flag, "=") {
 
 			// Split the flag into key and value
-			flagParts := strings.Split(flag, "=")
+			flagParts := strings.SplitN(flag, "=", 2)
 			key := flagParts[0]
 			value := flagParts[1]
 

--- a/pkg/metrics/util.go
+++ b/pkg/metrics/util.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/replicatedhq/embedded-cluster/pkg/metrics/types"
 	"github.com/replicatedhq/embedded-cluster/pkg/versions"
@@ -21,4 +22,34 @@ func EventPayload(ev types.Event) ([]byte, error) {
 	}
 	payload := map[string]interface{}{"event": ev, "versions": vmap}
 	return json.Marshal(payload)
+}
+
+var secretKeywords = []string{"password", "secret", "token", "key"}
+
+// redactFlags redacts presumed secret values from a string slice based on preset keywords.
+// For example, given ["--license", "./path", "--password", "123"], it will return ["--license", "./path", "--password", "*****"]
+func redactFlags(flags []string) []string {
+	result := make([]string, len(flags))
+
+	valueHasSecret := false
+	for i, flag := range flags {
+		// Check if the is the flag name or the value
+		isFlagKey := strings.HasPrefix(flag, "-")
+		// This is a flag value and the previous iteration detected one of the secret keywords, let's redact it
+		if !isFlagKey && valueHasSecret {
+			result[i] = "*****"
+			continue
+		}
+		result[i] = flag
+		// This is a flag value no point in checking it for the secret keywords
+		if !isFlagKey {
+			continue
+		}
+		for _, keyword := range secretKeywords {
+			if valueHasSecret = strings.Contains(flag, keyword); valueHasSecret {
+				break
+			}
+		}
+	}
+	return result
 }

--- a/pkg/metrics/util.go
+++ b/pkg/metrics/util.go
@@ -24,17 +24,17 @@ func EventPayload(ev types.Event) ([]byte, error) {
 	return json.Marshal(payload)
 }
 
-var secretKeywords = []string{"password", "secret", "token", "key"}
+var flagsToRedact = []string{"http-proxy", "https-proxy", "admin-console-password"}
 
-// redactFlags redacts presumed secret values from a string slice based on preset keywords.
-// For example, given ["--license", "./path", "--password", "123", "--a-secret=123"]
-// it will return ["--license", "./path", "--password", "*****", "--a-secret=*****"]"
+// redactFlags redacts secret values from a string slice based on preset flags to redact.
+// For example, given ["--license", "./path", "--admin-console-password", "123", --http-proxy=http://user:password@localhost:8080],
+// it will return ["--license", "./path", "--admin-console-password", "*****", --http-proxy=*****].
 func redactFlags(flags []string) []string {
 	result := make([]string, len(flags))
 
 	valueHasSecret := false
 	for i, flag := range flags {
-		// The previous iteration detected one of the secret keywords on flag key, let's redact this value
+		// The previous iteration detected one of the flags to redact, let's redact this value
 		if valueHasSecret {
 			result[i] = "*****"
 			valueHasSecret = false
@@ -50,8 +50,8 @@ func redactFlags(flags []string) []string {
 			key := flagParts[0]
 			value := flagParts[1]
 
-			// If the key has a secret keyword and the value is not empty, redact it
-			if hasSecretKeyword(key) && len(value) > 0 {
+			// If the key is a flag to redact and the value is not empty, redact it
+			if hasFlagToRedact(key) && len(value) > 0 {
 				result[i] = key + "=*****"
 			} else {
 				result[i] = flag
@@ -60,18 +60,18 @@ func redactFlags(flags []string) []string {
 		}
 
 		result[i] = flag
-		// This is a flag value no point in checking it for the secret keywords
+		// This is a flag value no point in checking it for secrets to redact
 		if !isFlagKey {
 			continue
 		}
-		valueHasSecret = hasSecretKeyword(flag)
+		valueHasSecret = hasFlagToRedact(flag)
 	}
 	return result
 }
 
-func hasSecretKeyword(value string) bool {
-	for _, keyword := range secretKeywords {
-		if strings.Contains(value, keyword) {
+func hasFlagToRedact(value string) bool {
+	for _, flag := range flagsToRedact {
+		if strings.Contains(value, flag) {
 			return true
 		}
 	}

--- a/pkg/metrics/util.go
+++ b/pkg/metrics/util.go
@@ -27,29 +27,53 @@ func EventPayload(ev types.Event) ([]byte, error) {
 var secretKeywords = []string{"password", "secret", "token", "key"}
 
 // redactFlags redacts presumed secret values from a string slice based on preset keywords.
-// For example, given ["--license", "./path", "--password", "123"], it will return ["--license", "./path", "--password", "*****"]
+// For example, given ["--license", "./path", "--password", "123", "--a-secret=123"]
+// it will return ["--license", "./path", "--password", "*****", "--a-secret=*****"]"
 func redactFlags(flags []string) []string {
 	result := make([]string, len(flags))
 
 	valueHasSecret := false
 	for i, flag := range flags {
-		// Check if the is the flag name or the value
-		isFlagKey := strings.HasPrefix(flag, "-")
-		// This is a flag value and the previous iteration detected one of the secret keywords, let's redact it
-		if !isFlagKey && valueHasSecret {
+		// The previous iteration detected one of the secret keywords on flag key, let's redact this value
+		if valueHasSecret {
 			result[i] = "*****"
+			valueHasSecret = false
 			continue
 		}
+		// Check if this is the flag name or the value
+		isFlagKey := strings.HasPrefix(flag, "-")
+		// Flag is of the form --key=value
+		if isFlagKey && strings.Contains(flag, "=") {
+
+			// Split the flag into key and value
+			flagParts := strings.Split(flag, "=")
+			key := flagParts[0]
+			value := flagParts[1]
+
+			// If the key has a secret keyword and the value is not empty, redact it
+			if hasSecretKeyword(key) && len(value) > 0 {
+				result[i] = key + "=*****"
+			} else {
+				result[i] = flag
+			}
+			continue
+		}
+
 		result[i] = flag
 		// This is a flag value no point in checking it for the secret keywords
 		if !isFlagKey {
 			continue
 		}
-		for _, keyword := range secretKeywords {
-			if valueHasSecret = strings.Contains(flag, keyword); valueHasSecret {
-				break
-			}
-		}
+		valueHasSecret = hasSecretKeyword(flag)
 	}
 	return result
+}
+
+func hasSecretKeyword(value string) bool {
+	for _, keyword := range secretKeywords {
+		if strings.Contains(value, keyword) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/metrics/util_test.go
+++ b/pkg/metrics/util_test.go
@@ -1,0 +1,47 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedactFlags(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		flags    []string
+		expected []string
+	}{
+		{
+			name:     "boolean secret flag",
+			flags:    []string{"some-command", "--boolean-flag-password"},
+			expected: []string{"some-command", "--boolean-flag-password"},
+		},
+		{
+			name:     "boolean flag followed by a flag to redact",
+			flags:    []string{"some-command", "--boolean-flag-password", "--admin-console-password", "value"},
+			expected: []string{"some-command", "--boolean-flag-password", "--admin-console-password", "*****"},
+		},
+		{
+			name:     "flag to redact followed by other flags",
+			flags:    []string{"some-secret-command", "--admin-console-password", "value", "--some-key", "some-value"},
+			expected: []string{"some-secret-command", "--admin-console-password", "*****", "--some-key", "some-value"},
+		},
+		{
+			name:     "redacts admin-console-password, http-proxy and https-proxy flags",
+			flags:    []string{"some-secret-command", "--admin-console-password", "value", "--https-proxy", "some-value", "--http-proxy", "another-value"},
+			expected: []string{"some-secret-command", "--admin-console-password", "*****", "--https-proxy", "*****", "--http-proxy", "*****"},
+		},
+		{
+			name:     "redacts flags using `=` assignement",
+			flags:    []string{"some-secret-command", "--admin-console-password=value", "--https-proxy", "some-value", "--no-secret", "another-value"},
+			expected: []string{"some-secret-command", "--admin-console-password=*****", "--https-proxy", "*****", "--no-secret", "another-value"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			req := require.New(t)
+			result := redactFlags(test.flags)
+			req.Equal(test.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Redact secrets sent through the metrics package through the flags parameter for installations. We do this by filtering the provided flags and, upon detecting predefined flags, redact the provided values and replace them by `"*****"`.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/116082/redact-secrets-from-embedded-cluster-bot-alerts-slack-channel

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Automated tests added.

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Redact potential secret information sent to our metrics backend through the provided flag parameters
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
