### PR TITLE
integration tests without custom domains

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/replicatedhq/embedded-cluster
 
-go 1.23.4
+go 1.24.0
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7

--- a/tests/dryrun/Dockerfile
+++ b/tests/dryrun/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.4-alpine AS build
+FROM golang:1.24.0-alpine AS build
 
 RUN apk add --no-cache ca-certificates curl git make bash
 

--- a/tests/dryrun/assets/cluster-config-nodomains.yaml
+++ b/tests/dryrun/assets/cluster-config-nodomains.yaml
@@ -1,0 +1,6 @@
+apiVersion: embeddedcluster.replicated.com/v1beta1
+kind: Config
+metadata:
+ name: "testconfig"
+spec:
+ version: "testversion"

--- a/tests/dryrun/assets/cluster-config.yaml
+++ b/tests/dryrun/assets/cluster-config.yaml
@@ -1,0 +1,9 @@
+apiVersion: embeddedcluster.replicated.com/v1beta1
+kind: Config
+metadata:
+ name: "testconfig"
+spec:
+ version: "testversion"
+ domains:
+   replicatedAppDomain: "fake-endpoint.com"
+   proxyRegistryDomain: "fake-replicated-proxy.test.net"

--- a/tests/dryrun/assets/install-release.yaml
+++ b/tests/dryrun/assets/install-release.yaml
@@ -3,7 +3,7 @@ channelID: "fake-channel-id"
 channelSlug: "fake-channel-slug"
 appSlug: "fake-app-slug"
 versionLabel: "fake-version-label"
-domains:
- replicatedRegistryDomain: "registry.staging.replicated.com"
- replicatedProxyDomain: "proxy.staging.replicated.com"
- replicatedAppDomain: "staging.replicated.app"
+defaultDomains:
+  replicatedAppDomain: "staging.replicated.app"
+  proxyRegistryDomain: "proxy.staging.replicated.com"
+  replicatedRegistryDomain: "registry.staging.replicated.com"

--- a/tests/dryrun/assets/install-release.yaml
+++ b/tests/dryrun/assets/install-release.yaml
@@ -3,3 +3,7 @@ channelID: "fake-channel-id"
 channelSlug: "fake-channel-slug"
 appSlug: "fake-app-slug"
 versionLabel: "fake-version-label"
+domains:
+ replicatedRegistryDomain: "registry.staging.replicated.com"
+ replicatedProxyDomain: "proxy.staging.replicated.com"
+ replicatedAppDomain: "staging.replicated.app"

--- a/tests/dryrun/install_test.go
+++ b/tests/dryrun/install_test.go
@@ -485,6 +485,7 @@ func TestCustomCidrInstallation(t *testing.T) {
 	t.Logf("%s: test complete", time.Now().Format(time.RFC3339))
 }
 
+// this test is to ensure that when no domains are provided in the cluster config that the domains from the embedded release file are used
 func TestNoDomains(t *testing.T) {
 	hcli := &helm.MockClient{}
 

--- a/tests/dryrun/install_test.go
+++ b/tests/dryrun/install_test.go
@@ -172,6 +172,14 @@ func testDefaultInstallationImpl(t *testing.T) {
 	assert.Equal(t, "10.244.0.0/17", k0sConfig.Spec.Network.PodCIDR)
 	assert.Equal(t, "10.244.128.0/17", k0sConfig.Spec.Network.ServiceCIDR)
 	assert.Contains(t, k0sConfig.Spec.API.SANs, "kubernetes.default.svc.cluster.local")
+
+	assert.Contains(t, k0sConfig.Spec.Images.MetricsServer.Image, "fake-replicated-proxy.test.net/anonymous")
+	assert.Contains(t, k0sConfig.Spec.Images.KubeProxy.Image, "fake-replicated-proxy.test.net/anonymous")
+	assert.Contains(t, k0sConfig.Spec.Images.CoreDNS.Image, "fake-replicated-proxy.test.net/anonymous")
+	assert.Contains(t, k0sConfig.Spec.Images.Pause.Image, "fake-replicated-proxy.test.net/anonymous")
+	assert.Contains(t, k0sConfig.Spec.Images.Calico.CNI.Image, "fake-replicated-proxy.test.net/anonymous")
+	assert.Contains(t, k0sConfig.Spec.Images.Calico.Node.Image, "fake-replicated-proxy.test.net/anonymous")
+	assert.Contains(t, k0sConfig.Spec.Images.Calico.KubeControllers.Image, "fake-replicated-proxy.test.net/anonymous")
 }
 
 func TestCustomDataDir(t *testing.T) {
@@ -473,6 +481,92 @@ func TestCustomCidrInstallation(t *testing.T) {
 
 	assert.Equal(t, "10.2.0.0/17", k0sConfig.Spec.Network.PodCIDR)
 	assert.Equal(t, "10.2.128.0/17", k0sConfig.Spec.Network.ServiceCIDR)
+
+	t.Logf("%s: test complete", time.Now().Format(time.RFC3339))
+}
+
+func TestNoDomains(t *testing.T) {
+	hcli := &helm.MockClient{}
+
+	mock.InOrder(
+		// 4 addons
+		hcli.On("Install", mock.Anything, mock.Anything).Times(4).Return(nil, nil),
+		hcli.On("Close").Once().Return(nil),
+	)
+
+	dr := dryrunInstallWithClusterConfig(t,
+		&dryrun.Client{HelmClient: hcli},
+		clusterConfigNoDomainsData,
+	)
+
+	// --- validate addons --- //
+
+	// openebs
+	assert.Equal(t, "Install", hcli.Calls[0].Method)
+	openebsOpts := hcli.Calls[0].Arguments[1].(helm.InstallOptions)
+	assert.Equal(t, "openebs", openebsOpts.ReleaseName)
+	assertHelmValues(t, openebsOpts.Values, map[string]interface{}{
+		"['localpv-provisioner'].localpv.basePath":         "/var/lib/embedded-cluster/openebs-local",
+		"['localpv-provisioner'].helperPod.image.registry": "proxy.staging.replicated.com/anonymous/",
+		"['localpv-provisioner'].localpv.image.registry":   "proxy.staging.replicated.com/anonymous/",
+		"['preUpgradeHook'].image.registry":                "proxy.staging.replicated.com/anonymous",
+	})
+
+	// embedded cluster operator
+	assert.Equal(t, "Install", hcli.Calls[1].Method)
+	operatorOpts := hcli.Calls[1].Arguments[1].(helm.InstallOptions)
+	assert.Equal(t, "embedded-cluster-operator", operatorOpts.ReleaseName)
+	assertHelmValues(t, operatorOpts.Values, map[string]interface{}{
+		"image.repository": "proxy.staging.replicated.com/anonymous/replicated/embedded-cluster-operator-image",
+	})
+
+	// velero
+	assert.Equal(t, "Install", hcli.Calls[2].Method)
+	veleroOpts := hcli.Calls[2].Arguments[1].(helm.InstallOptions)
+	assert.Equal(t, "velero", veleroOpts.ReleaseName)
+	assertHelmValues(t, veleroOpts.Values, map[string]interface{}{
+		"nodeAgent.podVolumePath": "/var/lib/embedded-cluster/k0s/kubelet/pods",
+		"image.repository":        "proxy.staging.replicated.com/anonymous/replicated/ec-velero",
+	})
+
+	// admin console
+	assert.Equal(t, "Install", hcli.Calls[3].Method)
+	adminConsoleOpts := hcli.Calls[3].Arguments[1].(helm.InstallOptions)
+	assert.Equal(t, "admin-console", adminConsoleOpts.ReleaseName)
+	assertHelmValues(t, adminConsoleOpts.Values, map[string]interface{}{
+		"kurlProxy.nodePort": float64(30000),
+	})
+	assertHelmValuePrefixes(t, adminConsoleOpts.Values, map[string]string{
+		"images.kotsadm":    "proxy.staging.replicated.com/anonymous",
+		"images.kurlProxy":  "proxy.staging.replicated.com/anonymous",
+		"images.migrations": "proxy.staging.replicated.com/anonymous",
+		"images.rqlite":     "proxy.staging.replicated.com/anonymous",
+	})
+
+	// --- validate installation object --- //
+	kcli, err := dr.KubeClient()
+	if err != nil {
+		t.Fatalf("failed to create kube client: %v", err)
+	}
+	in, err := kubeutils.GetLatestInstallation(context.TODO(), kcli)
+	if err != nil {
+		t.Fatalf("failed to get latest installation: %v", err)
+	}
+	// expected to be empty
+	assert.Equal(t, "", in.Spec.Config.Domains.ProxyRegistryDomain)
+	assert.Equal(t, "", in.Spec.Config.Domains.ReplicatedAppDomain)
+	assert.Equal(t, "", in.Spec.Config.Domains.ReplicatedRegistryDomain)
+
+	// --- validate k0s cluster config --- //
+	k0sConfig := readK0sConfig(t)
+
+	assert.Contains(t, k0sConfig.Spec.Images.MetricsServer.Image, "proxy.staging.replicated.com/anonymous")
+	assert.Contains(t, k0sConfig.Spec.Images.KubeProxy.Image, "proxy.staging.replicated.com/anonymous")
+	assert.Contains(t, k0sConfig.Spec.Images.CoreDNS.Image, "proxy.staging.replicated.com/anonymous")
+	assert.Contains(t, k0sConfig.Spec.Images.Pause.Image, "proxy.staging.replicated.com/anonymous")
+	assert.Contains(t, k0sConfig.Spec.Images.Calico.CNI.Image, "proxy.staging.replicated.com/anonymous")
+	assert.Contains(t, k0sConfig.Spec.Images.Calico.Node.Image, "proxy.staging.replicated.com/anonymous")
+	assert.Contains(t, k0sConfig.Spec.Images.Calico.KubeControllers.Image, "proxy.staging.replicated.com/anonymous")
 
 	t.Logf("%s: test complete", time.Now().Format(time.RFC3339))
 }

--- a/tests/dryrun/util.go
+++ b/tests/dryrun/util.go
@@ -34,12 +34,15 @@ var (
 	//go:embed assets/cluster-config.yaml
 	clusterConfigData string
 
+	//go:embed assets/cluster-config-nodomains.yaml
+	clusterConfigNoDomainsData string
+
 	//go:embed assets/install-license.yaml
 	licenseData string
 )
 
 func dryrunJoin(t *testing.T, args ...string) dryruntypes.DryRun {
-	if err := embedReleaseData(); err != nil {
+	if err := embedReleaseData(clusterConfigData); err != nil {
 		t.Fatalf("fail to embed release data: %v", err)
 	}
 
@@ -60,7 +63,11 @@ func dryrunJoin(t *testing.T, args ...string) dryruntypes.DryRun {
 }
 
 func dryrunInstall(t *testing.T, c *dryrun.Client, args ...string) dryruntypes.DryRun {
-	if err := embedReleaseData(); err != nil {
+	return dryrunInstallWithClusterConfig(t, c, clusterConfigData, args...)
+}
+
+func dryrunInstallWithClusterConfig(t *testing.T, c *dryrun.Client, clusterConfig string, args ...string) dryruntypes.DryRun {
+	if err := embedReleaseData(clusterConfig); err != nil {
 		t.Fatalf("fail to embed release data: %v", err)
 	}
 
@@ -88,7 +95,7 @@ func dryrunInstall(t *testing.T, c *dryrun.Client, args ...string) dryruntypes.D
 }
 
 func dryrunUpdate(t *testing.T, args ...string) dryruntypes.DryRun {
-	if err := embedReleaseData(); err != nil {
+	if err := embedReleaseData(clusterConfigData); err != nil {
 		t.Fatalf("fail to embed release data: %v", err)
 	}
 
@@ -107,10 +114,10 @@ func dryrunUpdate(t *testing.T, args ...string) dryruntypes.DryRun {
 	return *dr
 }
 
-func embedReleaseData() error {
+func embedReleaseData(clusterConfig string) error {
 	if err := release.SetReleaseDataForTests(map[string][]byte{
 		"release.yaml":        []byte(releaseData),
-		"cluster-config.yaml": []byte(clusterConfigData),
+		"cluster-config.yaml": []byte(clusterConfig),
 	}); err != nil {
 		return fmt.Errorf("set release data: %v", err)
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

This adds a new dryrun test that runs without any custom domains set, and updates the default dryrun tests to have a EC config object with custom domains set.

It then checks that images (helm chart and k0s) use the correct repositories.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
