### PR TITLE
Fix cleaning up helm values before install / upgrade

### DIFF
--- a/pkg/addons/adminconsole/static/values.tpl.yaml
+++ b/pkg/addons/adminconsole/static/values.tpl.yaml
@@ -7,7 +7,6 @@ images:
 {{- end }}
 isHA: false
 isHelmManaged: false
-isEC2Install: true
 kurlProxy:
     enabled: true
     nodePort: 30000

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -545,6 +545,8 @@ func cleanUpMapValue(v interface{}) interface{} {
 	switch v := v.(type) {
 	case []interface{}:
 		return cleanUpInterfaceArray(v)
+	case []map[string]interface{}:
+		return cleanUpMapInterfaceArray(v)
 	case map[string]interface{}:
 		return cleanUpGenericMap(v)
 	case map[interface{}]interface{}:
@@ -567,6 +569,15 @@ func cleanUpInterfaceArray(in []interface{}) []interface{} {
 	result := make([]interface{}, len(in))
 	for i, v := range in {
 		result[i] = cleanUpMapValue(v)
+	}
+	return result
+}
+
+// Cleans up a slice of map to interface into slice of actual values
+func cleanUpMapInterfaceArray(in []map[string]interface{}) []map[string]interface{} {
+	result := make([]map[string]interface{}, len(in))
+	for i, v := range in {
+		result[i] = cleanUpGenericMap(v)
 	}
 	return result
 }

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -546,7 +546,9 @@ func cleanUpMapValue(v interface{}) interface{} {
 	case []interface{}:
 		return cleanUpInterfaceArray(v)
 	case []map[string]interface{}:
-		return cleanUpMapInterfaceArray(v)
+		return cleanUpGenericMapArray(v)
+	case []map[interface{}]interface{}:
+		return cleanUpInterfaceMapArray(v)
 	case map[string]interface{}:
 		return cleanUpGenericMap(v)
 	case map[interface{}]interface{}:
@@ -574,10 +576,19 @@ func cleanUpInterfaceArray(in []interface{}) []interface{} {
 }
 
 // Cleans up a slice of map to interface into slice of actual values
-func cleanUpMapInterfaceArray(in []map[string]interface{}) []map[string]interface{} {
+func cleanUpGenericMapArray(in []map[string]interface{}) []map[string]interface{} {
 	result := make([]map[string]interface{}, len(in))
 	for i, v := range in {
 		result[i] = cleanUpGenericMap(v)
+	}
+	return result
+}
+
+// Cleans up a slice of map to interface into slice of actual values
+func cleanUpInterfaceMapArray(in []map[interface{}]interface{}) []map[string]interface{} {
+	result := make([]map[string]interface{}, len(in))
+	for i, v := range in {
+		result[i] = cleanUpInterfaceMap(v)
 	}
 	return result
 }

--- a/pkg/helm/client_test.go
+++ b/pkg/helm/client_test.go
@@ -84,7 +84,7 @@ func Test_cleanUpGenericMap(t *testing.T) {
 			},
 		},
 		{
-			name: "nested map, map interface array keys",
+			name: "nested map, generic map array keys",
 			in: map[string]interface{}{
 				"nest": map[interface{}]interface{}{
 					"abc":    "xyz",
@@ -92,6 +92,37 @@ func Test_cleanUpGenericMap(t *testing.T) {
 					"float":  1.5,
 					"bool":   true,
 					"array": []map[string]interface{}{
+						{
+							"name":  "example",
+							"value": "true",
+						},
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"nest": map[string]interface{}{
+					"abc":    "xyz",
+					"number": 5,
+					"float":  1.5,
+					"bool":   true,
+					"array": []map[string]interface{}{
+						{
+							"name":  "example",
+							"value": "true",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "nested map, interface map array keys",
+			in: map[string]interface{}{
+				"nest": map[interface{}]interface{}{
+					"abc":    "xyz",
+					"number": 5,
+					"float":  1.5,
+					"bool":   true,
+					"array": []map[interface{}]interface{}{
 						{
 							"name":  "example",
 							"value": "true",

--- a/pkg/helm/client_test.go
+++ b/pkg/helm/client_test.go
@@ -1,8 +1,9 @@
 package helm
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func Test_cleanUpGenericMap(t *testing.T) {
@@ -78,6 +79,37 @@ func Test_cleanUpGenericMap(t *testing.T) {
 					"bool":   true,
 					"array": []interface{}{
 						"element",
+					},
+				},
+			},
+		},
+		{
+			name: "nested map, map interface array keys",
+			in: map[string]interface{}{
+				"nest": map[interface{}]interface{}{
+					"abc":    "xyz",
+					"number": 5,
+					"float":  1.5,
+					"bool":   true,
+					"array": []map[string]interface{}{
+						{
+							"name":  "example",
+							"value": "true",
+						},
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"nest": map[string]interface{}{
+					"abc":    "xyz",
+					"number": 5,
+					"float":  1.5,
+					"bool":   true,
+					"array": []map[string]interface{}{
+						{
+							"name":  "example",
+							"value": "true",
+						},
 					},
 				},
 			},


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Fixes an issue when cleaning up helm values before install / upgrade where `[]map[string]interface{}` types weren't handled, which broke admin console upgrades in some scenarios.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE