### PR TITLE
feat(preflights): add support for TCP connection checks on the hpc template

### DIFF
--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -209,7 +209,7 @@ func InstallCmd(ctx context.Context, name string) *cobra.Command {
 				return fmt.Errorf("unable to determine pod and service CIDRs: %w", err)
 			}
 
-			if err := RunHostPreflights(cmd, applier, replicatedAPIURL, proxyRegistryURL, isAirgap, proxy, cidrCfg, assumeYes); err != nil {
+			if err := RunHostPreflights(cmd, applier, replicatedAPIURL, proxyRegistryURL, isAirgap, proxy, cidrCfg, nil, assumeYes); err != nil {
 				metrics.ReportApplyFinished(cmd.Context(), licenseFile, nil, err)
 				if err == ErrPreflightsHaveFail {
 					return ErrNothingElseToAdd

--- a/cmd/installer/cli/install_runpreflights.go
+++ b/cmd/installer/cli/install_runpreflights.go
@@ -126,7 +126,7 @@ func InstallRunPreflightsCmd(ctx context.Context, name string) *cobra.Command {
 				return fmt.Errorf("unable to determine pod and service CIDRs: %w", err)
 			}
 
-			if err := RunHostPreflights(cmd, applier, replicatedAPIURL, proxyRegistryURL, isAirgap, proxy, cidrCfg, assumeYes); err != nil {
+			if err := RunHostPreflights(cmd, applier, replicatedAPIURL, proxyRegistryURL, isAirgap, proxy, cidrCfg, nil, assumeYes); err != nil {
 				if err == ErrPreflightsHaveFail {
 					return ErrNothingElseToAdd
 				}
@@ -330,7 +330,7 @@ func getAddonsApplier(cmd *cobra.Command, opts addonsApplierOpts, adminConsolePw
 // RunHostPreflights runs the host preflights we found embedded in the binary
 // on all configured hosts. We attempt to read HostPreflights from all the
 // embedded Helm Charts and from the Kots Application Release files.
-func RunHostPreflights(cmd *cobra.Command, applier *addons.Applier, replicatedAPIURL, proxyRegistryURL string, isAirgap bool, proxy *ecv1beta1.ProxySpec, cidrCfg *CIDRConfig, assumeYes bool) error {
+func RunHostPreflights(cmd *cobra.Command, applier *addons.Applier, replicatedAPIURL, proxyRegistryURL string, isAirgap bool, proxy *ecv1beta1.ProxySpec, cidrCfg *CIDRConfig, tcpConnectionsRequired []string, assumeYes bool) error {
 	hpf, err := applier.HostPreflights()
 	if err != nil {
 		return fmt.Errorf("unable to read host preflights: %w", err)
@@ -351,6 +351,7 @@ func RunHostPreflights(cmd *cobra.Command, applier *addons.Applier, replicatedAP
 		SystemArchitecture:      runtime.GOARCH,
 		FromCIDR:                cidrCfg.PodCIDR,
 		ToCIDR:                  cidrCfg.ServiceCIDR,
+		TCPConnectionsRequired:  tcpConnectionsRequired,
 	}.WithCIDRData(cidrCfg.PodCIDR, cidrCfg.ServiceCIDR, cidrCfg.GlobalCIDR)
 
 	if err != nil {

--- a/cmd/installer/cli/join.go
+++ b/cmd/installer/cli/join.go
@@ -14,6 +14,7 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/helpers"
 	"github.com/replicatedhq/embedded-cluster/pkg/highavailability"
 	"github.com/replicatedhq/embedded-cluster/pkg/k0s"
+	"github.com/replicatedhq/embedded-cluster/pkg/kotsadm"
 	"github.com/replicatedhq/embedded-cluster/pkg/kubeutils"
 	"github.com/replicatedhq/embedded-cluster/pkg/metrics"
 	"github.com/replicatedhq/embedded-cluster/pkg/netutils"
@@ -85,7 +86,7 @@ func JoinCmd(ctx context.Context, name string) *cobra.Command {
 			}
 
 			logrus.Debugf("fetching join token remotely")
-			jcmd, err := getJoinToken(cmd.Context(), args[0], args[1])
+			jcmd, err := kotsadm.GetJoinToken(cmd.Context(), args[0], args[1])
 			if err != nil {
 				return fmt.Errorf("unable to get join token: %w", err)
 			}
@@ -347,7 +348,7 @@ func startK0sService() error {
 	return nil
 }
 
-func applyNetworkConfiguration(cmd *cobra.Command, jcmd *JoinCommandResponse) error {
+func applyNetworkConfiguration(cmd *cobra.Command, jcmd *kotsadm.JoinCommandResponse) error {
 	if jcmd.InstallationSpec.Network != nil {
 		clusterSpec := config.RenderK0sConfig()
 
@@ -385,7 +386,7 @@ func applyNetworkConfiguration(cmd *cobra.Command, jcmd *JoinCommandResponse) er
 }
 
 // startAndWaitForK0s starts the k0s service and waits for the node to be ready.
-func startAndWaitForK0s(cmd *cobra.Command, name string, jcmd *JoinCommandResponse) error {
+func startAndWaitForK0s(cmd *cobra.Command, name string, jcmd *kotsadm.JoinCommandResponse) error {
 	loading := spinner.Start()
 	defer loading.Close()
 	loading.Infof("Installing %s node", name)
@@ -410,7 +411,7 @@ func startAndWaitForK0s(cmd *cobra.Command, name string, jcmd *JoinCommandRespon
 
 // applyJoinConfigurationOverrides applies both config overrides received from the kots api.
 // Applies first the EmbeddedOverrides and then the EndUserOverrides.
-func applyJoinConfigurationOverrides(jcmd *JoinCommandResponse) error {
+func applyJoinConfigurationOverrides(jcmd *kotsadm.JoinCommandResponse) error {
 	patch, err := jcmd.EmbeddedOverrides()
 	if err != nil {
 		return fmt.Errorf("unable to get embedded overrides: %w", err)

--- a/cmd/installer/cli/join.go
+++ b/cmd/installer/cli/join.go
@@ -182,7 +182,7 @@ func JoinCmd(ctx context.Context, name string) *cobra.Command {
 			// jcmd.InstallationSpec.MetricsBaseURL is the replicated.app endpoint url
 			replicatedAPIURL := jcmd.InstallationSpec.MetricsBaseURL
 			proxyRegistryURL := fmt.Sprintf("https://%s", runtimeconfig.ProxyRegistryAddress)
-			if err := RunHostPreflights(cmd, applier, replicatedAPIURL, proxyRegistryURL, isAirgap, jcmd.InstallationSpec.Proxy, cidrCfg, assumeYes); err != nil {
+			if err := RunHostPreflights(cmd, applier, replicatedAPIURL, proxyRegistryURL, isAirgap, jcmd.InstallationSpec.Proxy, cidrCfg, jcmd.TCPConnectionsRequired, assumeYes); err != nil {
 				metrics.ReportJoinFailed(cmd.Context(), jcmd.InstallationSpec.MetricsBaseURL, jcmd.ClusterID, err)
 				if err == ErrPreflightsHaveFail {
 					return ErrNothingElseToAdd

--- a/cmd/installer/cli/join_runpreflights.go
+++ b/cmd/installer/cli/join_runpreflights.go
@@ -122,7 +122,7 @@ func JoinRunPreflightsCmd(ctx context.Context, name string) *cobra.Command {
 			logrus.Debugf("running host preflights")
 			replicatedAPIURL := jcmd.InstallationSpec.MetricsBaseURL
 			proxyRegistryURL := fmt.Sprintf("https://%s", runtimeconfig.ProxyRegistryAddress)
-			if err := RunHostPreflights(cmd, applier, replicatedAPIURL, proxyRegistryURL, isAirgap, jcmd.InstallationSpec.Proxy, cidrCfg, assumeYes); err != nil {
+			if err := RunHostPreflights(cmd, applier, replicatedAPIURL, proxyRegistryURL, isAirgap, jcmd.InstallationSpec.Proxy, cidrCfg, jcmd.TCPConnectionsRequired, assumeYes); err != nil {
 				if err == ErrPreflightsHaveFail {
 					return ErrNothingElseToAdd
 				}

--- a/cmd/installer/cli/join_runpreflights.go
+++ b/cmd/installer/cli/join_runpreflights.go
@@ -157,6 +157,7 @@ type JoinCommandResponse struct {
 	ClusterID              uuid.UUID                  `json:"clusterID"`
 	EmbeddedClusterVersion string                     `json:"embeddedClusterVersion"`
 	AirgapRegistryAddress  string                     `json:"airgapRegistryAddress"`
+	TCPConnectionsRequired []string                   `json:"tcpConnectionsRequired"`
 	InstallationSpec       ecv1beta1.InstallationSpec `json:"installationSpec,omitempty"`
 }
 

--- a/cmd/installer/cli/join_runpreflights.go
+++ b/cmd/installer/cli/join_runpreflights.go
@@ -2,24 +2,18 @@ package cli
 
 import (
 	"context"
-	"crypto/tls"
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"os"
 	"strings"
-	"time"
 
-	"github.com/google/uuid"
-	"github.com/k0sproject/dig"
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg/configutils"
+	"github.com/replicatedhq/embedded-cluster/pkg/kotsadm"
 	"github.com/replicatedhq/embedded-cluster/pkg/netutils"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/replicatedhq/embedded-cluster/pkg/versions"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 )
 
 func JoinRunPreflightsCmd(ctx context.Context, name string) *cobra.Command {
@@ -47,7 +41,7 @@ func JoinRunPreflightsCmd(ctx context.Context, name string) *cobra.Command {
 			}
 
 			logrus.Debugf("fetching join token remotely")
-			jcmd, err := getJoinToken(cmd.Context(), args[0], args[1])
+			jcmd, err := kotsadm.GetJoinToken(cmd.Context(), args[0], args[1])
 			if err != nil {
 				return fmt.Errorf("unable to get join token: %w", err)
 			}
@@ -148,73 +142,4 @@ func JoinRunPreflightsCmd(ctx context.Context, name string) *cobra.Command {
 	cmd.Flags().SetNormalizeFunc(normalizeNoPromptToYes)
 
 	return cmd
-}
-
-// JoinCommandResponse is the response from the kots api we use to fetch the k0s join token.
-type JoinCommandResponse struct {
-	K0sJoinCommand         string                     `json:"k0sJoinCommand"`
-	K0sToken               string                     `json:"k0sToken"`
-	ClusterID              uuid.UUID                  `json:"clusterID"`
-	EmbeddedClusterVersion string                     `json:"embeddedClusterVersion"`
-	AirgapRegistryAddress  string                     `json:"airgapRegistryAddress"`
-	TCPConnectionsRequired []string                   `json:"tcpConnectionsRequired"`
-	InstallationSpec       ecv1beta1.InstallationSpec `json:"installationSpec,omitempty"`
-}
-
-// extractK0sConfigOverridePatch parses the provided override and returns a dig.Mapping that
-// can be then applied on top a k0s configuration file to set both `api` and `storage` spec
-// fields. All other fields in the override are ignored.
-func (j JoinCommandResponse) extractK0sConfigOverridePatch(data []byte) (dig.Mapping, error) {
-	config := dig.Mapping{}
-	if err := yaml.Unmarshal(data, &config); err != nil {
-		return nil, fmt.Errorf("unable to unmarshal embedded config: %w", err)
-	}
-	result := dig.Mapping{}
-	if api := config.DigMapping("config", "spec", "api"); len(api) > 0 {
-		result.DigMapping("config", "spec")["api"] = api
-	}
-	if storage := config.DigMapping("config", "spec", "storage"); len(storage) > 0 {
-		result.DigMapping("config", "spec")["storage"] = storage
-	}
-	return result, nil
-}
-
-// EndUserOverrides returns a dig.Mapping that can be applied on top of a k0s configuration.
-// This patch is assembled based on the EndUserK0sConfigOverrides field.
-func (j JoinCommandResponse) EndUserOverrides() (dig.Mapping, error) {
-	return j.extractK0sConfigOverridePatch([]byte(j.InstallationSpec.EndUserK0sConfigOverrides))
-}
-
-// EmbeddedOverrides returns a dig.Mapping that can be applied on top of a k0s configuration.
-// This patch is assembled based on the K0sUnsupportedOverrides field.
-func (j JoinCommandResponse) EmbeddedOverrides() (dig.Mapping, error) {
-	return j.extractK0sConfigOverridePatch([]byte(j.InstallationSpec.Config.UnsupportedOverrides.K0s))
-}
-
-// getJoinToken issues a request to the kots api to get the actual join command
-// based on the short token provided by the user.
-func getJoinToken(ctx context.Context, baseURL, shortToken string) (*JoinCommandResponse, error) {
-	url := fmt.Sprintf("https://%s/api/v1/embedded-cluster/join?token=%s", baseURL, shortToken)
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, fmt.Errorf("unable to create request: %w", err)
-	}
-
-	// this will generally be a self-signed certificate created by kurl-proxy
-	insecureClient := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
-	resp, err := insecureClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("unable to get join token: %w", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-	}
-	var command JoinCommandResponse
-	if err := json.NewDecoder(resp.Body).Decode(&command); err != nil {
-		return nil, fmt.Errorf("unable to decode response: %w", err)
-	}
-	return &command, nil
 }

--- a/pkg/dryrun/dryrun.go
+++ b/pkg/dryrun/dryrun.go
@@ -9,6 +9,7 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/dryrun/types"
 	"github.com/replicatedhq/embedded-cluster/pkg/helpers"
 	"github.com/replicatedhq/embedded-cluster/pkg/k0s"
+	"github.com/replicatedhq/embedded-cluster/pkg/kotsadm"
 	"github.com/replicatedhq/embedded-cluster/pkg/kubeutils"
 	"github.com/replicatedhq/embedded-cluster/pkg/metrics"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
@@ -28,6 +29,7 @@ type Client struct {
 	Helpers   *Helpers
 	Metrics   *Sender
 	K0sClient *K0sClient
+	Kotsadm   *Kotsadm
 }
 
 func Init(outputFile string, client *Client) {
@@ -53,10 +55,14 @@ func Init(outputFile string, client *Client) {
 	if client.K0sClient == nil {
 		client.K0sClient = &K0sClient{}
 	}
+	if client.Kotsadm == nil {
+		client.Kotsadm = NewKotsadm()
+	}
 	kubeutils.Set(client.KubeUtils)
 	helpers.Set(client.Helpers)
 	metrics.Set(client.Metrics)
 	k0s.Set(client.K0sClient)
+	kotsadm.Set(client.Kotsadm)
 }
 
 func Dump() error {

--- a/pkg/dryrun/kotsadm.go
+++ b/pkg/dryrun/kotsadm.go
@@ -1,0 +1,62 @@
+package dryrun
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/replicatedhq/embedded-cluster/pkg/kotsadm"
+)
+
+var _ kotsadm.ClientInterface = (*Kotsadm)(nil)
+
+type response struct {
+	resp interface{}
+	err  error
+}
+
+type Kotsadm struct {
+	mockHandlers map[string]response
+}
+
+func NewKotsadm() *Kotsadm {
+	return &Kotsadm{
+		mockHandlers: map[string]response{},
+	}
+}
+
+func (c *Kotsadm) setResponse(resp interface{}, err error, methodName string, args ...string) error {
+	methodExists := false
+	t := reflect.TypeOf(c)
+	for i := 0; i < t.NumMethod(); i++ {
+		if methodExists = t.Method(i).Name == methodName; methodExists {
+			break
+		}
+	}
+	if !methodExists {
+		return fmt.Errorf("method %s does not exist, cannot mock reponse", methodName)
+	}
+	key := strings.Join(append([]string{methodName}, args...), ":")
+	c.mockHandlers[key] = response{resp: resp, err: err}
+	return nil
+}
+
+func (c *Kotsadm) SetGetJoinTokenResponse(baseURL, shortToken string, resp *kotsadm.JoinCommandResponse, err error) {
+	mockErr := c.setResponse(resp, err, "GetJoinToken", baseURL, shortToken)
+	if mockErr != nil {
+		panic(mockErr)
+	}
+}
+
+// GetJoinToken issues a request to the kots api to get the actual join command
+// based on the short token provided by the user.
+func (c *Kotsadm) GetJoinToken(ctx context.Context, baseURL, shortToken string) (*kotsadm.JoinCommandResponse, error) {
+	key := strings.Join([]string{"GetJoinToken", baseURL, shortToken}, ":")
+	fmt.Println(c.mockHandlers)
+	if handler, ok := c.mockHandlers[key]; ok {
+		return handler.resp.(*kotsadm.JoinCommandResponse), handler.err
+	} else {
+		return nil, fmt.Errorf("no response set for GetJoinToken, baseURL: %s, shortToken: %s", baseURL, shortToken)
+	}
+}

--- a/pkg/dryrun/kotsadm.go
+++ b/pkg/dryrun/kotsadm.go
@@ -56,7 +56,6 @@ func (c *Kotsadm) SetGetJoinTokenResponse(baseURL, shortToken string, resp *kots
 // based on the short token provided by the user.
 func (c *Kotsadm) GetJoinToken(ctx context.Context, baseURL, shortToken string) (*kotsadm.JoinCommandResponse, error) {
 	key := strings.Join([]string{"GetJoinToken", baseURL, shortToken}, ":")
-	fmt.Println(c.mockHandlers)
 	if handler, ok := c.mockHandlers[key]; ok {
 		return handler.resp.(*kotsadm.JoinCommandResponse), handler.err
 	} else {

--- a/pkg/dryrun/kotsadm.go
+++ b/pkg/dryrun/kotsadm.go
@@ -16,10 +16,12 @@ type response struct {
 	err  error
 }
 
+// Kotsadm is a mockable implementation of the kotsadm.ClientInterface.
 type Kotsadm struct {
 	mockHandlers map[string]response
 }
 
+// NewKotsadm returns a new Kotsadm API client, to be used with the dryrun package.
 func NewKotsadm() *Kotsadm {
 	return &Kotsadm{
 		mockHandlers: map[string]response{},
@@ -42,6 +44,7 @@ func (c *Kotsadm) setResponse(resp interface{}, err error, methodName string, ar
 	return nil
 }
 
+// SetGetJoinTokenResponse sets the response for the GetJoinToken method, based on the provided baseURL and shortToken.
 func (c *Kotsadm) SetGetJoinTokenResponse(baseURL, shortToken string, resp *kotsadm.JoinCommandResponse, err error) {
 	mockErr := c.setResponse(resp, err, "GetJoinToken", baseURL, shortToken)
 	if mockErr != nil {

--- a/pkg/kotsadm/client.go
+++ b/pkg/kotsadm/client.go
@@ -1,0 +1,42 @@
+package kotsadm
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+var _ ClientInterface = (*Client)(nil)
+
+type Client struct{}
+
+// GetJoinToken issues a request to the kots api to get the actual join command
+// based on the short token provided by the user.
+func (c *Client) GetJoinToken(ctx context.Context, baseURL, shortToken string) (*JoinCommandResponse, error) {
+	url := fmt.Sprintf("https://%s/api/v1/embedded-cluster/join?token=%s", baseURL, shortToken)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create request: %w", err)
+	}
+
+	// this will generally be a self-signed certificate created by kurl-proxy
+	insecureClient := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
+	resp, err := insecureClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get join token: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+	var command JoinCommandResponse
+	if err := json.NewDecoder(resp.Body).Decode(&command); err != nil {
+		return nil, fmt.Errorf("unable to decode response: %w", err)
+	}
+	return &command, nil
+}

--- a/pkg/kotsadm/interface.go
+++ b/pkg/kotsadm/interface.go
@@ -1,0 +1,29 @@
+package kotsadm
+
+import (
+	"context"
+)
+
+var (
+	_kotsadm ClientInterface
+)
+
+func init() {
+	Set(&Client{})
+}
+
+func Set(kotsadm ClientInterface) {
+	_kotsadm = kotsadm
+}
+
+type ClientInterface interface {
+	GetJoinToken(ctx context.Context, baseURL, shortToken string) (*JoinCommandResponse, error)
+}
+
+// Convenience functions
+
+// GetJoinToken is a helper function that issues a request to the kots api to get the actual join command
+// based on the short token provided by the user.
+func GetJoinToken(ctx context.Context, baseURL, shortToken string) (*JoinCommandResponse, error) {
+	return _kotsadm.GetJoinToken(ctx, baseURL, shortToken)
+}

--- a/pkg/kotsadm/types.go
+++ b/pkg/kotsadm/types.go
@@ -1,0 +1,51 @@
+package kotsadm
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/k0sproject/dig"
+	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"gopkg.in/yaml.v2"
+)
+
+// JoinCommandResponse is the response from the kots api we use to fetch the k0s join token.
+type JoinCommandResponse struct {
+	K0sJoinCommand         string                     `json:"k0sJoinCommand"`
+	K0sToken               string                     `json:"k0sToken"`
+	ClusterID              uuid.UUID                  `json:"clusterID"`
+	EmbeddedClusterVersion string                     `json:"embeddedClusterVersion"`
+	AirgapRegistryAddress  string                     `json:"airgapRegistryAddress"`
+	TCPConnectionsRequired []string                   `json:"tcpConnectionsRequired"`
+	InstallationSpec       ecv1beta1.InstallationSpec `json:"installationSpec,omitempty"`
+}
+
+// extractK0sConfigOverridePatch parses the provided override and returns a dig.Mapping that
+// can be then applied on top a k0s configuration file to set both `api` and `storage` spec
+// fields. All other fields in the override are ignored.
+func (j JoinCommandResponse) extractK0sConfigOverridePatch(data []byte) (dig.Mapping, error) {
+	config := dig.Mapping{}
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal embedded config: %w", err)
+	}
+	result := dig.Mapping{}
+	if api := config.DigMapping("config", "spec", "api"); len(api) > 0 {
+		result.DigMapping("config", "spec")["api"] = api
+	}
+	if storage := config.DigMapping("config", "spec", "storage"); len(storage) > 0 {
+		result.DigMapping("config", "spec")["storage"] = storage
+	}
+	return result, nil
+}
+
+// EndUserOverrides returns a dig.Mapping that can be applied on top of a k0s configuration.
+// This patch is assembled based on the EndUserK0sConfigOverrides field.
+func (j JoinCommandResponse) EndUserOverrides() (dig.Mapping, error) {
+	return j.extractK0sConfigOverridePatch([]byte(j.InstallationSpec.EndUserK0sConfigOverrides))
+}
+
+// EmbeddedOverrides returns a dig.Mapping that can be applied on top of a k0s configuration.
+// This patch is assembled based on the K0sUnsupportedOverrides field.
+func (j JoinCommandResponse) EmbeddedOverrides() (dig.Mapping, error) {
+	return j.extractK0sConfigOverridePatch([]byte(j.InstallationSpec.Config.UnsupportedOverrides.K0s))
+}

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -153,6 +153,12 @@ spec:
         collectorName: check-network-namespace-connectivity
         fromCIDR: '{{ .FromCIDR }}'
         toCIDR: '{{ .ToCIDR }}'
+{{- range $index, $element := .TCPConnectionsRequired}}
+    - tcpConnect:
+        collectorName: 'tcp-connect-{{$index}}'
+        address: '{{ $element }}'
+        timeout: 30s
+{{- end}}
   analyzers:
     - cpu:
         checkName: CPU
@@ -891,3 +897,15 @@ spec:
             message: Communication between {{ "{{ .FromCIDR }}" }} and {{ "{{ .ToCIDR }}" }} is working
         - fail:
             message: Network communication between the pods network CIDR {{ "{{ .FromCIDR }}" }} and the services network CIDR {{ "{{ .ToCIDR }}" }} is currently disrupted on this node. This issue may prevent pods from properly interacting with services. To resolve this, please review and adjust the firewall configuration on this node to ensure it allows traffic between these network CIDRs.
+{{- range $index, $element := .TCPConnectionsRequired}}
+    - tcpConnect:
+        checkName: "TCP Connection to {{ $element }}"
+        collectorName: "tcp-connect-{{$index}}"
+        outcomes:
+          - fail:
+              when: "error"
+              message: "Error connecting to {{ $element }}. Ensure that the host can connect to {{ $element }}."
+          - pass:
+              when: "connected"
+              message: "Successfully connected to {{ $element }}."
+{{- end}}

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -903,8 +903,14 @@ spec:
         collectorName: "tcp-connect-{{$index}}"
         outcomes:
           - fail:
+              when: "connection-refused"
+              message: "Error connecting to {{ $element }}. Connection refused. Ensure that the host can connect to {{ $element }}."
+          - fail:
+              when: "connection-timeout"
+              message: "Error connecting to {{ $element }}. Connection timed out. Ensure that the host can connect to {{ $element }}."
+          - fail:
               when: "error"
-              message: "Error connecting to {{ $element }}. Ensure that the host can connect to {{ $element }}."
+              message: "Error connecting to {{ $element }}. Unexpected Error. Ensure that the host can connect to {{ $element }}."
           - pass:
               when: "connected"
               message: "Successfully connected to {{ $element }}."

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -904,13 +904,13 @@ spec:
         outcomes:
           - fail:
               when: "connection-refused"
-              message: "A TCP connection to {{ $element }} is required, but the connection was refused. This can occur if IP routing is not possible between this host and {{ $element }}, if your firewall doesn’t allow traffic between this host and {{ $element }}, etc."
+              message: "A TCP connection to {{ $element }} is required, but the connection was refused. This can occur, for example, if IP routing is not possible between this host and {{ $element }}, or if your firewall doesn’t allow traffic between this host and {{ $element }}."
           - fail:
               when: "connection-timeout"
-              message: "A TCP connection to {{ $element }} is required, but the connection timed out. This can occur if IP routing is not possible between this host and {{ $element }}, if your firewall doesn’t allow traffic between this host and {{ $element }}, etc."
+              message: "A TCP connection to {{ $element }} is required, but the connection timed out. This can occur, for example, if IP routing is not possible between this host and {{ $element }}, or if your firewall doesn’t allow traffic between this host and {{ $element }}."
           - fail:
               when: "error"
-              message: "A TCP connection to {{ $element }} is required, but an unexpected error occurred. This can occur if IP routing is not possible between this host and {{ $element }}, if your firewall doesn’t allow traffic between this host and {{ $element }}, etc."
+              message: "A TCP connection to {{ $element }} is required, but an unexpected error occurred. This can occur, for example, if IP routing is not possible between this host and {{ $element }}, or if your firewall doesn’t allow traffic between this host and {{ $element }}."
           - pass:
               when: "connected"
               message: "Successful TCP connection to {{ $element }}."

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -910,7 +910,7 @@ spec:
               message: "Error connecting to {{ $element }}. Connection timed out. Ensure that the host can connect to {{ $element }}."
           - fail:
               when: "error"
-              message: "Error connecting to {{ $element }}. Unexpected Error. Ensure that the host can connect to {{ $element }}."
+              message: "Error connecting to {{ $element }}. Unexpected error. Ensure that the host can connect to {{ $element }}."
           - pass:
               when: "connected"
               message: "Successfully connected to {{ $element }}."

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -904,14 +904,14 @@ spec:
         outcomes:
           - fail:
               when: "connection-refused"
-              message: "Error connecting to {{ $element }}. Connection refused. Ensure that the host can connect to {{ $element }}."
+              message: "A TCP connection to {{ $element }} is required, but the connection was refused. This can occur if IP routing is not possible between this host and {{ $element }}, if your firewall doesn’t allow traffic between this host and {{ $element }}, etc."
           - fail:
               when: "connection-timeout"
-              message: "Error connecting to {{ $element }}. Connection timed out. Ensure that the host can connect to {{ $element }}."
+              message: "A TCP connection to {{ $element }} is required, but the connection timed out. This can occur if IP routing is not possible between this host and {{ $element }}, if your firewall doesn’t allow traffic between this host and {{ $element }}, etc."
           - fail:
               when: "error"
-              message: "Error connecting to {{ $element }}. Unexpected error. Ensure that the host can connect to {{ $element }}."
+              message: "A TCP connection to {{ $element }} is required, but an unexpected error occurred. This can occur if IP routing is not possible between this host and {{ $element }}, if your firewall doesn’t allow traffic between this host and {{ $element }}, etc."
           - pass:
               when: "connected"
-              message: "Successfully connected to {{ $element }}."
+              message: "Successful TCP connection to {{ $element }}."
 {{- end}}

--- a/pkg/preflights/template_test.go
+++ b/pkg/preflights/template_test.go
@@ -344,7 +344,7 @@ func TestTemplateNoTCPConnectionsRequired(t *testing.T) {
 
 	req := require.New(t)
 	// No TCP connections are provided
-	tl := TemplateData{}
+	tl := types.TemplateData{}
 	hpfc, err := GetClusterHostPreflights(context.Background(), tl)
 	req.NoError(err)
 
@@ -413,19 +413,19 @@ func TestTemplateTCPConnectionsRequired(t *testing.T) {
 					{
 						Fail: &v1beta2.SingleOutcome{
 							When:    "connection-refused",
-							Message: "A TCP connection to 192.168.10.1:6443 is required, but the connection was refused. This can occur if IP routing is not possible between this host and 192.168.10.1:6443, if your firewall doesn’t allow traffic between this host and 192.168.10.1:6443, etc.",
+							Message: "A TCP connection to 192.168.10.1:6443 is required, but the connection was refused. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:6443, or if your firewall doesn’t allow traffic between this host and 192.168.10.1:6443.",
 						},
 					},
 					{
 						Fail: &v1beta2.SingleOutcome{
 							When:    "connection-timeout",
-							Message: "A TCP connection to 192.168.10.1:6443 is required, but the connection timed out. This can occur if IP routing is not possible between this host and 192.168.10.1:6443, if your firewall doesn’t allow traffic between this host and 192.168.10.1:6443, etc.",
+							Message: "A TCP connection to 192.168.10.1:6443 is required, but the connection timed out. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:6443, or if your firewall doesn’t allow traffic between this host and 192.168.10.1:6443.",
 						},
 					},
 					{
 						Fail: &v1beta2.SingleOutcome{
 							When:    "error",
-							Message: "A TCP connection to 192.168.10.1:6443 is required, but an unexpected error occurred. This can occur if IP routing is not possible between this host and 192.168.10.1:6443, if your firewall doesn’t allow traffic between this host and 192.168.10.1:6443, etc.",
+							Message: "A TCP connection to 192.168.10.1:6443 is required, but an unexpected error occurred. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:6443, or if your firewall doesn’t allow traffic between this host and 192.168.10.1:6443.",
 						},
 					},
 					{
@@ -477,19 +477,19 @@ func TestTemplateTCPConnectionsRequired(t *testing.T) {
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "connection-refused",
-								Message: "A TCP connection to 192.168.10.1:6443 is required, but the connection was refused. This can occur if IP routing is not possible between this host and 192.168.10.1:6443, if your firewall doesn’t allow traffic between this host and 192.168.10.1:6443, etc.",
+								Message: "A TCP connection to 192.168.10.1:6443 is required, but the connection was refused. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:6443, or if your firewall doesn’t allow traffic between this host and 192.168.10.1:6443.",
 							},
 						},
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "connection-timeout",
-								Message: "A TCP connection to 192.168.10.1:6443 is required, but the connection timed out. This can occur if IP routing is not possible between this host and 192.168.10.1:6443, if your firewall doesn’t allow traffic between this host and 192.168.10.1:6443, etc.",
+								Message: "A TCP connection to 192.168.10.1:6443 is required, but the connection timed out. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:6443, or if your firewall doesn’t allow traffic between this host and 192.168.10.1:6443.",
 							},
 						},
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "error",
-								Message: "A TCP connection to 192.168.10.1:6443 is required, but an unexpected error occurred. This can occur if IP routing is not possible between this host and 192.168.10.1:6443, if your firewall doesn’t allow traffic between this host and 192.168.10.1:6443, etc.",
+								Message: "A TCP connection to 192.168.10.1:6443 is required, but an unexpected error occurred. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:6443, or if your firewall doesn’t allow traffic between this host and 192.168.10.1:6443.",
 							},
 						},
 						{
@@ -506,19 +506,19 @@ func TestTemplateTCPConnectionsRequired(t *testing.T) {
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "connection-refused",
-								Message: "A TCP connection to 192.168.10.1:9443 is required, but the connection was refused. This can occur if IP routing is not possible between this host and 192.168.10.1:9443, if your firewall doesn’t allow traffic between this host and 192.168.10.1:9443, etc.",
+								Message: "A TCP connection to 192.168.10.1:9443 is required, but the connection was refused. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:9443, or if your firewall doesn’t allow traffic between this host and 192.168.10.1:9443.",
 							},
 						},
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "connection-timeout",
-								Message: "A TCP connection to 192.168.10.1:9443 is required, but the connection timed out. This can occur if IP routing is not possible between this host and 192.168.10.1:9443, if your firewall doesn’t allow traffic between this host and 192.168.10.1:9443, etc.",
+								Message: "A TCP connection to 192.168.10.1:9443 is required, but the connection timed out. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:9443, or if your firewall doesn’t allow traffic between this host and 192.168.10.1:9443.",
 							},
 						},
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "error",
-								Message: "A TCP connection to 192.168.10.1:9443 is required, but an unexpected error occurred. This can occur if IP routing is not possible between this host and 192.168.10.1:9443, if your firewall doesn’t allow traffic between this host and 192.168.10.1:9443, etc.",
+								Message: "A TCP connection to 192.168.10.1:9443 is required, but an unexpected error occurred. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:9443, or if your firewall doesn’t allow traffic between this host and 192.168.10.1:9443.",
 							},
 						},
 						{
@@ -535,19 +535,19 @@ func TestTemplateTCPConnectionsRequired(t *testing.T) {
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "connection-refused",
-								Message: "A TCP connection to 192.168.10.1:2380 is required, but the connection was refused. This can occur if IP routing is not possible between this host and 192.168.10.1:2380, if your firewall doesn’t allow traffic between this host and 192.168.10.1:2380, etc.",
+								Message: "A TCP connection to 192.168.10.1:2380 is required, but the connection was refused. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:2380, or if your firewall doesn’t allow traffic between this host and 192.168.10.1:2380.",
 							},
 						},
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "connection-timeout",
-								Message: "A TCP connection to 192.168.10.1:2380 is required, but the connection timed out. This can occur if IP routing is not possible between this host and 192.168.10.1:2380, if your firewall doesn’t allow traffic between this host and 192.168.10.1:2380, etc.",
+								Message: "A TCP connection to 192.168.10.1:2380 is required, but the connection timed out. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:2380, or if your firewall doesn’t allow traffic between this host and 192.168.10.1:2380.",
 							},
 						},
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "error",
-								Message: "A TCP connection to 192.168.10.1:2380 is required, but an unexpected error occurred. This can occur if IP routing is not possible between this host and 192.168.10.1:2380, if your firewall doesn’t allow traffic between this host and 192.168.10.1:2380, etc.",
+								Message: "A TCP connection to 192.168.10.1:2380 is required, but an unexpected error occurred. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:2380, or if your firewall doesn’t allow traffic between this host and 192.168.10.1:2380.",
 							},
 						},
 						{
@@ -564,19 +564,19 @@ func TestTemplateTCPConnectionsRequired(t *testing.T) {
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "connection-refused",
-								Message: "A TCP connection to 192.168.10.1:10250 is required, but the connection was refused. This can occur if IP routing is not possible between this host and 192.168.10.1:10250, if your firewall doesn’t allow traffic between this host and 192.168.10.1:10250, etc.",
+								Message: "A TCP connection to 192.168.10.1:10250 is required, but the connection was refused. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:10250, or if your firewall doesn’t allow traffic between this host and 192.168.10.1:10250.",
 							},
 						},
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "connection-timeout",
-								Message: "A TCP connection to 192.168.10.1:10250 is required, but the connection timed out. This can occur if IP routing is not possible between this host and 192.168.10.1:10250, if your firewall doesn’t allow traffic between this host and 192.168.10.1:10250, etc.",
+								Message: "A TCP connection to 192.168.10.1:10250 is required, but the connection timed out. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:10250, or if your firewall doesn’t allow traffic between this host and 192.168.10.1:10250.",
 							},
 						},
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "error",
-								Message: "A TCP connection to 192.168.10.1:10250 is required, but an unexpected error occurred. This can occur if IP routing is not possible between this host and 192.168.10.1:10250, if your firewall doesn’t allow traffic between this host and 192.168.10.1:10250, etc.",
+								Message: "A TCP connection to 192.168.10.1:10250 is required, but an unexpected error occurred. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:10250, or if your firewall doesn’t allow traffic between this host and 192.168.10.1:10250.",
 							},
 						},
 						{
@@ -594,7 +594,7 @@ func TestTemplateTCPConnectionsRequired(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			req := require.New(t)
-			tl := TemplateData{TCPConnectionsRequired: test.tcpConnections}
+			tl := types.TemplateData{TCPConnectionsRequired: test.tcpConnections}
 			hpfc, err := GetClusterHostPreflights(context.Background(), tl)
 			req.NoError(err)
 

--- a/pkg/preflights/template_test.go
+++ b/pkg/preflights/template_test.go
@@ -412,8 +412,20 @@ func TestTemplateTCPConnectionsRequired(t *testing.T) {
 				Outcomes: []*v1beta2.Outcome{
 					{
 						Fail: &v1beta2.SingleOutcome{
+							When:    "connection-refused",
+							Message: "Error connecting to 192.168.10.1:6443. Connection refused. Ensure that the host can connect to 192.168.10.1:6443.",
+						},
+					},
+					{
+						Fail: &v1beta2.SingleOutcome{
+							When:    "connection-timeout",
+							Message: "Error connecting to 192.168.10.1:6443. Connection timed out. Ensure that the host can connect to 192.168.10.1:6443.",
+						},
+					},
+					{
+						Fail: &v1beta2.SingleOutcome{
 							When:    "error",
-							Message: "Error connecting to 192.168.10.1:6443. Ensure that the host can connect to 192.168.10.1:6443.",
+							Message: "Error connecting to 192.168.10.1:6443. Unexpected error. Ensure that the host can connect to 192.168.10.1:6443.",
 						},
 					},
 					{
@@ -464,8 +476,20 @@ func TestTemplateTCPConnectionsRequired(t *testing.T) {
 					Outcomes: []*v1beta2.Outcome{
 						{
 							Fail: &v1beta2.SingleOutcome{
+								When:    "connection-refused",
+								Message: "Error connecting to 192.168.10.1:6443. Connection refused. Ensure that the host can connect to 192.168.10.1:6443.",
+							},
+						},
+						{
+							Fail: &v1beta2.SingleOutcome{
+								When:    "connection-timeout",
+								Message: "Error connecting to 192.168.10.1:6443. Connection timed out. Ensure that the host can connect to 192.168.10.1:6443.",
+							},
+						},
+						{
+							Fail: &v1beta2.SingleOutcome{
 								When:    "error",
-								Message: "Error connecting to 192.168.10.1:6443. Ensure that the host can connect to 192.168.10.1:6443.",
+								Message: "Error connecting to 192.168.10.1:6443. Unexpected error. Ensure that the host can connect to 192.168.10.1:6443.",
 							},
 						},
 						{
@@ -481,8 +505,20 @@ func TestTemplateTCPConnectionsRequired(t *testing.T) {
 					Outcomes: []*v1beta2.Outcome{
 						{
 							Fail: &v1beta2.SingleOutcome{
+								When:    "connection-refused",
+								Message: "Error connecting to 192.168.10.1:9443. Connection refused. Ensure that the host can connect to 192.168.10.1:9443.",
+							},
+						},
+						{
+							Fail: &v1beta2.SingleOutcome{
+								When:    "connection-timeout",
+								Message: "Error connecting to 192.168.10.1:9443. Connection timed out. Ensure that the host can connect to 192.168.10.1:9443.",
+							},
+						},
+						{
+							Fail: &v1beta2.SingleOutcome{
 								When:    "error",
-								Message: "Error connecting to 192.168.10.1:9443. Ensure that the host can connect to 192.168.10.1:9443.",
+								Message: "Error connecting to 192.168.10.1:9443. Unexpected error. Ensure that the host can connect to 192.168.10.1:9443.",
 							},
 						},
 						{
@@ -498,8 +534,20 @@ func TestTemplateTCPConnectionsRequired(t *testing.T) {
 					Outcomes: []*v1beta2.Outcome{
 						{
 							Fail: &v1beta2.SingleOutcome{
+								When:    "connection-refused",
+								Message: "Error connecting to 192.168.10.1:2380. Connection refused. Ensure that the host can connect to 192.168.10.1:2380.",
+							},
+						},
+						{
+							Fail: &v1beta2.SingleOutcome{
+								When:    "connection-timeout",
+								Message: "Error connecting to 192.168.10.1:2380. Connection timed out. Ensure that the host can connect to 192.168.10.1:2380.",
+							},
+						},
+						{
+							Fail: &v1beta2.SingleOutcome{
 								When:    "error",
-								Message: "Error connecting to 192.168.10.1:2380. Ensure that the host can connect to 192.168.10.1:2380.",
+								Message: "Error connecting to 192.168.10.1:2380. Unexpected error. Ensure that the host can connect to 192.168.10.1:2380.",
 							},
 						},
 						{
@@ -515,8 +563,20 @@ func TestTemplateTCPConnectionsRequired(t *testing.T) {
 					Outcomes: []*v1beta2.Outcome{
 						{
 							Fail: &v1beta2.SingleOutcome{
+								When:    "connection-refused",
+								Message: "Error connecting to 192.168.10.1:10250. Connection refused. Ensure that the host can connect to 192.168.10.1:10250.",
+							},
+						},
+						{
+							Fail: &v1beta2.SingleOutcome{
+								When:    "connection-timeout",
+								Message: "Error connecting to 192.168.10.1:10250. Connection timed out. Ensure that the host can connect to 192.168.10.1:10250.",
+							},
+						},
+						{
+							Fail: &v1beta2.SingleOutcome{
 								When:    "error",
-								Message: "Error connecting to 192.168.10.1:10250. Ensure that the host can connect to 192.168.10.1:10250.",
+								Message: "Error connecting to 192.168.10.1:10250. Unexpected error. Ensure that the host can connect to 192.168.10.1:10250.",
 							},
 						},
 						{

--- a/pkg/preflights/template_test.go
+++ b/pkg/preflights/template_test.go
@@ -413,25 +413,25 @@ func TestTemplateTCPConnectionsRequired(t *testing.T) {
 					{
 						Fail: &v1beta2.SingleOutcome{
 							When:    "connection-refused",
-							Message: "Error connecting to 192.168.10.1:6443. Connection refused. Ensure that the host can connect to 192.168.10.1:6443.",
+							Message: "A TCP connection to 192.168.10.1:6443 is required, but the connection was refused. This can occur if IP routing is not possible between this host and 192.168.10.1:6443, if your firewall doesn’t allow traffic between this host and 192.168.10.1:6443, etc.",
 						},
 					},
 					{
 						Fail: &v1beta2.SingleOutcome{
 							When:    "connection-timeout",
-							Message: "Error connecting to 192.168.10.1:6443. Connection timed out. Ensure that the host can connect to 192.168.10.1:6443.",
+							Message: "A TCP connection to 192.168.10.1:6443 is required, but the connection timed out. This can occur if IP routing is not possible between this host and 192.168.10.1:6443, if your firewall doesn’t allow traffic between this host and 192.168.10.1:6443, etc.",
 						},
 					},
 					{
 						Fail: &v1beta2.SingleOutcome{
 							When:    "error",
-							Message: "Error connecting to 192.168.10.1:6443. Unexpected error. Ensure that the host can connect to 192.168.10.1:6443.",
+							Message: "A TCP connection to 192.168.10.1:6443 is required, but an unexpected error occurred. This can occur if IP routing is not possible between this host and 192.168.10.1:6443, if your firewall doesn’t allow traffic between this host and 192.168.10.1:6443, etc.",
 						},
 					},
 					{
 						Pass: &v1beta2.SingleOutcome{
 							When:    "connected",
-							Message: "Successfully connected to 192.168.10.1:6443.",
+							Message: "Successful TCP connection to 192.168.10.1:6443.",
 						},
 					},
 				},
@@ -477,25 +477,25 @@ func TestTemplateTCPConnectionsRequired(t *testing.T) {
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "connection-refused",
-								Message: "Error connecting to 192.168.10.1:6443. Connection refused. Ensure that the host can connect to 192.168.10.1:6443.",
+								Message: "A TCP connection to 192.168.10.1:6443 is required, but the connection was refused. This can occur if IP routing is not possible between this host and 192.168.10.1:6443, if your firewall doesn’t allow traffic between this host and 192.168.10.1:6443, etc.",
 							},
 						},
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "connection-timeout",
-								Message: "Error connecting to 192.168.10.1:6443. Connection timed out. Ensure that the host can connect to 192.168.10.1:6443.",
+								Message: "A TCP connection to 192.168.10.1:6443 is required, but the connection timed out. This can occur if IP routing is not possible between this host and 192.168.10.1:6443, if your firewall doesn’t allow traffic between this host and 192.168.10.1:6443, etc.",
 							},
 						},
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "error",
-								Message: "Error connecting to 192.168.10.1:6443. Unexpected error. Ensure that the host can connect to 192.168.10.1:6443.",
+								Message: "A TCP connection to 192.168.10.1:6443 is required, but an unexpected error occurred. This can occur if IP routing is not possible between this host and 192.168.10.1:6443, if your firewall doesn’t allow traffic between this host and 192.168.10.1:6443, etc.",
 							},
 						},
 						{
 							Pass: &v1beta2.SingleOutcome{
 								When:    "connected",
-								Message: "Successfully connected to 192.168.10.1:6443.",
+								Message: "Successful TCP connection to 192.168.10.1:6443.",
 							},
 						},
 					},
@@ -506,25 +506,25 @@ func TestTemplateTCPConnectionsRequired(t *testing.T) {
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "connection-refused",
-								Message: "Error connecting to 192.168.10.1:9443. Connection refused. Ensure that the host can connect to 192.168.10.1:9443.",
+								Message: "A TCP connection to 192.168.10.1:9443 is required, but the connection was refused. This can occur if IP routing is not possible between this host and 192.168.10.1:9443, if your firewall doesn’t allow traffic between this host and 192.168.10.1:9443, etc.",
 							},
 						},
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "connection-timeout",
-								Message: "Error connecting to 192.168.10.1:9443. Connection timed out. Ensure that the host can connect to 192.168.10.1:9443.",
+								Message: "A TCP connection to 192.168.10.1:9443 is required, but the connection timed out. This can occur if IP routing is not possible between this host and 192.168.10.1:9443, if your firewall doesn’t allow traffic between this host and 192.168.10.1:9443, etc.",
 							},
 						},
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "error",
-								Message: "Error connecting to 192.168.10.1:9443. Unexpected error. Ensure that the host can connect to 192.168.10.1:9443.",
+								Message: "A TCP connection to 192.168.10.1:9443 is required, but an unexpected error occurred. This can occur if IP routing is not possible between this host and 192.168.10.1:9443, if your firewall doesn’t allow traffic between this host and 192.168.10.1:9443, etc.",
 							},
 						},
 						{
 							Pass: &v1beta2.SingleOutcome{
 								When:    "connected",
-								Message: "Successfully connected to 192.168.10.1:9443.",
+								Message: "Successful TCP connection to 192.168.10.1:9443.",
 							},
 						},
 					},
@@ -535,25 +535,25 @@ func TestTemplateTCPConnectionsRequired(t *testing.T) {
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "connection-refused",
-								Message: "Error connecting to 192.168.10.1:2380. Connection refused. Ensure that the host can connect to 192.168.10.1:2380.",
+								Message: "A TCP connection to 192.168.10.1:2380 is required, but the connection was refused. This can occur if IP routing is not possible between this host and 192.168.10.1:2380, if your firewall doesn’t allow traffic between this host and 192.168.10.1:2380, etc.",
 							},
 						},
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "connection-timeout",
-								Message: "Error connecting to 192.168.10.1:2380. Connection timed out. Ensure that the host can connect to 192.168.10.1:2380.",
+								Message: "A TCP connection to 192.168.10.1:2380 is required, but the connection timed out. This can occur if IP routing is not possible between this host and 192.168.10.1:2380, if your firewall doesn’t allow traffic between this host and 192.168.10.1:2380, etc.",
 							},
 						},
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "error",
-								Message: "Error connecting to 192.168.10.1:2380. Unexpected error. Ensure that the host can connect to 192.168.10.1:2380.",
+								Message: "A TCP connection to 192.168.10.1:2380 is required, but an unexpected error occurred. This can occur if IP routing is not possible between this host and 192.168.10.1:2380, if your firewall doesn’t allow traffic between this host and 192.168.10.1:2380, etc.",
 							},
 						},
 						{
 							Pass: &v1beta2.SingleOutcome{
 								When:    "connected",
-								Message: "Successfully connected to 192.168.10.1:2380.",
+								Message: "Successful TCP connection to 192.168.10.1:2380.",
 							},
 						},
 					},
@@ -564,25 +564,25 @@ func TestTemplateTCPConnectionsRequired(t *testing.T) {
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "connection-refused",
-								Message: "Error connecting to 192.168.10.1:10250. Connection refused. Ensure that the host can connect to 192.168.10.1:10250.",
+								Message: "A TCP connection to 192.168.10.1:10250 is required, but the connection was refused. This can occur if IP routing is not possible between this host and 192.168.10.1:10250, if your firewall doesn’t allow traffic between this host and 192.168.10.1:10250, etc.",
 							},
 						},
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "connection-timeout",
-								Message: "Error connecting to 192.168.10.1:10250. Connection timed out. Ensure that the host can connect to 192.168.10.1:10250.",
+								Message: "A TCP connection to 192.168.10.1:10250 is required, but the connection timed out. This can occur if IP routing is not possible between this host and 192.168.10.1:10250, if your firewall doesn’t allow traffic between this host and 192.168.10.1:10250, etc.",
 							},
 						},
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "error",
-								Message: "Error connecting to 192.168.10.1:10250. Unexpected error. Ensure that the host can connect to 192.168.10.1:10250.",
+								Message: "A TCP connection to 192.168.10.1:10250 is required, but an unexpected error occurred. This can occur if IP routing is not possible between this host and 192.168.10.1:10250, if your firewall doesn’t allow traffic between this host and 192.168.10.1:10250, etc.",
 							},
 						},
 						{
 							Pass: &v1beta2.SingleOutcome{
 								When:    "connected",
-								Message: "Successfully connected to 192.168.10.1:10250.",
+								Message: "Successful TCP connection to 192.168.10.1:10250.",
 							},
 						},
 					},

--- a/pkg/preflights/template_test.go
+++ b/pkg/preflights/template_test.go
@@ -343,7 +343,8 @@ func TestTemplateWithCIDRData(t *testing.T) {
 func TestTemplateNoTCPConnectionsRequired(t *testing.T) {
 
 	req := require.New(t)
-	tl := TemplateData{TCPConnectionsRequired: []string{"192.10.11.1:9090"}}
+	// No TCP connections are provided
+	tl := TemplateData{}
 	hpfc, err := GetClusterHostPreflights(context.Background(), tl)
 	req.NoError(err)
 

--- a/pkg/preflights/types/template.go
+++ b/pkg/preflights/types/template.go
@@ -32,6 +32,7 @@ type TemplateData struct {
 	NoProxy                 string
 	FromCIDR                string
 	ToCIDR                  string
+	TCPConnectionsRequired  []string
 }
 
 // WithCIDRData sets the respective CIDR properties in the TemplateData struct based on the provided CIDR strings

--- a/tests/dryrun/join_test.go
+++ b/tests/dryrun/join_test.go
@@ -73,25 +73,25 @@ func TestJoinTCPConnectionsRequired(t *testing.T) {
 				assert.Contains(t, hc.TCPConnect.Outcomes, &v1beta2.Outcome{
 					Fail: &v1beta2.SingleOutcome{
 						When:    "connection-refused",
-						Message: "Error connecting to 10.0.0.1:6443. Connection refused. Ensure that the host can connect to 10.0.0.1:6443.",
+						Message: "A TCP connection to 10.0.0.1:6443 is required, but the connection was refused. This can occur if IP routing is not possible between this host and 10.0.0.1:6443, if your firewall doesn’t allow traffic between this host and 10.0.0.1:6443, etc.",
 					},
 				})
 				assert.Contains(t, hc.TCPConnect.Outcomes, &v1beta2.Outcome{
 					Fail: &v1beta2.SingleOutcome{
 						When:    "connection-timeout",
-						Message: "Error connecting to 10.0.0.1:6443. Connection timed out. Ensure that the host can connect to 10.0.0.1:6443.",
+						Message: "A TCP connection to 10.0.0.1:6443 is required, but the connection timed out. This can occur if IP routing is not possible between this host and 10.0.0.1:6443, if your firewall doesn’t allow traffic between this host and 10.0.0.1:6443, etc.",
 					},
 				})
 				assert.Contains(t, hc.TCPConnect.Outcomes, &v1beta2.Outcome{
 					Fail: &v1beta2.SingleOutcome{
 						When:    "error",
-						Message: "Error connecting to 10.0.0.1:6443. Unexpected error. Ensure that the host can connect to 10.0.0.1:6443.",
+						Message: "A TCP connection to 10.0.0.1:6443 is required, but an unexpected error occurred. This can occur if IP routing is not possible between this host and 10.0.0.1:6443, if your firewall doesn’t allow traffic between this host and 10.0.0.1:6443, etc.",
 					},
 				})
 				assert.Contains(t, hc.TCPConnect.Outcomes, &v1beta2.Outcome{
 					Pass: &v1beta2.SingleOutcome{
 						When:    "connected",
-						Message: "Successfully connected to 10.0.0.1:6443.",
+						Message: "Successful TCP connection to 10.0.0.1:6443.",
 					},
 				})
 			},
@@ -104,25 +104,25 @@ func TestJoinTCPConnectionsRequired(t *testing.T) {
 				assert.Contains(t, hc.TCPConnect.Outcomes, &v1beta2.Outcome{
 					Fail: &v1beta2.SingleOutcome{
 						When:    "connection-refused",
-						Message: "Error connecting to 10.0.0.1:9443. Connection refused. Ensure that the host can connect to 10.0.0.1:9443.",
+						Message: "A TCP connection to 10.0.0.1:9443 is required, but the connection was refused. This can occur if IP routing is not possible between this host and 10.0.0.1:9443, if your firewall doesn’t allow traffic between this host and 10.0.0.1:9443, etc.",
 					},
 				})
 				assert.Contains(t, hc.TCPConnect.Outcomes, &v1beta2.Outcome{
 					Fail: &v1beta2.SingleOutcome{
 						When:    "connection-timeout",
-						Message: "Error connecting to 10.0.0.1:9443. Connection timed out. Ensure that the host can connect to 10.0.0.1:9443.",
+						Message: "A TCP connection to 10.0.0.1:9443 is required, but the connection timed out. This can occur if IP routing is not possible between this host and 10.0.0.1:9443, if your firewall doesn’t allow traffic between this host and 10.0.0.1:9443, etc.",
 					},
 				})
 				assert.Contains(t, hc.TCPConnect.Outcomes, &v1beta2.Outcome{
 					Fail: &v1beta2.SingleOutcome{
 						When:    "error",
-						Message: "Error connecting to 10.0.0.1:9443. Unexpected error. Ensure that the host can connect to 10.0.0.1:9443.",
+						Message: "A TCP connection to 10.0.0.1:9443 is required, but an unexpected error occurred. This can occur if IP routing is not possible between this host and 10.0.0.1:9443, if your firewall doesn’t allow traffic between this host and 10.0.0.1:9443, etc.",
 					},
 				})
 				assert.Contains(t, hc.TCPConnect.Outcomes, &v1beta2.Outcome{
 					Pass: &v1beta2.SingleOutcome{
 						When:    "connected",
-						Message: "Successfully connected to 10.0.0.1:9443.",
+						Message: "Successful TCP connection to 10.0.0.1:9443.",
 					},
 				})
 			},

--- a/tests/dryrun/join_test.go
+++ b/tests/dryrun/join_test.go
@@ -1,12 +1,36 @@
 package dryrun
 
 import (
-	_ "embed"
+	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
+	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"github.com/replicatedhq/embedded-cluster/pkg/dryrun"
+	"github.com/replicatedhq/embedded-cluster/pkg/kotsadm"
 )
 
 func TestJoin(t *testing.T) {
+	drFile := filepath.Join(t.TempDir(), "ec-dryrun.yaml")
+	client := &dryrun.Client{
+		Kotsadm: dryrun.NewKotsadm(),
+	}
+	clusterID := uuid.New()
+	jcmd := &kotsadm.JoinCommandResponse{
+		K0sJoinCommand:         "/usr/local/bin/k0s install controller --enable-worker --no-taints --labels kots.io/embedded-cluster-role=total-1,kots.io/embedded-cluster-role-0=controller-test,controller-label=controller-label-value",
+		K0sToken:               "some-k0s-token",
+		EmbeddedClusterVersion: "v0.0.0",
+		ClusterID:              clusterID,
+		InstallationSpec: ecv1beta1.InstallationSpec{
+			ClusterID: clusterID.String(),
+			Config: &ecv1beta1.ConfigSpec{
+				UnsupportedOverrides: ecv1beta1.UnsupportedOverrides{},
+			},
+		},
+	}
+	client.Kotsadm.SetGetJoinTokenResponse("10.0.0.1", "some-token", jcmd, nil)
+	dryrun.Init(drFile, client)
 	dryrunJoin(t, "10.0.0.1", "some-token")
 	t.Logf("%s: test complete", time.Now().Format(time.RFC3339))
 }

--- a/tests/dryrun/join_test.go
+++ b/tests/dryrun/join_test.go
@@ -1,0 +1,12 @@
+package dryrun
+
+import (
+	_ "embed"
+	"testing"
+	"time"
+)
+
+func TestJoin(t *testing.T) {
+	dryrunJoin(t, "192.168.10.1:30000", "some-token")
+	t.Logf("%s: test complete", time.Now().Format(time.RFC3339))
+}

--- a/tests/dryrun/join_test.go
+++ b/tests/dryrun/join_test.go
@@ -73,19 +73,19 @@ func TestJoinTCPConnectionsRequired(t *testing.T) {
 				assert.Contains(t, hc.TCPConnect.Outcomes, &v1beta2.Outcome{
 					Fail: &v1beta2.SingleOutcome{
 						When:    "connection-refused",
-						Message: "A TCP connection to 10.0.0.1:6443 is required, but the connection was refused. This can occur if IP routing is not possible between this host and 10.0.0.1:6443, if your firewall doesn’t allow traffic between this host and 10.0.0.1:6443, etc.",
+						Message: "A TCP connection to 10.0.0.1:6443 is required, but the connection was refused. This can occur, for example, if IP routing is not possible between this host and 10.0.0.1:6443, or if your firewall doesn’t allow traffic between this host and 10.0.0.1:6443.",
 					},
 				})
 				assert.Contains(t, hc.TCPConnect.Outcomes, &v1beta2.Outcome{
 					Fail: &v1beta2.SingleOutcome{
 						When:    "connection-timeout",
-						Message: "A TCP connection to 10.0.0.1:6443 is required, but the connection timed out. This can occur if IP routing is not possible between this host and 10.0.0.1:6443, if your firewall doesn’t allow traffic between this host and 10.0.0.1:6443, etc.",
+						Message: "A TCP connection to 10.0.0.1:6443 is required, but the connection timed out. This can occur, for example, if IP routing is not possible between this host and 10.0.0.1:6443, or if your firewall doesn’t allow traffic between this host and 10.0.0.1:6443.",
 					},
 				})
 				assert.Contains(t, hc.TCPConnect.Outcomes, &v1beta2.Outcome{
 					Fail: &v1beta2.SingleOutcome{
 						When:    "error",
-						Message: "A TCP connection to 10.0.0.1:6443 is required, but an unexpected error occurred. This can occur if IP routing is not possible between this host and 10.0.0.1:6443, if your firewall doesn’t allow traffic between this host and 10.0.0.1:6443, etc.",
+						Message: "A TCP connection to 10.0.0.1:6443 is required, but an unexpected error occurred. This can occur, for example, if IP routing is not possible between this host and 10.0.0.1:6443, or if your firewall doesn’t allow traffic between this host and 10.0.0.1:6443.",
 					},
 				})
 				assert.Contains(t, hc.TCPConnect.Outcomes, &v1beta2.Outcome{
@@ -104,19 +104,19 @@ func TestJoinTCPConnectionsRequired(t *testing.T) {
 				assert.Contains(t, hc.TCPConnect.Outcomes, &v1beta2.Outcome{
 					Fail: &v1beta2.SingleOutcome{
 						When:    "connection-refused",
-						Message: "A TCP connection to 10.0.0.1:9443 is required, but the connection was refused. This can occur if IP routing is not possible between this host and 10.0.0.1:9443, if your firewall doesn’t allow traffic between this host and 10.0.0.1:9443, etc.",
+						Message: "A TCP connection to 10.0.0.1:9443 is required, but the connection was refused. This can occur, for example, if IP routing is not possible between this host and 10.0.0.1:9443, or if your firewall doesn’t allow traffic between this host and 10.0.0.1:9443.",
 					},
 				})
 				assert.Contains(t, hc.TCPConnect.Outcomes, &v1beta2.Outcome{
 					Fail: &v1beta2.SingleOutcome{
 						When:    "connection-timeout",
-						Message: "A TCP connection to 10.0.0.1:9443 is required, but the connection timed out. This can occur if IP routing is not possible between this host and 10.0.0.1:9443, if your firewall doesn’t allow traffic between this host and 10.0.0.1:9443, etc.",
+						Message: "A TCP connection to 10.0.0.1:9443 is required, but the connection timed out. This can occur, for example, if IP routing is not possible between this host and 10.0.0.1:9443, or if your firewall doesn’t allow traffic between this host and 10.0.0.1:9443.",
 					},
 				})
 				assert.Contains(t, hc.TCPConnect.Outcomes, &v1beta2.Outcome{
 					Fail: &v1beta2.SingleOutcome{
 						When:    "error",
-						Message: "A TCP connection to 10.0.0.1:9443 is required, but an unexpected error occurred. This can occur if IP routing is not possible between this host and 10.0.0.1:9443, if your firewall doesn’t allow traffic between this host and 10.0.0.1:9443, etc.",
+						Message: "A TCP connection to 10.0.0.1:9443 is required, but an unexpected error occurred. This can occur, for example, if IP routing is not possible between this host and 10.0.0.1:9443, or if your firewall doesn’t allow traffic between this host and 10.0.0.1:9443.",
 					},
 				})
 				assert.Contains(t, hc.TCPConnect.Outcomes, &v1beta2.Outcome{

--- a/tests/dryrun/join_test.go
+++ b/tests/dryrun/join_test.go
@@ -7,6 +7,6 @@ import (
 )
 
 func TestJoin(t *testing.T) {
-	dryrunJoin(t, "192.168.10.1:30000", "some-token")
+	dryrunJoin(t, "10.0.0.1", "some-token")
 	t.Logf("%s: test complete", time.Now().Format(time.RFC3339))
 }

--- a/tests/dryrun/join_test.go
+++ b/tests/dryrun/join_test.go
@@ -72,8 +72,20 @@ func TestJoinTCPConnectionsRequired(t *testing.T) {
 			validate: func(hc *troubleshootv1beta2.HostAnalyze) {
 				assert.Contains(t, hc.TCPConnect.Outcomes, &v1beta2.Outcome{
 					Fail: &v1beta2.SingleOutcome{
+						When:    "connection-refused",
+						Message: "Error connecting to 10.0.0.1:6443. Connection refused. Ensure that the host can connect to 10.0.0.1:6443.",
+					},
+				})
+				assert.Contains(t, hc.TCPConnect.Outcomes, &v1beta2.Outcome{
+					Fail: &v1beta2.SingleOutcome{
+						When:    "connection-timeout",
+						Message: "Error connecting to 10.0.0.1:6443. Connection timed out. Ensure that the host can connect to 10.0.0.1:6443.",
+					},
+				})
+				assert.Contains(t, hc.TCPConnect.Outcomes, &v1beta2.Outcome{
+					Fail: &v1beta2.SingleOutcome{
 						When:    "error",
-						Message: "Error connecting to 10.0.0.1:6443. Ensure that the host can connect to 10.0.0.1:6443.",
+						Message: "Error connecting to 10.0.0.1:6443. Unexpected error. Ensure that the host can connect to 10.0.0.1:6443.",
 					},
 				})
 				assert.Contains(t, hc.TCPConnect.Outcomes, &v1beta2.Outcome{
@@ -91,8 +103,20 @@ func TestJoinTCPConnectionsRequired(t *testing.T) {
 			validate: func(hc *troubleshootv1beta2.HostAnalyze) {
 				assert.Contains(t, hc.TCPConnect.Outcomes, &v1beta2.Outcome{
 					Fail: &v1beta2.SingleOutcome{
+						When:    "connection-refused",
+						Message: "Error connecting to 10.0.0.1:9443. Connection refused. Ensure that the host can connect to 10.0.0.1:9443.",
+					},
+				})
+				assert.Contains(t, hc.TCPConnect.Outcomes, &v1beta2.Outcome{
+					Fail: &v1beta2.SingleOutcome{
+						When:    "connection-timeout",
+						Message: "Error connecting to 10.0.0.1:9443. Connection timed out. Ensure that the host can connect to 10.0.0.1:9443.",
+					},
+				})
+				assert.Contains(t, hc.TCPConnect.Outcomes, &v1beta2.Outcome{
+					Fail: &v1beta2.SingleOutcome{
 						When:    "error",
-						Message: "Error connecting to 10.0.0.1:9443. Ensure that the host can connect to 10.0.0.1:9443.",
+						Message: "Error connecting to 10.0.0.1:9443. Unexpected error. Ensure that the host can connect to 10.0.0.1:9443.",
 					},
 				})
 				assert.Contains(t, hc.TCPConnect.Outcomes, &v1beta2.Outcome{

--- a/tests/dryrun/join_test.go
+++ b/tests/dryrun/join_test.go
@@ -2,6 +2,7 @@ package dryrun
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -9,9 +10,12 @@ import (
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg/dryrun"
 	"github.com/replicatedhq/embedded-cluster/pkg/kotsadm"
+	"github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
+	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestJoin(t *testing.T) {
+func TestJoinTCPConnectionsRequired(t *testing.T) {
 	drFile := filepath.Join(t.TempDir(), "ec-dryrun.yaml")
 	client := &dryrun.Client{
 		Kotsadm: dryrun.NewKotsadm(),
@@ -28,9 +32,78 @@ func TestJoin(t *testing.T) {
 				UnsupportedOverrides: ecv1beta1.UnsupportedOverrides{},
 			},
 		},
+		TCPConnectionsRequired: []string{"10.0.0.1:6443", "10.0.0.1:9443"},
 	}
 	client.Kotsadm.SetGetJoinTokenResponse("10.0.0.1", "some-token", jcmd, nil)
 	dryrun.Init(drFile, client)
-	dryrunJoin(t, "10.0.0.1", "some-token")
+	dr := dryrunJoin(t, "10.0.0.1", "some-token")
+
+	// --- validate host preflight spec --- //
+	assertCollectors(t, dr.HostPreflightSpec.Collectors, map[string]struct {
+		match    func(*troubleshootv1beta2.HostCollect) bool
+		validate func(*troubleshootv1beta2.HostCollect)
+	}{
+		"TCPConnect-0": {
+			match: func(hc *troubleshootv1beta2.HostCollect) bool {
+				return hc.TCPConnect != nil && strings.HasPrefix(hc.TCPConnect.CollectorName, "tcp-connect-0")
+			},
+			validate: func(hc *troubleshootv1beta2.HostCollect) {
+				assert.Equal(t, "10.0.0.1:6443", hc.TCPConnect.Address)
+			},
+		},
+		"TCPConnect-1": {
+			match: func(hc *troubleshootv1beta2.HostCollect) bool {
+				return hc.TCPConnect != nil && strings.HasPrefix(hc.TCPConnect.CollectorName, "tcp-connect-1")
+			},
+			validate: func(hc *troubleshootv1beta2.HostCollect) {
+				assert.Equal(t, "10.0.0.1:9443", hc.TCPConnect.Address)
+			},
+		},
+	})
+
+	assertAnalyzers(t, dr.HostPreflightSpec.Analyzers, map[string]struct {
+		match    func(*troubleshootv1beta2.HostAnalyze) bool
+		validate func(*troubleshootv1beta2.HostAnalyze)
+	}{
+		"TCPConnect-0": {
+			match: func(hc *troubleshootv1beta2.HostAnalyze) bool {
+				return hc.TCPConnect != nil && strings.HasPrefix(hc.TCPConnect.CollectorName, "tcp-connect-0")
+			},
+			validate: func(hc *troubleshootv1beta2.HostAnalyze) {
+				assert.Contains(t, hc.TCPConnect.Outcomes, &v1beta2.Outcome{
+					Fail: &v1beta2.SingleOutcome{
+						When:    "error",
+						Message: "Error connecting to 10.0.0.1:6443. Ensure that the host can connect to 10.0.0.1:6443.",
+					},
+				})
+				assert.Contains(t, hc.TCPConnect.Outcomes, &v1beta2.Outcome{
+					Pass: &v1beta2.SingleOutcome{
+						When:    "connected",
+						Message: "Successfully connected to 10.0.0.1:6443.",
+					},
+				})
+			},
+		},
+		"TCPConnect-1": {
+			match: func(hc *troubleshootv1beta2.HostAnalyze) bool {
+				return hc.TCPConnect != nil && strings.HasPrefix(hc.TCPConnect.CollectorName, "tcp-connect-1")
+			},
+			validate: func(hc *troubleshootv1beta2.HostAnalyze) {
+				assert.Contains(t, hc.TCPConnect.Outcomes, &v1beta2.Outcome{
+					Fail: &v1beta2.SingleOutcome{
+						When:    "error",
+						Message: "Error connecting to 10.0.0.1:9443. Ensure that the host can connect to 10.0.0.1:9443.",
+					},
+				})
+				assert.Contains(t, hc.TCPConnect.Outcomes, &v1beta2.Outcome{
+					Pass: &v1beta2.SingleOutcome{
+						When:    "connected",
+						Message: "Successfully connected to 10.0.0.1:9443.",
+					},
+				})
+			},
+		},
+	})
+
 	t.Logf("%s: test complete", time.Now().Format(time.RFC3339))
 }

--- a/tests/dryrun/util.go
+++ b/tests/dryrun/util.go
@@ -35,6 +35,30 @@ var (
 	licenseData string
 )
 
+func dryrunJoin(t *testing.T, host, token string, args ...string) dryruntypes.DryRun {
+	if err := embedReleaseData(); err != nil {
+		t.Fatalf("fail to embed release data: %v", err)
+	}
+
+	drFile := filepath.Join(t.TempDir(), "ec-dryrun.yaml")
+	dryrun.Init(drFile, nil)
+
+	if err := runInstallerCmd(
+		append([]string{
+			"join",
+			"--yes",
+		}, args...)...,
+	); err != nil {
+		t.Fatalf("fail to dryrun join embedded-cluster: %v", err)
+	}
+
+	dr, err := dryrun.Load()
+	if err != nil {
+		t.Fatalf("fail to unmarshal dryrun output: %v", err)
+	}
+	return *dr
+}
+
 func dryrunInstall(t *testing.T, args ...string) dryruntypes.DryRun {
 	if err := embedReleaseData(); err != nil {
 		t.Fatalf("fail to embed release data: %v", err)

--- a/tests/dryrun/util.go
+++ b/tests/dryrun/util.go
@@ -40,9 +40,6 @@ func dryrunJoin(t *testing.T, args ...string) dryruntypes.DryRun {
 		t.Fatalf("fail to embed release data: %v", err)
 	}
 
-	drFile := filepath.Join(t.TempDir(), "ec-dryrun.yaml")
-	dryrun.Init(drFile, nil)
-
 	if err := runInstallerCmd(
 		append([]string{
 			"join",

--- a/tests/dryrun/util.go
+++ b/tests/dryrun/util.go
@@ -35,7 +35,7 @@ var (
 	licenseData string
 )
 
-func dryrunJoin(t *testing.T, host, token string, args ...string) dryruntypes.DryRun {
+func dryrunJoin(t *testing.T, args ...string) dryruntypes.DryRun {
 	if err := embedReleaseData(); err != nil {
 		t.Fatalf("fail to embed release data: %v", err)
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
This PR adds support for checking for TCP connections provided by the newly added information to the join endpoint in KOTS - https://github.com/replicatedhq/kots/pull/5004 - we pickup the endpoints provided and create preflight checks based on it.

We also add support for `join` commands in our `dryrun` test utility (which we we use to test this logic).


#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/113015/preflight-remote-access-on-join

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Yes we've added series of both unit tests and tests using the `dryrun` utility.

~~While working on testing this out locally I've hit - https://app.shortcut.com/replicated/story/116682/join-run-preflights-cmd-is-currently-broken-due-to-missing-flags - which I'm working on fixing through:~~
- ~~https://github.com/replicatedhq/embedded-cluster/pull/1568~~
- ~~https://github.com/replicatedhq/embedded-cluster/pull/1567~~

~~Once that's merged I'll share some examples of local usage.~~

After a installing on node0 and bootstraping node1
```
root@node1:/replicatedhq/embedded-cluster# output/bin/embedded-cluster join run-preflights 172.17.0.2:30000 4HqkUsKtuLtfTyF4oSo64zSy
✔  Host files materialized!
✔  Host preflights succeeded!
Host preflights completed successfully
```

On node0:
```
root@node0:/replicatedhq/embedded-cluster# iptables -A INPUT -p tcp -s 172.17.0.4 --dport 6443 -j REJECT
```

On node1:
```
root@node1:/replicatedhq/embedded-cluster# iptables -A OUTPUT -p tcp -d 172.17.0.2 --dport 9443 -j DROP
root@node1:/replicatedhq/embedded-cluster# output/bin/embedded-cluster join run-preflights 172.17.0.2:30000 4HqkUsKtuLtfTyF4oSo64zSy
✔  Host files materialized!
✗  2 host preflights failed

 •  Error connecting to 172.17.0.2:6443. Connection refused. Ensure that the host can connect to 172.17.0.2:6443.
 •  Error connecting to 172.17.0.2:9443. Connection timed out. Ensure that the host can connect to 172.17.0.2:9443.

Please address these issues and try again.
Error:
```

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Enable embedded cluster node joins to preflight Node to Node communications
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
I don't think so(?)
