### PR TITLE
Add firewall-cmd --list-all to host support bundle

### DIFF
--- a/pkg/goods/support/host-support-bundle.tmpl.yaml
+++ b/pkg/goods/support/host-support-bundle.tmpl.yaml
@@ -206,9 +206,13 @@ spec:
       collectorName: runtime-config
       path: /etc/embedded-cluster/*
   - run:
-        collectorName: "systemctl-firewalld-status"
-        command: "systemctl"
-        args: ["status", "firewalld"]
+      collectorName: "systemctl-firewalld-status"
+      command: "systemctl"
+      args: ["status", "firewalld"]
+  - run:
+      collectorName: "firewalld-cmd-list-all"
+      command: "firewalld-cmd"
+      args: ["--list-all"]
   - run:
       collectorName: "systemctl-resolved-status"
       command: "systemctl"


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Adds `firewalld-cmd --list-all` so we can see what potential firewall rules are in place via `firewalld`

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
