### PR TITLE
fix(dr): use Status.CompletionTimestamp for sorting backups

### DIFF
--- a/cmd/installer/cli/restore.go
+++ b/cmd/installer/cli/restore.go
@@ -35,6 +35,7 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/release"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/replicatedhq/embedded-cluster/pkg/spinner"
+	"github.com/replicatedhq/embedded-cluster/pkg/versions"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -1054,6 +1055,7 @@ func pickBackupToRestore(backups []disasterrecovery.ReplicatedBackup) *disasterr
 			latestBackup = &b
 			continue
 		}
+		// Should this use Status.StartTimestamp instead of Status.CompletionTimestamp?
 		if b.GetCompletionTimestamp().After(latestBackup.GetCompletionTimestamp().Time) {
 			latestBackup = &b
 		}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

The creation timestamp represents the time at which the CR was created in the new restore cluster and does not reflect the creation timestamp of the backup. Revert the change to use prior Status.CompletionTimestamp field.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
