### PR TITLE
chore(ci): address melange's latest change

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -254,7 +254,7 @@ jobs:
         run: |
           export K0S_VERSION=$(make print-PREVIOUS_K0S_VERSION)
           export K0S_GO_VERSION=$(make print-PREVIOUS_K0S_GO_VERSION)
-          export EC_VERSION=$(git describe --tags --abbrev=4 --match='[0-9]*.[0-9]*.[0-9]*')-pk
+          export EC_VERSION=$(git describe --tags --abbrev=4 --match='[0-9]*.[0-9]*.[0-9]*')-previous-k0s
           export APP_VERSION=appver-dev-${{ needs.git-sha.outputs.git_sha }}-previous-k0s
           # avoid rate limiting
           export FIO_VERSION=$(gh release list --repo axboe/fio --json tagName,isLatest | jq -r '.[] | select(.isLatest==true)|.tagName' | cut -d- -f2)
@@ -357,7 +357,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export K0S_VERSION=$(make print-K0S_VERSION)
-          export EC_VERSION=$(git describe --tags --abbrev=4 --match='[0-9]*.[0-9]*.[0-9]*')-up
+          export EC_VERSION=$(git describe --tags --abbrev=4 --match='[0-9]*.[0-9]*.[0-9]*')-upgrade
           export APP_VERSION=appver-dev-${{ needs.git-sha.outputs.git_sha }}-upgrade
           # avoid rate limiting
           export FIO_VERSION=$(gh release list --repo axboe/fio --json tagName,isLatest | jq -r '.[] | select(.isLatest==true)|.tagName' | cut -d- -f2)
@@ -481,7 +481,7 @@ jobs:
           ./scripts/ci-release-app.sh
 
           # install the previous k0s version to ensure an upgrade occurs
-          export EC_VERSION="$(git describe --tags --abbrev=4 --match='[0-9]*.[0-9]*.[0-9]*')-pk"
+          export EC_VERSION="$(git describe --tags --abbrev=4 --match='[0-9]*.[0-9]*.[0-9]*')-previous-k0s"
           export APP_VERSION="appver-${SHORT_SHA}-previous-k0s"
           export RELEASE_YAML_DIR=e2e/kots-release-install
           ./scripts/ci-release-app.sh
@@ -499,7 +499,7 @@ jobs:
           ./scripts/ci-release-app.sh
 
           # and finally an app upgrade
-          export EC_VERSION="$(git describe --tags --abbrev=4 --match='[0-9]*.[0-9]*.[0-9]*')-up"
+          export EC_VERSION="$(git describe --tags --abbrev=4 --match='[0-9]*.[0-9]*.[0-9]*')-upgrade"
           export APP_VERSION="appver-${SHORT_SHA}-upgrade"
           export RELEASE_YAML_DIR=e2e/kots-release-upgrade
           ./scripts/ci-release-app.sh
@@ -521,7 +521,7 @@ jobs:
           ./scripts/ci-release-app.sh
 
           # install the previous k0s version to ensure an upgrade occurs
-          export EC_VERSION="$(git describe --tags --abbrev=4 --match='[0-9]*.[0-9]*.[0-9]*')-pk"
+          export EC_VERSION="$(git describe --tags --abbrev=4 --match='[0-9]*.[0-9]*.[0-9]*')-previous-k0s"
           export APP_VERSION="appver-${SHORT_SHA}-previous-k0s"
           export RELEASE_YAML_DIR=e2e/kots-release-install
           ./scripts/ci-release-app.sh
@@ -533,7 +533,7 @@ jobs:
           ./scripts/ci-release-app.sh
 
           # and finally an app upgrade
-          export EC_VERSION="$(git describe --tags --abbrev=4 --match='[0-9]*.[0-9]*.[0-9]*')-up"
+          export EC_VERSION="$(git describe --tags --abbrev=4 --match='[0-9]*.[0-9]*.[0-9]*')-upgrade"
           export APP_VERSION="appver-${SHORT_SHA}-upgrade"
           export RELEASE_YAML_DIR=e2e/kots-release-upgrade
           ./scripts/ci-release-app.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -181,7 +181,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export K0S_VERSION=$(make print-K0S_VERSION)
-          export EC_VERSION=$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*')
+          export EC_VERSION=$(git describe --tags --abbrev=4 --match='[0-9]*.[0-9]*.[0-9]*')
           export SHORT_SHA=dev-${{ needs.git-sha.outputs.git_sha }}
           export APP_VERSION=appver-dev-${{ needs.git-sha.outputs.git_sha }}
           # avoid rate limiting
