### PR TITLE
Using a flat irvyignore file to be compatible with GHA

### DIFF
--- a/.github/actions/scan-image/action.yml
+++ b/.github/actions/scan-image/action.yml
@@ -26,7 +26,7 @@ runs:
         ignore-unfixed: true
         severity: CRITICAL,HIGH,MEDIUM
         exit-code: 1
-        trivyignores: .trivyignore.yaml
+        trivyignores: .trivyignore
 
     - name: Output sarif
       uses: aquasecurity/trivy-action@0.24.0

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,2 @@
+# Accepted upstream; not in code path; https://github.com/kubernetes/kubernetes/pull/121842
+CVE-2023-47108

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,5 +1,0 @@
-vulnerabilities:
-  - id: CVE-2023-47108
-    paths:
-      - usr/local/bin/kube-proxy
-    statement: Accepted upstream; not in code path; https://github.com/kubernetes/kubernetes/pull/121842


### PR DESCRIPTION
#### What this PR does / why we need it:
Looks like the trivyignore approach with the trivyignore yaml file [didn't work](https://github.com/replicatedhq/embedded-cluster/actions/runs/12279581825/job/34264596355). I believe this is because the [trivy github action](https://github.com/aquasecurity/trivy-action/blob/18f2510ee396bbf400402947b394f2dd8c87dbb0/entrypoint.sh#L11-L28) converts the *.yaml files into flat files. But trivy will only parse yaml files if they [end with a yaml or yml extension](https://trivy.dev/latest/docs/configuration/filtering/#by-finding-ids:~:text=When%20the%20extension%20of%20the%20specified%20ignore%20file%20is%20either%20.yml%20or%20.yaml%2C%20Trivy%20will%20load%20the%20file%20as%20YAML.%20For%20the%20.trivyignore.yaml%20file%2C%20you%20can%20set%20ignored%20IDs%20separately%20for%20vulnerabilities%2C%20misconfigurations%2C%20secrets%2C%20or%20licenses1.). I will try to go with the flat file approach for the trivyignore to see if that will change something

#### Which issue(s) this PR fixes:
The Scan image job continuously flagged this high CVE, but it is a false positive.

#### Does this PR require a test?
no

#### Does this PR require a release note?
no

#### Does this PR require documentation?
no
