### PR TITLE
fix(dev): skip kernel module preflight checks on docker for mac

### DIFF
--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -996,39 +996,51 @@ spec:
     - kernelModules:
         checkName: "Overlay kernel module"
         outcomes:
-          - fail:
-              when: "overlay != loaded,loadable"
-              message: The 'overlay' kernel module is not loaded or loadable
+          - pass:
+              when: "rosetta == loaded"
+              message: The kernel is likely linuxkit, skipping kernel module check
           - pass:
               when: "overlay == loaded,loadable"
               message: The 'overlay' kernel module is loaded or loadable
+          - fail:
+              when: ""
+              message: The 'overlay' kernel module is not loaded or loadable
     - kernelModules:
         checkName: "IP tables kernel module"
         outcomes:
-          - fail:
-              when: "ip_tables != loaded,loadable"
-              message: The 'ip_tables' kernel module is not loaded or loadable
+          - pass:
+              when: "rosetta == loaded"
+              message: The kernel is likely linuxkit, skipping kernel module check
           - pass:
               when: "ip_tables == loaded,loadable"
               message: The 'ip_tables' kernel module is loaded or loadable
+          - fail:
+              when: ""
+              message: The 'ip_tables' kernel module is not loaded or loadable
     - kernelModules:
         checkName: "BR Netfilter kernel module"
         outcomes:
-          - fail:
-              when: "br_netfilter != loaded,loadable"
-              message: The 'br_netfilter' kernel module is not loaded or loadable
+          - pass:
+              when: "rosetta == loaded"
+              message: The kernel is likely linuxkit, skipping kernel module check
           - pass:
               when: "br_netfilter == loaded,loadable"
               message: The 'br_netfilter' kernel module is loaded or loadable
+          - fail:
+              when: ""
+              message: The 'br_netfilter' kernel module is not loaded or loadable
     - kernelModules:
         checkName: "NF Conntrack kernel module"
         outcomes:
-          - fail:
-              when: "nf_conntrack != loaded,loadable"
-              message: The 'nf_conntrack' kernel module is not loaded or loadable
+          - pass:
+              when: "rosetta == loaded"
+              message: The kernel is likely linuxkit, skipping kernel module check
           - pass:
               when: "nf_conntrack == loaded,loadable"
               message: The 'nf_conntrack' kernel module is loaded or loadable
+          - fail:
+              when: ""
+              message: The 'nf_conntrack' kernel module is not loaded or loadable
     - networkNamespaceConnectivity:
         collectorName: check-network-namespace-connectivity
         outcomes:


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

install fails in dev env on docker for mac with

```
✗  4 host preflights failed

 •  The 'overlay' kernel module is not loaded or loadable      
 •  The 'ip_tables' kernel module is not loaded or loadable    
 •  The 'br_netfilter' kernel module is not loaded or loadable 
 •  The 'nf_conntrack' kernel module is not loaded or loadable 

Please address these issues and try again.
```

This is because of weirdness with linuxkit

```
root@node0:/replicatedhq/embedded-cluster# lsmod
Module                  Size  Used by
shiftfs                28672  -2
selfowner              28672  -2
rosetta                12288  -2
grpcfuse               12288  -2
fakeowner             122880  -2
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
