### PR TITLE
Remove cidr flags from instructions of join preflights

### DIFF
--- a/cmd/installer/cli/join_runpreflights.go
+++ b/cmd/installer/cli/join_runpreflights.go
@@ -108,6 +108,7 @@ func runJoinPreflights(ctx context.Context, jcmd *kotsadm.JoinCommandResponse, f
 		IgnoreHostPreflights:   flags.ignoreHostPreflights,
 		AssumeYes:              flags.assumeYes,
 		TCPConnectionsRequired: jcmd.TCPConnectionsRequired,
+		IsJoin:                 true,
 	}); err != nil {
 		return err
 	}

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -869,7 +869,12 @@ spec:
         outcomes:
           - fail:
               when: "true"
-              message: The node IP {{ .NodeIP }} cannot be within the Pod CIDR range {{ .PodCIDR.CIDR }}. Use --pod-cidr to specify a different Pod CIDR, or use --network-interface to specify a different network interface.
+              message: |
+                {{ if .IsJoin -}}
+                The node IP {{ .NodeIP }} cannot be within the Pod CIDR range {{ .PodCIDR.CIDR }}. Use --network-interface to specify a different network interface.
+                {{- else -}}
+                The node IP {{ .NodeIP }} cannot be within the Pod CIDR range {{ .PodCIDR.CIDR }}. Use --pod-cidr to specify a different Pod CIDR, or use --network-interface to specify a different network interface.
+                {{- end }}
           - pass:
               when: "false" 
               message: The node IP {{ .NodeIP }} is not within the Pod CIDR range {{ .PodCIDR.CIDR }}.
@@ -881,7 +886,12 @@ spec:
         outcomes:
           - fail:
               when: "true"
-              message: The node IP {{ .NodeIP }} cannot be within the Service CIDR range {{ .ServiceCIDR.CIDR }}. Use --service-cidr to specify a different Service CIDR, or use --network-interface to specify a different network interface.
+              message: |
+                {{ if .IsJoin -}}
+                The node IP {{ .NodeIP }} cannot be within the Service CIDR range {{ .ServiceCIDR.CIDR }}. Use --network-interface to specify a different network interface.
+                {{- else -}}
+                The node IP {{ .NodeIP }} cannot be within the Service CIDR range {{ .ServiceCIDR.CIDR }}. Use --service-cidr to specify a different Service CIDR, or use --network-interface to specify a different network interface.
+                {{- end }}
           - pass:
               when: "false"
               message: The node IP {{ .NodeIP }} is not within the Service CIDR range {{ .ServiceCIDR.CIDR }}.
@@ -893,7 +903,12 @@ spec:
         outcomes:
           - fail:
               when: "true"
-              message: The node IP {{ .NodeIP }} cannot be within the CIDR range {{ .GlobalCIDR.CIDR }}. Use --cidr to specify a different CIDR block of available private IP addresses (/16 or larger), or use --network-interface to specify a different network interface.
+              message: |
+                {{ if .IsJoin -}}
+                The node IP {{ .NodeIP }} cannot be within the CIDR range {{ .GlobalCIDR.CIDR }}. Use --network-interface to specify a different network interface.
+                {{- else -}}
+                The node IP {{ .NodeIP }} cannot be within the CIDR range {{ .GlobalCIDR.CIDR }}. Use --cidr to specify a different CIDR block of available private IP addresses (/16 or larger), or use --network-interface to specify a different network interface.
+                {{- end }}
           - pass:
               when: "false"
               message: The node IP {{ .NodeIP }} is not within the Global CIDR range {{ .GlobalCIDR.CIDR }}.
@@ -1043,13 +1058,13 @@ spec:
         outcomes:
           - fail:
               when: "connection-refused"
-              message: "A TCP connection to {{ $element }} is required, but the connection was refused. This can occur, for example, if IP routing is not possible between this host and {{ $element }}, or if your firewall doesn’t allow traffic between this host and {{ $element }}."
+              message: "A TCP connection to {{ $element }} is required, but the connection was refused. This can occur, for example, if IP routing is not possible between this host and {{ $element }}, or if your firewall doesn't allow traffic between this host and {{ $element }}."
           - fail:
               when: "connection-timeout"
-              message: "A TCP connection to {{ $element }} is required, but the connection timed out. This can occur, for example, if IP routing is not possible between this host and {{ $element }}, or if your firewall doesn’t allow traffic between this host and {{ $element }}."
+              message: "A TCP connection to {{ $element }} is required, but the connection timed out. This can occur, for example, if IP routing is not possible between this host and {{ $element }}, or if your firewall doesn't allow traffic between this host and {{ $element }}."
           - fail:
               when: "error"
