### PR TITLE
fix: configure kernel modules and settings per k0s

### DIFF
--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -255,6 +255,11 @@ func runInstall(ctx context.Context, name string, flags InstallCmdFlags, metrics
 		logrus.Debugf("unable to configure sysctl: %v", err)
 	}
 
+	logrus.Debugf("configuring kernel modules")
+	if err := configutils.ConfigureKernelModules(); err != nil {
+		logrus.Debugf("unable to configure kernel modules: %v", err)
+	}
+
 	logrus.Debugf("configuring network manager")
 	if err := configureNetworkManager(ctx); err != nil {
 		return fmt.Errorf("unable to configure network manager: %w", err)

--- a/cmd/installer/cli/install_runpreflights.go
+++ b/cmd/installer/cli/install_runpreflights.go
@@ -62,6 +62,11 @@ func runInstallRunPreflights(ctx context.Context, name string, flags InstallCmdF
 		logrus.Debugf("unable to configure sysctl: %v", err)
 	}
 
+	logrus.Debugf("configuring kernel modules")
+	if err := configutils.ConfigureKernelModules(); err != nil {
+		logrus.Debugf("unable to configure kernel modules: %v", err)
+	}
+
 	logrus.Debugf("running install preflights")
 	if err := runInstallPreflights(ctx, flags, nil); err != nil {
 		if errors.Is(err, preflights.ErrPreflightsHaveFail) {

--- a/cmd/installer/cli/join.go
+++ b/cmd/installer/cli/join.go
@@ -138,6 +138,11 @@ func runJoin(ctx context.Context, name string, flags JoinCmdFlags, jcmd *kotsadm
 		logrus.Debugf("unable to configure sysctl: %v", err)
 	}
 
+	logrus.Debugf("configuring kernel modules")
+	if err := configutils.ConfigureKernelModules(); err != nil {
+		logrus.Debugf("unable to configure kernel modules: %v", err)
+	}
+
 	logrus.Debugf("configuring network manager")
 	if err := configureNetworkManager(ctx); err != nil {
 		return fmt.Errorf("unable to configure network manager: %w", err)

--- a/cmd/installer/cli/join_runpreflights.go
+++ b/cmd/installer/cli/join_runpreflights.go
@@ -66,6 +66,11 @@ func runJoinRunPreflights(ctx context.Context, name string, flags JoinCmdFlags, 
 		logrus.Debugf("unable to configure sysctl: %v", err)
 	}
 
+	logrus.Debugf("configuring kernel modules")
+	if err := configutils.ConfigureKernelModules(); err != nil {
+		logrus.Debugf("unable to configure kernel modules: %v", err)
+	}
+
 	cidrCfg, err := getJoinCIDRConfig(jcmd)
 	if err != nil {
 		return fmt.Errorf("unable to get join CIDR config: %w", err)

--- a/cmd/installer/cli/restore.go
+++ b/cmd/installer/cli/restore.go
@@ -135,16 +135,6 @@ func runRestore(ctx context.Context, name string, flags InstallCmdFlags, s3Store
 		}
 	}
 
-	logrus.Debugf("configuring sysctl")
-	if err := configutils.ConfigureSysctl(); err != nil {
-		logrus.Debugf("unable to configure sysctl: %v", err)
-	}
-
-	logrus.Debugf("configuring kernel modules")
-	if err := configutils.ConfigureKernelModules(); err != nil {
-		logrus.Debugf("unable to configure kernel modules: %v", err)
-	}
-
 	logrus.Debugf("getting restore state")
 	state := getECRestoreState(ctx)
 	logrus.Debugf("restore state is: %q", state)
@@ -367,6 +357,16 @@ func runRestoreStepNew(ctx context.Context, name string, flags InstallCmdFlags, 
 		if err := validateS3BackupStore(s3Store); err != nil {
 			return fmt.Errorf("unable to validate backup store: %w", err)
 		}
+	}
+
+	logrus.Debugf("configuring sysctl")
+	if err := configutils.ConfigureSysctl(); err != nil {
+		logrus.Debugf("unable to configure sysctl: %v", err)
+	}
+
+	logrus.Debugf("configuring kernel modules")
+	if err := configutils.ConfigureKernelModules(); err != nil {
+		logrus.Debugf("unable to configure kernel modules: %v", err)
 	}
 
 	logrus.Debugf("configuring network manager")

--- a/cmd/installer/cli/restore.go
+++ b/cmd/installer/cli/restore.go
@@ -140,6 +140,11 @@ func runRestore(ctx context.Context, name string, flags InstallCmdFlags, s3Store
 		logrus.Debugf("unable to configure sysctl: %v", err)
 	}
 
+	logrus.Debugf("configuring kernel modules")
+	if err := configutils.ConfigureKernelModules(); err != nil {
+		logrus.Debugf("unable to configure kernel modules: %v", err)
+	}
+
 	logrus.Debugf("getting restore state")
 	state := getECRestoreState(ctx)
 	logrus.Debugf("restore state is: %q", state)

--- a/pkg/configutils/runtime.go
+++ b/pkg/configutils/runtime.go
@@ -92,7 +92,7 @@ func ensureKernelModulesLoaded() (finalErr error) {
 	scanner := bufio.NewScanner(bytes.NewReader(embeddedClusterModulesConf))
 	for scanner.Scan() {
 		module := strings.TrimSpace(scanner.Text())
-		if module != "" {
+		if module != "" && !strings.HasPrefix(module, "#") {
 			if err := modprobe(module); err != nil {
 				err = fmt.Errorf("modprobe %s: %w", module, err)
 				finalErr = multierr.Append(finalErr, err)

--- a/pkg/configutils/runtime.go
+++ b/pkg/configutils/runtime.go
@@ -14,9 +14,9 @@ import (
 	"go.uber.org/multierr"
 )
 
-// sysctlConfigPath is the path to the sysctl config file that is used to configure
-// the embedded cluster. This could have been a constant but we want to be able to
-// override it for testing purposes.
+// sysctlConfigPath is the path to the sysctl config file that is used to configure the embedded
+// cluster. This could have been a constant but we want to be able to override it for testing
+// purposes.
 var sysctlConfigPath = "/etc/sysctl.d/99-embedded-cluster.conf"
 
 var modulesLoadConfigPath = "/etc/modules-load.d/99-embedded-cluster.conf"
@@ -58,8 +58,8 @@ func sysctlConfig() error {
 	return nil
 }
 
-// ConfigureKernelModules writes the kernel modules config file and ensures the
-// kernel modules are loaded that are listed in the file.
+// ConfigureKernelModules writes the kernel modules config file and ensures the kernel modules are
+// loaded that are listed in the file.
 func ConfigureKernelModules() error {
 	if _, err := exec.LookPath("modprobe"); err != nil {
 		return fmt.Errorf("find modprobe binary: %w", err)
@@ -75,8 +75,8 @@ func ConfigureKernelModules() error {
 	return nil
 }
 
-// kernelModulesConfig writes the embedded kernel modules config to the
-// /etc/modules-load.d directory.
+// kernelModulesConfig writes the embedded kernel modules config to the /etc/modules-load.d
+// directory.
 func kernelModulesConfig() error {
 	if err := os.MkdirAll(filepath.Dir(modulesLoadConfigPath), 0755); err != nil {
 		return fmt.Errorf("create directory: %w", err)
@@ -87,8 +87,8 @@ func kernelModulesConfig() error {
 	return nil
 }
 
-// ensureKernelModulesLoaded ensures the kernel modules are loaded by iterating
-// over the modules in the config file and calling modprobe for each one.
+// ensureKernelModulesLoaded ensures the kernel modules are loaded by iterating over the modules in
+// the config file and calling modprobe for each one.
 func ensureKernelModulesLoaded() (finalErr error) {
 	scanner := bufio.NewScanner(bytes.NewReader(embeddedClusterModulesConf))
 	for scanner.Scan() {

--- a/pkg/configutils/runtime.go
+++ b/pkg/configutils/runtime.go
@@ -27,10 +27,11 @@ var embeddedClusterSysctlConf []byte
 //go:embed static/modules-load.d/99-embedded-cluster.conf
 var embeddedClusterModulesConf []byte
 
-// ConfigureSysctl writes the sysctl config file for the embedded cluster and
-// reloads the sysctl configuration. This function has a distinct behavior: if
-// the sysctl binary does not exist it returns an error but if it fails to lay
-// down the sysctl config on disk it simply returns nil.
+// ConfigureSysctl writes the sysctl config file for the embedded cluster and reloads the sysctl
+// configuration. This function has a distinct behavior: if the sysctl binary does not exist it
+// returns an error but if it fails to lay down the sysctl config on disk it simply returns nil.
+// NOTE: do not run this after the cluster has already been installed as it may revert sysctl
+// settings set by k0s and its extensions.
 func ConfigureSysctl() error {
 	if _, err := exec.LookPath("sysctl"); err != nil {
 		return fmt.Errorf("find sysctl binary: %w", err)

--- a/pkg/configutils/runtime.go
+++ b/pkg/configutils/runtime.go
@@ -1,13 +1,17 @@
 package configutils
 
 import (
+	"bufio"
+	"bytes"
 	_ "embed"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/replicatedhq/embedded-cluster/pkg/helpers"
+	"go.uber.org/multierr"
 )
 
 // sysctlConfigPath is the path to the sysctl config file that is used to configure
@@ -15,8 +19,13 @@ import (
 // override it for testing purposes.
 var sysctlConfigPath = "/etc/sysctl.d/99-embedded-cluster.conf"
 
-//go:embed static/99-embedded-cluster.conf
-var embeddedClusterConf []byte
+var modulesLoadConfigPath = "/etc/modules-load.d/99-embedded-cluster.conf"
+
+//go:embed static/sysctl.d/99-embedded-cluster.conf
+var embeddedClusterSysctlConf []byte
+
+//go:embed static/modules-load.d/99-embedded-cluster.conf
+var embeddedClusterModulesConf []byte
 
 // ConfigureSysctl writes the sysctl config file for the embedded cluster and
 // reloads the sysctl configuration. This function has a distinct behavior: if
@@ -24,26 +33,76 @@ var embeddedClusterConf []byte
 // down the sysctl config on disk it simply returns nil.
 func ConfigureSysctl() error {
 	if _, err := exec.LookPath("sysctl"); err != nil {
-		return fmt.Errorf("unable to find sysctl binary: %w", err)
+		return fmt.Errorf("find sysctl binary: %w", err)
 	}
 
-	if err := sysctlConfig(sysctlConfigPath); err != nil {
-		return fmt.Errorf("unable to materialize sysctl config: %w", err)
+	if err := sysctlConfig(); err != nil {
+		return fmt.Errorf("materialize sysctl config: %w", err)
 	}
 
 	if _, err := helpers.RunCommand("sysctl", "--system"); err != nil {
-		return fmt.Errorf("unable to configure sysctl: %w", err)
+		return fmt.Errorf("configure sysctl: %w", err)
 	}
 	return nil
 }
 
-// SysctlConfig writes the embedded sysctl config to the /etc/sysctl.d directory.
-func sysctlConfig(dstpath string) error {
-	if err := os.MkdirAll(filepath.Dir(dstpath), 0755); err != nil {
-		return fmt.Errorf("unable to create directory: %w", err)
+// sysctlConfig writes the embedded sysctl config to the /etc/sysctl.d directory.
+func sysctlConfig() error {
+	if err := os.MkdirAll(filepath.Dir(sysctlConfigPath), 0755); err != nil {
+		return fmt.Errorf("create directory: %w", err)
 	}
-	if err := os.WriteFile(dstpath, embeddedClusterConf, 0644); err != nil {
-		return fmt.Errorf("unable to write file: %w", err)
+	if err := os.WriteFile(sysctlConfigPath, embeddedClusterSysctlConf, 0644); err != nil {
+		return fmt.Errorf("write file: %w", err)
 	}
 	return nil
+}
+
+// ConfigureKernelModules writes the kernel modules config file and ensures the
+// kernel modules are loaded that are listed in the file.
+func ConfigureKernelModules() error {
+	if _, err := exec.LookPath("modprobe"); err != nil {
+		return fmt.Errorf("find modprobe binary: %w", err)
+	}
+
+	if err := kernelModulesConfig(); err != nil {
+		return fmt.Errorf("materialize kernel modules config: %w", err)
+	}
+
+	if err := ensureKernelModulesLoaded(); err != nil {
+		return fmt.Errorf("ensure kernel modules are loaded: %w", err)
+	}
+	return nil
+}
+
+// kernelModulesConfig writes the embedded kernel modules config to the
+// /etc/modules-load.d directory.
+func kernelModulesConfig() error {
+	if err := os.MkdirAll(filepath.Dir(modulesLoadConfigPath), 0755); err != nil {
+		return fmt.Errorf("create directory: %w", err)
+	}
+	if err := os.WriteFile(modulesLoadConfigPath, embeddedClusterModulesConf, 0644); err != nil {
+		return fmt.Errorf("write file: %w", err)
+	}
+	return nil
+}
+
+// ensureKernelModulesLoaded ensures the kernel modules are loaded by iterating
+// over the modules in the config file and calling modprobe for each one.
+func ensureKernelModulesLoaded() (finalErr error) {
+	scanner := bufio.NewScanner(bytes.NewReader(embeddedClusterModulesConf))
+	for scanner.Scan() {
+		module := strings.TrimSpace(scanner.Text())
+		if module != "" {
+			if err := modprobe(module); err != nil {
+				err = fmt.Errorf("modprobe %s: %w", module, err)
+				finalErr = multierr.Append(finalErr, err)
+			}
+		}
+	}
+	return
+}
+
+func modprobe(module string) error {
+	_, err := helpers.RunCommand("modprobe", module)
+	return err
 }

--- a/pkg/configutils/static/modules-load.d/99-embedded-cluster.conf
+++ b/pkg/configutils/static/modules-load.d/99-embedded-cluster.conf
@@ -1,0 +1,6 @@
+# from https://github.com/k0sproject/k0s/blob/fb9fb09cdbea20afa64fbb0218c7eca0ac0a61c7/pkg/component/worker/kernelsetup_linux.go#L63-L75
+overlay
+ip_tables
+#ip6_tables
+br_netfilter
+nf_conntrack

--- a/pkg/configutils/static/sysctl.d/99-embedded-cluster.conf
+++ b/pkg/configutils/static/sysctl.d/99-embedded-cluster.conf
@@ -1,7 +1,14 @@
 # this entry enables ip forwarding. this feature is necessary as embedded
 # cluster creates virtual network interfaces and need the traffic among them to
-# be forwarded.
+# be forwarded and routed via iptables.
+# from https://github.com/k0sproject/k0s/blob/fb9fb09cdbea20afa64fbb0218c7eca0ac0a61c7/pkg/component/worker/kernelsetup_linux.go#L76-L81
 net.ipv4.ip_forward = 1
+net.ipv4.conf.all.forwarding = 1
+net.ipv4.conf.default.forwarding = 1
+net.ipv6.conf.all.forwarding = 1
+net.ipv6.conf.default.forwarding = 1
+net.bridge.bridge-nf-call-iptables = 1
+net.bridge.bridge-nf-call-ip6tables = 1
 
 # arp filter and ignore need to be disabled otherwise we can't have arp
 # resolving across the calico network interfaces.


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

This pr duplicates the [kernel configuration](https://github.com/k0sproject/k0s/blob/fb9fb09cdbea20afa64fbb0218c7eca0ac0a61c7/pkg/component/worker/kernelsetup_linux.go#L62-L82) from k0s as it is set using sysctl and is not persistent. It also duplicates the modprobe commands to enable and persist them.

It moves the call to ConfigureSysctl in the restore command to only run when this is a new restore, so as not to revert any settings that are set by installing k0s or extensions.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
