### PR TITLE
Backport setting the best network interface to install

### DIFF
--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -90,6 +90,17 @@ func InstallCmd(ctx context.Context, name string) *cobra.Command {
 				return fmt.Errorf("unable to parse cidr flags: %w", err)
 			}
 
+			// if a network interface flag was not provided, attempt to discover it
+			if networkInterface == "" {
+				autoInterface, err := determineBestNetworkInterface()
+				if err == nil {
+					// set the variable
+					networkInterface = autoInterface
+					// set it in cobra since we pass the cmd around in this version
+					cmd.Flags().Set("network-interface", autoInterface)
+				}
+			}
+
 			if os.Getenv("DISABLE_TELEMETRY") != "" {
 				metrics.DisableMetrics()
 			}


### PR DESCRIPTION
This was added to install2, adding it in install. We need to set the cobra flag for install because the cobra command object is passed around in a few places.

We don't error and fail if we can't determine the best interface. This allow the current behavior to continue to be the fall through.