### PR TITLE
fix(host-preflights): buildtin kernel modules file from wrong path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ K0S_GO_VERSION = v1.30.9+k0s.0
 PREVIOUS_K0S_VERSION ?= v1.29.9+k0s.0-ec.0
 PREVIOUS_K0S_GO_VERSION ?= v1.29.9+k0s.0
 K0S_BINARY_SOURCE_OVERRIDE =
-TROUBLESHOOT_VERSION = v0.116.3
+TROUBLESHOOT_VERSION = v0.116.4
 
 KOTS_VERSION = v$(shell awk '/^version/{print $$2}' pkg/addons/adminconsole/static/metadata.yaml | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
 # When updating KOTS_BINARY_URL_OVERRIDE, also update the KOTS_VERSION above or

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/replicatedhq/embedded-cluster/kinds v0.0.0
 	github.com/replicatedhq/embedded-cluster/utils v0.0.0
 	github.com/replicatedhq/kotskinds v0.0.0-20240814191029-3f677ee409a0
-	github.com/replicatedhq/troubleshoot v0.116.3
+	github.com/replicatedhq/troubleshoot v0.116.4
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -1439,8 +1439,8 @@ github.com/redis/go-redis/v9 v9.5.2/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/replicatedhq/kotskinds v0.0.0-20240814191029-3f677ee409a0 h1:Gi+Fs6583v7GmgQKJyaZuBzcih0z5YXBREDQ8AWY2JM=
 github.com/replicatedhq/kotskinds v0.0.0-20240814191029-3f677ee409a0/go.mod h1:QjhIUu3+OmHZ09u09j3FCoTt8F3BYtQglS+OLmftu9I=
-github.com/replicatedhq/troubleshoot v0.116.3 h1:GcE5G0pSX7fIdi98u2NBGSB4GlzNT4ID2U9tCtJfoM4=
-github.com/replicatedhq/troubleshoot v0.116.3/go.mod h1:OQwNwp78Xkfa/VwzNnDyiTFAAsZK1u3wApYncskHVl0=
+github.com/replicatedhq/troubleshoot v0.116.4 h1:SDa+bWiXArt4Ypkw3+qjMxl+QUWKZsR0t19A13Mx3G0=
+github.com/replicatedhq/troubleshoot v0.116.4/go.mod h1:OQwNwp78Xkfa/VwzNnDyiTFAAsZK1u3wApYncskHVl0=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Updates troubleshoot with this change

https://github.com/replicatedhq/troubleshoot/pull/1741

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes host preflight failures for kernel modules in environments where kernel modules are built in.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
