### PR TITLE
Add SELinux host preflight check

### DIFF
--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -161,7 +161,8 @@ spec:
 {{- end}}
     - run:
         collectorName: 'check-selinux'
-        command: 'getenforce'
+        command: 'sh'
+        args: ['-c', 'getenforce || echo "Not installed"']
   analyzers:
     - cpu:
         checkName: CPU

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -159,6 +159,9 @@ spec:
         address: '{{ $element }}'
         timeout: 30s
 {{- end}}
+    - run:
+        collectorName: 'check-selinux'
+        command: 'getenforce'
   analyzers:
     - cpu:
         checkName: CPU
@@ -950,3 +953,14 @@ spec:
               when: "connected"
               message: "Successful TCP connection to {{ $element }}."
 {{- end}}
+    - textAnalyze:
+        checkName: SELinux Status
+        fileName: host-collectors/run-host/check-selinux.txt
+        regex: 'Enforcing'
+        outcomes:
+          - fail:
+              when: 'true'
+              message: SELinux must be disabled or run in permissive mode.
+          - pass:
+              when: 'false'
+              message: SELinux is not in enforcing mode.

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -160,9 +160,9 @@ spec:
         timeout: 30s
 {{- end}}
     - run:
-        collectorName: 'check-selinux'
+        collectorName: 'selinux-mode'
         command: 'sh'
-        args: ['-c', 'getenforce || echo "Not installed"']
+        args: ['-c', 'getenforce || echo "Missing"']
   analyzers:
     - cpu:
         checkName: CPU
@@ -955,13 +955,19 @@ spec:
               message: "Successful TCP connection to {{ $element }}."
 {{- end}}
     - textAnalyze:
-        checkName: SELinux Status
-        fileName: host-collectors/run-host/check-selinux.txt
-        regex: 'Enforcing'
+        checkName: SELinux Mode
+        fileName: host-collectors/run-host/selinux-mode.txt
+        regexGroups: '(?P<Mode>.+)'
         outcomes:
           - fail:
-              when: 'true'
+              when: "Mode == 'Enforcing'"
               message: SELinux must be disabled or run in permissive mode.
           - pass:
-              when: 'false'
-              message: SELinux is not in enforcing mode.
+              when: "Mode == 'Permissive'"
+              message: SELinux is running in permissive mode.
+          - pass:
+              when: "Mode == 'Disabled'"
+              message: SELinux is disabled.
+          - pass:
+              when: "Mode == 'Missing'"
+              message: SELinux is not installed.

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -957,17 +957,17 @@ spec:
     - textAnalyze:
         checkName: SELinux Mode
         fileName: host-collectors/run-host/selinux-mode.txt
-        regexGroups: '(?P<Mode>.+)'
+        regexGroups: '(?P<Mode>Enforcing|Permissive|Disabled|Missing)'
         outcomes:
           - fail:
-              when: "Mode == 'Enforcing'"
+              when: "Mode == Enforcing"
               message: SELinux must be disabled or run in permissive mode.
           - pass:
-              when: "Mode == 'Permissive'"
+              when: "Mode == Permissive"
               message: SELinux is running in permissive mode.
           - pass:
-              when: "Mode == 'Disabled'"
+              when: "Mode == Disabled"
               message: SELinux is disabled.
           - pass:
-              when: "Mode == 'Missing'"
+              when: "Mode == Missing"
               message: SELinux is not installed.


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Adds an SELinux host preflight check that fails if SELinux is running in `enforcing` mode.

```bash
[salah@salah-selinux ~]$ getenforce
Enforcing

[salah@salah-selinux ~]$ sudo ./embedded-cluster-smoke-test-staging-app install run-preflights --license license.yaml
✔  Host files materialized!
✗  1 host preflight failed

 •  SELinux must be disabled or run in permissive mode. 

Please address this issue and try again.

[salah@salah-selinux ~]$ sudo setenforce 0
[salah@salah-selinux ~]$ getenforce
Permissive

[salah@salah-selinux ~]$ sudo ./embedded-cluster-smoke-test-staging-app install run-preflights --license license.yaml
✔  Host files materialized!
✔  Host preflights succeeded!
Host preflights completed successfully
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

[SC-110719](https://app.shortcut.com/replicated/story/110719)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds a preflight check to ensure that SELinux is not running in enforcing mode.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE