### PR TITLE
fix(ci): proxy chart to avoid 429 errors

### DIFF
--- a/e2e/kots-release-upgrade/cluster-config.yaml
+++ b/e2e/kots-release-upgrade/cluster-config.yaml
@@ -79,7 +79,7 @@ spec:
           values: |
             image:
               repository: proxy.replicated.com/anonymous/bloomberg/goldpinger
-        - chartname: oci://registry-1.docker.io/bitnamicharts/memcached
+        - chartname: oci://proxy.replicated.com/anonymous/bitnamicharts/memcached
           name: memcached
           namespace: memcached
           values: |

--- a/hack/test-installation.yaml
+++ b/hack/test-installation.yaml
@@ -41,7 +41,7 @@ spec:
             image:
               repository: proxy.replicated.com/anonymous/bloomberg/goldpinger
           version: 6.1.2
-        - chartname: oci://registry-1.docker.io/bitnamicharts/memcached
+        - chartname: oci://proxy.replicated.com/anonymous/bitnamicharts/memcached
           name: memcached
           namespace: memcached
           order: 4


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

upgrade failed

https://github.com/replicatedhq/embedded-cluster/actions/runs/13165274805/job/36744352264?pr=1814

```
Error: upgrade extensions: upgrade extensions: install extension memcached: process extension: install: helm install: pull oci: download chart oci://registry-1.docker.io/bitnamicharts/memcached: failed to copy: httpReadSeeker: failed open: unexpected status code https://registry-1.docker.io/v2/bitnamicharts/memcached/manifests/sha256:514981dbfb2df3d4a08b0e6622ae3fb569ead6d9da14580e5b66b668d3ddc68c: 429 Too Many Requests - Server message: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```

![686b44d088d81980eefad59c0c2a5a2bc246a314](https://github.com/user-attachments/assets/f4e32532-44b5-4380-82c9-a88463512d0a)

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
