### PR TITLE
fix: handle copy preflight results job already exists error

### DIFF
--- a/operator/controllers/installation_controller.go
+++ b/operator/controllers/installation_controller.go
@@ -508,9 +508,12 @@ func (r *InstallationReconciler) CopyHostPreflightResultsFromNodes(ctx context.C
 		}
 
 		if err := r.Create(ctx, job); err != nil {
-			return fmt.Errorf("failed to create job: %w", err)
+			if !errors.IsAlreadyExists(err) {
+				return fmt.Errorf("failed to create job: %w", err)
+			}
+		} else {
+			log.Info("Copy host preflight results job for node created", "node", event.NodeName, "installation", in.Name)
 		}
-		log.Info("Copy host preflight results job for node created", "node", event.NodeName, "installation", in.Name)
 	}
 
 	return nil

--- a/operator/controllers/installation_controller.go
+++ b/operator/controllers/installation_controller.go
@@ -32,7 +32,7 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -508,7 +508,7 @@ func (r *InstallationReconciler) CopyHostPreflightResultsFromNodes(ctx context.C
 		}
 
 		if err := r.Create(ctx, job); err != nil {
-			if !errors.IsAlreadyExists(err) {
+			if !k8serrors.IsAlreadyExists(err) {
 				return fmt.Errorf("failed to create job: %w", err)
 			}
 		} else {
@@ -641,7 +641,7 @@ func (r *InstallationReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// save the installation status. nothing more to do with it.
 	if err := r.Status().Update(ctx, in.DeepCopy()); err != nil {
-		if errors.IsConflict(err) {
+		if k8serrors.IsConflict(err) {
 			return ctrl.Result{}, fmt.Errorf("failed to update status: conflict")
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to update installation status: %w", err)


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Handles error

```
2024-12-18T20:19:03Z	ERROR	Reconciler error	{"controller": "installation", "controllerGroup": "embeddedcluster.replicated.com", "controllerKind": "Installation", "Installation": {"name":"20241218201903"}, "namespace": "", "name": "20241218201903", "reconcileID": "4ae2dd88-5eb6-4b9b-a4f8-d1d2d26d8400", "error": "failed to copy host preflight results: failed to create job: jobs.batch \"copy-host-preflight-results-node-027db-00\" already exists"}
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
