### PR TITLE
chore: print sbctl shell instead of sbctl serve in GitHub actions log

### DIFF
--- a/.github/actions/e2e-troubleshoot/action.yml
+++ b/.github/actions/e2e-troubleshoot/action.yml
@@ -56,9 +56,9 @@ runs:
       echo -e "\e[1;33m                                                                                                        \e[0m"
       echo -e "\e[1;33m   3- From inside the extracted directory, run:                                                         \e[0m"
       echo -e "\e[1;33m                                                                                                        \e[0m"
-      echo -e "\e[1;32m      sbctl serve -s .                                                                                  \e[0m"
+      echo -e "\e[1;32m      sbctl shell .                                                                                     \e[0m"
       echo -e "\e[1;33m                                                                                                        \e[0m"
-      echo -e "\e[1;33m   4- Export the printed kubeconfig to interact with the cluster.                                       \e[0m"
+      echo -e "\e[1;33m   4- Run kubectl commands in the new shell and run `exit` once done                                    \e[0m"
       echo -e "\e[1;33m                                                                                                        \e[0m"
       echo -e "\e[1;33m└──────────────────────────────────────────────────────────────────────────────────────────────────────┘\e[0m"
     shell: bash


### PR DESCRIPTION
#### What this PR does / why we need it:
Instruct users to use `sbctl shell` instead of `sbctl serve` in GitHub actions log. This was users do not have to create a new shell to run kubectl commands.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
