### PR TITLE
feat(customdomains): add metadata service to default no proxy list

### DIFF
--- a/cmd/installer/cli/proxy_test.go
+++ b/cmd/installer/cli/proxy_test.go
@@ -37,7 +37,7 @@ func Test_getProxySpecFromFlags(t *testing.T) {
 				HTTPProxy:       "http://proxy",
 				HTTPSProxy:      "https://proxy",
 				ProvidedNoProxy: "no-proxy-1,no-proxy-2",
-				NoProxy:         "localhost,127.0.0.1,.cluster.local,.svc,no-proxy-1,no-proxy-2,10.244.0.0/17,10.244.128.0/17",
+				NoProxy:         "localhost,127.0.0.1,.cluster.local,.svc,169.254.169.254,no-proxy-1,no-proxy-2,10.244.0.0/17,10.244.128.0/17",
 			},
 		},
 		{
@@ -66,7 +66,7 @@ func Test_getProxySpecFromFlags(t *testing.T) {
 				HTTPProxy:       "http://other-proxy",
 				HTTPSProxy:      "https://other-proxy",
 				ProvidedNoProxy: "other-no-proxy-1,other-no-proxy-2",
-				NoProxy:         "localhost,127.0.0.1,.cluster.local,.svc,other-no-proxy-1,other-no-proxy-2,10.244.0.0/17,10.244.128.0/17",
+				NoProxy:         "localhost,127.0.0.1,.cluster.local,.svc,169.254.169.254,other-no-proxy-1,other-no-proxy-2,10.244.0.0/17,10.244.128.0/17",
 			},
 		},
 		{
@@ -85,7 +85,7 @@ func Test_getProxySpecFromFlags(t *testing.T) {
 				HTTPProxy:       "http://other-proxy",
 				HTTPSProxy:      "https://other-proxy",
 				ProvidedNoProxy: "no-proxy-1,no-proxy-2,other-no-proxy-1,other-no-proxy-2",
-				NoProxy:         "localhost,127.0.0.1,.cluster.local,.svc,no-proxy-1,no-proxy-2,other-no-proxy-1,other-no-proxy-2,10.244.0.0/17,10.244.128.0/17",
+				NoProxy:         "localhost,127.0.0.1,.cluster.local,.svc,169.254.169.254,no-proxy-1,no-proxy-2,other-no-proxy-1,other-no-proxy-2,10.244.0.0/17,10.244.128.0/17",
 			},
 		},
 		{
@@ -102,7 +102,7 @@ func Test_getProxySpecFromFlags(t *testing.T) {
 				HTTPProxy:       "http://other-proxy",
 				HTTPSProxy:      "https://other-proxy",
 				ProvidedNoProxy: "other-no-proxy-1,other-no-proxy-2",
-				NoProxy:         "localhost,127.0.0.1,.cluster.local,.svc,other-no-proxy-1,other-no-proxy-2,1.1.1.1/24,2.2.2.2/24",
+				NoProxy:         "localhost,127.0.0.1,.cluster.local,.svc,169.254.169.254,other-no-proxy-1,other-no-proxy-2,1.1.1.1/24,2.2.2.2/24",
 			},
 		},
 		{
@@ -118,7 +118,7 @@ func Test_getProxySpecFromFlags(t *testing.T) {
 				HTTPProxy:       "http://other-proxy",
 				HTTPSProxy:      "https://other-proxy",
 				ProvidedNoProxy: "other-no-proxy-1,other-no-proxy-2",
-				NoProxy:         "localhost,127.0.0.1,.cluster.local,.svc,other-no-proxy-1,other-no-proxy-2,10.0.0.0/17,10.0.128.0/17",
+				NoProxy:         "localhost,127.0.0.1,.cluster.local,.svc,169.254.169.254,other-no-proxy-1,other-no-proxy-2,10.0.0.0/16",
 			},
 		},
 	}

--- a/cmd/installer/cli/proxy_test.go
+++ b/cmd/installer/cli/proxy_test.go
@@ -118,7 +118,7 @@ func Test_getProxySpecFromFlags(t *testing.T) {
 				HTTPProxy:       "http://other-proxy",
 				HTTPSProxy:      "https://other-proxy",
 				ProvidedNoProxy: "other-no-proxy-1,other-no-proxy-2",
-				NoProxy:         "localhost,127.0.0.1,.cluster.local,.svc,169.254.169.254,other-no-proxy-1,other-no-proxy-2,10.0.0.0/16",
+				NoProxy:         "localhost,127.0.0.1,.cluster.local,.svc,169.254.169.254,other-no-proxy-1,other-no-proxy-2,10.0.0.0/17,10.0.128.0/17",
 			},
 		},
 	}

--- a/pkg/runtimeconfig/defaults.go
+++ b/pkg/runtimeconfig/defaults.go
@@ -11,8 +11,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Holds the default no proxy values.
-var DefaultNoProxy = []string{"localhost", "127.0.0.1", ".cluster.local", ".svc"}
+// DefaultNoProxy holds the default no proxy values.
+var DefaultNoProxy = []string{
+	// localhost
+	"localhost", "127.0.0.1",
+	// kubernetes
+	".cluster.local", ".svc",
+	// cloud metadata service
+	"169.254.169.254",
+}
 
 const proxyRegistryAddress = "proxy.replicated.com"
 const KotsadmNamespace = "kotsadm"


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
The common cloud metadata service IP address "169.254.169.254" is now added to the NO_PROXY list by default.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
