### PR TITLE
chore(ci): lxd copy dir tar

### DIFF
--- a/e2e/cluster/lxd/cluster.go
+++ b/e2e/cluster/lxd/cluster.go
@@ -578,12 +578,6 @@ func CopyDirToNode(in *ClusterInput, node string, dir Dir) {
 
 	stdout := bytes.NewBuffer(nil)
 	stderr := bytes.NewBuffer(nil)
-	cmd := Command{
-		Node:   node,
-		Line:   []string{"tar", "-xf", "-", "-C", filepath.Dir(dir.DestPath)},
-		Stdout: &NoopCloser{stdout},
-		Stderr: &NoopCloser{stderr},
-	}
 
 	client, err := lxd.ConnectLXDUnix(lxdSocket, nil)
 	if err != nil {
@@ -591,7 +585,7 @@ func CopyDirToNode(in *ClusterInput, node string, dir Dir) {
 	}
 
 	req := api.InstanceExecPost{
-		Command:     cmd.Line,
+		Command:     []string{"tar", "-xf", "-", "-C", filepath.Dir(dir.DestPath)},
 		WaitForWS:   true,
 		Interactive: false,
 		Environment: map[string]string{},
@@ -599,8 +593,8 @@ func CopyDirToNode(in *ClusterInput, node string, dir Dir) {
 
 	args := lxd.InstanceExecArgs{
 		Stdin:    tmpFile,
-		Stdout:   cmd.Stdout,
-		Stderr:   cmd.Stderr,
+		Stdout:   &NoopCloser{stdout},
+		Stderr:   &NoopCloser{stderr},
 		DataDone: make(chan bool),
 	}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Tars directories before copying them to lxc container rather than copying files one at a time.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
