### PR TITLE
Add preflight check for directory permissions to prevent etcd startup failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ K0S_GO_VERSION = v1.30.9+k0s.0
 PREVIOUS_K0S_VERSION ?= v1.29.9+k0s.0-ec.0
 PREVIOUS_K0S_GO_VERSION ?= v1.29.9+k0s.0
 K0S_BINARY_SOURCE_OVERRIDE =
-TROUBLESHOOT_VERSION = v0.116.4
+TROUBLESHOOT_VERSION = v0.117.0
 
 KOTS_VERSION = v$(shell awk '/^version/{print $$2}' pkg/addons/adminconsole/static/metadata.yaml | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
 # When updating KOTS_BINARY_URL_OVERRIDE, also update the KOTS_VERSION above or

--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -232,6 +232,12 @@ func preRunInstall(cmd *cobra.Command, flags *InstallCmdFlags) error {
 		return fmt.Errorf("unable to write runtime config to disk: %w", err)
 	}
 
+	if err := os.Chmod(runtimeconfig.EmbeddedClusterHomeDirectory(), 0755); err != nil {
+		// don't fail as there are cases where we can't change the permissions (bind mounts, selinux, etc...),
+		// and we handle and surface those errors to the user later (host preflights, checking exec errors, etc...)
+		logrus.Debugf("unable to chmod embedded-cluster home dir: %s", err)
+	}
+
 	return nil
 }
 

--- a/cmd/installer/cli/join.go
+++ b/cmd/installer/cli/join.go
@@ -247,6 +247,12 @@ func runJoinVerifyAndPrompt(name string, flags JoinCmdFlags, jcmd *kotsadm.JoinC
 		return fmt.Errorf("unable to write runtime config: %w", err)
 	}
 
