### PR TITLE
chore(ci): fix dagger install, pin to 1.14.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -162,7 +162,7 @@ jobs:
 
       - name: Install dagger
         run: |
-          curl -fsSL https://dl.dagger.io/dagger/install.sh | sh
+          curl -fsSL https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=v0.14.0 sh
           sudo mv ./bin/dagger /usr/local/bin/dagger
 
       - name: Build
@@ -233,7 +233,7 @@ jobs:
 
       - name: Install dagger
         run: |
-          curl -fsSL https://dl.dagger.io/dagger/install.sh | sh
+          curl -fsSL https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=v0.14.0 sh
           sudo mv ./bin/dagger /usr/local/bin/dagger
 
       - name: Build
@@ -337,7 +337,7 @@ jobs:
 
       - name: Install dagger
         run: |
-          curl -fsSL https://dl.dagger.io/dagger/install.sh | sh
+          curl -fsSL https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=v0.14.0 sh
           sudo mv ./bin/dagger /usr/local/bin/dagger
 
       - name: Build

--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install dagger
         run: |
-          curl -fsSL https://dl.dagger.io/dagger/install.sh | sh
+          curl -fsSL https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=v0.14.0 sh
           sudo mv ./bin/dagger /usr/local/bin/dagger
 
       - name: Build and push local-artifact-mirror image

--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Install dagger
         run: |
-          curl -fsSL https://dl.dagger.io/dagger/install.sh | sh
+          curl -fsSL https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=v0.14.0 sh
           sudo mv ./bin/dagger /usr/local/bin/dagger
 
       - name: Build and push operator image
@@ -114,7 +114,7 @@ jobs:
 
       - name: Install dagger
         run: |
-          curl -fsSL https://dl.dagger.io/dagger/install.sh | sh
+          curl -fsSL https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=v0.14.0 sh
           sudo mv ./bin/dagger /usr/local/bin/dagger
 
       - name: Build and push local-artifact-mirror image


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Fixes

```
Run curl -fsSL https://dl.dagger.io/dagger/install.sh | sh
sh debug downloading files into /tmp/tmp.bMCBLN2FOj
sh debug http_download https://dl.dagger.io/dagger/releases/0.1[5](https://github.com/replicatedhq/embedded-cluster/actions/runs/12304485085/job/34342009714?pr=1619#step:5:6).1/dagger_v0.15.1_linux_amd64.tar.gz
sh debug http_download https://dl.dagger.io/dagger/releases/0.15.1/checksums.txt
sh err hash_sha25[6](https://github.com/replicatedhq/embedded-cluster/actions/runs/12304485085/job/34342009714?pr=1619#step:5:7)_verify checksum for '/tmp/tmp.bMCBLN2FOj/dagger_v0.15.1_linux_amd64.tar.gz' did not verify 5230bfd932ecaa02266efd830c5cf[7](https://github.com/replicatedhq/embedded-cluster/actions/runs/12304485085/job/34342009714?pr=1619#step:5:8)93367433242aec2ff6b3c13323[8](https://github.com/replicatedhq/embedded-cluster/actions/runs/12304485085/job/34342009714?pr=1619#step:5:9)bf8d266 vs 228c046ecaaa5a1cb5bc8dea12b8341f34e1128cc834f2dcd921bcbe6e72d10c
Error: Process completed with exit code 1.
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
