### PR TITLE
increase maximum airgap bundle build wait from 10m to 20m, with shorter increments

### DIFF
--- a/e2e/airgap.go
+++ b/e2e/airgap.go
@@ -9,10 +9,10 @@ import (
 )
 
 // downloadAirgapBundle downloads the airgap bundle for the given version to the destination path.
-// It retries the download up to 5 times if the bundle is less than 1GB.
+// It retries the download up to 20 times if the bundle is less than 1GB.
 // It cannot call t.Fatalf as it is used in a goroutine.
 func downloadAirgapBundle(t *testing.T, versionLabel string, destPath string, licenseID string) error {
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 20; i++ {
 		size, err := maybeDownloadAirgapBundle(versionLabel, destPath, licenseID)
 		if err != nil {
 			// when we deploy the api to staging it interrupts the download
@@ -28,7 +28,7 @@ func downloadAirgapBundle(t *testing.T, versionLabel string, destPath string, li
 				return fmt.Errorf("failed to remove airgap bundle at %s: %w", destPath, err)
 			}
 		}
-		time.Sleep(2 * time.Minute)
+		time.Sleep(1 * time.Minute)
 	}
 	return fmt.Errorf("failed to download airgap bundle for version %s after 5 attempts", versionLabel)
 }


### PR DESCRIPTION
an update to the API code makes these requests fail fast if there is no airgap bundle built instead of allowing a 300mb download, so there was dramatically less time being spent in this function than before

#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
