### PR TITLE
remove 'http_access allow localnet' from test squid config

### DIFF
--- a/e2e/scripts/install-and-configure-squid.sh
+++ b/e2e/scripts/install-and-configure-squid.sh
@@ -11,6 +11,7 @@ ssl_bump bump all
 
 acl whitelist dstdomain \"/etc/squid/sites.whitelist.txt\"
 http_access allow whitelist
+http_access deny all
 "
 
 whitelist_txt="

--- a/e2e/scripts/install-and-configure-squid.sh
+++ b/e2e/scripts/install-and-configure-squid.sh
@@ -9,8 +9,6 @@ acl step1 at_step SslBump1
 ssl_bump peek step1
 ssl_bump bump all
 
-http_access allow localnet
-
 acl whitelist dstdomain \"/etc/squid/sites.whitelist.txt\"
 http_access allow whitelist
 "


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

AFAICT this line isn't required for our tests, but it makes the proxy fail-open if you use this config in GCP

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
