### PR TITLE
fix(v2): retry enabling ha fails

### DIFF
--- a/pkg/addons/seaweedfs/install.go
+++ b/pkg/addons/seaweedfs/install.go
@@ -104,9 +104,10 @@ func ensureService(ctx context.Context, kcli client.Client, serviceCIDR string) 
 	if err := kcli.Get(ctx, client.ObjectKey{Name: obj.Name, Namespace: obj.Namespace}, &existingObj); err != nil && !k8serrors.IsNotFound(err) {
 		return errors.Wrap(err, "get s3 service")
 	} else if err == nil {
+		// if the service already exists and has the correct cluster IP, do not recreate it
 		if existingObj.Spec.ClusterIP == clusterIP {
 			return nil
-		fi
+		}
 		err := kcli.Delete(ctx, &existingObj)
 		if err != nil {
 			return errors.Wrap(err, "delete existing s3 service")

--- a/pkg/addons/seaweedfs/install.go
+++ b/pkg/addons/seaweedfs/install.go
@@ -46,7 +46,7 @@ func (s *SeaweedFS) createPreRequisites(ctx context.Context, kcli client.Client)
 		return errors.Wrap(err, "create namespace")
 	}
 
-	if err := createService(ctx, kcli, s.ServiceCIDR); err != nil {
+	if err := ensureService(ctx, kcli, s.ServiceCIDR); err != nil {
 		return errors.Wrap(err, "create s3 service")
 	}
 
@@ -69,7 +69,7 @@ func createNamespace(ctx context.Context, kcli client.Client, namespace string) 
 	return nil
 }
 
-func createService(ctx context.Context, kcli client.Client, serviceCIDR string) error {
+func ensureService(ctx context.Context, kcli client.Client, serviceCIDR string) error {
 	if serviceCIDR == "" {
 		return errors.New("service CIDR not present")
 	}
@@ -99,6 +99,21 @@ func createService(ctx context.Context, kcli client.Client, serviceCIDR string) 
 	}
 
 	obj.ObjectMeta.Labels = ApplyLabels(obj.ObjectMeta.Labels, "s3")
+
+	var existingObj corev1.Service
+	if err := kcli.Get(ctx, client.ObjectKey{Name: obj.Name, Namespace: obj.Namespace}, &existingObj); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return errors.Wrap(err, "get s3 service")
+		}
+	} else {
+		if existingObj.Spec.ClusterIP != clusterIP {
+			existingObj.Spec.ClusterIP = clusterIP
+			if err := kcli.Update(ctx, &existingObj); err != nil {
+				return errors.Wrap(err, "update s3 service")
+			}
+		}
+		return nil
+	}
 
 	if err := kcli.Create(ctx, obj); err != nil && !k8serrors.IsAlreadyExists(err) {
 		return errors.Wrap(err, "create s3 service")

--- a/pkg/addons/seaweedfs/install.go
+++ b/pkg/addons/seaweedfs/install.go
@@ -104,6 +104,9 @@ func ensureService(ctx context.Context, kcli client.Client, serviceCIDR string) 
 	if err := kcli.Get(ctx, client.ObjectKey{Name: obj.Name, Namespace: obj.Namespace}, &existingObj); err != nil && !k8serrors.IsNotFound(err) {
 		return errors.Wrap(err, "get s3 service")
 	} else if err == nil {
+		if existingObj.Spec.ClusterIP == clusterIP {
+			return nil
+		fi
 		err := kcli.Delete(ctx, &existingObj)
 		if err != nil {
 			return errors.Wrap(err, "delete existing s3 service")


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

fails with

```
unable to enable high availability: install seaweedfs: create prerequisites: create s3 service: create s3 service: Service "ec-seaweedfs-s3" is invalid: spec.clusterIPs: Invalid value: []string{"10.244.128.12"}: failed to allocate IP 10.244.128.12: provided IP is already allocated
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