@@ -254,7 +254,7 @@ jobs:
         run: |
           export K0S_VERSION=$(make print-PREVIOUS_K0S_VERSION)
           export K0S_GO_VERSION=$(make print-PREVIOUS_K0S_GO_VERSION)
-          export EC_VERSION=$(git describe --tags --abbrev=5 --match='[0-9]*.[0-9]*.[0-9]*')-pk
+          export EC_VERSION=$(git describe --tags --abbrev=4 --match='[0-9]*.[0-9]*.[0-9]*')-pk
           export APP_VERSION=appver-dev-${{ needs.git-sha.outputs.git_sha }}-prevk0s
           # avoid rate limiting
           export FIO_VERSION=$(gh release list --repo axboe/fio --json tagName,isLatest | jq -r '.[] | select(.isLatest==true)|.tagName' | cut -d- -f2)
@@ -357,7 +357,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export K0S_VERSION=$(make print-K0S_VERSION)
-          export EC_VERSION=$(git describe --tags --abbrev=5 --match='[0-9]*.[0-9]*.[0-9]*')-up
+          export EC_VERSION=$(git describe --tags --abbrev=4 --match='[0-9]*.[0-9]*.[0-9]*')-up
           export APP_VERSION=appver-dev-${{ needs.git-sha.outputs.git_sha }}-upgrade
           # avoid rate limiting
           export FIO_VERSION=$(gh release list --repo axboe/fio --json tagName,isLatest | jq -r '.[] | select(.isLatest==true)|.tagName' | cut -d- -f2)
@@ -481,25 +481,25 @@ jobs:
           ./scripts/ci-release-app.sh
 
           # install the previous k0s version to ensure an upgrade occurs
-          export EC_VERSION="$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*')-previous-k0s"
+          export EC_VERSION="$(git describe --tags --abbrev=4 --match='[0-9]*.[0-9]*.[0-9]*')-pk"
           export APP_VERSION="appver-${SHORT_SHA}-previous-k0s"
           export RELEASE_YAML_DIR=e2e/kots-release-install
           ./scripts/ci-release-app.sh
 
           # then install the current k0s version
-          export EC_VERSION="$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*')"
+          export EC_VERSION="$(git describe --tags --abbrev=4 --match='[0-9]*.[0-9]*.[0-9]*')"
           export APP_VERSION="appver-${SHORT_SHA}"
           export RELEASE_YAML_DIR=e2e/kots-release-install
           ./scripts/ci-release-app.sh
 
           # then a noop upgrade
-          export EC_VERSION="$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*')"
+          export EC_VERSION="$(git describe --tags --abbrev=4 --match='[0-9]*.[0-9]*.[0-9]*')"
           export APP_VERSION="appver-${SHORT_SHA}-noop"
           export RELEASE_YAML_DIR=e2e/kots-release-install
           ./scripts/ci-release-app.sh
 
           # and finally an app upgrade
-          export EC_VERSION="$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*')-upgrade"
+          export EC_VERSION="$(git describe --tags --abbrev=4 --match='[0-9]*.[0-9]*.[0-9]*')-up"
           export APP_VERSION="appver-${SHORT_SHA}-upgrade"
           export RELEASE_YAML_DIR=e2e/kots-release-upgrade
           ./scripts/ci-release-app.sh
@@ -521,19 +521,19 @@ jobs:
           ./scripts/ci-release-app.sh
 
           # install the previous k0s version to ensure an upgrade occurs
-          export EC_VERSION="$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*')-previous-k0s"
+          export EC_VERSION="$(git describe --tags --abbrev=4 --match='[0-9]*.[0-9]*.[0-9]*')-pk"
           export APP_VERSION="appver-${SHORT_SHA}-previous-k0s"
           export RELEASE_YAML_DIR=e2e/kots-release-install
           ./scripts/ci-release-app.sh
 
           # then install the current k0s version
-          export EC_VERSION="$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*')"
+          export EC_VERSION="$(git describe --tags --abbrev=4 --match='[0-9]*.[0-9]*.[0-9]*')"
           export APP_VERSION="appver-${SHORT_SHA}"
           export RELEASE_YAML_DIR=e2e/kots-release-install
           ./scripts/ci-release-app.sh
 
           # and finally an app upgrade
-          export EC_VERSION="$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*')-upgrade"
+          export EC_VERSION="$(git describe --tags --abbrev=4 --match='[0-9]*.[0-9]*.[0-9]*')-up"
           export APP_VERSION="appver-${SHORT_SHA}-upgrade"
           export RELEASE_YAML_DIR=e2e/kots-release-upgrade
           ./scripts/ci-release-app.sh
