### PR TITLE
Don't wrap CIDR errors

### DIFF
--- a/cmd/installer/cli/cidr.go
+++ b/cmd/installer/cli/cidr.go
@@ -20,7 +20,7 @@ func addCIDRFlags(cmd *cobra.Command) {
 
 func validateCIDRFlags(cmd *cobra.Command) error {
 	if cmd.Flags().Changed("cidr") && (cmd.Flags().Changed("pod-cidr") || cmd.Flags().Changed("service-cidr")) {
-		return fmt.Errorf("--cidr flag can't be used with --pod-cidr or --service-cidr")
+		return fmt.Errorf("--cidr can't be used with --pod-cidr or --service-cidr")
 	}
 
 	cidr, err := cmd.Flags().GetString("cidr")
@@ -29,7 +29,7 @@ func validateCIDRFlags(cmd *cobra.Command) error {
 	}
 
 	if err := netutils.ValidateCIDR(cidr, 16, true); err != nil {
-		return fmt.Errorf("invalid cidr %q: %w", cidr, err)
+		return err
 	}
 
 	return nil

--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -87,7 +87,7 @@ func InstallCmd(ctx context.Context, name string) *cobra.Command {
 			proxy = p
 
 			if err := validateCIDRFlags(cmd); err != nil {
-				return fmt.Errorf("unable to parse cidr flags: %w", err)
+				return err
 			}
 
 			// if a network interface flag was not provided, attempt to discover it

--- a/pkg/netutils/nets.go
+++ b/pkg/netutils/nets.go
@@ -39,11 +39,11 @@ func ValidateCIDR(cidr string, notLessThan int, private bool) error {
 	}
 
 	if ipnet.String() != cidr {
-		return fmt.Errorf("the provided address is not a valid CIDR")
+		return fmt.Errorf("The provided CIDR block (%s) is not valid", cidr)
 	}
 
 	if size, _ := ipnet.Mask.Size(); size > notLessThan {
-		return fmt.Errorf("cidr needs to be at least a /%d", notLessThan)
+		return fmt.Errorf("The provided CIDR block (%s) is too small. It must be /%d or larger.", cidr, notLessThan)
 	}
 
 	if !private {
@@ -57,7 +57,7 @@ func ValidateCIDR(cidr string, notLessThan int, private bool) error {
 		}
 	}
 
-	return fmt.Errorf("cidr is not in private ranges %s", strings.Join(privates, ", "))
+	return fmt.Errorf("The provided CIDR block (%s) is not in a private IP address range (%s)", cidr, strings.Join(privates, ", "))
 }
 
 // NetworksAreAdjacentAndSameSize returns true if the two provided CIDRs are

--- a/pkg/netutils/nets_test.go
+++ b/pkg/netutils/nets_test.go
@@ -53,7 +53,7 @@ func TestValidateCIDR(t *testing.T) {
 		{
 			name: "small cidr",
 			cidr: "10.0.0.0/24",
-			err:  "cidr needs to be at least a /16",
+			err:  "The provided CIDR block (10.0.0.0/24) is too small. It must be /16 or larger.",
 		},
 		{
 			name: "invalid cidr",
@@ -63,12 +63,12 @@ func TestValidateCIDR(t *testing.T) {
 		{
 			name: "a /32 cidr",
 			cidr: "10.0.0.0/32",
-			err:  "cidr needs to be at least a /16",
+			err:  "The provided CIDR block (10.0.0.0/32) is too small. It must be /16 or larger.",
 		},
 		{
 			name: "a public cidr",
 			cidr: "100.0.0.0/16",
-			err:  "cidr is not in private ranges",
+			err:  "The provided CIDR block (100.0.0.0/16) is not in a private IP address range (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)",
 		},
 		{
 			name: "matching the whole private range",
@@ -81,7 +81,7 @@ func TestValidateCIDR(t *testing.T) {
 		{
 			name: "not a cidr address",
 			cidr: "192.168.1.1/16",
-			err:  "the provided address is not a valid CIDR",
+			err:  "The provided CIDR block (192.168.1.1/16) is not valid",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
When you pass a bad CIDR block, the output looks like a wrapped Go error. This isn't helpful to users. Now, the errors are clear sentences to help people fix the problem.
#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE
#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE

Example:
```
root@node0:/replicatedhq/embedded-cluster# sudo ./output/bin/embedded-cluster install --cidr 16.0.0.0/16
The provided CIDR block (16.0.0.0/16) is not in a private IP address range (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
```