### PR TITLE
chore(ci): run TestFiveNodesAirgapUpgrade on main only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -884,7 +884,7 @@ jobs:
         if: needs.e2e.result != 'success'
         run: exit 1
       - name: fail if e2e-main job was not successful
-        if: needs.e2e-main.result != 'success'
+        if: needs.e2e-main.result != 'success' && needs.e2e-main.result != 'skipped'
         run: exit 1
       - name: fail if e2e-docker job was not successful
         if: needs.e2e-docker.result != 'success'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -763,7 +763,33 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        test:
+          - TestVersion
+          - TestCommandsRequireSudo
+          - TestResetAndReinstallAirgap
+          - TestSingleNodeAirgapUpgrade
+          - TestSingleNodeAirgapUpgradeConfigValues
+          - TestSingleNodeAirgapUpgradeCustomCIDR
+          - TestSingleNodeDisasterRecoveryWithProxy
+          - TestProxiedEnvironment
+          - TestProxiedCustomCIDR
+          - TestInstallWithPrivateCAs
+          - TestInstallWithMITMProxy
         include:
+          - test: TestMultiNodeAirgapUpgrade
+            runner: embedded-cluster
+          - test: TestMultiNodeAirgapUpgradeSameK0s
+            runner: embedded-cluster
+          - test: TestMultiNodeAirgapUpgradePreviousStable
+            runner: embedded-cluster
+          - test: TestAirgapUpgradeFromEC18
+            runner: embedded-cluster
+          - test: TestSingleNodeAirgapDisasterRecovery
+            runner: embedded-cluster
+          - test: TestMultiNodeAirgapHAInstallation
+            runner: embedded-cluster
+          - test: TestMultiNodeAirgapHADisasterRecovery
+            runner: embedded-cluster
           - test: TestFiveNodesAirgapUpgrade
             runner: embedded-cluster
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -817,7 +817,7 @@ jobs:
           version-specifier: ${{ needs.export-version-specifier.outputs.version_specifier }}
 
   e2e-main:
-    name: E2E (on merge) # this name is used by .github/workflows/automated-prs-manager.yaml
+    name: E2E (on merge)
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ${{ matrix.runner || 'ubuntu-22.04' }}
     needs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -763,33 +763,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test:
-          - TestVersion
-          - TestCommandsRequireSudo
-          - TestResetAndReinstallAirgap
-          - TestSingleNodeAirgapUpgrade
-          - TestSingleNodeAirgapUpgradeConfigValues
-          - TestSingleNodeAirgapUpgradeCustomCIDR
-          - TestSingleNodeDisasterRecoveryWithProxy
-          - TestProxiedEnvironment
-          - TestProxiedCustomCIDR
-          - TestInstallWithPrivateCAs
-          - TestInstallWithMITMProxy
         include:
-          - test: TestMultiNodeAirgapUpgrade
-            runner: embedded-cluster
-          - test: TestMultiNodeAirgapUpgradeSameK0s
-            runner: embedded-cluster
-          - test: TestMultiNodeAirgapUpgradePreviousStable
-            runner: embedded-cluster
-          - test: TestAirgapUpgradeFromEC18
-            runner: embedded-cluster
-          - test: TestSingleNodeAirgapDisasterRecovery
-            runner: embedded-cluster
-          - test: TestMultiNodeAirgapHAInstallation
-            runner: embedded-cluster
-          - test: TestMultiNodeAirgapHADisasterRecovery
-            runner: embedded-cluster
           - test: TestFiveNodesAirgapUpgrade
             runner: embedded-cluster
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -818,6 +818,50 @@ jobs:
           k0s-version-previous-stable: ${{ needs.find-previous-stable.outputs.k0s_version }}
           version-specifier: ${{ needs.export-version-specifier.outputs.version_specifier }}
 
+  e2e-main:
+    name: E2E (on merge) # this name is used by .github/workflows/automated-prs-manager.yaml
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ${{ matrix.runner || 'ubuntu-22.04' }}
+    needs:
+      - build-current
+      - build-legacydr
+      - build-previous-k0s
+      - build-upgrade
+      - find-previous-stable
+      - release-app
+      - export-version-specifier
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - test: TestFiveNodesAirgapUpgrade
+            runner: embedded-cluster
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Download current binary
+        uses: actions/download-artifact@v4
+        with:
+          name: current-release
+          path: output/bin
+
+      - uses: ./.github/actions/e2e
+        with:
+          test-name: '${{ matrix.test }}'
+          is-large-runner: ${{ matrix.runner == 'embedded-cluster' }}
+          airgap-license-id: ${{ secrets.STAGING_EMBEDDED_CLUSTER_AIRGAP_LICENSE_ID }}
+          snapshot-license-id: ${{ secrets.STAGING_EMBEDDED_CLUSTER_SNAPSHOT_LICENSE_ID }}
+          snapshot-license: ${{ secrets.STAGING_EMBEDDED_CLUSTER_SNAPSHOT_LICENSE }}
+          airgap-snapshot-license-id: ${{ secrets.STAGING_EMBEDDED_CLUSTER_AIRGAP_SNAPSHOT_LICENSE_ID }}
+          license-id: ${{ secrets.STAGING_EMBEDDED_CLUSTER_LICENSE_ID }}
+          license: ${{ secrets.STAGING_EMBEDDED_CLUSTER_LICENSE }}
+          dr-aws-access-key-id: ${{ secrets.TESTIM_AWS_ACCESS_KEY_ID }}
+          dr-aws-secret-access-key: ${{ secrets.TESTIM_AWS_SECRET_ACCESS_KEY }}
+          k0s-version: ${{ needs.build-current.outputs.k0s_version }}
+          k0s-version-previous: ${{ needs.build-previous-k0s.outputs.k0s_version }}
+          k0s-version-previous-stable: ${{ needs.find-previous-stable.outputs.k0s_version }}
+          version-specifier: ${{ needs.export-version-specifier.outputs.version_specifier }}
+
   # this job will validate that all the tests passed
   # it is used for the github branch protection rule
   validate-success:
@@ -825,6 +869,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs:
       - e2e
+      - e2e-main
       - e2e-docker
       - sanitize
       - test
@@ -837,6 +882,9 @@ jobs:
       # https://docs.github.com/en/actions/learn-github-actions/contexts#needs-context
       - name: fail if e2e job was not successful
         if: needs.e2e.result != 'success'
+        run: exit 1
+      - name: fail if e2e-main job was not successful
+        if: needs.e2e-main.result != 'success'
         run: exit 1
       - name: fail if e2e-docker job was not successful
         if: needs.e2e-docker.result != 'success'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -790,8 +790,6 @@ jobs:
             runner: embedded-cluster
           - test: TestMultiNodeAirgapHADisasterRecovery
             runner: embedded-cluster
-          - test: TestFiveNodesAirgapUpgrade
-            runner: embedded-cluster
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Removes the 5 node cluster test from the on pr suite and runs on merge only.

It’s not cover any scenarios that other tests aren’t testing other than to test scale and it is very flakey.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
