### PR TITLE
Ensure inotify settings meet the minimum requirements

### DIFF
--- a/pkg/configutils/runtime_test.go
+++ b/pkg/configutils/runtime_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConfigureSysctl(t *testing.T) {
+func TestSysctlConfig(t *testing.T) {
 	basedir, err := os.MkdirTemp("", "embedded-cluster-test-base-dir")
 	assert.NoError(t, err)
 	defer os.RemoveAll(basedir)
@@ -30,7 +30,7 @@ func TestConfigureSysctl(t *testing.T) {
 	defer os.RemoveAll(dstdir)
 
 	sysctlConfigPath = filepath.Join(dstdir, "sysctl.conf")
-	err = ConfigureSysctl()
+	err = sysctlConfig()
 	assert.NoError(t, err)
 
 	// check that the file exists.
@@ -41,6 +41,97 @@ func TestConfigureSysctl(t *testing.T) {
 	sysctlConfigPath = filepath.Join(dstdir, "non-existing-dir", "sysctl.conf")
 	// we do not expect an error here.
 	assert.NoError(t, err)
+}
+
+func TestDynamicSysctlConfig(t *testing.T) {
+	// Create a temporary config file.
+	configPath := filepath.Join(t.TempDir(), "99-dynamic-embedded-cluster.conf")
+
+	tests := []struct {
+		name            string
+		mockValues      map[string]int64
+		expectedLines   []string
+		unexpectedLines []string
+	}{
+		{
+			name: "inotify max_user values below minimum thresholds are updated",
+			mockValues: map[string]int64{
+				"fs.inotify.max_user_instances": 128,  // Below min
+				"fs.inotify.max_user_watches":   8192, // Below min
+			},
+			expectedLines: []string{
+				"fs.inotify.max_user_instances = 1024",
+				"fs.inotify.max_user_watches = 65536",
+			},
+		},
+		{
+			name: "only below minimum values of inotify max_user are updated",
+			mockValues: map[string]int64{
+				"fs.inotify.max_user_instances": 128,     // Below min
+				"fs.inotify.max_user_watches":   1048576, // Above min
+			},
+			expectedLines: []string{
+				"fs.inotify.max_user_instances = 1024",
+			},
+			unexpectedLines: []string{
+				"fs.inotify.max_user_watches",
+			},
+		},
+		{
+			name: "inotify max_user values above minimum thresholds are not updated",
+			mockValues: map[string]int64{
+				"fs.inotify.max_user_instances": 2048,    // Above min
+				"fs.inotify.max_user_watches":   1048576, // Above min
+			},
+			expectedLines: []string{}, // No updates needed
+			unexpectedLines: []string{
+				"fs.inotify.max_user_instances",
+				"fs.inotify.max_user_watches",
+			},
+		},
+		{
+			name: "inotify max_user values equal to minimum thresholds are not updated",
+			mockValues: map[string]int64{
+				"fs.inotify.max_user_instances": 1024,  // Equal to min
+				"fs.inotify.max_user_watches":   65536, // Equal to min
+			},
+			expectedLines: []string{}, // No updates needed
+			unexpectedLines: []string{
+				"fs.inotify.max_user_instances",
+				"fs.inotify.max_user_watches",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create mock getter
+			mockGetter := func(key string) (int64, error) {
+				value, exists := tt.mockValues[key]
+				if !exists {
+					t.Fatalf("unexpected key requested: %s", key)
+				}
+				return value, nil
+			}
+
+			err := generateDynamicSysctlConfig(mockGetter, configPath)
+			require.NoError(t, err)
+
+			// Read generated file
+			content, err := os.ReadFile(configPath)
+			require.NoError(t, err)
+
+			// Check for expected lines
+			for _, expectedLine := range tt.expectedLines {
+				assert.Contains(t, string(content), expectedLine)
+			}
+
+			// Check for unexpected lines
+			for _, unexpectedLine := range tt.unexpectedLines {
+				assert.NotContains(t, string(content), unexpectedLine)
+			}
+		})
+	}
 }
 
 func Test_ensureKernelModulesLoaded(t *testing.T) {
@@ -81,96 +172,5 @@ func Test_ensureKernelModulesLoaded(t *testing.T) {
 		if mock.Commands[i] != cmd {
 			t.Errorf("Expected command %q, got %q", cmd, mock.Commands[i])
 		}
-	}
-}
-
-func TestDynamicSysctlConfig(t *testing.T) {
-	// Create a temporary config file.
-	configPath := filepath.Join(t.TempDir(), "99-dynamic-embedded-cluster.conf")
-
-	tests := []struct {
-		name            string
-		mockValues      map[string]int64
-		expectedLines   []string
-		unexpectedLines []string
-	}{
-		{
-			name: "inotify max_user values below minimum thresholds are updated",
-			mockValues: map[string]int64{
-				"fs.inotify.max_user_instances": 512,   // Below min
-				"fs.inotify.max_user_watches":   65536, // Below min
-			},
-			expectedLines: []string{
-				"fs.inotify.max_user_instances = 1024",
-				"fs.inotify.max_user_watches = 1048576",
-			},
-		},
-		{
-			name: "only below minimum values of inotify max_user are updated",
-			mockValues: map[string]int64{
-				"fs.inotify.max_user_instances": 512,     // Below min
-				"fs.inotify.max_user_watches":   2097152, // Above min
-			},
-			expectedLines: []string{
-				"fs.inotify.max_user_instances = 1024",
-			},
-			unexpectedLines: []string{
-				"fs.inotify.max_user_watches",
-			},
-		},
-		{
-			name: "inotify max_user values above minimum thresholds are not updated",
-			mockValues: map[string]int64{
-				"fs.inotify.max_user_instances": 2048,    // Above min
-				"fs.inotify.max_user_watches":   2097152, // Above min
-			},
-			expectedLines: []string{}, // No updates needed
-			unexpectedLines: []string{
-				"fs.inotify.max_user_instances",
-				"fs.inotify.max_user_watches",
-			},
-		},
-		{
-			name: "inotify max_user values equal to minimum thresholds are not updated",
-			mockValues: map[string]int64{
-				"fs.inotify.max_user_instances": 1024,    // Equal to min
-				"fs.inotify.max_user_watches":   1048576, // Equal to min
-			},
-			expectedLines: []string{}, // No updates needed
-			unexpectedLines: []string{
-				"fs.inotify.max_user_instances",
-				"fs.inotify.max_user_watches",
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Create mock getter
-			mockGetter := func(key string) (int64, error) {
-				value, exists := tt.mockValues[key]
-				if !exists {
-					t.Fatalf("unexpected key requested: %s", key)
-				}
-				return value, nil
-			}
-
-			err := generateDynamicSysctlConfig(mockGetter, configPath)
-			require.NoError(t, err)
-
-			// Read generated file
-			content, err := os.ReadFile(configPath)
-			require.NoError(t, err)
-
-			// Check for expected lines
-			for _, expectedLine := range tt.expectedLines {
-				assert.Contains(t, string(content), expectedLine)
-			}
-
-			// Check for unexpected lines
-			for _, unexpectedLine := range tt.unexpectedLines {
-				assert.NotContains(t, string(content), unexpectedLine)
-			}
-		})
 	}
 }

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -1018,17 +1018,17 @@ spec:
         outcomes:
           - fail:
               when: "fs.inotify.max_user_instances < 1024"
-              message: "The system limit for inotify instances per user is too low. To increase it to the required minimum of 1024, edit /etc/sysctl.conf, add or update the line 'fs.inotify.max_user_instances=1024', and run 'sudo sysctl -p'."
+              message: "The system limit for inotify instances per user must be at least 1024. To increase it, edit /etc/sysctl.conf, add or edit the line 'fs.inotify.max_user_instances=1024', and run 'sudo sysctl -p'."
           - pass:
-              message: "The system allows a sufficient number of inotify instances per user."
+              message: "The system allows at least 1024 inotify instances per user."
     - sysctl:
         checkName: "Maximum number of inotify watches per user"
         outcomes:
           - fail:
               when: "fs.inotify.max_user_watches < 65536"
-              message: "The system limit for inotify watches per user is too low. To increase it to the required minimum of 65536, edit /etc/sysctl.conf, add or update the line 'fs.inotify.max_user_watches=65536', and run 'sudo sysctl -p'."
+              message: "The system limit for inotify watches per user must be at least 65536. To increase it, edit /etc/sysctl.conf, add or edit the line 'fs.inotify.max_user_watches=65536', and run 'sudo sysctl -p'."
           - pass:
-              message: "The system allows a sufficient number of inotify watches per user."
+              message: "The system allows at least 65536 inotify watches per user."
     - kernelModules:
         checkName: "Overlay kernel module"
         outcomes:

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -1013,6 +1013,22 @@ spec:
           - pass:
               when: 'net.bridge.bridge-nf-call-iptables == 1'
               message: "Bridge netfilter call iptables is enabled."
+    - sysctl:
+        checkName: "Maximum number of inotify instances per user"
+        outcomes:
+          - fail:
+              when: "fs.inotify.max_user_instances < 1024"
+              message: "The system limit for inotify instances per user is too low. To increase it to the required minimum of 1024, edit /etc/sysctl.conf, add or update the line 'fs.inotify.max_user_instances=1024', and run 'sudo sysctl -p'."
+          - pass:
+              message: "The system allows a sufficient number of inotify instances per user."
+    - sysctl:
+        checkName: "Maximum number of inotify watches per user"
+        outcomes:
+          - fail:
+              when: "fs.inotify.max_user_watches < 65536"
+              message: "The system limit for inotify watches per user is too low. To increase it to the required minimum of 65536, edit /etc/sysctl.conf, add or update the line 'fs.inotify.max_user_watches=65536', and run 'sudo sysctl -p'."
+          - pass:
+              message: "The system allows a sufficient number of inotify watches per user."
     - kernelModules:
         checkName: "Overlay kernel module"
         outcomes:


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

This PR adds dynamic sysctl configuration to ensure proper system settings for the embedded cluster. It:
- Automatically configures `fs.inotify.max_user_instances` and `fs.inotify.max_user_watches sysctl` values.
- Generates a dynamic sysctl config file that only updates their values when they're below required minimums
- Adds preflight checks to ensure the values meets the required minimums

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

[SC-119426](https://app.shortcut.com/replicated/story/119426)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Yes - unit tests have been added to verify the dynamic sysctl configuration logic.

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
The following kernel parameters are configured automatically: `fs.inotify.max_user_instances = 1024` and `fs.inotify.max_user_watches = 65536`.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE