### PR TITLE
don't report preflights bypassed if they weren't

### DIFF
--- a/pkg/preflights/run.go
+++ b/pkg/preflights/run.go
@@ -173,7 +173,7 @@ func runHostPreflights(ctx context.Context, hpf *v1beta2.HostPreflightSpec, opts
 		}
 
 		if opts.MetricsReporter != nil {
-			opts.MetricsReporter.ReportPreflightsFailed(ctx, *output, true)
+			opts.MetricsReporter.ReportPreflightsFailed(ctx, *output, false)
 		}
 		return ErrPreflightsHaveFail
 	}
@@ -202,7 +202,7 @@ func runHostPreflights(ctx context.Context, hpf *v1beta2.HostPreflightSpec, opts
 
 		if !prompts.New().Confirm("Do you want to continue?", false) {
 			if opts.MetricsReporter != nil {
-				opts.MetricsReporter.ReportPreflightsFailed(ctx, *output, true)
+				opts.MetricsReporter.ReportPreflightsFailed(ctx, *output, false)
 			}
 			return ErrPreflightsHaveFail
 		}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
We're sending `PreflightsBypassed` even when the user doesn't bypass them.

I ran an install where preflights failed:
```
core@alex-ec-selinux:~$ sudo ./gitea-mastodon install -l license.yaml
? Set the Admin Console password (minimum 6 characters): ******
? Confirm the Admin Console password: *****
Passwords don't match. Please try again.
? Set the Admin Console password (minimum 6 characters): ******
? Confirm the Admin Console password: ******
✔  Host files materialized!
✗  1 host preflight failed

 •  SELinux must be disabled or run in permissive mode. To run SELinux in permissive mode, edit /etc/selinux/config, change the line
    'SELINUX=enforcing' to 'SELINUX=permissive', save the file, and reboot. You can run getenforce to verify the change."

Please address this issue and try again.
```

But the reporting looked like this:
![CleanShot 2025-03-21 at 20 36 11](https://github.com/user-attachments/assets/03fc0a00-730d-4463-b470-dccc51b44c29)

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE