### PR TITLE
feat(ec): migration from v1 to v2 - fixes

### DIFF
--- a/kinds/apis/v1beta1/installation_types.go
+++ b/kinds/apis/v1beta1/installation_types.go
@@ -35,6 +35,7 @@ const (
 	InstallationStateInstalled              string = "Installed"
 	InstallationStateKubernetesInstalled    string = "KubernetesInstalled"
 	InstallationStateAddonsInstalling       string = "AddonsInstalling"
+	InstallationStateAddonsInstalled        string = "AddonsInstalled"
 	InstallationStateHelmChartUpdateFailure string = "HelmChartUpdateFailure"
 	InstallationStateObsolete               string = "Obsolete"
 	InstallationStateFailed                 string = "Failed"
@@ -49,7 +50,8 @@ const (
 )
 
 const (
-	DisableReconcileConditionType = "DisableReconcile"
+	ConditionTypeV2MigrationInProgress = "V2MigrationInProgress"
+	ConditionTypeDisableReconcile      = "DisableReconcile"
 )
 
 // ConfigSecretEntryName holds the entry name we are looking for in the secret

--- a/operator/controllers/installation_controller.go
+++ b/operator/controllers/installation_controller.go
@@ -590,7 +590,7 @@ func (r *InstallationReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
-	if k8sutil.CheckConditionStatus(in.Status, v1beta1.DisableReconcileConditionType) == metav1.ConditionTrue {
+	if k8sutil.CheckConditionStatus(in.Status, v1beta1.ConditionTypeDisableReconcile) == metav1.ConditionTrue {
 		log.Info("Installation reconciliation is disabled, reconciliation ended")
 		return ctrl.Result{}, nil
 	}

--- a/operator/pkg/cli/logging.go
+++ b/operator/pkg/cli/logging.go
@@ -13,3 +13,6 @@ func NewLogger(level logrus.Level) (logr.Logger, error) {
 	log := logrusr.New(logrusLog)
 	return log, nil
 }
+
+// LogFunc can be used as an argument to functions that log messages.
+type LogFunc func(string, ...any)

--- a/operator/pkg/cli/migrate_v2_pod.go
+++ b/operator/pkg/cli/migrate_v2_pod.go
@@ -74,9 +74,6 @@ var _migrateV2PodSpec = corev1.Pod{
 	},
 }
 
-// LogFunc can be used as an argument to Run to log messages.
-type LogFunc func(string, ...any)
-
 // runMigrateV2PodAndWait runs the v2 migration pod and waits for the pod to finish.
 func runMigrateV2PodAndWait(
 	ctx context.Context, logf LogFunc, cli client.Client,

--- a/operator/pkg/cli/migratev2/installation.go
+++ b/operator/pkg/cli/migratev2/installation.go
@@ -3,13 +3,71 @@ package migratev2
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg/kubeutils"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// setV2MigrationInProgress sets the Installation condition to indicate that the v2 migration is in
+// progress.
+func setV2MigrationInProgress(ctx context.Context, logf LogFunc, cli client.Client, in *ecv1beta1.Installation) error {
+	logf("Setting v2 migration in progress")
+
+	err := setInstallationCondition(ctx, cli, in, metav1.Condition{
+		Type:   ecv1beta1.ConditionTypeV2MigrationInProgress,
+		Status: metav1.ConditionTrue,
+		Reason: "V2MigrationInProgress",
+	})
+	if err != nil {
+		return fmt.Errorf("set v2 migration in progress condition: %w", err)
+	}
+
+	logf("Successfully set v2 migration in progress")
+	return nil
+}
+
+// waitForInstallationStateInstalled waits for the installation to be in a successful state and
+// ready for the migration.
+func waitForInstallationStateInstalled(ctx context.Context, logf LogFunc, cli client.Client, installation *ecv1beta1.Installation) error {
+	logf("Waiting for installation to reconcile")
+
+	err := wait.PollUntilContextCancel(ctx, 2*time.Second, true, func(ctx context.Context) (bool, error) {
+		in, err := kubeutils.GetCRDInstallation(ctx, cli, installation.Name)
+		if err != nil {
+			return false, fmt.Errorf("get installation: %w", err)
+		}
+
+		switch in.Status.State {
+		// Success states
+		case ecv1beta1.InstallationStateInstalled, ecv1beta1.InstallationStateAddonsInstalled:
+			return true, nil
+
+		// Failure states
+		case ecv1beta1.InstallationStateFailed, ecv1beta1.InstallationStateHelmChartUpdateFailure:
+			return false, fmt.Errorf("installation failed: %s", in.Status.Reason)
+		case ecv1beta1.InstallationStateObsolete:
+			return false, fmt.Errorf("installation is obsolete")
+
+		// In progress states
+		default:
+			return false, nil
+		}
+	})
+	if err != nil {
+		return err
+	}
+
+	logf("Installation reconciled")
+	return nil
+}
 
 // copyInstallationsToConfigMaps copies the Installation CRs to ConfigMaps.
 func copyInstallationsToConfigMaps(ctx context.Context, logf LogFunc, cli client.Client) error {
@@ -37,7 +95,6 @@ func copyInstallationsToConfigMaps(ctx context.Context, logf LogFunc, cli client
 
 func ensureInstallationConfigMap(ctx context.Context, cli client.Client, in *ecv1beta1.Installation) error {
 	copy := in.DeepCopy()
-	copy.Spec.SourceType = ecv1beta1.InstallationSourceTypeConfigMap
 	err := kubeutils.CreateInstallation(ctx, cli, copy)
 	if k8serrors.IsAlreadyExists(err) {
 		err := kubeutils.UpdateInstallation(ctx, cli, copy)
@@ -48,4 +105,47 @@ func ensureInstallationConfigMap(ctx context.Context, cli client.Client, in *ecv
 		return fmt.Errorf("create installation: %w", err)
 	}
 	return nil
+}
+
+// ensureInstallationStateInstalled sets the ConfigMap installation state to installed and updates
+// the status to mark the upgrade as complete.
+func ensureInstallationStateInstalled(ctx context.Context, logf LogFunc, cli client.Client, in *ecv1beta1.Installation) error {
+	logf("Setting installation state to installed")
+
+	// the installation will be in a ConfigMap at this point
+	copy, err := kubeutils.GetInstallation(ctx, cli, in.Name)
+	if err != nil {
+		return fmt.Errorf("get installation: %w", err)
+	}
+
+	copy.Status.SetState(v1beta1.InstallationStateInstalled, "V2MigrationComplete", nil)
+	meta.RemoveStatusCondition(&copy.Status.Conditions, ecv1beta1.ConditionTypeV2MigrationInProgress)
+	meta.RemoveStatusCondition(&copy.Status.Conditions, ecv1beta1.ConditionTypeDisableReconcile)
+
+	err = kubeutils.UpdateInstallationStatus(ctx, cli, copy)
+	if err != nil {
+		return fmt.Errorf("update installation status: %w", err)
+	}
+
+	logf("Successfully set installation state to installed")
+	return nil
+}
+
+func setInstallationCondition(ctx context.Context, cli client.Client, in *ecv1beta1.Installation, condition metav1.Condition) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var copy ecv1beta1.Installation
+		err := cli.Get(ctx, client.ObjectKey{Name: in.Name}, &copy)
+		if err != nil {
+			return fmt.Errorf("get installation: %w", err)
+		}
+
+		copy.Status.SetCondition(condition)
+
+		err = cli.Status().Update(ctx, &copy)
+		if err != nil {
+			return fmt.Errorf("update installation status: %w", err)
+		}
+
+		return nil
+	})
 }

--- a/operator/pkg/cli/migratev2/operator_test.go
+++ b/operator/pkg/cli/migratev2/operator_test.go
@@ -62,7 +62,7 @@ func Test_disableOperator(t *testing.T) {
 			require.NoError(t, err)
 
 			// Check that the DisableReconcile condition was set correctly
-			condition := meta.FindStatusCondition(updatedInstallation.Status.Conditions, ecv1beta1.DisableReconcileConditionType)
+			condition := meta.FindStatusCondition(updatedInstallation.Status.Conditions, ecv1beta1.ConditionTypeDisableReconcile)
 			require.NotNil(t, condition)
 			assert.Equal(t, metav1.ConditionTrue, condition.Status)
 			assert.Equal(t, "V2MigrationInProgress", condition.Reason)

--- a/pkg/kubeutils/kubeutils.go
+++ b/pkg/kubeutils/kubeutils.go
@@ -228,6 +228,8 @@ func (k *KubeUtils) WaitForInstallation(ctx context.Context, cli client.Client, 
 }
 
 func CreateInstallation(ctx context.Context, cli client.Client, in *ecv1beta1.Installation) error {
+	in.Spec.SourceType = ecv1beta1.InstallationSourceTypeConfigMap
+
 	data, err := json.Marshal(in)
 	if err != nil {
 		return fmt.Errorf("marshal installation: %w", err)


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Fixes an issue where the operator would not finish reconciling the installation before the migration runs leaving the upgrade in an unfinished state.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
