### PR TITLE
Keep 'v' when pushing manager binary to s3

### DIFF
--- a/scripts/ci-upload-binaries.sh
+++ b/scripts/ci-upload-binaries.sh
@@ -79,7 +79,7 @@ function managerbin() {
         fail "file build/manager-linux-$ARCH.tgz not found"
     fi
 
-    manager_version="${EC_VERSION#v}" # remove the 'v' prefix
+    manager_version="${EC_VERSION}"
 
     # upload the binary to the bucket
     retry 3 aws s3 cp --no-progress "build/manager-linux-$ARCH.tgz" "s3://${S3_BUCKET}/manager-binaries/${manager_version}-${ARCH}.tar.gz"


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Keeps the 'v' in the version when pushing the manager binary to s3 so it matches the version in the metadata file.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
No

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE