### PR TITLE
chore: add Windows Defender security tool in support bundle analyser

### DIFF
--- a/cmd/installer/goods/support/host-support-bundle.tmpl.yaml
+++ b/cmd/installer/goods/support/host-support-bundle.tmpl.yaml
@@ -298,7 +298,7 @@ spec:
   - run:
       collectorName: "ps-detect-antivirus-and-security-tools"
       command: "sh"
-      args: [-c, "ps -ef | grep -E 'clamav|sophos|esets_daemon|fsav|symantec|mfend|ds_agent|kav|bdagent|s1agent|falcon|illumio|xagt' | grep -v grep"]
+      args: [-c, "ps -ef | grep -E 'clamav|sophos|esets_daemon|fsav|symantec|mfend|ds_agent|kav|bdagent|s1agent|falcon|illumio|xagt|wdavdaemon' | grep -v grep"]
   - filesystemPerformance:
         collectorName: filesystem-write-latency-etcd
         timeout: 5m
@@ -620,7 +620,7 @@ spec:
   - textAnalyze:
       checkName: "Detect Threat Management and Network Security Tools"
       fileName: host-collectors/run-host/ps-detect-antivirus-and-security-tools.txt
-      regex: '\b(clamav|sophos|esets_daemon|fsav|symantec|mfend|ds_agent|kav|bdagent|s1agent|falcon|illumio|xagt)\b'
+      regex: '\b(clamav|sophos|esets_daemon|fsav|symantec|mfend|ds_agent|kav|bdagent|s1agent|falcon|illumio|xagt|wdavdaemon)\b'
       ignoreIfNoFiles: true
       outcomes:
         - fail:


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Add Windows Defender security tool in support bundle analyser

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Add Windows Defender security tool in support bundle analyser
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
