### PR TITLE
Default rp_filter to loose mode (2) instead of disabled (0)

### DIFF
--- a/pkg/configutils/static/99-embedded-cluster.conf
+++ b/pkg/configutils/static/99-embedded-cluster.conf
@@ -14,5 +14,5 @@ net.ipv4.conf.all.arp_ignore = 0
 # particularly when communicating with cluster services from the host. This is
 # because Kubernetes networking paths are not always seen as the "best reverse
 # path" by the kernel.
-net.ipv4.conf.default.rp_filter = 0
-net.ipv4.conf.all.rp_filter = 0
+net.ipv4.conf.default.rp_filter = 2
+net.ipv4.conf.all.rp_filter = 2

--- a/pkg/configutils/static/99-embedded-cluster.conf
+++ b/pkg/configutils/static/99-embedded-cluster.conf
@@ -10,9 +10,10 @@ net.ipv4.conf.default.arp_ignore = 0
 net.ipv4.conf.all.arp_filter = 0
 net.ipv4.conf.all.arp_ignore = 0
 
-# In Kubernetes environments, reverse path filtering can disrupt networking,
-# particularly when communicating with cluster services from the host. This is
-# because Kubernetes networking paths are not always seen as the "best reverse
-# path" by the kernel.
+# In Kubernetes environments, strict reverse path filtering (rp_filter = 1) can
+# disrupt networking, particularly when communicating with cluster services from
+# the host. This is because Kubernetes networking paths are not always seen as
+# the "best reverse path" by the kernel in strict mode. Loose reverse path
+# filtering (rp_filter = 2) is less restrictive and avoids these issues.
 net.ipv4.conf.default.rp_filter = 2
 net.ipv4.conf.all.rp_filter = 2

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -897,7 +897,7 @@ spec:
         outcomes:
           - fail:
               when: 'net.ipv4.conf.default.rp_filter == 1'
-              message: "Reverse path filtering must be set to either loose mode (2) or disabled (0) for newly created interfaces on the host. To change it, edit /etc/sysctl.conf, add the line 'net.ipv4.conf.default.rp_filter=2', and run 'sudo sysctl -p'."
+              message: "Reverse path filtering must be set to either loose mode (2 - preferred) or disabled (0) for newly created interfaces on the host. To change it, edit /etc/sysctl.conf, add the line 'net.ipv4.conf.default.rp_filter=2', and run 'sudo sysctl -p'."
           - pass:
               when: 'net.ipv4.conf.default.rp_filter == 2'
               message: "Reverse path filtering is set to loose mode for newly created interfaces on the host."
@@ -909,7 +909,7 @@ spec:
         outcomes:
           - fail:
               when: 'net.ipv4.conf.all.rp_filter == 1'
-              message: "Reverse path filtering must be set to either loose mode (2) or disabled (0) for all interfaces on the host. To change it, edit /etc/sysctl.conf, add the line 'net.ipv4.conf.all.rp_filter=2', and run 'sudo sysctl -p'."
+              message: "Reverse path filtering must be set to either loose mode (2 - preferred) or disabled (0) for all interfaces on the host. To change it, edit /etc/sysctl.conf, add the line 'net.ipv4.conf.all.rp_filter=2', and run 'sudo sysctl -p'."
           - pass:
               when: 'net.ipv4.conf.all.rp_filter == 2'
               message: "Reverse path filtering is set to loose mode for all interfaces on the host."

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -896,22 +896,26 @@ spec:
         checkName: "Reverse Path Filtering default value for newly created interfaces"
         outcomes:
           - fail:
-              when: 'net.ipv4.conf.default.rp_filter > 0'
-              message: "Reverse path filtering must be disabled by default for newly created interfaces on the host. To disable it, edit /etc/sysctl.conf, add the line 'net.ipv4.conf.default.rp_filter=0', and run 'sudo sysctl -p'."
+              when: 'net.ipv4.conf.default.rp_filter == 1'
+              message: "Reverse path filtering must be set to either loose mode (2) or disabled (0) for newly created interfaces on the host. To change it, edit /etc/sysctl.conf, add the line 'net.ipv4.conf.default.rp_filter=2', and run 'sudo sysctl -p'."
+          - pass:
+              when: 'net.ipv4.conf.default.rp_filter == 2'
+              message: "Reverse path filtering is set to loose mode for newly created interfaces on the host."
           - pass:
               when: 'net.ipv4.conf.default.rp_filter == 0'
-              message: "Reverse path filtering is disabled by default for newly created interfaces on the host."
-
+              message: "Reverse path filtering is disabled for newly created interfaces on the host."
     - sysctl:
         checkName: "Reverse Path Filtering value for all interfaces"
         outcomes:
           - fail:
-              when: 'net.ipv4.conf.all.rp_filter > 0'
-              message: "Reverse path filtering must be disabled for all interfaces on the host. To disable it, edit /etc/sysctl.conf, add the line 'net.ipv4.conf.all.rp_filter=0', and run 'sudo sysctl -p'."
+              when: 'net.ipv4.conf.all.rp_filter == 1'
+              message: "Reverse path filtering must be set to either loose mode (2) or disabled (0) for all interfaces on the host. To change it, edit /etc/sysctl.conf, add the line 'net.ipv4.conf.all.rp_filter=2', and run 'sudo sysctl -p'."
+          - pass:
+              when: 'net.ipv4.conf.all.rp_filter == 2'
+              message: "Reverse path filtering is set to loose mode for all interfaces on the host."
           - pass:
               when: 'net.ipv4.conf.all.rp_filter == 0'
               message: "Reverse path filtering is disabled for all interfaces on the host."
-
     - sysctl:
         checkName: "IP forwarding"
         outcomes:


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Looks like Calico [doesn't rely on sysctls](https://github.com/projectcalico/calico/blob/v3.12.0/release-notes/v3.12.0-release-notes.md#other-changes) to determine RPF anymore, so setting it to `2` shouldn't be an issue and is what's recommended and common.

This PR makes it so that we try to set `rp_filter` to loose mode (`2`) instead of disabled (`0`), but if we can't, we only fail if `rp_filter` is set to strict mode (`1`).

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-117729](https://app.shortcut.com/replicated/story/117729)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds preflight checks to ensure that reverse path filtering (rp_filter) is either disabled (0) or set to loose mode (2) for both default and all interfaces via kernel parameters `net.ipv4.conf.default.rp_filter` and `net.ipv4.conf.all.rp_filter`.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE