### PR TITLE
Update image-scan job to exclude kube-proxy

### DIFF
--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -119,7 +119,7 @@ jobs:
       - name: Build images matrix
         id: build-matrix
         run: |
-          IMAGES="[$(awk '{print $1}' images.txt | xargs -n1 | awk '{print "\""$1"\","}' | sed '$ s/.$//')]"
+          IMAGES="[$(awk '!/kube-proxy/' images.txt | awk '{print $1}' | xargs -n1 | awk '{print "\""$1"\","}' | sed '$ s/.$//')]"
           echo "matrix=$(jq -cn --argjson images "$IMAGES" '{image: $images}')" >> $GITHUB_OUTPUT
 
   scan:


### PR DESCRIPTION
#### What this PR does / why we need it:
Currently, every image scan workflow fails because of an image with an accepted vulnerability. This PR will exclude the image from the scan



#### Does this PR require a test?
no

#### Does this PR require a release note?
no

#### Does this PR require documentation?
no