### PR TITLE
Pass if clock is synced even if ntp is inactive

### DIFF
--- a/cmd/installer/goods/support/host-support-bundle.tmpl.yaml
+++ b/cmd/installer/goods/support/host-support-bundle.tmpl.yaml
@@ -432,6 +432,9 @@ spec:
             when: 'ntp == unsynchronized+active'
             message: NTP is enabled but the system clock is not synchronized. Synchronize the system clock to continue.
         - pass:
+            when: 'ntp == synchronized+inactive' # don't fail as the system clock might be managed by other protocols (e.g. PTP)
+            message: NTP is inactive but the system clock is synchronized
+        - pass:
             when: 'ntp == synchronized+active'
             message: NTP is enabled and the system clock is synchronized
         - fail:

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -233,8 +233,13 @@ spec:
               when: 'ntp == unsynchronized+active'
               message: NTP is enabled but the system clock is not synchronized. Synchronize the system clock to continue.
           - pass:
+              when: 'ntp == synchronized+inactive' # don't fail as the system clock might be managed by other protocols (e.g. PTP)
+              message: NTP is inactive but the system clock is synchronized
+          - pass:
               when: 'ntp == synchronized+active'
               message: NTP is enabled and the system clock is synchronized
+          - fail:
+              message: 'Unable to determine system clock status'
     - jsonCompare:
         checkName: Cgroups
         fileName: host-collectors/system/cgroups.json


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Pass if system clock is synced even if NTP is inactive as it might be managed by other protocols (e.g. PTP).

Example:
```
# ptp is active and managing the system clock
$ sudo pmc -u -b 0 'GET TIME_STATUS_NP'
sending: GET TIME_STATUS_NP
	000000.fffe.000002-0 seq 0 RESPONSE MANAGEMENT TIME_STATUS_NP 
		master_offset              239
		ingress_time               1739906646275502611
		cumulativeScaledRateOffset +0.000000000
		scaledLastGmPhaseChange    0
		gmTimeBaseIndicator        0
		lastGmPhaseChange          0x0000'0000000000000000.0000
		gmPresent                  true
		gmIdentity                 000000.fffe.000001

$ timedatectl status
...
System clock synchronized: yes
              NTP service: n/a
...

$ cat preflightbundle-2025-02-18T19_16_16/analysis.json
[
...
            "detail": "NTP is inactive but the system clock is synchronized",
...
]
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

[SC-119141](https://app.shortcut.com/replicated/story/119141)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Preflight checks now accept synchronized system clocks even if NTP is inactive, accommodating systems where the clock is managed by alternative protocols (e.g., PTP)
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE