### PR TITLE
Fix ability to resume restores

### DIFF
--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -220,6 +220,7 @@ func preRunInstall(cmd *cobra.Command, flags *InstallCmdFlags) error {
 	flags.isAirgap = flags.airgapBundle != ""
 
 	runtimeconfig.ApplyFlags(cmd.Flags())
+	os.Setenv("KUBECONFIG", runtimeconfig.PathToKubeConfig()) // this is needed for restore as well since it shares this function
 	os.Setenv("TMPDIR", runtimeconfig.EmbeddedClusterTmpSubDir())
 
 	if err := runtimeconfig.WriteToDisk(); err != nil {
@@ -615,9 +616,6 @@ func installAndStartCluster(ctx context.Context, networkInterface string, airgap
 	if err := waitForK0s(); err != nil {
 		return nil, fmt.Errorf("wait for node: %w", err)
 	}
-
-	// init the kubeconfig
-	os.Setenv("KUBECONFIG", runtimeconfig.PathToKubeConfig())
 
 	loading.Infof("Node installation finished!")
 	return cfg, nil


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

resuming the restore process requires the `KUBECONFIG` env var to be set in order to read the restore state from the cluster at the beginning.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE