### PR TITLE
fix: Update hard coded paths of system binaries in support bundle analysers

### DIFF
--- a/pkg/goods/support/host-support-bundle.tmpl.yaml
+++ b/pkg/goods/support/host-support-bundle.tmpl.yaml
@@ -559,7 +559,7 @@ spec:
   - textAnalyze:
       checkName: Check if 'modprobe' command exists in PATH
       fileName: host-collectors/run-host/check-modprobe.txt
-      regex: '/usr/sbin/modprobe'
+      regex: 'modprobe'
       outcomes:
         - pass:
             when: "true"
@@ -570,7 +570,7 @@ spec:
   - textAnalyze:
       checkName: Check if 'mount' command exists in PATH
       fileName: host-collectors/run-host/check-mount.txt
-      regex: '/usr/bin/mount'
+      regex: 'mount'
       outcomes:
         - pass:
             when: "true"
@@ -581,7 +581,7 @@ spec:
   - textAnalyze:
       checkName: Check if 'umount' command exists in PATH
       fileName: host-collectors/run-host/check-umount.txt
-      regex: '/usr/bin/umount'
+      regex: 'umount'
       outcomes:
         - pass:
             when: "true"


### PR DESCRIPTION
#### What this PR does / why we need it:
Update hard coded paths of `mount`, `umount` and `modprobe` in support bundle analysers.

#### Which issue(s) this PR fixes:
https://app.shortcut.com/replicated/story/117469/fix-hard-coded-path-host-preflight-checks-in-ec

#### Does this PR require a test?
NONE

#### Does this PR require a release note?
```release-note
Update hard coded paths of mount, umount and modprobe in support bundle analysers.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
