### PR TITLE
Add preflights for rp_filter kernel parameter

### DIFF
--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -252,7 +252,7 @@ func runInstall(ctx context.Context, name string, flags InstallCmdFlags, metrics
 
 	logrus.Debugf("configuring sysctl")
 	if err := configutils.ConfigureSysctl(); err != nil {
-		return fmt.Errorf("unable to configure sysctl: %w", err)
+		logrus.Debugf("unable to configure sysctl: %v", err)
 	}
 
 	logrus.Debugf("configuring network manager")

--- a/cmd/installer/cli/install_runpreflights.go
+++ b/cmd/installer/cli/install_runpreflights.go
@@ -57,8 +57,9 @@ func runInstallRunPreflights(ctx context.Context, name string, flags InstallCmdF
 		return fmt.Errorf("unable to materialize files: %w", err)
 	}
 
+	logrus.Debugf("configuring sysctl")
 	if err := configutils.ConfigureSysctl(); err != nil {
-		return fmt.Errorf("unable to configure sysctl: %w", err)
+		logrus.Debugf("unable to configure sysctl: %v", err)
 	}
 
 	logrus.Debugf("running install preflights")

--- a/cmd/installer/cli/join.go
+++ b/cmd/installer/cli/join.go
@@ -135,7 +135,7 @@ func runJoin(ctx context.Context, name string, flags JoinCmdFlags, jcmd *kotsadm
 
 	logrus.Debugf("configuring sysctl")
 	if err := configutils.ConfigureSysctl(); err != nil {
-		return fmt.Errorf("unable to configure sysctl: %w", err)
+		logrus.Debugf("unable to configure sysctl: %v", err)
 	}
 
 	logrus.Debugf("configuring network manager")

--- a/cmd/installer/cli/join_runpreflights.go
+++ b/cmd/installer/cli/join_runpreflights.go
@@ -63,7 +63,7 @@ func runJoinRunPreflights(ctx context.Context, name string, flags JoinCmdFlags, 
 
 	logrus.Debugf("configuring sysctl")
 	if err := configutils.ConfigureSysctl(); err != nil {
-		return fmt.Errorf("unable to configure sysctl: %w", err)
+		logrus.Debugf("unable to configure sysctl: %v", err)
 	}
 
 	cidrCfg, err := getJoinCIDRConfig(jcmd)

--- a/cmd/installer/cli/restore.go
+++ b/cmd/installer/cli/restore.go
@@ -137,7 +137,7 @@ func runRestore(ctx context.Context, name string, flags InstallCmdFlags, s3Store
 
 	logrus.Debugf("configuring sysctl")
 	if err := configutils.ConfigureSysctl(); err != nil {
-		return fmt.Errorf("unable to configure sysctl: %w", err)
+		logrus.Debugf("unable to configure sysctl: %v", err)
 	}
 
 	logrus.Debugf("getting restore state")

--- a/pkg/configutils/static/99-embedded-cluster.conf
+++ b/pkg/configutils/static/99-embedded-cluster.conf
@@ -9,3 +9,10 @@ net.ipv4.conf.default.arp_filter = 0
 net.ipv4.conf.default.arp_ignore = 0
 net.ipv4.conf.all.arp_filter = 0
 net.ipv4.conf.all.arp_ignore = 0
+
+# In Kubernetes environments, strict reverse path filtering (rp_filter = 1) can
+# disrupt networking, particularly when communicating with cluster services from
+# the host. This is because Kubernetes networking paths are not always seen as
+# the "best reverse path" by the kernel in strict mode.
+net.ipv4.conf.default.rp_filter = 0
+net.ipv4.conf.all.rp_filter = 0

--- a/pkg/configutils/static/99-embedded-cluster.conf
+++ b/pkg/configutils/static/99-embedded-cluster.conf
@@ -10,9 +10,9 @@ net.ipv4.conf.default.arp_ignore = 0
 net.ipv4.conf.all.arp_filter = 0
 net.ipv4.conf.all.arp_ignore = 0
 
-# In Kubernetes environments, strict reverse path filtering (rp_filter = 1) can
-# disrupt networking, particularly when communicating with cluster services from
-# the host. This is because Kubernetes networking paths are not always seen as
-# the "best reverse path" by the kernel in strict mode.
+# In Kubernetes environments, reverse path filtering can disrupt networking,
+# particularly when communicating with cluster services from the host. This is
+# because Kubernetes networking paths are not always seen as the "best reverse
+# path" by the kernel.
 net.ipv4.conf.default.rp_filter = 0
 net.ipv4.conf.all.rp_filter = 0

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -893,6 +893,26 @@ spec:
               when: 'net.ipv4.conf.all.arp_ignore == 0'
               message: "ARP ignore is disabled for all interfaces on the host."
     - sysctl:
+        checkName: "Reverse Path Filtering default value for newly created interfaces"
+        outcomes:
+          - fail:
+              when: 'net.ipv4.conf.default.rp_filter > 0'
+              message: "Reverse path filtering must be disabled by default for newly created interfaces on the host. To disable it, edit /etc/sysctl.conf, add the line 'net.ipv4.conf.default.rp_filter=0', and run 'sudo sysctl -p'."
+          - pass:
+              when: 'net.ipv4.conf.default.rp_filter == 0'
+              message: "Reverse path filtering is disabled by default for newly created interfaces on the host."
+
+    - sysctl:
+        checkName: "Reverse Path Filtering value for all interfaces"
+        outcomes:
+          - fail:
+              when: 'net.ipv4.conf.all.rp_filter > 0'
+              message: "Reverse path filtering must be disabled for all interfaces on the host. To disable it, edit /etc/sysctl.conf, add the line 'net.ipv4.conf.all.rp_filter=0', and run 'sudo sysctl -p'."
+          - pass:
+              when: 'net.ipv4.conf.all.rp_filter == 0'
+              message: "Reverse path filtering is disabled for all interfaces on the host."
+
+    - sysctl:
         checkName: "IP forwarding"
         outcomes:
           - fail:


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

In Kubernetes environments, reverse path filtering can disrupt networking, particularly when communicating with cluster services from the host. This is because Kubernetes networking paths are not always seen as the "best reverse path" by the kernel.

This PR adds host preflights for `rp_filter` kernel parameter to ensure that it is disabled.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-117729](https://app.shortcut.com/replicated/story/117729)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds preflight checks to ensure that the following kernel parameters are set: `net.ipv4.conf.default.rp_filter = 0`, and `net.ipv4.conf.all.rp_filter = 0`.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE