### PR TITLE
feat(customdomains): disable support bundle uri

### DIFF
--- a/operator/charts/embedded-cluster-operator/troubleshoot/cluster-support-bundle.yaml
+++ b/operator/charts/embedded-cluster-operator/troubleshoot/cluster-support-bundle.yaml
@@ -5,7 +5,8 @@ metadata:
   labels:
     troubleshoot.io/kind: support-bundle
 spec:
-  uri: https://raw.githubusercontent.com/replicatedhq/embedded-cluster/main/operator/charts/embedded-cluster-operator/troubleshoot/cluster-support-bundle.yaml
+  # NOTE: This is commented out until we have a decision on how to handle this with custom domains.
+  # uri: https://raw.githubusercontent.com/replicatedhq/embedded-cluster/main/operator/charts/embedded-cluster-operator/troubleshoot/cluster-support-bundle.yaml
   collectors:
   - clusterInfo: {}
   - clusterResources:


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Removing the support bundle URI as it conflicts with the custom domains work.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
