### PR TITLE
fix(lam): wait for service after start

### DIFF
--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -608,7 +608,7 @@ func installAndStartCluster(ctx context.Context, networkInterface string, airgap
 		return nil, fmt.Errorf("create config file: %w", err)
 	}
 	logrus.Debugf("creating systemd unit files")
-	if err := createSystemdUnitFiles(false, proxy); err != nil {
+	if err := createSystemdUnitFiles(ctx, false, proxy); err != nil {
 		return nil, fmt.Errorf("create systemd unit files: %w", err)
 	}
 
@@ -769,7 +769,7 @@ func validateAdminConsolePassword(password, passwordCheck string) bool {
 
 // createSystemdUnitFiles links the k0s systemd unit file. this also creates a new
 // systemd unit file for the local artifact mirror service.
-func createSystemdUnitFiles(isWorker bool, proxy *ecv1beta1.ProxySpec) error {
+func createSystemdUnitFiles(ctx context.Context, isWorker bool, proxy *ecv1beta1.ProxySpec) error {
 	dst := systemdUnitFileName()
 	if _, err := os.Lstat(dst); err == nil {
 		if err := os.Remove(dst); err != nil {
@@ -793,7 +793,7 @@ func createSystemdUnitFiles(isWorker bool, proxy *ecv1beta1.ProxySpec) error {
 	if _, err := helpers.RunCommand("systemctl", "daemon-reload"); err != nil {
 		return fmt.Errorf("unable to get reload systemctl daemon: %w", err)
 	}
-	if err := installAndEnableLocalArtifactMirror(); err != nil {
+	if err := installAndEnableLocalArtifactMirror(ctx); err != nil {
 		return fmt.Errorf("unable to install and enable local artifact mirror: %w", err)
 	}
 	return nil

--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -842,12 +842,14 @@ func installAndEnableLocalArtifactMirror(ctx context.Context) error {
 	if _, err := helpers.RunCommand("systemctl", "enable", "local-artifact-mirror"); err != nil {
 		return fmt.Errorf("unable to enable the local artifact mirror service: %w", err)
 	}
+	logrus.Debugf("Starting local artifact mirror")
 	if _, err := helpers.RunCommand("systemctl", "start", "local-artifact-mirror"); err != nil {
 		return fmt.Errorf("unable to start the local artifact mirror: %w", err)
 	}
 	if err := waitForLocalArtifactMirror(ctx); err != nil {
 		return fmt.Errorf("unable to wait for the local artifact mirror: %w", err)
 	}
+	logrus.Debugf("Local artifact mirror started!")
 	return nil
 }
 

--- a/cmd/installer/cli/join.go
+++ b/cmd/installer/cli/join.go
@@ -299,7 +299,8 @@ func installAndJoinCluster(ctx context.Context, jcmd *kotsadm.JoinCommandRespons
 
 	logrus.Debugf("creating systemd unit files")
 	// both controller and worker nodes will have 'worker' in the join command
-	if err := createSystemdUnitFiles(ctx, !strings.Contains(jcmd.K0sJoinCommand, "controller"), jcmd.InstallationSpec.Proxy); err != nil {
+	isWorker := !strings.Contains(jcmd.K0sJoinCommand, "controller")
+	if err := createSystemdUnitFiles(ctx, isWorker, jcmd.InstallationSpec.Proxy); err != nil {
 		return fmt.Errorf("unable to create systemd unit files: %w", err)
 	}
 

--- a/cmd/installer/cli/join.go
+++ b/cmd/installer/cli/join.go
@@ -299,7 +299,7 @@ func installAndJoinCluster(ctx context.Context, jcmd *kotsadm.JoinCommandRespons
 
 	logrus.Debugf("creating systemd unit files")
 	// both controller and worker nodes will have 'worker' in the join command
-	if err := createSystemdUnitFiles(!strings.Contains(jcmd.K0sJoinCommand, "controller"), jcmd.InstallationSpec.Proxy); err != nil {
+	if err := createSystemdUnitFiles(ctx, !strings.Contains(jcmd.K0sJoinCommand, "controller"), jcmd.InstallationSpec.Proxy); err != nil {
 		return fmt.Errorf("unable to create systemd unit files: %w", err)
 	}
 

--- a/cmd/installer/kotscli/kotscli.go
+++ b/cmd/installer/kotscli/kotscli.go
@@ -1,9 +1,7 @@
 package kotscli
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 	"os"
 	"regexp"
 	"strings"
@@ -14,7 +12,6 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/release"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/replicatedhq/embedded-cluster/pkg/spinner"
-	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -78,21 +75,14 @@ func Install(opts InstallOptions, msg *spinner.MessageWriter) error {
 	defer msg.SetMask(nil)
 	defer msg.SetLineBreaker(nil)
 
-	stdout := bytes.NewBuffer(nil)
-	stderr := bytes.NewBuffer(nil)
-
 	runCommandOptions := helpers.RunCommandOptions{
-		Stdout: io.MultiWriter(msg, stdout),
-		Stderr: stderr,
+		Stdout:       msg,
+		LogOnSuccess: true,
 		Env: map[string]string{
 			"EMBEDDED_CLUSTER_ID": metrics.ClusterID().String(),
 		},
 	}
 	err = helpers.RunCommandWithOptions(runCommandOptions, kotsBinPath, installArgs...)
-	logrus.Debugf("kotscli stdout: %s", stdout.String())
-	if out := strings.TrimSpace(stderr.String()); out != "" {
-		logrus.Debugf("kotscli stderr: %s", out)
-	}
 	if err != nil {
 		return fmt.Errorf("unable to install the application: %w", err)
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Checks systemctl status of LAM after installing and starting before proceeding with the rest of the install.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
