### PR TITLE
fix(cli): join run-preflights does not define network-interfaces flag

### DIFF
--- a/cmd/installer/cli/join_runpreflights.go
+++ b/cmd/installer/cli/join_runpreflights.go
@@ -23,9 +23,9 @@ import (
 
 func JoinRunPreflightsCmd(ctx context.Context, name string) *cobra.Command {
 	var (
-		airgapBundle string
-		assumeYes    bool
-		license      string
+		airgapBundle     string
+		networkInterface string
+		assumeYes        bool
 	)
 	cmd := &cobra.Command{
 		Use:   "run-preflights",
@@ -122,8 +122,8 @@ func JoinRunPreflightsCmd(ctx context.Context, name string) *cobra.Command {
 
 	cmd.Flags().StringVar(&airgapBundle, "airgap-bundle", "", "Path to the air gap bundle. If set, the installation will complete without internet access.")
 	cmd.Flags().MarkHidden("airgap-bundle")
+	cmd.Flags().StringVar(&networkInterface, "network-interface", "", "The network interface to use for the cluster")
 
-	cmd.Flags().StringVarP(&license, "license", "l", "", "Path to the license file")
 	cmd.Flags().BoolVar(&assumeYes, "yes", false, "Assume yes to all prompts.")
 	cmd.Flags().SetNormalizeFunc(normalizeNoPromptToYes)
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Running `join run-preflights (...)` errors out because we're not defining the network-interface flag. E.g.

```
output/bin/embedded-cluster join run-preflights 172.17.0.2:30000 zXQC3hsNPhtNJsRpESpvrSLp
Error: unable to get network-interface flag: flag accessed but not defined: network-interface
unable to get network-interface flag: flag accessed but not defined: network-interface
```

I believe we dropped this as part of #1523
See:
- https://github.com/replicatedhq/embedded-cluster/blob/fef6b677b1eaaba4a9b865018d6ba30c9e46ed9e/pkg/cmd/preflights.go#L118-L134

I also removed the license flag from the command since we don't use it and we don't need it.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
I've added `join` capabilities to our dry run test framework in - https://github.com/replicatedhq/embedded-cluster/pull/1554/files#diff-c31b722aa72dc3328c5889fb936be7bb3d1365cdbbf5dc4eac3bcb3bff399d3c - I'm happy to add a test for the `run-preflights` sub command once that gets merged.

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
