### PR TITLE
fix(openebs): cleanup stateful pods fails with permissions error

### DIFF
--- a/operator/charts/embedded-cluster-operator/templates/embedded-cluster-operator-clusterrole.yaml
+++ b/operator/charts/embedded-cluster-operator/templates/embedded-cluster-operator-clusterrole.yaml
@@ -48,20 +48,10 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
-  - pods
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-  - update
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - secrets
   - services
+  - configmaps
+  - pods
   verbs:
   - create
   - delete


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

I am adding full permissions to pods and configmaps rather than granular to avoid errors in the future.

```
2025-02-08T14:03:21Z    ERROR   Reconciler error   {"controller": "installation", "controllerGroup": "embeddedcluster.replicated.com", "controllerKind": "Installation", "Installation": {"name":"20250207235543"}, "namespace": "", "name": "20250207235543", "reconcileID": "513138bb-c41c-4032-bde5-aaade4f30db9", "error": "failed to reconcile openebs: failed to cleanup openebs stateful pods: delete pods with pvcs in namespace seaweedfs: delete pod seaweedfs-volume-1: pods \"seaweedfs-volume-1\" is forbidden: User \"system:serviceaccount:embedded-cluster:embedded-cluster-operator\" cannot delete resource \"pods\" in API group \"\" in the namespace \"seaweedfs\""}
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
