### PR TITLE
installer2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -379,10 +379,11 @@ bin/installer:
 bin/manager:
 	go build -o bin/manager ./cmd/manager
 
-# make test-embed channel=Unstable app=slackernews
+# make test-embed channel=<channelid> app=<appslug>
 .PHONY: test-embed
 test-emded: export OS=linux
 test-embed: export ARCH=amd64
+test-embed: VERSION=1.19.0+k8s-1.30
 test-embed: static embedded-cluster
 	@echo "Cleaning up previous release directory..."
 	rm -rf ./hack/release

--- a/cmd/installer/cli/cidr.go
+++ b/cmd/installer/cli/cidr.go
@@ -18,21 +18,37 @@ func addCIDRFlags(cmd *cobra.Command) {
 	cmd.Flags().String("cidr", ecv1beta1.DefaultNetworkCIDR, "CIDR block of available private IP addresses (/16 or larger)")
 }
 
-// DeterminePodAndServiceCIDRS determines, based on the command line flags,
+func parseCIDRFlags(cmd *cobra.Command) error {
+	if cmd.Flags().Changed("cidr") && (cmd.Flags().Changed("pod-cidr") || cmd.Flags().Changed("service-cidr")) {
+		return fmt.Errorf("--cidr flag can't be used with --pod-cidr or --service-cidr")
+	}
+
+	cidr, err := cmd.Flags().GetString("cidr")
+	if err != nil {
+		return fmt.Errorf("unable to get cidr flag: %w", err)
+	}
+
+	if err := netutils.ValidateCIDR(cidr, 16, true); err != nil {
+		return fmt.Errorf("invalid cidr %q: %w", cidr, err)
+	}
+
+	return nil
+}
+
+// getPODAndServiceCIDR determines, based on the command line flags,
 // what are the pod and service CIDRs to be used for the cluster. If both
 // --pod-cidr and --service-cidr have been set, they are used. Otherwise,
 // the cidr flag is split into pod and service CIDRs.
-func determinePodAndServiceCIDRs(cmd *cobra.Command) (string, string, error) {
-	podCIDRFlag, err := cmd.Flags().GetString("pod-cidr")
-	if err != nil {
-		return "", "", fmt.Errorf("unable to get pod-cidr flag: %w", err)
-	}
-	serviceCIDRFlag, err := cmd.Flags().GetString("service-cidr")
-	if err != nil {
-		return "", "", fmt.Errorf("unable to get service-cidr flag: %w", err)
-	}
-
-	if podCIDRFlag != "" || serviceCIDRFlag != "" {
+func getPODAndServiceCIDR(cmd *cobra.Command) (string, string, error) {
+	if cmd.Flags().Changed("pod-cidr") || cmd.Flags().Changed("service-cidr") {
+		podCIDRFlag, err := cmd.Flags().GetString("pod-cidr")
+		if err != nil {
+			return "", "", fmt.Errorf("unable to get pod-cidr flag: %w", err)
+		}
+		serviceCIDRFlag, err := cmd.Flags().GetString("service-cidr")
+		if err != nil {
+			return "", "", fmt.Errorf("unable to get service-cidr flag: %w", err)
+		}
 		return podCIDRFlag, serviceCIDRFlag, nil
 	}
 

--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -65,10 +65,12 @@ func InstallCmd(ctx context.Context, name string) *cobra.Command {
 			if os.Getuid() != 0 {
 				return fmt.Errorf("install command must be run as root")
 			}
+
 			if skipHostPreflights {
 				logrus.Warnf("Warning: --skip-host-preflights is deprecated and will be removed in a later version. Use --ignore-host-preflights instead.")
 			}
 
+			// TODO move this to pass params, not flags.  flags don't leave the cmd/ package
 			runtimeconfig.ApplyFlags(cmd.Flags())
 			os.Setenv("TMPDIR", runtimeconfig.EmbeddedClusterTmpSubDir())
 
@@ -76,34 +78,14 @@ func InstallCmd(ctx context.Context, name string) *cobra.Command {
 				return fmt.Errorf("unable to write runtime config to disk: %w", err)
 			}
 
-			var err error
-			proxy, err = getProxySpecFromFlags(cmd)
+			p, err := parseProxyFlags(cmd)
 			if err != nil {
-				return fmt.Errorf("unable to get proxy spec from flags: %w", err)
+				return fmt.Errorf("unable to parse proxy flags: %w", err)
 			}
+			proxy = p
 
-			proxy, err = includeLocalIPInNoProxy(cmd, proxy)
-			if err != nil {
-				licenseFlag, err := cmd.Flags().GetString("license")
-				if err != nil {
-					return fmt.Errorf("unable to get license flag: %w", err)
-				}
-				metrics.ReportApplyFinished(cmd.Context(), licenseFlag, err)
-				return err
-			}
-			setProxyEnv(proxy)
-
-			if cmd.Flags().Changed("cidr") && (cmd.Flags().Changed("pod-cidr") || cmd.Flags().Changed("service-cidr")) {
-				return fmt.Errorf("--cidr flag can't be used with --pod-cidr or --service-cidr")
-			}
-
-			cidr, err := cmd.Flags().GetString("cidr")
-			if err != nil {
-				return fmt.Errorf("unable to get cidr flag: %w", err)
-			}
-
-			if err := netutils.ValidateCIDR(cidr, 16, true); err != nil {
-				return fmt.Errorf("invalid cidr %q: %w", cidr, err)
+			if err := parseCIDRFlags(cmd); err != nil {
+				return fmt.Errorf("unable to parse cidr flags: %w", err)
 			}
 
 			return nil
@@ -113,12 +95,16 @@ func InstallCmd(ctx context.Context, name string) *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logrus.Debugf("checking if %s is already installed", name)
-			installed, err := k0s.IsInstalled(name)
+			installed, err := k0s.IsInstalled()
 			if err != nil {
 				return err
 			}
 			if installed {
-				return ErrNothingElseToAdd
+				logrus.Errorf("An installation has been detected on this machine.")
+				logrus.Infof("If you want to reinstall, you need to remove the existing installation first.")
+				logrus.Infof("You can do this by running the following command:")
+				logrus.Infof("\n  sudo ./%s reset\n", name)
+				os.Exit(1)
 			}
 
 			channelRelease, err := release.GetChannelRelease()
@@ -214,7 +200,7 @@ func InstallCmd(ctx context.Context, name string) *cobra.Command {
 				proxyRegistryURL = fmt.Sprintf("https://%s", runtimeconfig.ProxyRegistryAddress)
 			}
 
-			fromCIDR, toCIDR, err := DeterminePodAndServiceCIDRs(cmd)
+			fromCIDR, toCIDR, err := getPODAndServiceCIDR(cmd)
 			if err != nil {
 				return fmt.Errorf("unable to determine pod and service CIDRs: %w", err)
 			}
@@ -659,7 +645,7 @@ func ensureK0sConfig(cmd *cobra.Command, applier *addons.Applier) (*k0sconfig.Cl
 	cfg.Spec.API.Address = address
 	cfg.Spec.Storage.Etcd.PeerAddress = address
 
-	podCIDR, serviceCIDR, err := DeterminePodAndServiceCIDRs(cmd)
+	podCIDR, serviceCIDR, err := getPODAndServiceCIDR(cmd)
 	if err != nil {
 		return nil, fmt.Errorf("unable to determine pod and service CIDRs: %w", err)
 	}
@@ -739,30 +725,6 @@ func applyUnsupportedOverrides(cmd *cobra.Command, cfg *k0sconfig.ClusterConfig)
 	}
 
 	return cfg, nil
-}
-
-// DeterminePodAndServiceCIDRS determines, based on the command line flags,
-// what are the pod and service CIDRs to be used for the cluster. If both
-// --pod-cidr and --service-cidr have been set, they are used. Otherwise,
-// the cidr flag is split into pod and service CIDRs.
-func DeterminePodAndServiceCIDRs(cmd *cobra.Command) (string, string, error) {
-	if cmd.Flags().Changed("pod-cidr") || cmd.Flags().Changed("service-cidr") {
-		podCIDRFlag, err := cmd.Flags().GetString("pod-cidr")
-		if err != nil {
-			return "", "", fmt.Errorf("unable to get pod-cidr flag: %w", err)
-		}
-		serviceCIDRFlag, err := cmd.Flags().GetString("service-cidr")
-		if err != nil {
-			return "", "", fmt.Errorf("unable to get service-cidr flag: %w", err)
-		}
-		return podCIDRFlag, serviceCIDRFlag, nil
-	}
-
-	cidrFlag, err := cmd.Flags().GetString("cidr")
-	if err != nil {
-		return "", "", fmt.Errorf("unable to get cidr flag: %w", err)
-	}
-	return netutils.SplitNetworkCIDR(cidrFlag)
 }
 
 // createSystemdUnitFiles links the k0s systemd unit file. this also creates a new

--- a/cmd/installer/cli/install2.go
+++ b/cmd/installer/cli/install2.go
@@ -1,0 +1,224 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"github.com/replicatedhq/embedded-cluster/pkg/configutils"
+	"github.com/replicatedhq/embedded-cluster/pkg/helpers"
+	"github.com/replicatedhq/embedded-cluster/pkg/k0s"
+	"github.com/replicatedhq/embedded-cluster/pkg/metrics"
+	"github.com/replicatedhq/embedded-cluster/pkg/preflights"
+	"github.com/replicatedhq/embedded-cluster/pkg/prompts"
+	"github.com/replicatedhq/embedded-cluster/pkg/release"
+	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// Install2Cmd returns a cobra command for installing the embedded cluster.
+// This is the upcoming version of install without the operator and where
+// install does all of the work. This is a hidden command until it's tested
+// and ready.
+func Install2Cmd(ctx context.Context, name string) *cobra.Command {
+	var (
+		adminConsolePassword    string
+		adminConsolePort        int
+		airgapBundle            string
+		dataDir                 string
+		licenseFile             string
+		localArtifactMirrorPort int
+		networkInterface        string
+		assumeYes               bool
+		overrides               string
+		privateCAs              []string
+		skipHostPreflights      bool
+		ignoreHostPreflights    bool
+		configValues            string
+
+		proxy *ecv1beta1.ProxySpec
+	)
+
+	cmd := &cobra.Command{
+		Use:          "install2",
+		Short:        fmt.Sprintf("Experimental installer for %s", name),
+		Hidden:       true,
+		SilenceUsage: true,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if os.Getuid() != 0 {
+				return fmt.Errorf("install command must be run as root")
+			}
+
+			if skipHostPreflights {
+				logrus.Warnf("Warning: --skip-host-preflights is deprecated and will be removed in a later version. Use --ignore-host-preflights instead.")
+			}
+
+			p, err := parseProxyFlags(cmd)
+			if err != nil {
+				return err
+			}
+			proxy = p
+
+			if err := parseCIDRFlags(cmd); err != nil {
+				return err
+			}
+
+			// validate the the license is indeed a license file
+			_, err = helpers.ParseLicense(licenseFile)
+			if err != nil {
+				if err == helpers.ErrNotALicenseFile {
+					return fmt.Errorf("license file is not a valid license file")
+				}
+
+				return fmt.Errorf("unable to parse license file: %w", err)
+			}
+
+			runtimeconfig.ApplyFlags(cmd.Flags())
+			os.Setenv("TMPDIR", runtimeconfig.EmbeddedClusterTmpSubDir())
+
+			if err := runtimeconfig.WriteToDisk(); err != nil {
+				return fmt.Errorf("unable to write runtime config to disk: %w", err)
+			}
+
+			return nil
+		},
+		PostRun: func(cmd *cobra.Command, args []string) {
+			runtimeconfig.Cleanup()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			logrus.Debugf("checking if %s is already installed", name)
+			installed, err := k0s.IsInstalled()
+			if err != nil {
+				return err
+			}
+			if installed {
+				logrus.Errorf("An installation has been detected on this machine.")
+				logrus.Infof("If you want to reinstall, you need to remove the existing installation first.")
+				logrus.Infof("You can do this by running the following command:")
+				logrus.Infof("\n  sudo ./%s reset\n", name)
+				os.Exit(1)
+			}
+
+			channelRelease, err := release.GetChannelRelease()
+			if err != nil {
+				return fmt.Errorf("unable to read channel release data: %w", err)
+			}
+
+			if channelRelease != nil && channelRelease.Airgap && airgapBundle == "" && !assumeYes {
+				logrus.Warnf("You downloaded an air gap bundle but didn't provide it with --airgap-bundle.")
+				logrus.Warnf("If you continue, the installation will not use an air gap bundle and will connect to the internet.")
+				if !prompts.New().Confirm("Do you want to proceed with an online installation?", false) {
+					return ErrNothingElseToAdd
+				}
+			}
+
+			metrics.ReportApplyStarted(cmd.Context(), licenseFile)
+
+			logrus.Debugf("checking license matches")
+			license, err := getLicenseFromFilepath(licenseFile)
+			if err != nil {
+				metricErr := fmt.Errorf("unable to get license: %w", err)
+				metrics.ReportApplyFinished(cmd.Context(), licenseFile, metricErr)
+				return err // do not return the metricErr, as we want the user to see the error message without a prefix
+			}
+			isAirgap := false
+			if airgapBundle != "" {
+				isAirgap = true
+			}
+			if isAirgap {
+				logrus.Debugf("checking airgap bundle matches binary")
+				if err := checkAirgapMatches(airgapBundle); err != nil {
+					return err // we want the user to see the error message without a prefix
+				}
+			}
+
+			if !isAirgap {
+				if err := maybePromptForAppUpdate(cmd.Context(), prompts.New(), license, assumeYes); err != nil {
+					if errors.Is(err, ErrNothingElseToAdd) {
+						metrics.ReportApplyFinished(cmd.Context(), licenseFile, err)
+						return err
+					}
+					// If we get an error other than ErrNothingElseToAdd, we warn and continue as
+					// this check is not critical.
+					logrus.Debugf("WARNING: Failed to check for newer app versions: %v", err)
+				}
+			}
+
+			if err := preflights.ValidateApp(); err != nil {
+				metrics.ReportApplyFinished(cmd.Context(), licenseFile, err)
+				return err
+			}
+
+			_, err = maybeAskAdminConsolePassword(cmd, assumeYes)
+			if err != nil {
+				metrics.ReportApplyFinished(cmd.Context(), licenseFile, err)
+				return err
+			}
+
+			logrus.Debugf("materializing binaries")
+			if err := materializeFiles(airgapBundle); err != nil {
+				metrics.ReportApplyFinished(cmd.Context(), licenseFile, err)
+				return err
+			}
+
+			// run host preglights
+			logrus.Debugf("running host preflights")
+			fromCIDR, toCIDR, err := getPODAndServiceCIDR(cmd)
+			if err != nil {
+				return fmt.Errorf("unable to determine pod and service CIDRs: %w", err)
+			}
+
+			preflightOptions := preflights.PrepareAndRunOptions{
+				License:              license,
+				Proxy:                proxy,
+				ConnectivityFromCIDR: fromCIDR,
+				ConnectivityToCIDR:   toCIDR,
+			}
+			if err := preflights.PrepareAndRun(cmd.Context(), preflightOptions); err != nil {
+				return fmt.Errorf("unable to prepare and run preflights: %w", err)
+			}
+
+			logrus.Debugf("configuring sysctl")
+			if err := configutils.ConfigureSysctl(); err != nil {
+				return fmt.Errorf("unable to configure sysctl: %w", err)
+			}
+
+			logrus.Debugf("configuring network manager")
+			if err := configureNetworkManager(cmd.Context()); err != nil {
+				return fmt.Errorf("unable to configure network manager: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&adminConsolePassword, "admin-console-password", "", "Password for the Admin Console")
+	cmd.Flags().IntVar(&adminConsolePort, "admin-console-port", ecv1beta1.DefaultAdminConsolePort, "Port on which the Admin Console will be served")
+	cmd.Flags().StringVar(&airgapBundle, "airgap-bundle", "", "Path to the air gap bundle. If set, the installation will complete without internet access.")
+	cmd.Flags().StringVar(&dataDir, "data-dir", ecv1beta1.DefaultDataDir, "Path to the data directory")
+	cmd.Flags().StringVar(&licenseFile, "license", "", "Path to the license file")
+	cmd.Flags().IntVar(&localArtifactMirrorPort, "local-artifact-mirror-port", ecv1beta1.DefaultLocalArtifactMirrorPort, "Port on which the Local Artifact Mirror will be served")
+	cmd.Flags().StringVar(&networkInterface, "network-interface", "", "The network interface to use for the cluster")
+	cmd.Flags().BoolVar(&assumeYes, "yes", false, "Assume yes to all prompts.")
+
+	cmd.Flags().StringVar(&overrides, "overrides", "", "File with an EmbeddedClusterConfig object to override the default configuration")
+	cmd.Flags().MarkHidden("overrides")
+
+	cmd.Flags().StringSliceVar(&privateCAs, "private-ca", []string{}, "Path to a trusted private CA certificate file")
+
+	cmd.Flags().BoolVar(&skipHostPreflights, "skip-host-preflights", false, "Skip host preflight checks. This is not recommended and has been deprecated.")
+	cmd.Flags().MarkHidden("skip-host-preflights")
+	cmd.Flags().MarkDeprecated("skip-host-preflights", "This flag is deprecated and will be removed in a future version. Use --ignore-host-preflights instead.")
+
+	cmd.Flags().BoolVar(&ignoreHostPreflights, "ignore-host-preflights", false, "Run host preflight checks, but prompt the user to continue if they fail instead of exiting.")
+	cmd.Flags().StringVar(&configValues, "config-values", "", "path to a manifest containing config values (must be apiVersion: kots.io/v1beta1, kind: ConfigValues)")
+
+	addProxyFlags(cmd)
+	addCIDRFlags(cmd)
+	cmd.Flags().SetNormalizeFunc(normalizeNoPromptToYes)
+
+	return cmd
+}

--- a/cmd/installer/cli/install_runpreflights.go
+++ b/cmd/installer/cli/install_runpreflights.go
@@ -121,7 +121,7 @@ func InstallRunPreflightsCmd(ctx context.Context, name string) *cobra.Command {
 				proxyRegistryURL = fmt.Sprintf("https://%s", runtimeconfig.ProxyRegistryAddress)
 			}
 
-			fromCIDR, toCIDR, err := DeterminePodAndServiceCIDRs(cmd)
+			fromCIDR, toCIDR, err := getPODAndServiceCIDR(cmd)
 			if err != nil {
 				return fmt.Errorf("unable to determine pod and service CIDRs: %w", err)
 			}

--- a/cmd/installer/cli/join.go
+++ b/cmd/installer/cli/join.go
@@ -59,12 +59,16 @@ func JoinCmd(ctx context.Context, name string) *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logrus.Debugf("checking if %s is already installed", name)
-			installed, err := k0s.IsInstalled(name)
+			installed, err := k0s.IsInstalled()
 			if err != nil {
 				return err
 			}
 			if installed {
-				return ErrNothingElseToAdd
+				logrus.Errorf("An installation has been detected on this machine.")
+				logrus.Infof("If you want to join a node to an existing installation, you need to remove the existing installation first.")
+				logrus.Infof("You can do this by running the following command:")
+				logrus.Infof("\n  sudo ./%s reset\n", name)
+				os.Exit(1)
 			}
 
 			channelRelease, err := release.GetChannelRelease()

--- a/cmd/installer/cli/restore.go
+++ b/cmd/installer/cli/restore.go
@@ -225,12 +225,16 @@ func RestoreCmd(ctx context.Context, name string) *cobra.Command {
 			switch state {
 			case ecRestoreStateNew:
 				logrus.Debugf("checking if %s is already installed", name)
-				installed, err := k0s.IsInstalled(name)
+				installed, err := k0s.IsInstalled()
 				if err != nil {
 					return err
 				}
 				if installed {
-					return ErrNothingElseToAdd
+					logrus.Errorf("An installation has been detected on this machine.")
+					logrus.Infof("Before you can restore, you must remove the existing installation.")
+					logrus.Infof("You can do this by running the following command:")
+					logrus.Infof("\n  sudo ./%s reset\n", name)
+					os.Exit(1)
 				}
 
 				logrus.Infof("You'll be guided through the process of restoring %s from a backup.\n", name)
@@ -747,7 +751,7 @@ func ensureK0sConfigForRestore(cmd *cobra.Command, applier *addons.Applier) (*k0
 	cfg.Spec.API.Address = address
 	cfg.Spec.Storage.Etcd.PeerAddress = address
 
-	podCIDR, serviceCIDR, err := DeterminePodAndServiceCIDRs(cmd)
+	podCIDR, serviceCIDR, err := getPODAndServiceCIDR(cmd)
 	if err != nil {
 		return nil, fmt.Errorf("unable to determine pod and service CIDRs: %w", err)
 	}

--- a/cmd/installer/cli/root.go
+++ b/cmd/installer/cli/root.go
@@ -50,6 +50,7 @@ func RootCmd(ctx context.Context, name string) *cobra.Command {
 	}
 
 	cmd.AddCommand(InstallCmd(ctx, name))
+	cmd.AddCommand(Install2Cmd(ctx, name))
 	cmd.AddCommand(JoinCmd(ctx, name))
 	cmd.AddCommand(ShellCmd(ctx, name))
 	cmd.AddCommand(NodeCmd(ctx, name))

--- a/hack/dev-embed.go
+++ b/hack/dev-embed.go
@@ -14,7 +14,6 @@ func main() {
 }
 
 func run() int {
-	// Define flags
 	binaryPath := flag.String("binary", "", "Path to the binary file")
 	releasePath := flag.String("release", "", "Path to the release tar.gz file")
 	outputPath := flag.String("output", "", "Path to the output file")
@@ -22,19 +21,15 @@ func run() int {
 	sequence := flag.Int("sequence", 0, "Release sequence number")
 	channel := flag.String("channel", "", "Channel slug")
 
-	// Parse flags
 	flag.Parse()
 
-	// Validate required arguments
 	if *binaryPath == "" || *releasePath == "" || *outputPath == "" {
 		fmt.Printf("Usage: %s --binary <binary> --release <release.tar.gz> --output <output> [--label <label>] [--sequence <sequence>] [--channel <channel>]\n", os.Args[0])
 		return 1
 	}
 
-	// Log additional arguments for debugging
 	log.Printf("Embedding release with label=%q, sequence=%d, channel=%q", *label, *sequence, *channel)
 
-	// Call the embed function
 	if err := embed.EmbedReleaseDataInBinary(*binaryPath, *releasePath, *outputPath); err != nil {
 		log.Printf("Failed to embed release data: %v", err)
 		return 1

--- a/pkg/addons/embeddedclusteroperator/static/metadata.yaml
+++ b/pkg/addons/embeddedclusteroperator/static/metadata.yaml
@@ -5,16 +5,16 @@
 # $ make buildtools
 # $ output/bin/buildtools update addon <addon name>
 #
-version: 1.12.1+k8s-1.29
+version: 1.19.0+k8s-1.30
 location: oci://proxy.replicated.com/anonymous/registry.replicated.com/library/embedded-cluster-operator
 images:
     embedded-cluster-operator:
         repo: proxy.replicated.com/anonymous/replicated/embedded-cluster-operator-image
         tag:
-            amd64: v1.12.1-k8s-1.29-amd64@sha256:eeed01216b5d18dd05ac4f39351a055b4aebe5a9e35ed287595391b6988c8950
-            arm64: v1.11.1-k8s-1.29@sha256:2520e1593a323d5f7218d9501c6f6f08ef34d8eee4dbc4a7306878e3572aa4cb
+            amd64: v1.19.0-k8s-1.30
+            arm64: v1.19.0-k8s-1.30
     utils:
         repo: proxy.replicated.com/anonymous/replicated/ec-utils
         tag:
-            amd64: latest-amd64@sha256:92dec6e167ff57b35953da389ceffca0227056368d369a5b20a36fb2fe7e3e11
-            arm64: latest-arm64@sha256:a9ab9db181f9898283a8778070ef7945299ffc933d7da081b5326f3296da6d0a
+            amd64: latest
+            arm64: latest

--- a/pkg/addons2/addons.go
+++ b/pkg/addons2/addons.go
@@ -1,0 +1,1 @@
+package addons2

--- a/pkg/addons2/openebs/install.go
+++ b/pkg/addons2/openebs/install.go
@@ -1,0 +1,5 @@
+package openebs
+
+func (o *OpenEBS) Install() error {
+	return nil
+}

--- a/pkg/addons2/openebs/openebs.go
+++ b/pkg/addons2/openebs/openebs.go
@@ -1,0 +1,4 @@
+package openebs
+
+type OpenEBS struct {
+}

--- a/pkg/addons2/openebs/upgrade.go
+++ b/pkg/addons2/openebs/upgrade.go
@@ -1,0 +1,5 @@
+package openebs
+
+func (o *OpenEBS) Upgrade() error {
+	return nil
+}

--- a/pkg/addons2/types/types.go
+++ b/pkg/addons2/types/types.go
@@ -1,0 +1,10 @@
+package types
+
+import "github.com/replicatedhq/embedded-cluster/pkg/addons2/openebs"
+
+type AddOn interface {
+	Install() error
+	Upgrade() error
+}
+
+var _ AddOn = (*openebs.OpenEBS)(nil)

--- a/pkg/helpers/parse.go
+++ b/pkg/helpers/parse.go
@@ -1,12 +1,17 @@
 package helpers
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
 	embeddedclusterv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	kyaml "sigs.k8s.io/yaml"
+)
+
+var (
+	ErrNotALicenseFile = errors.New("not a license file")
 )
 
 // ParseEndUserConfig parses the end user configuration from the given file.
@@ -33,7 +38,7 @@ func ParseLicense(fpath string) (*kotsv1beta1.License, error) {
 	}
 	var license kotsv1beta1.License
 	if err := kyaml.Unmarshal(data, &license); err != nil {
-		return nil, fmt.Errorf("unable to unmarshal license file: %w", err)
+		return nil, ErrNotALicenseFile
 	}
 	return &license, nil
 }

--- a/pkg/k0s/install.go
+++ b/pkg/k0s/install.go
@@ -8,7 +8,6 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/helpers"
 	"github.com/replicatedhq/embedded-cluster/pkg/netutils"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
-	"github.com/sirupsen/logrus"
 )
 
 // Install runs the k0s install command and waits for it to finish. If no configuration
@@ -35,19 +34,13 @@ func Install(networkInterface string) error {
 
 // IsInstalled checks if the embedded cluster is already installed by looking for
 // the k0s configuration file existence.
-func IsInstalled(name string) (bool, error) {
-	cfgpath := runtimeconfig.PathToK0sConfig()
-	_, err := os.Stat(cfgpath)
-	switch {
-	case err == nil:
-		logrus.Errorf("An installation has been detected on this machine.")
-		logrus.Infof("If you want to reinstall, you need to remove the existing installation first.")
-		logrus.Infof("You can do this by running the following command:")
-		logrus.Infof("\n  sudo ./%s reset\n", name)
+func IsInstalled() (bool, error) {
+	_, err := os.Stat(runtimeconfig.PathToK0sConfig())
+	if err == nil {
 		return true, nil
-	case os.IsNotExist(err):
+	} else if os.IsNotExist(err) {
 		return false, nil
-	default:
-		return false, fmt.Errorf("unable to check if already installed: %w", err)
 	}
+
+	return false, fmt.Errorf("unable to check if already installed: %w", err)
 }

--- a/pkg/metrics/reporter.go
+++ b/pkg/metrics/reporter.go
@@ -21,6 +21,10 @@ import (
 var clusterIDMut sync.Mutex
 var clusterID *uuid.UUID
 
+func metricsEnabled() bool {
+	return os.Getenv("DISABLE_TELEMETRY") != ""
+}
+
 // BaseURL determines the base url to be used when sending metrics over.
 func BaseURL(license *kotsv1beta1.License) string {
 	if os.Getenv("EMBEDDED_CLUSTER_METRICS_BASEURL") != "" {
@@ -66,6 +70,10 @@ func SetClusterID(id uuid.UUID) {
 
 // ReportInstallationStarted reports that the installation has started.
 func ReportInstallationStarted(ctx context.Context, license *kotsv1beta1.License) {
+	if !metricsEnabled() {
+		return
+	}
+
 	rel, _ := release.GetChannelRelease()
 	appChannel, appVersion := "", ""
 	if rel != nil {
@@ -87,11 +95,19 @@ func ReportInstallationStarted(ctx context.Context, license *kotsv1beta1.License
 
 // ReportInstallationSucceeded reports that the installation has succeeded.
 func ReportInstallationSucceeded(ctx context.Context, license *kotsv1beta1.License) {
+	if !metricsEnabled() {
+		return
+	}
+
 	Send(ctx, BaseURL(license), types.InstallationSucceeded{ClusterID: ClusterID(), Version: versions.Version})
 }
 
 // ReportInstallationFailed reports that the installation has failed.
 func ReportInstallationFailed(ctx context.Context, license *kotsv1beta1.License, err error) {
+	if !metricsEnabled() {
+		return
+	}
+
 	Send(ctx, BaseURL(license), types.InstallationFailed{
 		ClusterID: ClusterID(),
 		Version:   versions.Version,
@@ -101,6 +117,10 @@ func ReportInstallationFailed(ctx context.Context, license *kotsv1beta1.License,
 
 // ReportJoinStarted reports that a join has started.
 func ReportJoinStarted(ctx context.Context, baseURL string, clusterID uuid.UUID) {
+	if !metricsEnabled() {
+		return
+	}
+
 	hostname, err := os.Hostname()
 	if err != nil {
 		logrus.Warnf("unable to get hostname: %s", err)
@@ -115,6 +135,10 @@ func ReportJoinStarted(ctx context.Context, baseURL string, clusterID uuid.UUID)
 
 // ReportJoinSucceeded reports that a join has finished successfully.
 func ReportJoinSucceeded(ctx context.Context, baseURL string, clusterID uuid.UUID) {
+	if !metricsEnabled() {
+		return
+	}
+
 	hostname, err := os.Hostname()
 	if err != nil {
 		logrus.Warnf("unable to get hostname: %s", err)
@@ -129,6 +153,10 @@ func ReportJoinSucceeded(ctx context.Context, baseURL string, clusterID uuid.UUI
 
 // ReportJoinFailed reports that a join has failed.
 func ReportJoinFailed(ctx context.Context, baseURL string, clusterID uuid.UUID, exterr error) {
+	if !metricsEnabled() {
+		return
+	}
+
 	hostname, err := os.Hostname()
 	if err != nil {
 		logrus.Warnf("unable to get hostname: %s", err)
@@ -144,6 +172,10 @@ func ReportJoinFailed(ctx context.Context, baseURL string, clusterID uuid.UUID, 
 
 // ReportApplyStarted reports an InstallationStarted event.
 func ReportApplyStarted(ctx context.Context, licenseFlag string) {
+	if !metricsEnabled() {
+		return
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	ReportInstallationStarted(ctx, License(licenseFlag))
@@ -151,6 +183,10 @@ func ReportApplyStarted(ctx context.Context, licenseFlag string) {
 
 // ReportApplyFinished reports an InstallationSucceeded or an InstallationFailed.
 func ReportApplyFinished(ctx context.Context, licenseFlag string, err error) {
+	if !metricsEnabled() {
+		return
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	if err != nil {

--- a/pkg/preflights/run.go
+++ b/pkg/preflights/run.go
@@ -1,0 +1,25 @@
+package preflights
+
+import (
+	"context"
+	"fmt"
+
+	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
+)
+
+type PrepareAndRunOptions struct {
+	License *kotsv1beta1.License
+	Proxy   *ecv1beta1.ProxySpec
+
+	ConnectivityFromCIDR string
+	ConnectivityToCIDR   string
+}
+
+func PrepareAndRun(ctx context.Context, opts PrepareAndRunOptions) error {
+	replicatedAPIURL := opts.License.Spec.Endpoint
+	proxyRegistryURL := fmt.Sprintf("https://%s", opts.Proxy.HTTPSProxy)
+
+	fmt.Printf("Running host preflights: %s, %s\n", replicatedAPIURL, proxyRegistryURL)
+	return nil
+}

--- a/pkg/websocket/server.go
+++ b/pkg/websocket/server.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+// wsDialer is the default dialer but with a shorter timeout.
 var wsDialer = &gwebsocket.Dialer{
 	HandshakeTimeout: 10 * time.Second,
 }


### PR DESCRIPTION
adds the new `install2` hidden command which does not actually install anything yet.

some related refactoring:

IsInstalled should not be responsible for printing the error output, it's a simple function. The caller should determine if and when to print a function. 

my local env test-embed: set the version since the git history is not the right place for this.

moved some of the proxy parsing out and into a parseProxyArgs function. it's not yet called everywhere, but will be .  

added an env var to not report metrics, using the closest name to an industry standard env var name i could find. 