### PR TITLE
do not build a separate binary for the legacy-dr test suite

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -213,75 +213,6 @@ jobs:
           echo "K0S_VERSION=\"$K0S_VERSION\""
           echo "k0s_version=$K0S_VERSION" >> "$GITHUB_OUTPUT"
 
-  build-legacydr:
-    name: Build legacy DR
-    runs-on: embedded-cluster-2
-    needs:
-      - git-sha
-    outputs:
-      k0s_version: ${{ steps.export.outputs.k0s_version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Cache embedded bins
-        uses: actions/cache@v4
-        with:
-          path: |
-            output/bins
-          key: bins-cache
-
-      - name: Setup go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-          cache-dependency-path: "**/*.sum"
-
-      - name: Install dagger
-        run: |
-          curl -fsSL https://dl.dagger.io/dagger/install.sh | sh
-          sudo mv ./bin/dagger /usr/local/bin/dagger
-
-      - name: Build
-        env:
-          APP_CHANNEL_ID: 2cHXb1RCttzpR0xvnNWyaZCgDBP
-          APP_CHANNEL_SLUG: ci
-          RELEASE_YAML_DIR: e2e/kots-release-install-legacydr
-          S3_BUCKET: "tf-staging-embedded-cluster-bin"
-          USES_DEV_BUCKET: "0"
-          AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_EMBEDDED_CLUSTER_UPLOAD_IAM_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_EMBEDDED_CLUSTER_UPLOAD_IAM_SECRET }}
-          AWS_REGION: "us-east-1"
-          USE_CHAINGUARD: "1"
-          UPLOAD_BINARIES: "1"
-          SKIP_RELEASE: "1"
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          export K0S_VERSION=$(make print-K0S_VERSION)
-          export EC_VERSION=$(git describe --tags --abbrev=4 --match='[0-9]*.[0-9]*.[0-9]*')-legacydr
-          export APP_VERSION=appver-dev-${{ needs.git-sha.outputs.git_sha }}-legacydr
-          # avoid rate limiting
-          export FIO_VERSION=$(gh release list --repo axboe/fio --json tagName,isLatest | jq -r '.[] | select(.isLatest==true)|.tagName' | cut -d- -f2)
-
-          ./scripts/build-and-release.sh
-          cp output/bin/embedded-cluster output/bin/embedded-cluster-legacydr
-
-      - name: Upload release
-        uses: actions/upload-artifact@v4
-        with:
-          name: legacydr-release
-          path: |
-            output/bin/embedded-cluster-legacydr
-
-      - name: Export k0s version
-        id: export
-        run: |
-          K0S_VERSION="$(make print-K0S_VERSION)"
-          echo "K0S_VERSION=\"$K0S_VERSION\""
-          echo "k0s_version=$K0S_VERSION" >> "$GITHUB_OUTPUT"
-
   build-previous-k0s:
     name: Build previous k0s
     runs-on: embedded-cluster-2
@@ -518,7 +449,6 @@ jobs:
     needs:
       - git-sha
       - build-current
-      - build-legacydr
       - build-previous-k0s
       - build-upgrade
       - find-previous-stable
@@ -591,7 +521,7 @@ jobs:
           ./scripts/ci-release-app.sh
 
           # promote a release with improved dr support
-          export EC_VERSION="$(git describe --tags --abbrev=4 --match='[0-9]*.[0-9]*.[0-9]*')-legacydr"
+          export EC_VERSION="$(git describe --tags --abbrev=4 --match='[0-9]*.[0-9]*.[0-9]*')"
           export APP_VERSION="appver-${SHORT_SHA}-legacydr"
           export RELEASE_YAML_DIR=e2e/kots-release-install-legacydr
           ./scripts/ci-release-app.sh
@@ -634,12 +564,6 @@ jobs:
           export EC_VERSION="$(git describe --tags --abbrev=4 --match='[0-9]*.[0-9]*.[0-9]*')"
           export APP_VERSION="appver-${SHORT_SHA}"
           export RELEASE_YAML_DIR=e2e/kots-release-install
-          ./scripts/ci-release-app.sh
-
-          # promote a release with improved dr support
-          export EC_VERSION="$(git describe --tags --abbrev=4 --match='[0-9]*.[0-9]*.[0-9]*')-legacydr"
-          export APP_VERSION="appver-${SHORT_SHA}-legacydr"
-          export RELEASE_YAML_DIR=e2e/kots-release-install-legacydr
           ./scripts/ci-release-app.sh
 
           # then a noop upgrade
@@ -687,7 +611,6 @@ jobs:
     needs:
       - git-sha
       - build-current
-      - build-legacydr
       - build-previous-k0s
       - build-upgrade
       - find-previous-stable
@@ -735,11 +658,6 @@ jobs:
         with:
           name: current-release
           path: output/bin
-      - name: Download new DR binary
-        uses: actions/download-artifact@v4
-        with:
-          name: legacydr-release
-          path: output/bin
       - name: Setup go
         uses: actions/setup-go@v5
         with:
@@ -786,7 +704,6 @@ jobs:
     runs-on: ${{ matrix.runner || 'ubuntu-22.04' }}
     needs:
       - build-current
-      - build-legacydr
       - build-previous-k0s
       - build-upgrade
       - find-previous-stable
@@ -854,7 +771,6 @@ jobs:
     runs-on: ${{ matrix.runner || 'ubuntu-22.04' }}
     needs:
       - build-current
-      - build-legacydr
       - build-previous-k0s
       - build-upgrade
       - find-previous-stable


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Instead of building a legacy-dr embedded cluster binary, use the normal binary and rely on replicated.app to embed the relevant app yaml files into it.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
