### PR TITLE
Accept CVE 2023 47108

### DIFF
--- a/.github/actions/scan-image/action.yml
+++ b/.github/actions/scan-image/action.yml
@@ -26,7 +26,7 @@ runs:
         ignore-unfixed: true
         severity: CRITICAL,HIGH,MEDIUM
         exit-code: 1
-        trivyignores: .trivyignore
+        trivyignores: .trivyignore.yaml
 
     - name: Output sarif
       uses: aquasecurity/trivy-action@0.24.0

--- a/.github/actions/scan-image/action.yml
+++ b/.github/actions/scan-image/action.yml
@@ -26,6 +26,7 @@ runs:
         ignore-unfixed: true
         severity: CRITICAL,HIGH,MEDIUM
         exit-code: 1
+        trivyignores: .trivyignore
 
     - name: Output sarif
       uses: aquasecurity/trivy-action@0.24.0

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,4 @@
+# Accept the risk
+CVE-2024-5535
+CVE-2024-45310
+CVE-2023-47108

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,4 +1,0 @@
-# Accept the risk
-CVE-2024-5535
-CVE-2024-45310
-CVE-2023-47108

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,5 @@
+vulnerabilities:
+  - id: CVE-2023-47108
+    paths:
+      - usr/local/bin/kube-proxy
+    statement: Accepted upstream; not in code path; https://github.com/kubernetes/kubernetes/pull/121842


### PR DESCRIPTION
#### What this PR does / why we need it:
CVE-2023-47108 is not in the code path for any Kubernetes component. It does not impact kube-proxy. This PR will silence the alerts about this CVE. See here for context:

https://kubernetes.slack.com/archives/CHGFYJVAN/p1722343995736019?thread_ts=1722343658.235969&cid=CHGFYJVAN

https://github.com/kubernetes/kubernetes/pull/121842

#### Which issue(s) this PR fixes:
The Scan image job continuously flagged this high CVE, but it is a false positive.

#### Does this PR require a test?
no

#### Does this PR require a release note?
no

#### Does this PR require documentation?
no
