### PR TITLE
Wait for k0s and node to be ready before proceeding

### DIFF
--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -626,9 +626,16 @@ func installAndStartCluster(ctx context.Context, networkInterface string, airgap
 	if err := k0s.Install(networkInterface); err != nil {
 		return nil, fmt.Errorf("install cluster: %w", err)
 	}
+
 	loading.Infof("Waiting for %s node to be ready", runtimeconfig.BinaryName())
+
 	logrus.Debugf("waiting for k0s to be ready")
 	if err := waitForK0s(); err != nil {
+		return nil, fmt.Errorf("wait for k0s: %w", err)
+	}
+
+	logrus.Debugf("waiting for node to be ready")
+	if err := waitForNode(ctx); err != nil {
 		return nil, fmt.Errorf("wait for node: %w", err)
 	}
 
@@ -945,6 +952,21 @@ func waitForK0s() error {
 		}
 		time.Sleep(2 * time.Second)
 	}
+}
+
+func waitForNode(ctx context.Context) error {
+	kcli, err := kubeutils.KubeClient()
+	if err != nil {
+		return fmt.Errorf("create kube client: %w", err)
+	}
+	hostname, err := os.Hostname()
+	if err != nil {
+		return fmt.Errorf("get hostname: %w", err)
+	}
+	if err := kubeutils.WaitForControllerNode(ctx, kcli, hostname); err != nil {
+		return fmt.Errorf("wait for node: %w", err)
+	}
+	return nil
 }
 
 func recordInstallation(ctx context.Context, kcli client.Client, flags InstallCmdFlags, k0sCfg *k0sv1beta1.ClusterConfig, disasterRecoveryEnabled bool) (*ecv1beta1.Installation, error) {

--- a/cmd/installer/cli/join.go
+++ b/cmd/installer/cli/join.go
@@ -206,7 +206,7 @@ func runJoin(ctx context.Context, name string, flags JoinCmdFlags, jcmd *kotsadm
 		return fmt.Errorf("unable to get hostname: %w", err)
 	}
 
-	if err := waitForNode(ctx, kcli, hostname); err != nil {
+	if err := waitForNodeToJoin(ctx, kcli, hostname); err != nil {
 		return fmt.Errorf("unable to wait for node: %w", err)
 	}
 
@@ -465,7 +465,7 @@ func runK0sInstallCommand(networkInterface string, fullcmd string) error {
 	return nil
 }
 
-func waitForNode(ctx context.Context, kcli client.Client, hostname string) error {
+func waitForNodeToJoin(ctx context.Context, kcli client.Client, hostname string) error {
 	loading := spinner.Start()
 	defer loading.Close()
 	loading.Infof("Waiting for node to join the cluster")


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Waits for both k0s and node to be ready before proceeding.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-116308](https://app.shortcut.com/replicated/story/116308)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Enhances installation reliability by adding proper wait conditions for k0s and node readiness before proceeding with subsequent installation steps.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE