### PR TITLE
feat: ensure use of custom domains in metrics reporting

### DIFF
--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -98,7 +98,9 @@ func InstallCmd(ctx context.Context, name string) *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clusterID := metrics.ClusterID()
-			metricsReporter := NewInstallReporter(flags.license, clusterID, cmd.CalledAs())
+			metricsReporter := NewInstallReporter(
+				flags.license.Spec.Endpoint, flags.license.Spec.LicenseID, clusterID, cmd.CalledAs(),
+			)
 			metricsReporter.ReportInstallationStarted(ctx)
 			if err := runInstall(cmd.Context(), name, flags, metricsReporter); err != nil {
 				metricsReporter.ReportInstallationFailed(ctx, err)
@@ -749,7 +751,7 @@ func maybePromptForAppUpdate(ctx context.Context, prompt prompts.Prompt, license
 	}
 	logrus.Debugf("Current app release is out-of-date")
 
-	apiURL := metrics.BaseURL(license)
+	apiURL := license.Spec.Endpoint
 	releaseURL := fmt.Sprintf("%s/embedded/%s/%s", apiURL, channelRelease.AppSlug, channelRelease.ChannelSlug)
 	logrus.Warnf("A newer version %s is available.", currentRelease.VersionLabel)
 	logrus.Infof(
@@ -1017,7 +1019,7 @@ func recordInstallation(ctx context.Context, kcli client.Client, flags InstallCm
 		},
 		Spec: ecv1beta1.InstallationSpec{
 			ClusterID:                 metrics.ClusterID().String(),
-			MetricsBaseURL:            metrics.BaseURL(flags.license),
+			MetricsBaseURL:            flags.license.Spec.Endpoint,
 			AirGap:                    flags.isAirgap,
 			Proxy:                     flags.proxy,
 			Network:                   networkSpecFromK0sConfig(k0sCfg),

--- a/cmd/installer/cli/install_runpreflights.go
+++ b/cmd/installer/cli/install_runpreflights.go
@@ -84,6 +84,9 @@ func runInstallRunPreflights(ctx context.Context, name string, flags InstallCmdF
 func runInstallPreflights(ctx context.Context, flags InstallCmdFlags, metricsReported preflights.MetricsReporter) error {
 	var replicatedAPIURL, proxyRegistryURL string
 	if flags.license != nil {
+		// TODO(customdomains): this is used by restore
+		// This requires us to either embed the license in the binary or require a license be
+		// provided to the restore command.
 		replicatedAPIURL = flags.license.Spec.Endpoint
 		proxyRegistryURL = fmt.Sprintf("https://%s", runtimeconfig.ProxyRegistryAddress)
 	}

--- a/cmd/installer/cli/metrics.go
+++ b/cmd/installer/cli/metrics.go
@@ -6,37 +6,38 @@ import (
 	"github.com/google/uuid"
 	"github.com/replicatedhq/embedded-cluster/pkg/metrics"
 	preflightstypes "github.com/replicatedhq/embedded-cluster/pkg/preflights/types"
-	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 )
 
 type InstallReporter struct {
-	license   *kotsv1beta1.License
+	baseURL   string
+	licenseID string
 	clusterID uuid.UUID
 	cmd       string
 }
 
-func NewInstallReporter(license *kotsv1beta1.License, clusterID uuid.UUID, cmd string) *InstallReporter {
+func NewInstallReporter(baseURL string, licenseID string, clusterID uuid.UUID, cmd string) *InstallReporter {
 	return &InstallReporter{
-		license:   license,
+		baseURL:   baseURL,
+		licenseID: licenseID,
 		clusterID: clusterID,
 		cmd:       cmd,
 	}
 }
 
 func (r *InstallReporter) ReportInstallationStarted(ctx context.Context) {
-	metrics.ReportInstallationStarted(ctx, r.license, r.clusterID)
+	metrics.ReportInstallationStarted(ctx, r.baseURL, r.licenseID, r.clusterID)
 }
 
 func (r *InstallReporter) ReportInstallationSucceeded(ctx context.Context) {
-	metrics.ReportInstallationSucceeded(ctx, r.license, r.clusterID)
+	metrics.ReportInstallationSucceeded(ctx, r.baseURL, r.clusterID)
 }
 
 func (r *InstallReporter) ReportInstallationFailed(ctx context.Context, err error) {
-	metrics.ReportInstallationFailed(ctx, r.license, r.clusterID, err)
+	metrics.ReportInstallationFailed(ctx, r.baseURL, r.clusterID, err)
 }
 
 func (r *InstallReporter) ReportPreflightsFailed(ctx context.Context, output preflightstypes.Output, bypassed bool) {
-	metrics.ReportPreflightsFailed(ctx, metrics.BaseURL(r.license), r.clusterID, output, bypassed, r.cmd)
+	metrics.ReportPreflightsFailed(ctx, r.baseURL, r.clusterID, output, bypassed, r.cmd)
 }
 
 type JoinReporter struct {

--- a/cmd/installer/cli/release.go
+++ b/cmd/installer/cli/release.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/replicatedhq/embedded-cluster/pkg/metrics"
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 )
 
@@ -33,7 +32,7 @@ func getCurrentAppChannelRelease(ctx context.Context, license *kotsv1beta1.Licen
 	query.Set("channelSequence", "") // sending an empty string will return the latest channel release
 	query.Set("isSemverSupported", "true")
 
-	apiURL := metrics.BaseURL(license)
+	apiURL := license.Spec.Endpoint
 	url := fmt.Sprintf("%s/release/%s/pending?%s", apiURL, license.Spec.AppSlug, query.Encode())
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {

--- a/cmd/installer/cli/restore.go
+++ b/cmd/installer/cli/restore.go
@@ -429,7 +429,9 @@ func runRestoreStepNew(ctx context.Context, name string, flags InstallCmdFlags, 
 		PrivateCAs:  flags.privateCAs,
 		ServiceCIDR: flags.cidrCfg.ServiceCIDR,
 		IsRestore:   true,
-		// TODO: pass in custom domain
+		// TODO(customdomains): pass in custom domain
+		// This requires us to either embed the license in the binary or require a license be
+		// provided to the restore command.
 	}); err != nil {
 		return err
 	}

--- a/pkg/metrics/interface.go
+++ b/pkg/metrics/interface.go
@@ -32,7 +32,10 @@ type SenderInterface interface {
 // Metrics endpoint can be overwritten by the license.spec.endpoint field.
 func Send(ctx context.Context, baseURL string, ev types.Event) {
 	if metricsDisabled {
-		logrus.Debugf("metrics are disabled, not sending event %s", ev.Title())
+		logrus.Debugf("Metrics are disabled, not sending event %s", ev.Title())
+		return
+	} else if baseURL == "" {
+		logrus.Debugf("Metrics base URL empty, not sending event %s", ev.Title())
 		return
 	}
 	s.Send(ctx, baseURL, ev)

--- a/pkg/metrics/reporter_test.go
+++ b/pkg/metrics/reporter_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/replicatedhq/embedded-cluster/pkg/metrics/types"
-	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,19 +46,12 @@ func TestReportInstallationStarted(t *testing.T) {
 				),
 			)
 			defer server.Close()
-			license := &kotsv1beta1.License{
-				Spec: kotsv1beta1.LicenseSpec{
-					LicenseID: "license-id",
-					AppSlug:   "app-slug",
-					Endpoint:  server.URL,
-				},
-			}
 			// Report call relies on os.Args to get the command and flags used so we nee to mock it
 			originalArgs := os.Args
 			defer func() { os.Args = originalArgs }()
 			os.Args = append([]string{os.Args[0]}, test.OSArgs...)
 
-			ReportInstallationStarted(context.Background(), license, ClusterID())
+			ReportInstallationStarted(context.Background(), server.URL, "license-id", ClusterID())
 		})
 	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

When we fully support custom domains we need to ensure we do not reach out to replicated.app

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
