### PR TITLE
fix(seaweedfs): collect logs from all pods in the namespace

### DIFF
--- a/operator/charts/embedded-cluster-operator/troubleshoot/cluster-support-bundle.yaml
+++ b/operator/charts/embedded-cluster-operator/troubleshoot/cluster-support-bundle.yaml
@@ -103,35 +103,7 @@ spec:
       name: podlogs/seaweedfs
       namespace: seaweedfs
       selector:
-      - app.kubernetes.io/component=objectstorage-provisioner
-      limits:
-        maxAge: 720h
-  - logs:
-      name: podlogs/seaweedfs
-      namespace: seaweedfs
-      selector:
-      - app.kubernetes.io/component=filer
-      limits:
-        maxAge: 720h
-  - logs:
-      name: podlogs/seaweedfs
-      namespace: seaweedfs
-      selector:
-      - app.kubernetes.io/component=master
-      limits:
-        maxAge: 720h
-  - logs:
-      name: podlogs/seaweedfs
-      namespace: seaweedfs
-      selector:
-      - app.kubernetes.io/component=s3
-      limits:
-        maxAge: 720h
-  - logs:
-      name: podlogs/seaweedfs
-      namespace: seaweedfs
-      selector:
-      - app.kubernetes.io/component=volume
+      - app.kubernetes.io/instance=seaweedfs
       limits:
         maxAge: 720h
   analyzers:


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

seaweedfs-bucket-hook logs are missing

```
 kubectl -n seaweedfs get pods --show-labels
NAME                          READY   STATUS    RESTARTS   AGE     LABELS
seaweedfs-bucket-hook-kc4bp   0/1     Error     0          3h31m   app.kubernetes.io/instance=seaweedfs,app.kubernetes.io/managed-by=Helm,batch.kubernetes.io/controller-uid=2ccab79d-52ba-435e-bbe7-1d3a21724c08,batch.kubernetes.io/job-name=seaweedfs-bucket-hook,controller-uid=2ccab79d-52ba-435e-bbe7-1d3a21724c08,job-name=seaweedfs-bucket-hook
seaweedfs-bucket-hook-lxmp5   1/1     Running   0          3h26m   app.kubernetes.io/instance=seaweedfs,app.kubernetes.io/managed-by=Helm,batch.kubernetes.io/controller-uid=2ccab79d-52ba-435e-bbe7-1d3a21724c08,batch.kubernetes.io/job-name=seaweedfs-bucket-hook,controller-uid=2ccab79d-52ba-435e-bbe7-1d3a21724c08,job-name=seaweedfs-bucket-hook
seaweedfs-filer-0             1/1     Running   0          3h32m   app.kubernetes.io/component=filer,app.kubernetes.io/instance=seaweedfs,app.kubernetes.io/name=seaweedfs,apps.kubernetes.io/pod-index=0,controller-revision-hash=seaweedfs-filer-7b4f49f6fc,helm.sh/chart=seaweedfs-4.0.384,statefulset.kubernetes.io/pod-name=seaweedfs-filer-0
seaweedfs-filer-1             1/1     Running   0          3h32m   app.kubernetes.io/component=filer,app.kubernetes.io/instance=seaweedfs,app.kubernetes.io/name=seaweedfs,apps.kubernetes.io/pod-index=1,controller-revision-hash=seaweedfs-filer-7b4f49f6fc,helm.sh/chart=seaweedfs-4.0.384,statefulset.kubernetes.io/pod-name=seaweedfs-filer-1
seaweedfs-filer-2             1/1     Running   0          3h32m   app.kubernetes.io/component=filer,app.kubernetes.io/instance=seaweedfs,app.kubernetes.io/name=seaweedfs,apps.kubernetes.io/pod-index=2,controller-revision-hash=seaweedfs-filer-7b4f49f6fc,helm.sh/chart=seaweedfs-4.0.384,statefulset.kubernetes.io/pod-name=seaweedfs-filer-2
seaweedfs-master-0            1/1     Running   0          3h32m   app.kubernetes.io/component=master,app.kubernetes.io/instance=seaweedfs,app.kubernetes.io/name=seaweedfs,apps.kubernetes.io/pod-index=0,controller-revision-hash=seaweedfs-master-7655dff6f4,helm.sh/chart=seaweedfs-4.0.384,statefulset.kubernetes.io/pod-name=seaweedfs-master-0
seaweedfs-volume-0            1/1     Running   0          3h32m   app.kubernetes.io/component=volume,app.kubernetes.io/instance=seaweedfs,app.kubernetes.io/name=seaweedfs,apps.kubernetes.io/pod-index=0,controller-revision-hash=seaweedfs-volume-5bf5f66c4c,helm.sh/chart=seaweedfs-4.0.384,statefulset.kubernetes.io/pod-name=seaweedfs-volume-0
seaweedfs-volume-1            1/1     Running   0          3h32m   app.kubernetes.io/component=volume,app.kubernetes.io/instance=seaweedfs,app.kubernetes.io/name=seaweedfs,apps.kubernetes.io/pod-index=1,controller-revision-hash=seaweedfs-volume-5bf5f66c4c,helm.sh/chart=seaweedfs-4.0.384,statefulset.kubernetes.io/pod-name=seaweedfs-volume-1
seaweedfs-volume-2            1/1     Running   0          3h32m   app.kubernetes.io/component=volume,app.kubernetes.io/instance=seaweedfs,app.kubernetes.io/name=seaweedfs,apps.kubernetes.io/pod-index=2,controller-revision-hash=seaweedfs-volume-5bf5f66c4c,helm.sh/chart=seaweedfs-4.0.384,statefulset.kubernetes.io/pod-name=seaweedfs-volume-2
```

Looks like our earliest version is 3.67.0
https://github.com/replicatedhq/embedded-cluster/blame/9b75d0e87de72ba2b5241100024427b81e5b205d/Makefile#L21

Which looks to still have the labels
https://github.com/seaweedfs/seaweedfs/blob/3.67/k8s/charts/seaweedfs/templates/master-statefulset.yaml#L11

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