@@ -542,7 +542,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           export SHORT_SHA=dev-${{ needs.git-sha.outputs.git_sha }}
-          export EC_VERSION="$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*')"
+          export EC_VERSION="$(git describe --tags --abbrev=4 --match='[0-9]*.[0-9]*.[0-9]*')"
           export APP_VERSION="appver-${SHORT_SHA}"
 
           echo "This PR has been released (on staging) and is available for download with a embedded-cluster-smoke-test-staging-app [license ID](https://vendor.staging.replicated.com/apps/embedded-cluster-smoke-test-staging-app/customers?sort=name-asc)." > download-link.txt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -255,7 +255,7 @@ jobs:
           export K0S_VERSION=$(make print-PREVIOUS_K0S_VERSION)
           export K0S_GO_VERSION=$(make print-PREVIOUS_K0S_GO_VERSION)
           export EC_VERSION=$(git describe --tags --abbrev=4 --match='[0-9]*.[0-9]*.[0-9]*')-pk
-          export APP_VERSION=appver-dev-${{ needs.git-sha.outputs.git_sha }}-prevk0s
+          export APP_VERSION=appver-dev-${{ needs.git-sha.outputs.git_sha }}-previous-k0s
           # avoid rate limiting
           export FIO_VERSION=$(gh release list --repo axboe/fio --json tagName,isLatest | jq -r '.[] | select(.isLatest==true)|.tagName' | cut -d- -f2)
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -254,8 +254,8 @@ jobs:
         run: |
           export K0S_VERSION=$(make print-PREVIOUS_K0S_VERSION)
           export K0S_GO_VERSION=$(make print-PREVIOUS_K0S_GO_VERSION)
-          export EC_VERSION=$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*')-previous-k0s
-          export APP_VERSION=appver-dev-${{ needs.git-sha.outputs.git_sha }}-previous-k0s
+          export EC_VERSION=$(git describe --tags --abbrev=5 --match='[0-9]*.[0-9]*.[0-9]*')-pk
+          export APP_VERSION=appver-dev-${{ needs.git-sha.outputs.git_sha }}-prevk0s
           # avoid rate limiting
           export FIO_VERSION=$(gh release list --repo axboe/fio --json tagName,isLatest | jq -r '.[] | select(.isLatest==true)|.tagName' | cut -d- -f2)
 
@@ -357,7 +357,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export K0S_VERSION=$(make print-K0S_VERSION)
-          export EC_VERSION=$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*')-upgrade
+          export EC_VERSION=$(git describe --tags --abbrev=5 --match='[0-9]*.[0-9]*.[0-9]*')-up
           export APP_VERSION=appver-dev-${{ needs.git-sha.outputs.git_sha }}-upgrade
           # avoid rate limiting
           export FIO_VERSION=$(gh release list --repo axboe/fio --json tagName,isLatest | jq -r '.[] | select(.isLatest==true)|.tagName' | cut -d- -f2)

--- a/common.mk
+++ b/common.mk
@@ -16,7 +16,7 @@ MELANGE ?= $(LOCALBIN)/melange
 APKO ?= $(LOCALBIN)/apko
 
 ## Version to use for building
-VERSION ?= $(shell git describe --tags --match='[0-9]*.[0-9]*.[0-9]*')
+VERSION ?= $(shell git describe --tags --match='[0-9]*.[0-9]*.[0-9]*' --abbrev=5)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/common.mk
+++ b/common.mk
@@ -16,7 +16,7 @@ MELANGE ?= $(LOCALBIN)/melange
 APKO ?= $(LOCALBIN)/apko
 
 ## Version to use for building
-VERSION ?= $(shell git describe --tags --match='[0-9]*.[0-9]*.[0-9]*' --abbrev=5)
+VERSION ?= $(shell git describe --tags --match='[0-9]*.[0-9]*.[0-9]*' --abbrev=4)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	APKOImageVersion    = "latest"
-	MelangeImageVersion = "latest"
+	MelangeImageVersion = "0.15"
 )
 
 type EmbeddedCluster struct {

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	APKOImageVersion    = "latest"
-	MelangeImageVersion = "0.15"
+	MelangeImageVersion = "0.15.14"
 )
 
 type EmbeddedCluster struct {

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	APKOImageVersion    = "latest"
-	MelangeImageVersion = "0.15.14"
+	MelangeImageVersion = "latest"
 )
 
 type EmbeddedCluster struct {

--- a/operator/deploy/apko.tmpl.yaml
+++ b/operator/deploy/apko.tmpl.yaml
@@ -6,7 +6,7 @@ contents:
     - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     - ./melange.rsa.pub
   packages:
-    - embedded-cluster-operator  # This is expected to be built locally by `melange`.
+    - ec-operator  # This is expected to be built locally by `melange`.
     - ca-certificates-bundle
 
 accounts:

--- a/operator/deploy/melange.tmpl.yaml
+++ b/operator/deploy/melange.tmpl.yaml
@@ -1,5 +1,5 @@
 package:
-  name: embedded-cluster-operator
+  name: ec-operator
   version: ${PACKAGE_VERSION}
   epoch: 0
   description: Embedded Cluster Operator

--- a/pkg/addons/adminconsole/adminconsole.go
+++ b/pkg/addons/adminconsole/adminconsole.go
@@ -9,9 +9,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
-	"github.com/replicatedhq/embedded-cluster/pkg/versions"
-
 	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/kinds/types"
@@ -23,6 +20,7 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/metrics"
 	"github.com/replicatedhq/embedded-cluster/pkg/netutils"
 	"github.com/replicatedhq/embedded-cluster/pkg/release"
+	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/replicatedhq/embedded-cluster/pkg/spinner"
 	"github.com/replicatedhq/embedded-cluster/pkg/versions"
 	"github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"

--- a/scripts/build-and-release.sh
+++ b/scripts/build-and-release.sh
@@ -35,7 +35,7 @@ export REPLICATED_API_ORIGIN REPLICATED_APP REPLICATED_API_TOKEN AWS_ACCESS_KEY_
 
 function init_vars() {
     if [ -z "${EC_VERSION:-}" ]; then
-        EC_VERSION=$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*')
+        EC_VERSION=$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*' --abbrev=5)
     fi
     if [ -z "${APP_VERSION:-}" ]; then
         APP_VERSION="appver-dev-$(git rev-parse --short HEAD)"

--- a/scripts/build-and-release.sh
+++ b/scripts/build-and-release.sh
@@ -35,7 +35,7 @@ export REPLICATED_API_ORIGIN REPLICATED_APP REPLICATED_API_TOKEN AWS_ACCESS_KEY_
 
 function init_vars() {
     if [ -z "${EC_VERSION:-}" ]; then
-        EC_VERSION=$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*' --abbrev=5)
+        EC_VERSION=$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*' --abbrev=4)
     fi
     if [ -z "${APP_VERSION:-}" ]; then
         APP_VERSION="appver-dev-$(git rev-parse --short HEAD)"

--- a/scripts/ci-build-bin.sh
+++ b/scripts/ci-build-bin.sh
@@ -18,7 +18,7 @@ fi
 
 function init_vars() {
     if [ -z "${EC_VERSION:-}" ]; then
-        EC_VERSION=$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*')
+        EC_VERSION=$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*' --abbrev=5)
     fi
     if [ -z "${K0S_VERSION:-}" ]; then
         K0S_VERSION=$(make print-K0S_VERSION)

--- a/scripts/ci-build-bin.sh
+++ b/scripts/ci-build-bin.sh
@@ -18,7 +18,7 @@ fi
 
 function init_vars() {
     if [ -z "${EC_VERSION:-}" ]; then
-        EC_VERSION=$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*' --abbrev=5)
+        EC_VERSION=$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*' --abbrev=4)
     fi
     if [ -z "${K0S_VERSION:-}" ]; then
         K0S_VERSION=$(make print-K0S_VERSION)

--- a/scripts/ci-build-deps.sh
+++ b/scripts/ci-build-deps.sh
@@ -10,7 +10,7 @@ USE_CHAINGUARD=${USE_CHAINGUARD:-1}
 
 function init_vars() {
     if [ -z "${EC_VERSION:-}" ]; then
-      EC_VERSION=$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*' --abbrev=5)
+      EC_VERSION=$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*' --abbrev=4)
     fi
 
     require EC_VERSION "${EC_VERSION:-}"

--- a/scripts/ci-build-deps.sh
+++ b/scripts/ci-build-deps.sh
@@ -10,7 +10,7 @@ USE_CHAINGUARD=${USE_CHAINGUARD:-1}
 
 function init_vars() {
     if [ -z "${EC_VERSION:-}" ]; then
-        EC_VERSION=$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*')
+      EC_VERSION=$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*' --abbrev=5)
     fi
 
     require EC_VERSION "${EC_VERSION:-}"

--- a/scripts/ci-embed-release.sh
+++ b/scripts/ci-embed-release.sh
@@ -23,7 +23,7 @@ fi
 
 function init_vars() {
     if [ -z "${EC_VERSION:-}" ]; then
-        EC_VERSION=$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*' --abbrev=5)
+        EC_VERSION=$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*' --abbrev=4)
     fi
     if [ -z "${APP_VERSION:-}" ]; then
         local short_sha=

--- a/scripts/ci-embed-release.sh
+++ b/scripts/ci-embed-release.sh
@@ -23,7 +23,7 @@ fi
 
 function init_vars() {
     if [ -z "${EC_VERSION:-}" ]; then
-        EC_VERSION=$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*')
+        EC_VERSION=$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*' --abbrev=5)
     fi
     if [ -z "${APP_VERSION:-}" ]; then
         local short_sha=

--- a/scripts/ci-release-app.sh
+++ b/scripts/ci-release-app.sh
@@ -23,7 +23,7 @@ require REPLICATED_API_ORIGIN "${REPLICATED_API_ORIGIN:-}"
 
 function init_vars() {
     if [ -z "${EC_VERSION:-}" ]; then
-        EC_VERSION=$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*')
+        EC_VERSION=$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*' --abbrev=5)
     fi
     if [ -z "${APP_VERSION:-}" ]; then
         local short_sha=

--- a/scripts/ci-release-app.sh
+++ b/scripts/ci-release-app.sh
@@ -23,7 +23,7 @@ require REPLICATED_API_ORIGIN "${REPLICATED_API_ORIGIN:-}"
 
 function init_vars() {
     if [ -z "${EC_VERSION:-}" ]; then
-        EC_VERSION=$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*' --abbrev=5)
+        EC_VERSION=$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*' --abbrev=4)
     fi
     if [ -z "${APP_VERSION:-}" ]; then
         local short_sha=

--- a/scripts/ci-upload-binaries.sh
+++ b/scripts/ci-upload-binaries.sh
@@ -20,7 +20,7 @@ require S3_BUCKET "${S3_BUCKET}"
 
 function init_vars() {
     if [ -z "${EC_VERSION:-}" ]; then
-        EC_VERSION=$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*')
+        EC_VERSION=$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*' --abbrev=5)
     fi
     if [ -z "${K0S_VERSION:-}" ]; then
         K0S_VERSION=$(make print-K0S_VERSION)

--- a/scripts/ci-upload-binaries.sh
+++ b/scripts/ci-upload-binaries.sh
@@ -20,7 +20,7 @@ require S3_BUCKET "${S3_BUCKET}"
 
 function init_vars() {
     if [ -z "${EC_VERSION:-}" ]; then
-        EC_VERSION=$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*' --abbrev=5)
+        EC_VERSION=$(git describe --tags --match='[0-9]*.[0-9]*.[0-9]*' --abbrev=4)
     fi
     if [ -z "${K0S_VERSION:-}" ]; then
         K0S_VERSION=$(make print-K0S_VERSION)


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

For more context see - https://replicated.slack.com/archives/C0499EGNPNY/p1732733447572059

With the latest `melange` changes through - https://github.com/chainguard-dev/melange/pull/1622 - our CI pipelines started failing with:
```
INFO error during command execution: failed to build image components: building layers: building layers: for arch "amd64": installing apk packages: installing packages: installing embedded-cluster-operator (ver:1.19.0+k8s-1.30-59-gf845a740-upgrade-r0 arch:x86_64): unable to update scripts.tar for pkg embedded-cluster-operator: unable to write scripts header for embedded-cluster-operator-1.19.0+k8s-1.30-59-gf845a740-upgrade-r0.Q17P2Pb+0fdYeQTtIVeyqFDm8XEYE=.melange.yaml: archive/tar: cannot encode header: Format specifies USTAR; and USTAR cannot encode Name="embedded-cluster-operator-1.19.0+k8s-1.30-59-gf845a740-upgrade-r0.Q17P2Pb+0fdYeQTtIVeyqFDm8XEYE=.melange.yaml"
```

The way the name header is built can be seen here:
- https://github.com/chainguard-dev/apko/blob/3680d0fed60f20a0a514a26b49182aa0064c08ce/pkg/apk/apk/installed.go#L158

The change introduced was enough to trip the USTAR 100 byte limit.

To prevent this we're reducing the package name + version we use in the `melange.yaml` for the operator:
- https://github.com/replicatedhq/embedded-cluster/blob/fa700cdae5823b638e9a4df2832591a78918db23/operator/deploy/melange.tmpl.yaml#L2-L3 

This is a quick workaround. We might wanna further reduce the version/name (does it even matter the version we use for the melange package here?) or even have a chat with chainguard to understand what's the best way to overcome this and avoid being hit by this in the near future.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