+	if err := os.Chmod(runtimeconfig.EmbeddedClusterHomeDirectory(), 0755); err != nil {
+		// don't fail as there are cases where we can't change the permissions (bind mounts, selinux, etc...),
+		// and we handle and surface those errors to the user later (host preflights, checking exec errors, etc...)
+		logrus.Debugf("unable to chmod embedded-cluster home dir: %s", err)
+	}
+
 	// check to make sure the version returned by the join token is the same as the one we are running
 	if strings.TrimPrefix(jcmd.EmbeddedClusterVersion, "v") != strings.TrimPrefix(versions.Version, "v") {
 		return fmt.Errorf("embedded cluster version mismatch - this binary is version %q, but the cluster is running version %q", versions.Version, jcmd.EmbeddedClusterVersion)

--- a/e2e/preflights_test.go
+++ b/e2e/preflights_test.go
@@ -154,7 +154,7 @@ func TestPreflights(t *testing.T) {
 			},
 		},
 		{
-			name: "Should verify data directory permissions failures",
+			name: "Should contain data directory permissions failures",
 			assert: func(t *testing.T, results *types.Output) {
 				for _, res := range results.Fail {
 					if res.Title == "Data Directory Permissions" {

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/replicatedhq/embedded-cluster/kinds v0.0.0
 	github.com/replicatedhq/embedded-cluster/utils v0.0.0
 	github.com/replicatedhq/kotskinds v0.0.0-20240814191029-3f677ee409a0
-	github.com/replicatedhq/troubleshoot v0.116.4
+	github.com/replicatedhq/troubleshoot v0.117.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.19.0
@@ -134,6 +134,7 @@ require (
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5 // indirect
+	github.com/ebitengine/purego v0.8.2 // indirect
 	github.com/envoyproxy/go-control-plane v0.13.1 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.1.0 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
@@ -231,8 +232,7 @@ require (
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/segmentio/ksuid v1.0.4 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
-	github.com/shirou/gopsutil/v3 v3.24.5 // indirect
-	github.com/shoenig/go-m1cpu v0.1.6 // indirect
+	github.com/shirou/gopsutil/v4 v4.25.1 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -867,6 +867,8 @@ github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5 h1:iFaUwBSo5Svw6L
 github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5/go.mod h1:qssHWj60/X5sZFNxpG4HBPDHVqxNm4DfnCKgrbZOT+s=
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/ebitengine/purego v0.8.2 h1:jPPGWs2sZ1UgOSgD2bClL0MJIqu58nOmIcBuXr62z1I=
+github.com/ebitengine/purego v0.8.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=
 github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -1439,8 +1441,8 @@ github.com/redis/go-redis/v9 v9.5.2/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/replicatedhq/kotskinds v0.0.0-20240814191029-3f677ee409a0 h1:Gi+Fs6583v7GmgQKJyaZuBzcih0z5YXBREDQ8AWY2JM=
 github.com/replicatedhq/kotskinds v0.0.0-20240814191029-3f677ee409a0/go.mod h1:QjhIUu3+OmHZ09u09j3FCoTt8F3BYtQglS+OLmftu9I=
-github.com/replicatedhq/troubleshoot v0.116.4 h1:SDa+bWiXArt4Ypkw3+qjMxl+QUWKZsR0t19A13Mx3G0=
-github.com/replicatedhq/troubleshoot v0.116.4/go.mod h1:OQwNwp78Xkfa/VwzNnDyiTFAAsZK1u3wApYncskHVl0=
+github.com/replicatedhq/troubleshoot v0.117.0 h1:FCw8VodGF/tetL7ZvdOhnjFDOvSDqMq/kce9/dsfHfc=
+github.com/replicatedhq/troubleshoot v0.117.0/go.mod h1:Xt6P84cvEyfyp9J/7EblCqINXHeTc+1zqfJY/KqjOss=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
@@ -1468,12 +1470,8 @@ github.com/segmentio/ksuid v1.0.4 h1:sBo2BdShXjmcugAMwjugoGUdUV0pcxY5mW4xKRn3v4c
 github.com/segmentio/ksuid v1.0.4/go.mod h1:/XUiZBD3kVx5SmUOl55voK5yeAbBNNIed+2O73XgrPE=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
-github.com/shirou/gopsutil/v3 v3.24.5 h1:i0t8kL+kQTvpAYToeuiVk3TgDeKOFioZO3Ztz/iZ9pI=
-github.com/shirou/gopsutil/v3 v3.24.5/go.mod h1:bsoOS1aStSs9ErQ1WWfxllSeS1K5D+U30r2NfcubMVk=
-github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
-github.com/shoenig/go-m1cpu v0.1.6/go.mod h1:1JJMcUBvfNwpq05QDQVAnx3gUHr9IYF7GNg9SUEw2VQ=
-github.com/shoenig/test v0.6.4 h1:kVTaSd7WLz5WZ2IaoM0RSzRsUD+m8wRR+5qvntpn4LU=
-github.com/shoenig/test v0.6.4/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnjqq0k=
+github.com/shirou/gopsutil/v4 v4.25.1 h1:QSWkTc+fu9LTAWfkZwZ6j8MSUk4A2LV7rbH0ZqmLjXs=
+github.com/shirou/gopsutil/v4 v4.25.1/go.mod h1:RoUCUpndaJFtT+2zsZzzmhvbfGoDCJ7nFXKJf8GqJbI=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -164,6 +164,16 @@ spec:
         collectorName: 'selinux-mode'
         command: 'sh'
         args: ['-c', 'getenforce || echo "Missing"']
+    - run:
+        collectorName: 'check-k0s-dir-permissions'
+        command: 'sh'
+        args:
+          - -c
+          - |
+            # check the directory, its parents, and root
+            dir="{{ .K0sDataDir }}"
+            while [ "$dir" != "/" ]; do find "$dir" -maxdepth 0 ! -perm -111; dir=$(dirname "$dir"); done
+            find "/" -maxdepth 0 ! -perm -111
   analyzers:
     - cpu:
         checkName: CPU
@@ -1119,3 +1129,14 @@ spec:
           - pass:
               when: "Mode == Missing"
               message: SELinux is not installed.
+    - textAnalyze:
+        checkName: K0s Data Directory Execute Permissions
+        fileName: host-collectors/run-host/check-k0s-dir-permissions.txt
+        regexGroups: '(?ms)(?P<Dirs>.*)'
+        outcomes:
+          - pass:
+              when: "Dirs == ''"
+              message: "The k0s data directory ({{ .K0sDataDir }}) and all its parent directories have execute permissions"
+          - fail:
+              message: >-
+                The following directories lack execute permissions: {{ `{{ .Dirs | trim | splitList "\n" | join ", " }}` }}.

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -165,13 +165,14 @@ spec:
         command: 'sh'
         args: ['-c', 'getenforce || echo "Missing"']
     - run:
-        collectorName: 'check-k0s-dir-permissions'
+        # check execute permissions on the data directory, its parents, and root.
+        # this is necessary for executing binaries in the data directory by other users (e.g. etcd).
+        collectorName: 'check-data-dir-permissions'
         command: 'sh'
         args:
           - -c
           - |
-            # check the directory, its parents, and root
-            dir="{{ .K0sDataDir }}"
+            dir="{{ .DataDir }}"
             while [ "$dir" != "/" ]; do find "$dir" -maxdepth 0 ! -perm -111; dir=$(dirname "$dir"); done
             find "/" -maxdepth 0 ! -perm -111
   analyzers:
@@ -1130,13 +1131,13 @@ spec:
               when: "Mode == Missing"
               message: SELinux is not installed.
     - textAnalyze:
-        checkName: K0s Data Directory Execute Permissions
-        fileName: host-collectors/run-host/check-k0s-dir-permissions.txt
+        checkName: Data Directory Permissions
+        fileName: host-collectors/run-host/check-data-dir-permissions.txt
         regexGroups: '(?ms)(?P<Dirs>.*)'
         outcomes:
           - pass:
               when: "Dirs == ''"
-              message: "The k0s data directory ({{ .K0sDataDir }}) and all its parent directories have execute permissions"
+              message: "The data directory ({{ .DataDir }}) and all its parent directories have execute permissions"
           - fail:
               message: >-
                 The following directories lack execute permissions: {{ `{{ .Dirs | trim | splitList "\n" | join ", " }}` }}.

--- a/pkg/runtimeconfig/runtimeconfig.go
+++ b/pkg/runtimeconfig/runtimeconfig.go
@@ -34,10 +34,16 @@ func Cleanup() {
 // EmbeddedClusterHomeDirectory returns the parent directory. Inside this parent directory we
 // store all the embedded-cluster related files.
 func EmbeddedClusterHomeDirectory() string {
+	dir := ecv1beta1.DefaultDataDir
 	if runtimeConfig.DataDir != "" {
-		return runtimeConfig.DataDir
+		dir = runtimeConfig.DataDir
 	}
-	return ecv1beta1.DefaultDataDir
+	if err := os.Chmod(dir, 0755); err != nil {
+		// don't fail as there are cases where we can't change the permissions (bind mounts, selinux, etc...),
+		// and we handle and surface those errors to the user later (host preflights, checking exec errors, etc...)
+		logrus.Debugf("unable to chmod embedded-cluster home dir: %s", err)
+	}
+	return dir
 }
 
 // EmbeddedClusterTmpSubDir returns the path to the tmp directory where embedded-cluster

--- a/pkg/runtimeconfig/runtimeconfig.go
+++ b/pkg/runtimeconfig/runtimeconfig.go
@@ -34,16 +34,10 @@ func Cleanup() {
 // EmbeddedClusterHomeDirectory returns the parent directory. Inside this parent directory we
 // store all the embedded-cluster related files.
 func EmbeddedClusterHomeDirectory() string {
-	dir := ecv1beta1.DefaultDataDir
 	if runtimeConfig.DataDir != "" {
-		dir = runtimeConfig.DataDir
+		return runtimeConfig.DataDir
 	}
-	if err := os.Chmod(dir, 0755); err != nil && !os.IsNotExist(err) {
-		// don't fail as there are cases where we can't change the permissions (bind mounts, selinux, etc...),
-		// and we handle and surface those errors to the user later (host preflights, checking exec errors, etc...)
-		logrus.Debugf("unable to chmod embedded-cluster home dir: %s", err)
-	}
-	return dir
+	return ecv1beta1.DefaultDataDir
 }
 
 // EmbeddedClusterTmpSubDir returns the path to the tmp directory where embedded-cluster

--- a/pkg/runtimeconfig/runtimeconfig.go
+++ b/pkg/runtimeconfig/runtimeconfig.go
@@ -38,7 +38,7 @@ func EmbeddedClusterHomeDirectory() string {
 	if runtimeConfig.DataDir != "" {
 		dir = runtimeConfig.DataDir
 	}
-	if err := os.Chmod(dir, 0755); err != nil {
+	if err := os.Chmod(dir, 0755); err != nil && !os.IsNotExist(err) {
 		// don't fail as there are cases where we can't change the permissions (bind mounts, selinux, etc...),
 		// and we handle and surface those errors to the user later (host preflights, checking exec errors, etc...)
 		logrus.Debugf("unable to chmod embedded-cluster home dir: %s", err)


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

This PR ensures that the k0s data directory and its parent directories have execute permissions. This is necessary for the k0s etcd user to execute the etcd binary. Without proper execute permissions, the etcd service will fail to start, causing cluster initialization failures.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

Fixes:
- [SC-120515](https://app.shortcut.com/replicated/story/120515)
- [SC-120528](https://app.shortcut.com/replicated/story/120528)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Adds a preflight check to verify execute permissions on the data directory and its parent directories, preventing cluster startup failures due to etcd permission issues.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE