### PR TITLE
feat: enable v2 in the Config spec

### DIFF
--- a/kinds/apis/v1beta1/config_types.go
+++ b/kinds/apis/v1beta1/config_types.go
@@ -176,7 +176,11 @@ func ConvertFrom(e k0sv1beta1.HelmExtensions, t *Helm) (*Helm, error) {
 
 // ConfigSpec defines the desired state of Config
 type ConfigSpec struct {
-	Version              string               `json:"version,omitempty"`
+	Version string `json:"version,omitempty"`
+	// V2Enabled is a temporary property that can be used to opt-in to the new installer. If set,
+	// v1 installations will be migrated to v2 on upgrade. This property will be removed once the
+	// new installer is fully implemented and the old installer is removed.
+	V2Enabled            bool                 `json:"v2Enabled,omitempty"`
 	BinaryOverrideURL    string               `json:"binaryOverrideUrl,omitempty"`
 	MetadataOverrideURL  string               `json:"metadataOverrideUrl,omitempty"`
 	Roles                Roles                `json:"roles,omitempty"`


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Adds a `v2Enabled` property to the `embeddedcluster.replicated.com/v1beta1` Config spec can be used to opt-in to the new installer. If set, v1 installations will be migrated to v2 on upgrade. This property will be removed once the new installer is fully implemented and the old installer is removed.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
