### PR TITLE
fix(cli): join run-preflights should define skip & ignore preflights flags with defaults

### DIFF
--- a/cmd/installer/cli/join_runpreflights.go
+++ b/cmd/installer/cli/join_runpreflights.go
@@ -23,9 +23,11 @@ import (
 
 func JoinRunPreflightsCmd(ctx context.Context, name string) *cobra.Command {
 	var (
-		airgapBundle     string
-		networkInterface string
-		assumeYes        bool
+		airgapBundle         string
+		networkInterface     string
+		assumeYes            bool
+		skipHostPreflights   bool
+		ignoreHostPreflights bool
 	)
 	cmd := &cobra.Command{
 		Use:   "run-preflights",
@@ -123,6 +125,9 @@ func JoinRunPreflightsCmd(ctx context.Context, name string) *cobra.Command {
 	cmd.Flags().StringVar(&airgapBundle, "airgap-bundle", "", "Path to the air gap bundle. If set, the installation will complete without internet access.")
 	cmd.Flags().MarkHidden("airgap-bundle")
 	cmd.Flags().StringVar(&networkInterface, "network-interface", "", "The network interface to use for the cluster")
+	cmd.Flags().BoolVar(&skipHostPreflights, "skip-host-preflights", false, "Skip host preflight checks. This is not recommended and has been deprecated.")
+	cmd.Flags().MarkHidden("skip-host-preflights")
+	cmd.Flags().BoolVar(&ignoreHostPreflights, "ignore-host-preflights", false, "Run host preflight checks, but prompt the user to continue if they fail instead of exiting.")
 
 	cmd.Flags().BoolVar(&assumeYes, "yes", false, "Assume yes to all prompts.")
 	cmd.Flags().SetNormalizeFunc(normalizeNoPromptToYes)


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Similar to - https://github.com/replicatedhq/embedded-cluster/pull/1567

Running join run-preflights (...) errors out because we're not defining the skip-host-preflights and ignore-host-preflights flag. E.g.
```
root@node1:/replicatedhq/embedded-cluster# output/bin/embedded-cluster join run-preflights 172.17.0.2:30000 HBA9OCthEHACKgtxIhYrHbfp
✔  Host files materialized!
✗
Error: unable to get skip-host-preflights flag: flag accessed but not defined: skip-host-preflights
unable to get skip-host-preflights flag: flag accessed but not defined: skip-host-preflights
```

This PR should fix it.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/116682/join-run-preflights-cmd-is-currently-broken-due-to-missing-flags

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
I've added join capabilities to our dry run test framework in - https://github.com/replicatedhq/embedded-cluster/pull/1554/files#diff-c31b722aa72dc3328c5889fb936be7bb3d1365cdbbf5dc4eac3bcb3bff399d3c - I'm happy to add a test for the run-preflights sub command once that gets merged.

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
