### PR TITLE
chore: add default fail outcome if ntp status is unknown

### DIFF
--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -230,6 +230,8 @@ spec:
           - pass:
               when: 'ntp == synchronized+active'
               message: NTP is enabled and the system clock is synchronized
+          - fail:
+              message: 'Unable to determine system clock status'
     - jsonCompare:
         checkName: Cgroups
         fileName: host-collectors/system/cgroups.json


### PR DESCRIPTION
#### What this PR does / why we need it:
Add a default fail message to system clock host preflight.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
