### PR TITLE
fix(v2): disable atomic rollback on helm install addon

### DIFF
--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -323,6 +323,8 @@ func (h *HelmClient) Install(ctx context.Context, opts InstallOptions) (*release
 	client.CreateNamespace = true
 	client.WaitForJobs = true
 	client.Wait = true
+	// we don't set client.Atomic = true on install as it makes installation failures difficult to
+	// debug since it will rollback the release.
 
 	if opts.Timeout != 0 {
 		client.Timeout = opts.Timeout

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -323,7 +323,6 @@ func (h *HelmClient) Install(ctx context.Context, opts InstallOptions) (*release
 	client.CreateNamespace = true
 	client.WaitForJobs = true
 	client.Wait = true
-	client.Atomic = true
 
 	if opts.Timeout != 0 {
 		client.Timeout = opts.Timeout


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

rollback on installation makes things hard to debug as it deletes pods and i cannot get logs

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