-              message: "A TCP connection to {{ $element }} is required, but an unexpected error occurred. This can occur, for example, if IP routing is not possible between this host and {{ $element }}, or if your firewall doesn’t allow traffic between this host and {{ $element }}."
+              message: "A TCP connection to {{ $element }} is required, but an unexpected error occurred. This can occur, for example, if IP routing is not possible between this host and {{ $element }}, or if your firewall doesn't allow traffic between this host and {{ $element }}."
           - pass:
               when: "connected"
               message: "Successful TCP connection to {{ $element }}."

--- a/pkg/preflights/run.go
+++ b/pkg/preflights/run.go
@@ -36,6 +36,7 @@ type PrepareAndRunOptions struct {
 	AssumeYes              bool
 	TCPConnectionsRequired []string
 	MetricsReporter        MetricsReporter
+	IsJoin                 bool
 }
 
 type MetricsReporter interface {
@@ -68,6 +69,7 @@ func PrepareAndRun(ctx context.Context, opts PrepareAndRunOptions) error {
 		ToCIDR:                  opts.ServiceCIDR,
 		TCPConnectionsRequired:  opts.TCPConnectionsRequired,
 		NodeIP:                  opts.NodeIP,
+		IsJoin:                  opts.IsJoin,
 	}.WithCIDRData(opts.PodCIDR, opts.ServiceCIDR, opts.GlobalCIDR)
 
 	if err != nil {

--- a/pkg/preflights/template_test.go
+++ b/pkg/preflights/template_test.go
@@ -413,19 +413,19 @@ func TestTemplateTCPConnectionsRequired(t *testing.T) {
 					{
 						Fail: &v1beta2.SingleOutcome{
 							When:    "connection-refused",
-							Message: "A TCP connection to 192.168.10.1:6443 is required, but the connection was refused. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:6443, or if your firewall doesn’t allow traffic between this host and 192.168.10.1:6443.",
+							Message: "A TCP connection to 192.168.10.1:6443 is required, but the connection was refused. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:6443, or if your firewall doesn't allow traffic between this host and 192.168.10.1:6443.",
 						},
 					},
 					{
 						Fail: &v1beta2.SingleOutcome{
 							When:    "connection-timeout",
-							Message: "A TCP connection to 192.168.10.1:6443 is required, but the connection timed out. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:6443, or if your firewall doesn’t allow traffic between this host and 192.168.10.1:6443.",
+							Message: "A TCP connection to 192.168.10.1:6443 is required, but the connection timed out. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:6443, or if your firewall doesn't allow traffic between this host and 192.168.10.1:6443.",
 						},
 					},
 					{
 						Fail: &v1beta2.SingleOutcome{
 							When:    "error",
-							Message: "A TCP connection to 192.168.10.1:6443 is required, but an unexpected error occurred. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:6443, or if your firewall doesn’t allow traffic between this host and 192.168.10.1:6443.",
+							Message: "A TCP connection to 192.168.10.1:6443 is required, but an unexpected error occurred. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:6443, or if your firewall doesn't allow traffic between this host and 192.168.10.1:6443.",
 						},
 					},
 					{
@@ -477,19 +477,19 @@ func TestTemplateTCPConnectionsRequired(t *testing.T) {
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "connection-refused",
-								Message: "A TCP connection to 192.168.10.1:6443 is required, but the connection was refused. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:6443, or if your firewall doesn’t allow traffic between this host and 192.168.10.1:6443.",
+								Message: "A TCP connection to 192.168.10.1:6443 is required, but the connection was refused. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:6443, or if your firewall doesn't allow traffic between this host and 192.168.10.1:6443.",
 							},
 						},
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "connection-timeout",
-								Message: "A TCP connection to 192.168.10.1:6443 is required, but the connection timed out. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:6443, or if your firewall doesn’t allow traffic between this host and 192.168.10.1:6443.",
+								Message: "A TCP connection to 192.168.10.1:6443 is required, but the connection timed out. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:6443, or if your firewall doesn't allow traffic between this host and 192.168.10.1:6443.",
 							},
 						},
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "error",
-								Message: "A TCP connection to 192.168.10.1:6443 is required, but an unexpected error occurred. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:6443, or if your firewall doesn’t allow traffic between this host and 192.168.10.1:6443.",
+								Message: "A TCP connection to 192.168.10.1:6443 is required, but an unexpected error occurred. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:6443, or if your firewall doesn't allow traffic between this host and 192.168.10.1:6443.",
 							},
 						},
 						{
@@ -506,19 +506,19 @@ func TestTemplateTCPConnectionsRequired(t *testing.T) {
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "connection-refused",
-								Message: "A TCP connection to 192.168.10.1:9443 is required, but the connection was refused. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:9443, or if your firewall doesn’t allow traffic between this host and 192.168.10.1:9443.",
+								Message: "A TCP connection to 192.168.10.1:9443 is required, but the connection was refused. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:9443, or if your firewall doesn't allow traffic between this host and 192.168.10.1:9443.",
 							},
 						},
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "connection-timeout",
-								Message: "A TCP connection to 192.168.10.1:9443 is required, but the connection timed out. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:9443, or if your firewall doesn’t allow traffic between this host and 192.168.10.1:9443.",
+								Message: "A TCP connection to 192.168.10.1:9443 is required, but the connection timed out. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:9443, or if your firewall doesn't allow traffic between this host and 192.168.10.1:9443.",
 							},
 						},
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "error",
-								Message: "A TCP connection to 192.168.10.1:9443 is required, but an unexpected error occurred. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:9443, or if your firewall doesn’t allow traffic between this host and 192.168.10.1:9443.",
+								Message: "A TCP connection to 192.168.10.1:9443 is required, but an unexpected error occurred. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:9443, or if your firewall doesn't allow traffic between this host and 192.168.10.1:9443.",
 							},
 						},
 						{
@@ -535,19 +535,19 @@ func TestTemplateTCPConnectionsRequired(t *testing.T) {
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "connection-refused",
-								Message: "A TCP connection to 192.168.10.1:2380 is required, but the connection was refused. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:2380, or if your firewall doesn’t allow traffic between this host and 192.168.10.1:2380.",
+								Message: "A TCP connection to 192.168.10.1:2380 is required, but the connection was refused. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:2380, or if your firewall doesn't allow traffic between this host and 192.168.10.1:2380.",
 							},
 						},
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "connection-timeout",
-								Message: "A TCP connection to 192.168.10.1:2380 is required, but the connection timed out. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:2380, or if your firewall doesn’t allow traffic between this host and 192.168.10.1:2380.",
+								Message: "A TCP connection to 192.168.10.1:2380 is required, but the connection timed out. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:2380, or if your firewall doesn't allow traffic between this host and 192.168.10.1:2380.",
 							},
 						},
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "error",
-								Message: "A TCP connection to 192.168.10.1:2380 is required, but an unexpected error occurred. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:2380, or if your firewall doesn’t allow traffic between this host and 192.168.10.1:2380.",
+								Message: "A TCP connection to 192.168.10.1:2380 is required, but an unexpected error occurred. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:2380, or if your firewall doesn't allow traffic between this host and 192.168.10.1:2380.",
 							},
 						},
 						{
@@ -564,19 +564,19 @@ func TestTemplateTCPConnectionsRequired(t *testing.T) {
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "connection-refused",
-								Message: "A TCP connection to 192.168.10.1:10250 is required, but the connection was refused. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:10250, or if your firewall doesn’t allow traffic between this host and 192.168.10.1:10250.",
+								Message: "A TCP connection to 192.168.10.1:10250 is required, but the connection was refused. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:10250, or if your firewall doesn't allow traffic between this host and 192.168.10.1:10250.",
 							},
 						},
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "connection-timeout",
-								Message: "A TCP connection to 192.168.10.1:10250 is required, but the connection timed out. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:10250, or if your firewall doesn’t allow traffic between this host and 192.168.10.1:10250.",
+								Message: "A TCP connection to 192.168.10.1:10250 is required, but the connection timed out. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:10250, or if your firewall doesn't allow traffic between this host and 192.168.10.1:10250.",
 							},
 						},
 						{
 							Fail: &v1beta2.SingleOutcome{
 								When:    "error",
-								Message: "A TCP connection to 192.168.10.1:10250 is required, but an unexpected error occurred. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:10250, or if your firewall doesn’t allow traffic between this host and 192.168.10.1:10250.",
+								Message: "A TCP connection to 192.168.10.1:10250 is required, but an unexpected error occurred. This can occur, for example, if IP routing is not possible between this host and 192.168.10.1:10250, or if your firewall doesn't allow traffic between this host and 192.168.10.1:10250.",
 							},
 						},
 						{

--- a/pkg/preflights/types/template.go
+++ b/pkg/preflights/types/template.go
@@ -34,6 +34,7 @@ type TemplateData struct {
 	ToCIDR                  string
 	TCPConnectionsRequired  []string
 	NodeIP                  string
+	IsJoin                  bool
 }
 
 // WithCIDRData sets the respective CIDR properties in the TemplateData struct based on the provided CIDR strings

--- a/tests/dryrun/join_test.go
+++ b/tests/dryrun/join_test.go
@@ -103,19 +103,19 @@ func TestJoinTCPConnectionsRequired(t *testing.T) {
 				assert.Contains(t, hc.TCPConnect.Outcomes, &troubleshootv1beta2.Outcome{
 					Fail: &troubleshootv1beta2.SingleOutcome{
 						When:    "connection-refused",
-						Message: "A TCP connection to 10.0.0.1:9443 is required, but the connection was refused. This can occur, for example, if IP routing is not possible between this host and 10.0.0.1:9443, or if your firewall doesn’t allow traffic between this host and 10.0.0.1:9443.",
+						Message: "A TCP connection to 10.0.0.1:9443 is required, but the connection was refused. This can occur, for example, if IP routing is not possible between this host and 10.0.0.1:9443, or if your firewall doesn't allow traffic between this host and 10.0.0.1:9443.",
 					},
 				})
 				assert.Contains(t, hc.TCPConnect.Outcomes, &troubleshootv1beta2.Outcome{
 					Fail: &troubleshootv1beta2.SingleOutcome{
 						When:    "connection-timeout",
-						Message: "A TCP connection to 10.0.0.1:9443 is required, but the connection timed out. This can occur, for example, if IP routing is not possible between this host and 10.0.0.1:9443, or if your firewall doesn’t allow traffic between this host and 10.0.0.1:9443.",
+						Message: "A TCP connection to 10.0.0.1:9443 is required, but the connection timed out. This can occur, for example, if IP routing is not possible between this host and 10.0.0.1:9443, or if your firewall doesn't allow traffic between this host and 10.0.0.1:9443.",
 					},
 				})
 				assert.Contains(t, hc.TCPConnect.Outcomes, &troubleshootv1beta2.Outcome{
 					Fail: &troubleshootv1beta2.SingleOutcome{
 						When:    "error",
-						Message: "A TCP connection to 10.0.0.1:9443 is required, but an unexpected error occurred. This can occur, for example, if IP routing is not possible between this host and 10.0.0.1:9443, or if your firewall doesn’t allow traffic between this host and 10.0.0.1:9443.",
+						Message: "A TCP connection to 10.0.0.1:9443 is required, but an unexpected error occurred. This can occur, for example, if IP routing is not possible between this host and 10.0.0.1:9443, or if your firewall doesn't allow traffic between this host and 10.0.0.1:9443.",
 					},
 				})
 				assert.Contains(t, hc.TCPConnect.Outcomes, &troubleshootv1beta2.Outcome{

--- a/tests/dryrun/join_test.go
+++ b/tests/dryrun/join_test.go
@@ -72,19 +72,19 @@ func TestJoinTCPConnectionsRequired(t *testing.T) {
 				assert.Contains(t, hc.TCPConnect.Outcomes, &troubleshootv1beta2.Outcome{
 					Fail: &troubleshootv1beta2.SingleOutcome{
 						When:    "connection-refused",
-						Message: "A TCP connection to 10.0.0.1:6443 is required, but the connection was refused. This can occur, for example, if IP routing is not possible between this host and 10.0.0.1:6443, or if your firewall doesn’t allow traffic between this host and 10.0.0.1:6443.",
+						Message: "A TCP connection to 10.0.0.1:6443 is required, but the connection was refused. This can occur, for example, if IP routing is not possible between this host and 10.0.0.1:6443, or if your firewall doesn't allow traffic between this host and 10.0.0.1:6443.",
 					},
 				})
 				assert.Contains(t, hc.TCPConnect.Outcomes, &troubleshootv1beta2.Outcome{
 					Fail: &troubleshootv1beta2.SingleOutcome{
 						When:    "connection-timeout",
-						Message: "A TCP connection to 10.0.0.1:6443 is required, but the connection timed out. This can occur, for example, if IP routing is not possible between this host and 10.0.0.1:6443, or if your firewall doesn’t allow traffic between this host and 10.0.0.1:6443.",
+						Message: "A TCP connection to 10.0.0.1:6443 is required, but the connection timed out. This can occur, for example, if IP routing is not possible between this host and 10.0.0.1:6443, or if your firewall doesn't allow traffic between this host and 10.0.0.1:6443.",
 					},
 				})
 				assert.Contains(t, hc.TCPConnect.Outcomes, &troubleshootv1beta2.Outcome{
 					Fail: &troubleshootv1beta2.SingleOutcome{
 						When:    "error",
-						Message: "A TCP connection to 10.0.0.1:6443 is required, but an unexpected error occurred. This can occur, for example, if IP routing is not possible between this host and 10.0.0.1:6443, or if your firewall doesn’t allow traffic between this host and 10.0.0.1:6443.",
+						Message: "A TCP connection to 10.0.0.1:6443 is required, but an unexpected error occurred. This can occur, for example, if IP routing is not possible between this host and 10.0.0.1:6443, or if your firewall doesn't allow traffic between this host and 10.0.0.1:6443.",
 					},
 				})
 				assert.Contains(t, hc.TCPConnect.Outcomes, &troubleshootv1beta2.Outcome{


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Removes cidr flags from instructions of join preflights as these flags aren't available.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE