### PR TITLE
Default to release domains and don't fallback to license

### DIFF
--- a/cmd/installer/cli/install_runpreflights.go
+++ b/cmd/installer/cli/install_runpreflights.go
@@ -82,8 +82,8 @@ func runInstallRunPreflights(ctx context.Context, name string, flags InstallCmdF
 }
 
 func runInstallPreflights(ctx context.Context, flags InstallCmdFlags, metricsReported preflights.MetricsReporter) error {
-	replicatedAPIURL := runtimeconfig.ReplicatedAppURL(flags.license)
-	proxyRegistryURL := runtimeconfig.ProxyRegistryURL()
+	replicatedAppURL := replicatedAppURL()
+	proxyRegistryURL := proxyRegistryURL()
 
 	nodeIP, err := netutils.FirstValidAddress(flags.networkInterface)
 	if err != nil {
@@ -91,7 +91,7 @@ func runInstallPreflights(ctx context.Context, flags InstallCmdFlags, metricsRep
 	}
 
 	if err := preflights.PrepareAndRun(ctx, preflights.PrepareAndRunOptions{
-		ReplicatedAPIURL:     replicatedAPIURL,
+		ReplicatedAppURL:     replicatedAppURL,
 		ProxyRegistryURL:     proxyRegistryURL,
 		Proxy:                flags.proxy,
 		PodCIDR:              flags.cidrCfg.PodCIDR,

--- a/cmd/installer/cli/join.go
+++ b/cmd/installer/cli/join.go
@@ -366,7 +366,8 @@ func installK0sBinary() error {
 
 func applyNetworkConfiguration(networkInterface string, jcmd *kotsadm.JoinCommandResponse) error {
 	if jcmd.InstallationSpec.Network != nil {
-		clusterSpec := config.RenderK0sConfig(runtimeconfig.ProxyRegistryDomain())
+		domains := runtimeconfig.GetDomains(jcmd.InstallationSpec.Config)
+		clusterSpec := config.RenderK0sConfig(domains.ProxyRegistryDomain)
 
 		address, err := netutils.FirstValidAddress(networkInterface)
 		if err != nil {

--- a/cmd/installer/cli/join_runpreflights.go
+++ b/cmd/installer/cli/join_runpreflights.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/replicatedhq/embedded-cluster/pkg/configutils"
 	"github.com/replicatedhq/embedded-cluster/pkg/kotsadm"
+	"github.com/replicatedhq/embedded-cluster/pkg/netutil"
 	"github.com/replicatedhq/embedded-cluster/pkg/netutils"
 	"github.com/replicatedhq/embedded-cluster/pkg/preflights"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
@@ -96,9 +97,11 @@ func runJoinPreflights(ctx context.Context, jcmd *kotsadm.JoinCommandResponse, f
 		return fmt.Errorf("unable to find first valid address: %w", err)
 	}
 
+	domains := runtimeconfig.GetDomains(jcmd.InstallationSpec.Config)
+
 	if err := preflights.PrepareAndRun(ctx, preflights.PrepareAndRunOptions{
-		ReplicatedAPIURL:       jcmd.InstallationSpec.MetricsBaseURL, // MetricsBaseURL is the replicated.app endpoint url
-		ProxyRegistryURL:       runtimeconfig.ProxyRegistryURL(),
+		ReplicatedAppURL:       netutil.MaybeAddHTTPS(domains.ReplicatedAppDomain),
+		ProxyRegistryURL:       netutil.MaybeAddHTTPS(domains.ProxyRegistryDomain),
 		Proxy:                  jcmd.InstallationSpec.Proxy,
 		PodCIDR:                cidrCfg.PodCIDR,
 		ServiceCIDR:            cidrCfg.ServiceCIDR,

--- a/cmd/installer/cli/release.go
+++ b/cmd/installer/cli/release.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 )
 
@@ -33,7 +32,7 @@ func getCurrentAppChannelRelease(ctx context.Context, license *kotsv1beta1.Licen
 	query.Set("channelSequence", "") // sending an empty string will return the latest channel release
 	query.Set("isSemverSupported", "true")
 
-	apiURL := runtimeconfig.ReplicatedAppURL(license)
+	apiURL := replicatedAppURL()
 	url := fmt.Sprintf("%s/release/%s/pending?%s", apiURL, license.Spec.AppSlug, query.Encode())
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {

--- a/cmd/installer/kotscli/kotscli.go
+++ b/cmd/installer/kotscli/kotscli.go
@@ -24,7 +24,7 @@ type InstallOptions struct {
 	Namespace             string
 	AirgapBundle          string
 	ConfigValuesFile      string
-	ReplicatedAPIEndpoint string
+	ReplicatedAppEndpoint string
 }
 
 func Install(opts InstallOptions, msg *spinner.MessageWriter) error {
@@ -81,8 +81,8 @@ func Install(opts InstallOptions, msg *spinner.MessageWriter) error {
 			"EMBEDDED_CLUSTER_ID": metrics.ClusterID().String(),
 		},
 	}
-	if opts.ReplicatedAPIEndpoint != "" {
-		runCommandOptions.Env["REPLICATED_APP_ENDPOINT"] = opts.ReplicatedAPIEndpoint
+	if opts.ReplicatedAppEndpoint != "" {
+		runCommandOptions.Env["REPLICATED_APP_ENDPOINT"] = opts.ReplicatedAppEndpoint
 	}
 	err = helpers.RunCommandWithOptions(runCommandOptions, kotsBinPath, installArgs...)
 	if err != nil {

--- a/operator/pkg/upgrade/job.go
+++ b/operator/pkg/upgrade/job.go
@@ -245,10 +245,8 @@ func operatorImageName(ctx context.Context, cli client.Client, in *ecv1beta1.Ins
 	}
 	for _, image := range meta.Images {
 		if strings.Contains(image, "embedded-cluster-operator-image") {
-			if in.Spec.Config != nil && in.Spec.Config.Domains.ProxyRegistryDomain != "" {
-				image = strings.Replace(image, "proxy.replicated.com", in.Spec.Config.Domains.ProxyRegistryDomain, 1)
-			}
-
+			domains := runtimeconfig.GetDomains(in.Spec.Config)
+			image = strings.Replace(image, "proxy.replicated.com", domains.ProxyRegistryDomain, 1)
 			return image, nil
 		}
 	}

--- a/operator/pkg/upgrade/upgrade.go
+++ b/operator/pkg/upgrade/upgrade.go
@@ -177,12 +177,9 @@ func updateClusterConfig(ctx context.Context, cli client.Client, in *ecv1beta1.I
 		return fmt.Errorf("get cluster config: %w", err)
 	}
 
-	proxyRegistryDomain := runtimeconfig.DefaultProxyRegistryDomain
-	if in != nil && in.Spec.Config != nil && in.Spec.Config.Domains.ProxyRegistryDomain != "" {
-		proxyRegistryDomain = in.Spec.Config.Domains.ProxyRegistryDomain
-	}
+	domains := runtimeconfig.GetDomains(in.Spec.Config)
 
-	cfg := config.RenderK0sConfig(proxyRegistryDomain)
+	cfg := config.RenderK0sConfig(domains.ProxyRegistryDomain)
 	if currentCfg.Spec.Images != nil {
 		if reflect.DeepEqual(*currentCfg.Spec.Images, *cfg.Spec.Images) {
 			return nil

--- a/pkg/addons/adminconsole/values.go
+++ b/pkg/addons/adminconsole/values.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
 	"github.com/replicatedhq/embedded-cluster/pkg/metrics"
+	"github.com/replicatedhq/embedded-cluster/pkg/netutil"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -39,7 +40,7 @@ func (a *AdminConsole) GenerateHelmValues(ctx context.Context, kcli client.Clien
 	}
 
 	if a.ReplicatedAppDomain != "" {
-		copiedValues["replicatedAppEndpoint"] = a.ReplicatedAppDomain
+		copiedValues["replicatedAppEndpoint"] = netutil.MaybeAddHTTPS(a.ReplicatedAppDomain)
 	}
 	if a.ReplicatedRegistryDomain != "" {
 		copiedValues["replicatedRegistryDomain"] = a.ReplicatedRegistryDomain

--- a/pkg/addons/highavailability.go
+++ b/pkg/addons/highavailability.go
@@ -11,7 +11,7 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/constants"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
 	"github.com/replicatedhq/embedded-cluster/pkg/kubeutils"
-	"github.com/replicatedhq/embedded-cluster/pkg/netutil"
+	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/replicatedhq/embedded-cluster/pkg/spinner"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -53,10 +53,12 @@ func EnableHA(ctx context.Context, kcli client.Client, hcli helm.Client, isAirga
 	if isAirgap {
 		loading.Infof("Enabling high availability")
 
+		domains := runtimeconfig.GetDomains(cfgspec)
+
 		// TODO (@salah): add support for end user overrides
 		sw := &seaweedfs.SeaweedFS{
 			ServiceCIDR:         serviceCIDR,
-			ProxyRegistryDomain: cfgspec.Domains.ProxyRegistryDomain,
+			ProxyRegistryDomain: domains.ProxyRegistryDomain,
 		}
 		exists, err := hcli.ReleaseExists(ctx, sw.Namespace(), sw.ReleaseName())
 		if err != nil {
@@ -75,7 +77,7 @@ func EnableHA(ctx context.Context, kcli client.Client, hcli helm.Client, isAirga
 		// TODO (@salah): add support for end user overrides
 		reg := &registry.Registry{
 			ServiceCIDR:         serviceCIDR,
-			ProxyRegistryDomain: cfgspec.Domains.ProxyRegistryDomain,
+			ProxyRegistryDomain: domains.ProxyRegistryDomain,
 			IsHA:                true,
 		}
 		logrus.Debugf("Migrating registry data")
@@ -111,22 +113,23 @@ func EnableHA(ctx context.Context, kcli client.Client, hcli helm.Client, isAirga
 	}
 
 	logrus.Debugf("High availability enabled!")
-
 	loading.Infof("High availability enabled!")
 	return nil
 }
 
 // EnableAdminConsoleHA enables high availability for the admin console.
 func EnableAdminConsoleHA(ctx context.Context, kcli client.Client, hcli helm.Client, isAirgap bool, serviceCIDR string, proxy *ecv1beta1.ProxySpec, cfgspec *ecv1beta1.ConfigSpec) error {
+	domains := runtimeconfig.GetDomains(cfgspec)
+
 	// TODO (@salah): add support for end user overrides
 	ac := &adminconsole.AdminConsole{
 		IsAirgap:                 isAirgap,
 		IsHA:                     true,
 		Proxy:                    proxy,
 		ServiceCIDR:              serviceCIDR,
-		ReplicatedAppDomain:      netutil.MaybeAddHTTPS(cfgspec.Domains.ReplicatedAppDomain),
-		ProxyRegistryDomain:      cfgspec.Domains.ProxyRegistryDomain,
-		ReplicatedRegistryDomain: cfgspec.Domains.ReplicatedRegistryDomain,
+		ReplicatedAppDomain:      domains.ReplicatedAppDomain,
+		ProxyRegistryDomain:      domains.ProxyRegistryDomain,
+		ReplicatedRegistryDomain: domains.ReplicatedRegistryDomain,
 	}
 	if err := ac.Upgrade(ctx, kcli, hcli, addOnOverrides(ac, cfgspec, nil)); err != nil {
 		return errors.Wrap(err, "upgrade admin console")

--- a/pkg/addons/install.go
+++ b/pkg/addons/install.go
@@ -13,7 +13,7 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/velero"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
 	"github.com/replicatedhq/embedded-cluster/pkg/kubeutils"
-	"github.com/replicatedhq/embedded-cluster/pkg/netutil"
+	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/replicatedhq/embedded-cluster/pkg/spinner"
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 )
@@ -61,19 +61,14 @@ func Install(ctx context.Context, hcli helm.Client, opts InstallOptions) error {
 }
 
 func getAddOnsForInstall(opts InstallOptions) []types.AddOn {
-	var replicatedAppDomain, proxyRegistryDomain, replicatedRegistryDomain string
-	if opts.EmbeddedConfigSpec != nil {
-		replicatedAppDomain = netutil.MaybeAddHTTPS(opts.EmbeddedConfigSpec.Domains.ReplicatedAppDomain)
-		proxyRegistryDomain = opts.EmbeddedConfigSpec.Domains.ProxyRegistryDomain
-		replicatedRegistryDomain = opts.EmbeddedConfigSpec.Domains.ReplicatedRegistryDomain
-	}
+	domains := runtimeconfig.GetDomains(opts.EmbeddedConfigSpec)
 
 	addOns := []types.AddOn{
 		&openebs.OpenEBS{
-			ProxyRegistryDomain: proxyRegistryDomain,
+			ProxyRegistryDomain: domains.ProxyRegistryDomain,
 		},
 		&embeddedclusteroperator.EmbeddedClusterOperator{
-			ProxyRegistryDomain: proxyRegistryDomain,
+			ProxyRegistryDomain: domains.ProxyRegistryDomain,
 			IsAirgap:            opts.IsAirgap,
 			Proxy:               opts.Proxy,
 		},
@@ -81,14 +76,14 @@ func getAddOnsForInstall(opts InstallOptions) []types.AddOn {
 
 	if opts.IsAirgap {
 		addOns = append(addOns, &registry.Registry{
-			ProxyRegistryDomain: proxyRegistryDomain,
+			ProxyRegistryDomain: domains.ProxyRegistryDomain,
 			ServiceCIDR:         opts.ServiceCIDR,
 		})
 	}
 
 	if opts.DisasterRecoveryEnabled {
 		addOns = append(addOns, &velero.Velero{
-			ProxyRegistryDomain: proxyRegistryDomain,
+			ProxyRegistryDomain: domains.ProxyRegistryDomain,
 			Proxy:               opts.Proxy,
 		})
 	}
@@ -100,9 +95,9 @@ func getAddOnsForInstall(opts InstallOptions) []types.AddOn {
 		Password:                 opts.AdminConsolePwd,
 		PrivateCAs:               opts.PrivateCAs,
 		KotsInstaller:            opts.KotsInstaller,
-		ReplicatedAppDomain:      replicatedAppDomain,
-		ProxyRegistryDomain:      proxyRegistryDomain,
-		ReplicatedRegistryDomain: replicatedRegistryDomain,
+		ReplicatedAppDomain:      domains.ReplicatedAppDomain,
+		ProxyRegistryDomain:      domains.ProxyRegistryDomain,
+		ReplicatedRegistryDomain: domains.ReplicatedRegistryDomain,
 	}
 	addOns = append(addOns, adminConsoleAddOn)
 
@@ -110,18 +105,15 @@ func getAddOnsForInstall(opts InstallOptions) []types.AddOn {
 }
 
 func getAddOnsForRestore(opts InstallOptions) []types.AddOn {
-	var proxyRegistryDomain string
-	if opts.EmbeddedConfigSpec != nil {
-		proxyRegistryDomain = opts.EmbeddedConfigSpec.Domains.ProxyRegistryDomain
-	}
+	domains := runtimeconfig.GetDomains(opts.EmbeddedConfigSpec)
 
 	addOns := []types.AddOn{
 		&openebs.OpenEBS{
-			ProxyRegistryDomain: proxyRegistryDomain,
+			ProxyRegistryDomain: domains.ProxyRegistryDomain,
 		},
 		&velero.Velero{
 			Proxy:               opts.Proxy,
-			ProxyRegistryDomain: proxyRegistryDomain,
+			ProxyRegistryDomain: domains.ProxyRegistryDomain,
 		},
 	}
 	return addOns

--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -42,12 +42,12 @@ spec:
     - http:
         collectorName: http-replicated-app
         get:
-          url: '{{ .ReplicatedAPIURL }}'
+          url: '{{ .ReplicatedAppURL }}'
           timeout: 5s
           tls:
             cacert: '{{ .PrivateCA }}'
           proxy: '{{ .HTTPSProxy }}'
-        exclude: '{{ or .IsAirgap (eq .ReplicatedAPIURL "") }}'
+        exclude: '{{ or .IsAirgap (eq .ReplicatedAppURL "") }}'
     - http:
         collectorName: http-proxy-replicated-com
         get:
@@ -410,25 +410,25 @@ spec:
     - http:
         checkName: API Access
         collectorName: http-replicated-app
-        exclude: '{{ or .IsAirgap (eq .ReplicatedAPIURL "") }}'
+        exclude: '{{ or .IsAirgap (eq .ReplicatedAppURL "") }}'
         outcomes:
           - fail:
               when: error
               message: >
-                Error connecting to {{ .ReplicatedAPIURL }}.
+                Error connecting to {{ .ReplicatedAppURL }}.
                 Ensure your firewall is properly configured, and use --http-proxy,
                 --https-proxy, and --no-proxy if there is a proxy server.
-                The static IP addresses for {{ .ReplicatedAPIURL }} are
+                The static IP addresses for {{ .ReplicatedAppURL }} are
                 162.159.133.41 and 162.159.134.41.
           - pass:
               when: 'statusCode == 200'
-              message: 'Connected to {{ .ReplicatedAPIURL }}'
+              message: 'Connected to {{ .ReplicatedAppURL }}'
           - fail:
               message: >
-                Error connecting to {{ .ReplicatedAPIURL }}.
+                Error connecting to {{ .ReplicatedAppURL }}.
                 Ensure your firewall is properly configured, and use --http-proxy,
                 --https-proxy, and --no-proxy if there is a proxy server.
-                The static IP addresses for {{ .ReplicatedAPIURL }} are
+                The static IP addresses for {{ .ReplicatedAppURL }} are
                 162.159.133.41 and 162.159.134.41.
     - http:
         checkName: Proxy Registry Access

--- a/pkg/preflights/run.go
+++ b/pkg/preflights/run.go
@@ -22,7 +22,7 @@ import (
 var ErrPreflightsHaveFail = metrics.NewErrorNoFail(fmt.Errorf("host preflight failures detected"))
 
 type PrepareAndRunOptions struct {
-	ReplicatedAPIURL       string
+	ReplicatedAppURL       string
 	ProxyRegistryURL       string
 	Proxy                  *ecv1beta1.ProxySpec
 	PodCIDR                string
@@ -55,7 +55,7 @@ func PrepareAndRun(ctx context.Context, opts PrepareAndRunOptions) error {
 	}
 
 	data, err := types.TemplateData{
-		ReplicatedAPIURL:        opts.ReplicatedAPIURL,
+		ReplicatedAppURL:        opts.ReplicatedAppURL,
 		ProxyRegistryURL:        opts.ProxyRegistryURL,
 		IsAirgap:                opts.IsAirgap,
 		AdminConsolePort:        runtimeconfig.AdminConsolePort(),

--- a/pkg/preflights/types/template.go
+++ b/pkg/preflights/types/template.go
@@ -14,7 +14,7 @@ type CIDRData struct {
 
 type TemplateData struct {
 	IsAirgap                bool
-	ReplicatedAPIURL        string
+	ReplicatedAppURL        string
 	ProxyRegistryURL        string
 	AdminConsolePort        int
 	LocalArtifactMirrorPort int

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -165,11 +165,18 @@ func parseVeleroRestore(data []byte) (*velerov1.Restore, error) {
 
 // ChannelRelease contains information about a specific app release inside a channel.
 type ChannelRelease struct {
-	VersionLabel string `yaml:"versionLabel"`
-	ChannelID    string `yaml:"channelID"`
-	ChannelSlug  string `yaml:"channelSlug"`
-	AppSlug      string `yaml:"appSlug"`
-	Airgap       bool   `yaml:"airgap"`
+	VersionLabel   string  `yaml:"versionLabel"`
+	ChannelID      string  `yaml:"channelID"`
+	ChannelSlug    string  `yaml:"channelSlug"`
+	AppSlug        string  `yaml:"appSlug"`
+	Airgap         bool    `yaml:"airgap"`
+	DefaultDomains Domains `yaml:"defaultDomains"`
+}
+
+type Domains struct {
+	ReplicatedAppDomain      string `yaml:"replicatedAppDomain,omitempty"`
+	ProxyRegistryDomain      string `yaml:"proxyRegistryDomain,omitempty"`
+	ReplicatedRegistryDomain string `yaml:"replicatedRegistryDomain,omitempty"`
 }
 
 // GetChannelRelease reads the embedded channel release object. If no channel release is found,

--- a/pkg/runtimeconfig/defaults.go
+++ b/pkg/runtimeconfig/defaults.go
@@ -5,9 +5,8 @@ import (
 	"path/filepath"
 
 	"github.com/gosimple/slug"
-	"github.com/replicatedhq/embedded-cluster/pkg/netutil"
+	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg/release"
-	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	"github.com/sirupsen/logrus"
 )
 
@@ -21,7 +20,9 @@ var DefaultNoProxy = []string{
 	"169.254.169.254",
 }
 
+const DefaultReplicatedAppDomain = "replicated.app"
 const DefaultProxyRegistryDomain = "proxy.replicated.com"
+const DefaultReplicatedRegistryDomain = "registry.replicated.com"
 const KotsadmNamespace = "kotsadm"
 const KotsadmServiceAccount = "kotsadm"
 const SeaweedFSNamespace = "seaweedfs"
@@ -86,37 +87,43 @@ func PathToECConfig() string {
 	return "/etc/embedded-cluster/ec.yaml"
 }
 
-// ReplicatedAppURL returns the replicated app domain. The first priority is the domain configured within the embedded cluster config.
-// The second priority is the domain configured within the license. If neither is configured, no domain is returned.
-// (This should only happen when restoring a cluster without domains set)
-func ReplicatedAppURL(license *kotsv1beta1.License) string {
-	// get the configured domains from the embedded cluster config
-	cfg := release.GetEmbeddedClusterConfig()
-	if cfg != nil && cfg.Spec.Domains.ReplicatedAppDomain != "" {
-		return netutil.MaybeAddHTTPS(cfg.Spec.Domains.ReplicatedAppDomain)
+// GetDomains returns the domains for the embedded cluster. The first priority is the domains configured within the provided config spec.
+// The second priority is the domains configured within the channel release. If neither is configured, the default domains are returned.
+func GetDomains(cfgspec *ecv1beta1.ConfigSpec) ecv1beta1.Domains {
+	replicatedAppDomain := DefaultReplicatedAppDomain
+	proxyRegistryDomain := DefaultProxyRegistryDomain
+	replicatedRegistryDomain := DefaultReplicatedRegistryDomain
+
+	// get defaults from channel release if available
+	rel := release.GetChannelRelease()
+	if rel != nil {
+		if rel.DefaultDomains.ReplicatedAppDomain != "" {
+			replicatedAppDomain = rel.DefaultDomains.ReplicatedAppDomain
+		}
+		if rel.DefaultDomains.ProxyRegistryDomain != "" {
+			proxyRegistryDomain = rel.DefaultDomains.ProxyRegistryDomain
+		}
+		if rel.DefaultDomains.ReplicatedRegistryDomain != "" {
+			replicatedRegistryDomain = rel.DefaultDomains.ReplicatedRegistryDomain
+		}
 	}
 
-	if license != nil {
-		return netutil.MaybeAddHTTPS(license.Spec.Endpoint)
-	}
-	return ""
-}
-
-// ProxyRegistryDomain returns the proxy registry domain.
-// The first priority is the domain configured within the embedded cluster config.
-// If that is not configured, the default address is returned.
-func ProxyRegistryDomain() string {
-	cfg := release.GetEmbeddedClusterConfig()
-	if cfg != nil && cfg.Spec.Domains.ProxyRegistryDomain != "" {
-		return cfg.Spec.Domains.ProxyRegistryDomain
+	// get overrides from config spec if available
+	if cfgspec != nil {
+		if cfgspec.Domains.ReplicatedAppDomain != "" {
+			replicatedAppDomain = cfgspec.Domains.ReplicatedAppDomain
+		}
+		if cfgspec.Domains.ProxyRegistryDomain != "" {
+			proxyRegistryDomain = cfgspec.Domains.ProxyRegistryDomain
+		}
+		if cfgspec.Domains.ReplicatedRegistryDomain != "" {
+			replicatedRegistryDomain = cfgspec.Domains.ReplicatedRegistryDomain
+		}
 	}
 
-	return DefaultProxyRegistryDomain
-}
-
-// ProxyRegistryURL returns the proxy registry address with a https or http prefix.
-// The first priority is the address configured within the embedded cluster config.
-// If that is not configured, the default address is returned.
-func ProxyRegistryURL() string {
-	return netutil.MaybeAddHTTPS(ProxyRegistryDomain())
+	return ecv1beta1.Domains{
+		ReplicatedAppDomain:      replicatedAppDomain,
+		ProxyRegistryDomain:      proxyRegistryDomain,
+		ReplicatedRegistryDomain: replicatedRegistryDomain,
+	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Defaults to release domains embedded in the binary (or installation) and doesn't fall back to license

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Yes

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE