### PR TITLE
Install EC manager systemd service on install, join, and restore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,13 @@ ifneq ($(DISABLE_FIO_BUILD),1)
 	cp output/bins/fio-$(FIO_VERSION)-$(ARCH) $@
 endif
 
+.PHONY: pkg/goods/bins/manager
+pkg/goods/bins/manager:
+	mkdir -p pkg/goods/bins
+	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o output/bins/manager ./cmd/manager
+	cp output/bins/manager $@
+	touch $@
+
 .PHONY: pkg/goods/internal/bins/kubectl-kots
 pkg/goods/internal/bins/kubectl-kots:
 	mkdir -p pkg/goods/internal/bins
@@ -210,6 +217,7 @@ static: pkg/goods/bins/k0s \
 	pkg/goods/bins/kubectl-support_bundle \
 	pkg/goods/bins/local-artifact-mirror \
 	pkg/goods/bins/fio \
+	pkg/goods/bins/manager \
 	pkg/goods/internal/bins/kubectl-kots
 
 .PHONY: static-dryrun
@@ -220,6 +228,7 @@ static-dryrun:
 		pkg/goods/bins/kubectl-support_bundle \
 		pkg/goods/bins/local-artifact-mirror \
 		pkg/goods/bins/fio \
+		pkg/goods/bins/manager \
 		pkg/goods/internal/bins/kubectl-kots
 
 .PHONY: embedded-cluster-linux-amd64

--- a/cmd/installer/cli/join.go
+++ b/cmd/installer/cli/join.go
@@ -266,6 +266,13 @@ func JoinCmd(ctx context.Context, name string) *cobra.Command {
 				return err
 			}
 
+			logrus.Debugf("installing manager")
+			if err := installAndEnableManager(); err != nil {
+				err := fmt.Errorf("unable to install and enable manager: %w", err)
+				metrics.ReportJoinFailed(cmd.Context(), jcmd.InstallationSpec.MetricsBaseURL, jcmd.ClusterID, err)
+				return err
+			}
+
 			enabledHighAvailabilityFlag, err := cmd.Flags().GetBool("enable-ha")
 			if err != nil {
 				return fmt.Errorf("unable to get enable-ha flag: %w", err)

--- a/cmd/installer/cli/restore.go
+++ b/cmd/installer/cli/restore.go
@@ -360,6 +360,11 @@ func RestoreCmd(ctx context.Context, name string) *cobra.Command {
 					return err
 				}
 
+				logrus.Debugf("installing manager")
+				if err := installAndEnableManager(); err != nil {
+					return fmt.Errorf("unable to install manager: %w", err)
+				}
+
 				fallthrough
 
 			case ecRestoreStateWaitForNodes:

--- a/pkg/goods/materializer.go
+++ b/pkg/goods/materializer.go
@@ -59,6 +59,19 @@ func (m *Materializer) LocalArtifactMirrorUnitFile() error {
 	return nil
 }
 
+// ManagerUnitFile writes to disk the manager systemd unit file.
+func (m *Materializer) ManagerUnitFile() error {
+	content, err := systemdfs.ReadFile("systemd/manager.service")
+	if err != nil {
+		return fmt.Errorf("open unit file: %w", err)
+	}
+	dstpath := fmt.Sprintf("/etc/systemd/system/%s.service", runtimeconfig.ManagerServiceName)
+	if err := os.WriteFile(dstpath, content, 0644); err != nil {
+		return fmt.Errorf("write file: %w", err)
+	}
+	return nil
+}
+
 // CalicoNetworkManagerConfig materializes a configuration file for the network manager. This
 // configuration file instructs the network manager to ignore any interface being managed by
 // the calico network cni.

--- a/pkg/goods/systemd/manager.service
+++ b/pkg/goods/systemd/manager.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Embedded Cluster Manager
+
+[Service]
+ExecStart=/var/lib/embedded-cluster/bin/manager start
+Restart=always
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg/runtimeconfig/defaults.go
+++ b/pkg/runtimeconfig/defaults.go
@@ -1,6 +1,7 @@
 package runtimeconfig
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -10,9 +11,9 @@ import (
 
 // Holds the default no proxy values.
 var DefaultNoProxy = []string{"localhost", "127.0.0.1", ".cluster.local", ".svc"}
+var ManagerServiceName = fmt.Sprintf("%s-manager", BinaryName())
 
 const ProxyRegistryAddress = "proxy.replicated.com"
-
 const KotsadmNamespace = "kotsadm"
 const SeaweedFSNamespace = "seaweedfs"
 const RegistryNamespace = "registry"

--- a/pkg/websocket/server.go
+++ b/pkg/websocket/server.go
@@ -17,6 +17,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+// wsDialer is the default dialer but with a shorter timeout.
+var wsDialer = &gwebsocket.Dialer{
+	HandshakeTimeout: 10 * time.Second,
+}
+
 func ConnectToKOTSWebSocket(ctx context.Context) {
 	for {
 		if err := attemptConnection(ctx); err != nil {
@@ -57,8 +62,7 @@ func attemptConnection(ctx context.Context) error {
 		return fmt.Errorf("parse websocket url: %w", err)
 	}
 
-	dialer := gwebsocket.DefaultDialer
-	conn, _, err := dialer.Dial(u.String(), nil)
+	conn, _, err := wsDialer.Dial(u.String(), nil)
 	if err != nil {
 		return fmt.Errorf("connect to websocket server: %w", err)
 	}

--- a/pkg/websocket/server.go
+++ b/pkg/websocket/server.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// wsDialer is the default dialer but with a shorter timeout.
 var wsDialer = &gwebsocket.Dialer{
 	HandshakeTimeout: 10 * time.Second,
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Installs and enables the EC manager systemd service on install, join, and restore.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-116592](https://app.shortcut.com/replicated/story/116592)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE