### PR TITLE
fix: make helm.SetValue more robust

### DIFF
--- a/pkg/addons/adminconsole/values.go
+++ b/pkg/addons/adminconsole/values.go
@@ -57,7 +57,7 @@ func (a *AdminConsole) GenerateHelmValues(ctx context.Context, kcli client.Clien
 
 	copiedValues["extraEnv"] = extraEnv
 
-	copiedValues, err = helm.SetValue(copiedValues, "kurlProxy.nodePort", runtimeconfig.AdminConsolePort())
+	err = helm.SetValue(copiedValues, "kurlProxy.nodePort", runtimeconfig.AdminConsolePort())
 	if err != nil {
 		return nil, errors.Wrap(err, "set kurlProxy.nodePort")
 	}

--- a/pkg/addons/openebs/values.go
+++ b/pkg/addons/openebs/values.go
@@ -20,7 +20,7 @@ func (o *OpenEBS) GenerateHelmValues(ctx context.Context, kcli client.Client, ov
 		return nil, errors.Wrap(err, "unmarshal helm values")
 	}
 
-	copiedValues, err = helm.SetValue(copiedValues, `["localpv-provisioner"].localpv.basePath`, runtimeconfig.EmbeddedClusterOpenEBSLocalSubDir())
+	err = helm.SetValue(copiedValues, "localpv-provisioner.localpv.basePath", runtimeconfig.EmbeddedClusterOpenEBSLocalSubDir())
 	if err != nil {
 		return nil, errors.Wrap(err, "set localpv-provisioner.localpv.basePath")
 	}

--- a/pkg/addons/seaweedfs/values.go
+++ b/pkg/addons/seaweedfs/values.go
@@ -22,13 +22,13 @@ func (s *SeaweedFS) GenerateHelmValues(ctx context.Context, kcli client.Client, 
 	}
 
 	dataPath := filepath.Join(runtimeconfig.EmbeddedClusterSeaweedfsSubDir(), "ssd")
-	copiedValues, err = helm.SetValue(copiedValues, "master.data.hostPathPrefix", dataPath)
+	err = helm.SetValue(copiedValues, "master.data.hostPathPrefix", dataPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "set helm values global.data.hostPathPrefix")
 	}
 
 	logsPath := filepath.Join(runtimeconfig.EmbeddedClusterSeaweedfsSubDir(), "storage")
-	copiedValues, err = helm.SetValue(copiedValues, "master.logs.hostPathPrefix", logsPath)
+	err = helm.SetValue(copiedValues, "master.logs.hostPathPrefix", logsPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "set helm values global.logs.hostPathPrefix")
 	}

--- a/pkg/addons/velero/values.go
+++ b/pkg/addons/velero/values.go
@@ -32,7 +32,7 @@ func (v *Velero) GenerateHelmValues(ctx context.Context, kcli client.Client, ove
 	}
 
 	podVolumePath := filepath.Join(runtimeconfig.EmbeddedClusterK0sSubDir(), "kubelet/pods")
-	copiedValues, err = helm.SetValue(copiedValues, "nodeAgent.podVolumePath", podVolumePath)
+	err = helm.SetValue(copiedValues, "nodeAgent.podVolumePath", podVolumePath)
 	if err != nil {
 		return nil, errors.Wrap(err, "set helm value nodeAgent.podVolumePath")
 	}

--- a/pkg/helm/values.go
+++ b/pkg/helm/values.go
@@ -1,15 +1,17 @@
 package helm
 
 import (
+	"encoding/json"
 	"fmt"
 
 	jsonpatch "github.com/evanphx/json-patch"
-	"github.com/k0sproject/dig"
 	"github.com/ohler55/ojg/jp"
 	"gopkg.in/yaml.v3"
+	"helm.sh/helm/v3/pkg/strvals"
 	k8syaml "sigs.k8s.io/yaml"
 )
 
+// UnmarshalValues unmarshals the given JSON compatible YAML string into a map[string]interface{}.
 func UnmarshalValues(valuesYaml string) (map[string]interface{}, error) {
 	newValuesMap := map[string]interface{}{}
 	if err := yaml.Unmarshal([]byte(valuesYaml), &newValuesMap); err != nil {
@@ -18,6 +20,7 @@ func UnmarshalValues(valuesYaml string) (map[string]interface{}, error) {
 	return newValuesMap, nil
 }
 
+// MarshalValues marshals the given map[string]interface{} into a JSON compatible YAML string.
 func MarshalValues(values map[string]interface{}) (string, error) {
 	newValuesYaml, err := yaml.Marshal(values)
 	if err != nil {
@@ -26,25 +29,22 @@ func MarshalValues(values map[string]interface{}) (string, error) {
 	return string(newValuesYaml), nil
 }
 
-// SetValue sets the value at the given path in the values map.
-// NOTE: this function does not support creating new maps. It only supports setting values in
-// existing ones.
-func SetValue(values map[string]interface{}, path string, newValue interface{}) (map[string]interface{}, error) {
-	newValuesMap := dig.Mapping(values)
-
-	x, err := jp.ParseString(path)
+// SetValue sets the value at the given path in the values map. It uses the notation defined by
+// helm "--set-json" flag.
+func SetValue(values map[string]interface{}, path string, newValue interface{}) error {
+	val, err := json.Marshal(newValue)
 	if err != nil {
-		return nil, fmt.Errorf("parse json path %q: %w", path, err)
+		return fmt.Errorf("parse value: %w", err)
 	}
-
-	err = x.Set(newValuesMap, newValue)
+	s := fmt.Sprintf("%s=%s", path, val)
+	err = strvals.ParseJSON(s, values)
 	if err != nil {
-		return nil, fmt.Errorf("set json path %q to %q: %w", path, newValue, err)
+		return fmt.Errorf("helm set json: %w", err)
 	}
-
-	return newValuesMap, nil
+	return nil
 }
 
+// GetValue gets the value at the given JSON path in the values map.
 func GetValue(values map[string]interface{}, path string) (interface{}, error) {
 	x, err := jp.ParseString(path)
 	if err != nil {
@@ -57,6 +57,7 @@ func GetValue(values map[string]interface{}, path string) (interface{}, error) {
 	return v[0], nil
 }
 
+// PatchValues patches the values map with the given RFC6902 JSON patch.
 func PatchValues(values map[string]interface{}, patchYAML string) (map[string]interface{}, error) {
 	if len(patchYAML) == 0 {
 		return values, nil

--- a/tests/dryrun/install_test.go
+++ b/tests/dryrun/install_test.go
@@ -58,7 +58,7 @@ func TestDefaultInstallation(t *testing.T) {
 	adminConsoleOpts := hcli.Calls[3].Arguments[1].(helm.InstallOptions)
 	assert.Equal(t, "admin-console", adminConsoleOpts.ReleaseName)
 	assertHelmValues(t, adminConsoleOpts.Values, map[string]interface{}{
-		"kurlProxy.nodePort": int(30000),
+		"kurlProxy.nodePort": float64(30000),
 	})
 
 	// --- validate os env --- //
@@ -278,7 +278,7 @@ func TestCustomPortsInstallation(t *testing.T) {
 	adminConsoleOpts := hcli.Calls[3].Arguments[1].(helm.InstallOptions)
 	assert.Equal(t, "admin-console", adminConsoleOpts.ReleaseName)
 	assertHelmValues(t, adminConsoleOpts.Values, map[string]interface{}{
-		"kurlProxy.nodePort": int(30002),
+		"kurlProxy.nodePort": float64(30002),
 	})
 
 	// --- validate host preflight spec --- //


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Makes setting values mimic helm's --set-json argument.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
