### PR TITLE
feat(ha): node local loadbalancing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -113,6 +113,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Make manifests
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: make -C operator manifests
     - name: Check CRDs
       run: |

--- a/Makefile
+++ b/Makefile
@@ -155,8 +155,10 @@ cmd/installer/goods/internal/bins/kubectl-kots:
 	if [ "$(KOTS_BINARY_URL_OVERRIDE)" != "" ]; then \
 		$(MAKE) output/bins/kubectl-kots-override ; \
 		cp output/bins/kubectl-kots-override $@ ; \
+		echo "$(eval KOTS_VERSION := kots-dev-$(shell shasum -a 256 $@ | cut -c1-8))" ; \
 	elif [ "$(KOTS_BINARY_FILE_OVERRIDE)" != "" ]; then \
 		cp $(KOTS_BINARY_FILE_OVERRIDE) $@ ; \
+		echo "$(eval KOTS_VERSION := kots-dev-$(shell shasum -a 256 $@ | cut -c1-8))" ; \
 	else \
 		$(MAKE) output/bins/kubectl-kots-$(KOTS_VERSION)-$(ARCH) ; \
 		cp output/bins/kubectl-kots-$(KOTS_VERSION)-$(ARCH) $@ ; \

--- a/Makefile
+++ b/Makefile
@@ -155,10 +155,8 @@ cmd/installer/goods/internal/bins/kubectl-kots:
 	if [ "$(KOTS_BINARY_URL_OVERRIDE)" != "" ]; then \
 		$(MAKE) output/bins/kubectl-kots-override ; \
 		cp output/bins/kubectl-kots-override $@ ; \
-		echo "$(eval KOTS_VERSION := kots-dev-$(shell shasum -a 256 $@ | cut -c1-8))" ; \
 	elif [ "$(KOTS_BINARY_FILE_OVERRIDE)" != "" ]; then \
 		cp $(KOTS_BINARY_FILE_OVERRIDE) $@ ; \
-		echo "$(eval KOTS_VERSION := kots-dev-$(shell shasum -a 256 $@ | cut -c1-8))" ; \
 	else \
 		$(MAKE) output/bins/kubectl-kots-$(KOTS_VERSION)-$(ARCH) ; \
 		cp output/bins/kubectl-kots-$(KOTS_VERSION)-$(ARCH) $@ ; \

--- a/cmd/buildtools/k0s.go
+++ b/cmd/buildtools/k0s.go
@@ -76,6 +76,12 @@ var k0sImageComponents = map[string]addonComponent{
 			return fmt.Sprintf("registry.k8s.io/pause:%s", opts.upstreamVersion.Original()), nil
 		},
 	},
+	"quay.io/k0sproject/envoy-distroless": {
+		name: "envoy-distroless",
+		getWolfiPackageName: func(opts addonComponentOptions) string {
+			return fmt.Sprintf("envoy-%d.%d", opts.upstreamVersion.Major(), opts.upstreamVersion.Minor())
+		},
+	},
 }
 
 var updateK0sImagesCommand = &cli.Command{

--- a/cmd/buildtools/utils.go
+++ b/cmd/buildtools/utils.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -145,10 +146,12 @@ func ResolveApkoPackageVersion(componentName, packageName, packageVersion string
 		fmt.Sprintf("PACKAGE_NAME=%s", packageName),
 		fmt.Sprintf("PACKAGE_VERSION=%s", packageVersion),
 	}
+	var errBuf bytes.Buffer
 	cmd := exec.Command("make", args...)
+	cmd.Stderr = &errBuf
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("run command: %w: %s", err, string(out))
+		return "", fmt.Errorf("run command: %w: %s", err, errBuf.String())
 	}
 	return strings.TrimSpace(string(out)), nil
 }

--- a/deploy/images/envoy-distroless/apko.tmpl.yaml
+++ b/deploy/images/envoy-distroless/apko.tmpl.yaml
@@ -1,0 +1,31 @@
+# source: https://github.com/chainguard-images/images/blob/bea234042585fd6db129bc2c836aad4937f55799/images/envoy/config/main.tf
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  packages:
+    - envoy~${PACKAGE_VERSION}
+    - envoy-config~${PACKAGE_VERSION}
+    - envoy-oci-entrypoint~${PACKAGE_VERSION}
+    - su-exec
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+paths:
+  - path: /etc/envoy
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+
+entrypoint:
+  command: /var/lib/envoy/init/envoy-entrypoint.sh

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -1851,11 +1851,12 @@ func TestMultiNodeAirgapUpgradePreviousStable(t *testing.T) {
 // for them to report ready. Runs additional high availability validations afterwards.
 func TestMultiNodeHAInstallation(t *testing.T) {
 	tc := docker.NewCluster(&docker.ClusterInput{
-		T:            t,
-		Nodes:        4,
-		Distro:       "debian-bookworm",
-		LicensePath:  "license.yaml",
-		ECBinaryPath: "../output/bin/embedded-cluster",
+		T:                      t,
+		Nodes:                  4,
+		Distro:                 "debian-bookworm",
+		LicensePath:            "license.yaml",
+		ECBinaryPath:           "../output/bin/embedded-cluster",
+		SupportBundleNodeIndex: 2,
 	})
 	defer tc.Cleanup()
 
@@ -1999,6 +2000,7 @@ func TestMultiNodeAirgapHAInstallation(t *testing.T) {
 		WithProxy:               true,
 		AirgapInstallBundlePath: airgapInstallBundlePath,
 		AirgapUpgradeBundlePath: airgapUpgradeBundlePath,
+		SupportBundleNodeIndex:  2,
 	})
 	defer tc.Cleanup()
 

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -1955,7 +1955,7 @@ func TestMultiNodeHAInstallation(t *testing.T) {
 
 	stdout, stderr, err = tc.RunCommandOnNode(2, []string{"check-nodes-removed.sh", "3"})
 	if err != nil {
-		t.Fatalf("fail to remove controller node 2: %v: %s: %s", err, stdout, stderr)
+		t.Fatalf("fail to check nodes removed: %v: %s: %s", err, stdout, stderr)
 	}
 
 	t.Logf("%s: checking nllb", time.Now().Format(time.RFC3339))
@@ -2029,10 +2029,7 @@ func TestMultiNodeAirgapHAInstallation(t *testing.T) {
 	if _, _, err := tc.RunCommandOnNode(0, line); err != nil {
 		t.Fatalf("fail to remove airgap bundle on node %s: %v", tc.Nodes[0], err)
 	}
-	line = []string{"rm", "/usr/local/bin/embedded-cluster"}
-	if _, _, err := tc.RunCommandOnNode(0, line); err != nil {
-		t.Fatalf("fail to remove embedded-cluster binary on node %s: %v", tc.Nodes[0], err)
-	}
+	// do not remove the embedded-cluster binary as it is used for reset
 
 	if _, _, err := tc.SetupPlaywrightAndRunTest("deploy-app"); err != nil {
 		t.Fatalf("fail to run playwright test deploy-app: %v", err)
@@ -2097,7 +2094,10 @@ func TestMultiNodeAirgapHAInstallation(t *testing.T) {
 	if _, _, err := tc.RunCommandOnNode(2, line); err != nil {
 		t.Fatalf("fail to remove airgap bundle on node 2: %v", err)
 	}
-	// don't remove the embedded-cluster binary as it is used for reset
+	line = []string{"rm", "/usr/local/bin/embedded-cluster"}
+	if _, _, err := tc.RunCommandOnNode(2, line); err != nil {
+		t.Fatalf("fail to remove embedded-cluster binary on node 2: %v", err)
+	}
 
 	// join another controller in HA mode
 	stdout, stderr, err = tc.RunPlaywrightTest("get-join-controller-command")
@@ -2173,7 +2173,7 @@ func TestMultiNodeAirgapHAInstallation(t *testing.T) {
 	stdout, stderr, err = tc.RunCommandOnNode(0, []string{bin, "reset", "--yes"})
 	if err != nil {
 		t.Logf("stdout: %s\nstderr: %s", stdout, stderr)
-		t.Fatalf("fail to remove controller node %s:", err)
+		t.Fatalf("fail to remove controller node 0 %s:", err)
 	}
 	if !strings.Contains(stdout, "High-availability clusters must maintain at least three controller nodes") {
 		t.Errorf("reset output does not contain the ha warning")
@@ -2182,7 +2182,7 @@ func TestMultiNodeAirgapHAInstallation(t *testing.T) {
 
 	stdout, _, err = tc.RunCommandOnNode(2, []string{"check-nodes-removed.sh", "3"})
 	if err != nil {
-		t.Fatalf("fail to remove controller node 2: %v: %s: %s", err, stdout, stderr)
+		t.Fatalf("fail to check nodes removed: %v: %s: %s", err, stdout, stderr)
 	}
 
 	t.Logf("%s: checking nllb", time.Now().Format(time.RFC3339))

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -538,7 +538,7 @@ func TestSingleNodeUpgradePreviousStable(t *testing.T) {
 		t.Fatalf("fail to check installation state: %v: %s: %s", err, stdout, stderr)
 	}
 
-	appUpgradeVersion := fmt.Sprintf("appver-%s-upgrade", os.Getenv("SHORT_SHA"))
+	appUpgradeVersion := fmt.Sprintf("appver-%s-noop", os.Getenv("SHORT_SHA"))
 	testArgs := []string{appUpgradeVersion}
 
 	t.Logf("%s: upgrading cluster", time.Now().Format(time.RFC3339))
@@ -546,7 +546,27 @@ func TestSingleNodeUpgradePreviousStable(t *testing.T) {
 		t.Fatalf("fail to run playwright test deploy-app: %v: %s: %s", err, stdout, stderr)
 	}
 
-	t.Logf("%s: checking installation state after upgrade", time.Now().Format(time.RFC3339))
+	t.Logf("%s: re-installing kots cli on node 0", time.Now().Format(time.RFC3339))
+	line = []string{"install-kots-cli.sh"}
+	if stdout, stderr, err := tc.RunCommandOnNode(0, line); err != nil {
+		t.Fatalf("fail to install kots cli on node 0: %v: %s: %s", err, stdout, stderr)
+	}
+
+	t.Logf("%s: checking installation state after noop upgrade", time.Now().Format(time.RFC3339))
+	line = []string{"check-installation-state.sh", appUpgradeVersion, k8sVersion()}
+	if stdout, stderr, err := tc.RunCommandOnNode(0, line); err != nil {
+		t.Fatalf("fail to check installation state: %v: %s: %s", err, stdout, stderr)
+	}
+
+	appUpgradeVersion = fmt.Sprintf("appver-%s-upgrade", os.Getenv("SHORT_SHA"))
+	testArgs = []string{appUpgradeVersion}
+
+	t.Logf("%s: upgrading cluster a second time", time.Now().Format(time.RFC3339))
+	if stdout, stderr, err := tc.RunPlaywrightTest("deploy-upgrade", testArgs...); err != nil {
+		t.Fatalf("fail to run playwright test deploy-app: %v: %s: %s", err, stdout, stderr)
+	}
+
+	t.Logf("%s: checking installation state after second upgrade", time.Now().Format(time.RFC3339))
 	line = []string{"check-postupgrade-state.sh", k8sVersion(), ecUpgradeTargetVersion()}
 	if stdout, stderr, err := tc.RunCommandOnNode(0, line); err != nil {
 		t.Fatalf("fail to check postupgrade state: %v: %s: %s", err, stdout, stderr)
@@ -684,7 +704,7 @@ func TestUpgradeEC18FromReplicatedApp(t *testing.T) {
 		t.Fatalf("fail to check installation state: %v: %s: %s", err, stdout, stderr)
 	}
 
-	appUpgradeVersion := fmt.Sprintf("appver-%s-upgrade", os.Getenv("SHORT_SHA"))
+	appUpgradeVersion := fmt.Sprintf("appver-%s-noop", os.Getenv("SHORT_SHA"))
 	testArgs := []string{appUpgradeVersion}
 
 	t.Logf("%s: upgrading cluster", time.Now().Format(time.RFC3339))
@@ -692,7 +712,27 @@ func TestUpgradeEC18FromReplicatedApp(t *testing.T) {
 		t.Fatalf("fail to run playwright test deploy-app: %v: %s: %s", err, stdout, stderr)
 	}
 
-	t.Logf("%s: checking installation state after upgrade", time.Now().Format(time.RFC3339))
+	t.Logf("%s: re-installing kots cli on node 0", time.Now().Format(time.RFC3339))
+	line = []string{"install-kots-cli.sh"}
+	if stdout, stderr, err := tc.RunCommandOnNode(0, line); err != nil {
+		t.Fatalf("fail to install kots cli on node 0: %v: %s: %s", err, stdout, stderr)
+	}
+
+	t.Logf("%s: checking installation state after noop upgrade", time.Now().Format(time.RFC3339))
+	line = []string{"check-installation-state.sh", appUpgradeVersion, k8sVersion()}
+	if stdout, stderr, err := tc.RunCommandOnNode(0, line, withEnv); err != nil {
+		t.Fatalf("fail to check installation state: %v: %s: %s", err, stdout, stderr)
+	}
+
+	appUpgradeVersion = fmt.Sprintf("appver-%s-upgrade", os.Getenv("SHORT_SHA"))
+	testArgs = []string{appUpgradeVersion}
+
+	t.Logf("%s: upgrading cluster a second time", time.Now().Format(time.RFC3339))
+	if stdout, stderr, err := tc.RunPlaywrightTest("deploy-upgrade", testArgs...); err != nil {
+		t.Fatalf("fail to run playwright test deploy-app: %v: %s: %s", err, stdout, stderr)
+	}
+
+	t.Logf("%s: checking installation state after second upgrade", time.Now().Format(time.RFC3339))
 	line = []string{"check-postupgrade-state.sh", k8sVersion(), ecUpgradeTargetVersion()}
 	if stdout, stderr, err := tc.RunCommandOnNode(0, line, withEnv); err != nil {
 		t.Fatalf("fail to check postupgrade state: %v: %s: %s", err, stdout, stderr)

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -538,7 +538,7 @@ func TestSingleNodeUpgradePreviousStable(t *testing.T) {
 		t.Fatalf("fail to check installation state: %v: %s: %s", err, stdout, stderr)
 	}
 
-	appUpgradeVersion := fmt.Sprintf("appver-%s-noop", os.Getenv("SHORT_SHA"))
+	appUpgradeVersion := fmt.Sprintf("appver-%s-upgrade", os.Getenv("SHORT_SHA"))
 	testArgs := []string{appUpgradeVersion}
 
 	t.Logf("%s: upgrading cluster", time.Now().Format(time.RFC3339))
@@ -546,27 +546,7 @@ func TestSingleNodeUpgradePreviousStable(t *testing.T) {
 		t.Fatalf("fail to run playwright test deploy-app: %v: %s: %s", err, stdout, stderr)
 	}
 
-	t.Logf("%s: re-installing kots cli on node 0", time.Now().Format(time.RFC3339))
-	line = []string{"install-kots-cli.sh"}
-	if stdout, stderr, err := tc.RunCommandOnNode(0, line); err != nil {
-		t.Fatalf("fail to install kots cli on node 0: %v: %s: %s", err, stdout, stderr)
-	}
-
-	t.Logf("%s: checking installation state after noop upgrade", time.Now().Format(time.RFC3339))
-	line = []string{"check-installation-state.sh", appUpgradeVersion, k8sVersion()}
-	if stdout, stderr, err := tc.RunCommandOnNode(0, line); err != nil {
-		t.Fatalf("fail to check installation state: %v: %s: %s", err, stdout, stderr)
-	}
-
-	appUpgradeVersion = fmt.Sprintf("appver-%s-upgrade", os.Getenv("SHORT_SHA"))
-	testArgs = []string{appUpgradeVersion}
-
-	t.Logf("%s: upgrading cluster a second time", time.Now().Format(time.RFC3339))
-	if stdout, stderr, err := tc.RunPlaywrightTest("deploy-upgrade", testArgs...); err != nil {
-		t.Fatalf("fail to run playwright test deploy-app: %v: %s: %s", err, stdout, stderr)
-	}
-
-	t.Logf("%s: checking installation state after second upgrade", time.Now().Format(time.RFC3339))
+	t.Logf("%s: checking installation state after upgrade", time.Now().Format(time.RFC3339))
 	line = []string{"check-postupgrade-state.sh", k8sVersion(), ecUpgradeTargetVersion()}
 	if stdout, stderr, err := tc.RunCommandOnNode(0, line); err != nil {
 		t.Fatalf("fail to check postupgrade state: %v: %s: %s", err, stdout, stderr)
@@ -704,7 +684,7 @@ func TestUpgradeEC18FromReplicatedApp(t *testing.T) {
 		t.Fatalf("fail to check installation state: %v: %s: %s", err, stdout, stderr)
 	}
 
-	appUpgradeVersion := fmt.Sprintf("appver-%s-noop", os.Getenv("SHORT_SHA"))
+	appUpgradeVersion := fmt.Sprintf("appver-%s-upgrade", os.Getenv("SHORT_SHA"))
 	testArgs := []string{appUpgradeVersion}
 
 	t.Logf("%s: upgrading cluster", time.Now().Format(time.RFC3339))
@@ -712,27 +692,7 @@ func TestUpgradeEC18FromReplicatedApp(t *testing.T) {
 		t.Fatalf("fail to run playwright test deploy-app: %v: %s: %s", err, stdout, stderr)
 	}
 
-	t.Logf("%s: re-installing kots cli on node 0", time.Now().Format(time.RFC3339))
-	line = []string{"install-kots-cli.sh"}
-	if stdout, stderr, err := tc.RunCommandOnNode(0, line); err != nil {
-		t.Fatalf("fail to install kots cli on node 0: %v: %s: %s", err, stdout, stderr)
-	}
-
-	t.Logf("%s: checking installation state after noop upgrade", time.Now().Format(time.RFC3339))
-	line = []string{"check-installation-state.sh", appUpgradeVersion, k8sVersion()}
-	if stdout, stderr, err := tc.RunCommandOnNode(0, line, withEnv); err != nil {
-		t.Fatalf("fail to check installation state: %v: %s: %s", err, stdout, stderr)
-	}
-
-	appUpgradeVersion = fmt.Sprintf("appver-%s-upgrade", os.Getenv("SHORT_SHA"))
-	testArgs = []string{appUpgradeVersion}
-
-	t.Logf("%s: upgrading cluster a second time", time.Now().Format(time.RFC3339))
-	if stdout, stderr, err := tc.RunPlaywrightTest("deploy-upgrade", testArgs...); err != nil {
-		t.Fatalf("fail to run playwright test deploy-app: %v: %s: %s", err, stdout, stderr)
-	}
-
-	t.Logf("%s: checking installation state after second upgrade", time.Now().Format(time.RFC3339))
+	t.Logf("%s: checking installation state after upgrade", time.Now().Format(time.RFC3339))
 	line = []string{"check-postupgrade-state.sh", k8sVersion(), ecUpgradeTargetVersion()}
 	if stdout, stderr, err := tc.RunCommandOnNode(0, line, withEnv); err != nil {
 		t.Fatalf("fail to check postupgrade state: %v: %s: %s", err, stdout, stderr)

--- a/e2e/reset_test.go
+++ b/e2e/reset_test.go
@@ -109,7 +109,7 @@ func TestMultiNodeReset(t *testing.T) {
 
 	stdout, stderr, err = tc.RunCommandOnNode(0, []string{"check-nodes-removed.sh", "2"})
 	if err != nil {
-		t.Fatalf("fail to remove worker node 0: %v: %s: %s", err, stdout, stderr)
+		t.Fatalf("fail to check nodes removed: %v: %s: %s", err, stdout, stderr)
 	}
 
 	t.Logf("%s: checking installation state", time.Now().Format(time.RFC3339))

--- a/e2e/scripts/check-nllb.sh
+++ b/e2e/scripts/check-nllb.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# This script is meant to be run after deleting the first control plane node to ensure the cluster
+# is still functional.
+
 set -euxo pipefail
 
 DIR=/usr/local/bin

--- a/e2e/scripts/check-nllb.sh
+++ b/e2e/scripts/check-nllb.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+DIR=/usr/local/bin
+. $DIR/common.sh
+
+function main() {
+    local worker_node=
+    worker_node=$(kubectl get nodes -l node-role.kubernetes.io/control-plane!=true -oname | awk -F/ 'NR==1{print $2}')
+
+    if [ -z "$worker_node" ]; then
+        echo "No worker node found"
+        exit 1
+    fi
+
+    local kotsadm_image=
+    kotsadm_image=$(kubectl -n kotsadm get deploy kotsadm  -o jsonpath='{.spec.template.spec.containers[0].image}')
+
+    # run the pod on a worker node
+    kubectl run test-nllb --image "$kotsadm_image" --overrides='{"spec": { "nodeSelector": {"kubernetes.io/hostname": "'"$worker_node"'"}}}' --command -- sleep infinity
+
+    # wait for the pod to be running
+    if ! kubectl wait --for=condition=ready pod/test-nllb --timeout=1m; then
+        echo "Pod test-nllb did not become ready"
+        kubectl describe pod test-nllb
+        exit 1
+    fi
+}
+
+main "$@"

--- a/e2e/scripts/check-nllb.sh
+++ b/e2e/scripts/check-nllb.sh
@@ -23,7 +23,8 @@ function main() {
     fi
 
     # run the pod on a worker node
-    kubectl run test-nllb --image "$kotsadm_image" --overrides='{"spec": { "nodeSelector": {"kubernetes.io/hostname": "'"$worker_node"'"}}}' --command -- sleep infinity
+    kubectl run test-nllb --image "$kotsadm_image" \
+        --overrides='{"spec": { "nodeSelector": {"kubernetes.io/hostname": "'"$worker_node"'"}}}' --command -- sleep infinity
 
     # wait for the pod to be running
     if ! kubectl wait --for=condition=ready pod/test-nllb --timeout=1m; then

--- a/e2e/scripts/check-nllb.sh
+++ b/e2e/scripts/check-nllb.sh
@@ -17,6 +17,11 @@ function main() {
     local kotsadm_image=
     kotsadm_image=$(kubectl -n kotsadm get deploy kotsadm  -o jsonpath='{.spec.template.spec.containers[0].image}')
 
+    if [ -z "$kotsadm_image" ]; then
+        echo "No kotsadm image found"
+        exit 1
+    fi
+
     # run the pod on a worker node
     kubectl run test-nllb --image "$kotsadm_image" --overrides='{"spec": { "nodeSelector": {"kubernetes.io/hostname": "'"$worker_node"'"}}}' --command -- sleep infinity
 

--- a/e2e/scripts/restore-installation-airgap.exp
+++ b/e2e/scripts/restore-installation-airgap.exp
@@ -92,7 +92,7 @@ expect {
 }
 
 expect {
-    -timeout 210 "Velero is ready!" {}
+    -timeout 300 "Velero is ready!" {}
     timeout {
       puts "\n\nFailed to wait for Velero to be ready."
       exit 1

--- a/e2e/scripts/restore-installation.exp
+++ b/e2e/scripts/restore-installation.exp
@@ -92,7 +92,7 @@ expect {
 }
 
 expect {
-    -timeout 210 "Velero is ready!" {}
+    -timeout 300 "Velero is ready!" {}
     timeout {
       puts "\n\nFailed to wait for Velero to be ready."
       exit 1

--- a/e2e/scripts/restore-multi-node-airgap-phase1.exp
+++ b/e2e/scripts/restore-multi-node-airgap-phase1.exp
@@ -80,7 +80,7 @@ expect {
 }
 
 expect {
-    -timeout 210 "Velero is ready!" {}
+    -timeout 300 "Velero is ready!" {}
     timeout {
       puts "\n\nFailed to wait for Velero to be ready."
       exit 1

--- a/e2e/scripts/restore-multi-node-phase1.exp
+++ b/e2e/scripts/restore-multi-node-phase1.exp
@@ -80,7 +80,7 @@ expect {
 }
 
 expect {
-    -timeout 210 "Velero is ready!" {}
+    -timeout 300 "Velero is ready!" {}
     timeout {
       puts "\n\nFailed to wait for Velero to be ready."
       exit 1

--- a/e2e/scripts/resume-restore.exp
+++ b/e2e/scripts/resume-restore.exp
@@ -85,7 +85,7 @@ expect {
 }
 
 expect {
-    -timeout 210 "Velero is ready!" {}
+    -timeout 300 "Velero is ready!" {}
     timeout {
       puts "\n\nFailed to wait for Velero to be ready."
       exit 1

--- a/operator/pkg/upgrade/upgrade.go
+++ b/operator/pkg/upgrade/upgrade.go
@@ -189,11 +189,17 @@ func updateClusterConfig(ctx context.Context, cli client.Client, in *ecv1beta1.I
 		}
 	}
 
-	if currentCfg.Spec.Network.NodeLocalLoadBalancing == nil ||
-		!reflect.DeepEqual(*currentCfg.Spec.Network.NodeLocalLoadBalancing, *cfg.Spec.Network.NodeLocalLoadBalancing) {
-
-		currentCfg.Spec.Network.NodeLocalLoadBalancing = cfg.Spec.Network.NodeLocalLoadBalancing
-		didUpdate = true
+	if currentCfg.Spec.Network != nil &&
+		currentCfg.Spec.Network.NodeLocalLoadBalancing != nil &&
+		currentCfg.Spec.Network.NodeLocalLoadBalancing.EnvoyProxy != nil &&
+		currentCfg.Spec.Network.NodeLocalLoadBalancing.EnvoyProxy.Image != nil {
+		if !reflect.DeepEqual(
+			*currentCfg.Spec.Network.NodeLocalLoadBalancing.EnvoyProxy.Image,
+			*cfg.Spec.Network.NodeLocalLoadBalancing.EnvoyProxy.Image,
+		) {
+			currentCfg.Spec.Network.NodeLocalLoadBalancing.EnvoyProxy.Image = cfg.Spec.Network.NodeLocalLoadBalancing.EnvoyProxy.Image
+			didUpdate = true
+		}
 	}
 
 	if !didUpdate {

--- a/operator/pkg/upgrade/upgrade.go
+++ b/operator/pkg/upgrade/upgrade.go
@@ -189,7 +189,9 @@ func updateClusterConfig(ctx context.Context, cli client.Client, in *ecv1beta1.I
 		}
 	}
 
-	if currentCfg.Spec.Network.NodeLocalLoadBalancing == nil || !reflect.DeepEqual(*currentCfg.Spec.Network.NodeLocalLoadBalancing, *cfg.Spec.Network.NodeLocalLoadBalancing) {
+	if currentCfg.Spec.Network.NodeLocalLoadBalancing == nil ||
+		!reflect.DeepEqual(*currentCfg.Spec.Network.NodeLocalLoadBalancing, *cfg.Spec.Network.NodeLocalLoadBalancing) {
+
 		currentCfg.Spec.Network.NodeLocalLoadBalancing = cfg.Spec.Network.NodeLocalLoadBalancing
 		didUpdate = true
 	}

--- a/operator/pkg/upgrade/upgrade.go
+++ b/operator/pkg/upgrade/upgrade.go
@@ -179,14 +179,24 @@ func updateClusterConfig(ctx context.Context, cli client.Client, in *ecv1beta1.I
 
 	domains := runtimeconfig.GetDomains(in.Spec.Config)
 
+	didUpdate := false
+
 	cfg := config.RenderK0sConfig(domains.ProxyRegistryDomain)
 	if currentCfg.Spec.Images != nil {
-		if reflect.DeepEqual(*currentCfg.Spec.Images, *cfg.Spec.Images) {
-			return nil
+		if !reflect.DeepEqual(*currentCfg.Spec.Images, *cfg.Spec.Images) {
+			currentCfg.Spec.Images = cfg.Spec.Images
+			didUpdate = true
 		}
 	}
 
-	currentCfg.Spec.Images = cfg.Spec.Images
+	if currentCfg.Spec.Network.NodeLocalLoadBalancing == nil || !reflect.DeepEqual(*currentCfg.Spec.Network.NodeLocalLoadBalancing, *cfg.Spec.Network.NodeLocalLoadBalancing) {
+		currentCfg.Spec.Network.NodeLocalLoadBalancing = cfg.Spec.Network.NodeLocalLoadBalancing
+		didUpdate = true
+	}
+
+	if !didUpdate {
+		return nil
+	}
 
 	unstructured, err := helpers.K0sClusterConfigTo129Compat(&currentCfg)
 	if err != nil {

--- a/operator/pkg/upgrade/upgrade_test.go
+++ b/operator/pkg/upgrade/upgrade_test.go
@@ -90,11 +90,16 @@ func TestUpdateClusterConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "updates node local load balancing when nil",
+			name: "does not enable node local load balancing when nil",
 			currentConfig: &k0sv1beta1.ClusterConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "k0s",
 					Namespace: "kube-system",
+				},
+				Spec: &k0sv1beta1.ClusterSpec{
+					Network: &k0sv1beta1.Network{
+						NodeLocalLoadBalancing: nil,
+					},
 				},
 			},
 			installation: &ecv1beta1.Installation{
@@ -107,7 +112,7 @@ func TestUpdateClusterConfig(t *testing.T) {
 				},
 			},
 			validate: func(t *testing.T, updatedConfig *k0sv1beta1.ClusterConfig) {
-				assert.True(t, updatedConfig.Spec.Network.NodeLocalLoadBalancing.Enabled)
+				assert.False(t, updatedConfig.Spec.Network.NodeLocalLoadBalancing.Enabled)
 				assert.Equal(t, k0sv1beta1.NllbTypeEnvoyProxy, updatedConfig.Spec.Network.NodeLocalLoadBalancing.Type)
 				assert.Contains(t, updatedConfig.Spec.Network.NodeLocalLoadBalancing.EnvoyProxy.Image.Image, "registry.com/")
 			},

--- a/operator/pkg/upgrade/upgrade_test.go
+++ b/operator/pkg/upgrade/upgrade_test.go
@@ -1,0 +1,106 @@
+package upgrade
+
+import (
+	"context"
+	"testing"
+
+	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestUpdateClusterConfig(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, k0sv1beta1.AddToScheme(scheme))
+
+	tests := []struct {
+		name          string
+		currentConfig *k0sv1beta1.ClusterConfig
+		installation  *ecv1beta1.Installation
+		validate      func(t *testing.T, updatedConfig *k0sv1beta1.ClusterConfig)
+	}{
+		{
+			name: "updates node local load balancing when different",
+			currentConfig: &k0sv1beta1.ClusterConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "k0s",
+					Namespace: "kube-system",
+				},
+				Spec: &k0sv1beta1.ClusterSpec{
+					Network: &k0sv1beta1.Network{
+						NodeLocalLoadBalancing: &k0sv1beta1.NodeLocalLoadBalancing{
+							Enabled: true,
+							Type:    k0sv1beta1.NllbTypeEnvoyProxy,
+							EnvoyProxy: &k0sv1beta1.EnvoyProxy{
+								Image: &k0sv1beta1.ImageSpec{
+									Image:   "some-image",
+									Version: "some-version",
+								},
+							},
+						},
+					},
+				},
+			},
+			installation: &ecv1beta1.Installation{
+				Spec: ecv1beta1.InstallationSpec{
+					Config: &ecv1beta1.ConfigSpec{
+						Domains: ecv1beta1.Domains{
+							ProxyRegistryDomain: "registry.com",
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, updatedConfig *k0sv1beta1.ClusterConfig) {
+				assert.True(t, updatedConfig.Spec.Network.NodeLocalLoadBalancing.Enabled)
+				assert.Equal(t, k0sv1beta1.NllbTypeEnvoyProxy, updatedConfig.Spec.Network.NodeLocalLoadBalancing.Type)
+				assert.Contains(t, updatedConfig.Spec.Network.NodeLocalLoadBalancing.EnvoyProxy.Image.Image, "registry.com/")
+			},
+		},
+		{
+			name: "updates node local load balancing when nil",
+			currentConfig: &k0sv1beta1.ClusterConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "k0s",
+					Namespace: "kube-system",
+				},
+			},
+			installation: &ecv1beta1.Installation{
+				Spec: ecv1beta1.InstallationSpec{
+					Config: &ecv1beta1.ConfigSpec{
+						Domains: ecv1beta1.Domains{
+							ProxyRegistryDomain: "registry.com",
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, updatedConfig *k0sv1beta1.ClusterConfig) {
+				assert.True(t, updatedConfig.Spec.Network.NodeLocalLoadBalancing.Enabled)
+				assert.Equal(t, k0sv1beta1.NllbTypeEnvoyProxy, updatedConfig.Spec.Network.NodeLocalLoadBalancing.Type)
+				assert.Contains(t, updatedConfig.Spec.Network.NodeLocalLoadBalancing.EnvoyProxy.Image.Image, "registry.com/")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cli := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tt.currentConfig).
+				Build()
+
+			err := updateClusterConfig(context.Background(), cli, tt.installation)
+			require.NoError(t, err)
+
+			var updatedConfig k0sv1beta1.ClusterConfig
+			err = cli.Get(context.Background(), client.ObjectKey{Name: "k0s", Namespace: "kube-system"}, &updatedConfig)
+			require.NoError(t, err)
+
+			tt.validate(t, &updatedConfig)
+		})
+	}
+}

--- a/operator/pkg/upgrade/upgrade_test.go
+++ b/operator/pkg/upgrade/upgrade_test.go
@@ -25,6 +25,34 @@ func TestUpdateClusterConfig(t *testing.T) {
 		validate      func(t *testing.T, updatedConfig *k0sv1beta1.ClusterConfig)
 	}{
 		{
+			name: "updates images with proxy registry domain",
+			currentConfig: &k0sv1beta1.ClusterConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "k0s",
+					Namespace: "kube-system",
+				},
+			},
+			installation: &ecv1beta1.Installation{
+				Spec: ecv1beta1.InstallationSpec{
+					Config: &ecv1beta1.ConfigSpec{
+						Domains: ecv1beta1.Domains{
+							ProxyRegistryDomain: "registry.com",
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, updatedConfig *k0sv1beta1.ClusterConfig) {
+				assert.Contains(t, updatedConfig.Spec.Images.CoreDNS.Image, "registry.com/")
+				assert.Contains(t, updatedConfig.Spec.Images.Calico.Node.Image, "registry.com/")
+				assert.Contains(t, updatedConfig.Spec.Images.Calico.CNI.Image, "registry.com/")
+				assert.Contains(t, updatedConfig.Spec.Images.Calico.KubeControllers.Image, "registry.com/")
+				assert.Contains(t, updatedConfig.Spec.Images.MetricsServer.Image, "registry.com/")
+				assert.Contains(t, updatedConfig.Spec.Images.KubeProxy.Image, "registry.com/")
+				assert.Contains(t, updatedConfig.Spec.Images.Pause.Image, "registry.com/")
+				assert.Contains(t, updatedConfig.Spec.Network.NodeLocalLoadBalancing.EnvoyProxy.Image.Image, "registry.com/")
+			},
+		},
+		{
 			name: "updates node local load balancing when different",
 			currentConfig: &k0sv1beta1.ClusterConfig{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,6 +34,8 @@ func RenderK0sConfig(proxyRegistryDomain string) *k0sconfig.ClusterConfig {
 	}
 	cfg.Spec.API.ExtraArgs["service-node-port-range"] = DefaultServiceNodePortRange
 	cfg.Spec.API.SANs = append(cfg.Spec.API.SANs, "kubernetes.default.svc.cluster.local")
+	cfg.Spec.Network.NodeLocalLoadBalancing.Enabled = true
+	cfg.Spec.Network.NodeLocalLoadBalancing.Type = "EnvoyProxy"
 	overrideK0sImages(cfg, proxyRegistryDomain)
 	return cfg
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,7 +35,7 @@ func RenderK0sConfig(proxyRegistryDomain string) *k0sconfig.ClusterConfig {
 	cfg.Spec.API.ExtraArgs["service-node-port-range"] = DefaultServiceNodePortRange
 	cfg.Spec.API.SANs = append(cfg.Spec.API.SANs, "kubernetes.default.svc.cluster.local")
 	cfg.Spec.Network.NodeLocalLoadBalancing.Enabled = true
-	cfg.Spec.Network.NodeLocalLoadBalancing.Type = "EnvoyProxy"
+	cfg.Spec.Network.NodeLocalLoadBalancing.Type = k0sconfig.NllbTypeEnvoyProxy
 	overrideK0sImages(cfg, proxyRegistryDomain)
 	return cfg
 }

--- a/pkg/config/images.go
+++ b/pkg/config/images.go
@@ -33,8 +33,7 @@ func ListK0sImages(cfg *k0sv1beta1.ClusterConfig) []string {
 		// skip these images
 		case cfg.Spec.Images.KubeRouter.CNI.URI(),
 			cfg.Spec.Images.KubeRouter.CNIInstaller.URI(),
-			cfg.Spec.Images.Konnectivity.URI(),
-			cfg.Spec.Network.NodeLocalLoadBalancing.EnvoyProxy.Image.URI():
+			cfg.Spec.Images.Konnectivity.URI():
 		default:
 			if strings.Contains(image, constant.KubePauseContainerImage) {
 				// there's a bug in GetImageURIs where it always returns the original pause image
@@ -52,6 +51,15 @@ func overrideK0sImages(cfg *k0sv1beta1.ClusterConfig, proxyRegistryDomain string
 	if cfg.Spec.Images == nil {
 		cfg.Spec.Images = &k0sv1beta1.ClusterImages{}
 	}
+	if cfg.Spec.Network == nil {
+		cfg.Spec.Network = &k0sv1beta1.Network{}
+	}
+	if cfg.Spec.Network.NodeLocalLoadBalancing == nil {
+		cfg.Spec.Network.NodeLocalLoadBalancing = &k0sv1beta1.NodeLocalLoadBalancing{}
+	}
+	if cfg.Spec.Network.NodeLocalLoadBalancing.EnvoyProxy == nil {
+		cfg.Spec.Network.NodeLocalLoadBalancing.EnvoyProxy = &k0sv1beta1.EnvoyProxy{}
+	}
 
 	if proxyRegistryDomain == "" {
 		cfg.Spec.Images.CoreDNS.Image = Metadata.Images["coredns"].Repo
@@ -61,6 +69,7 @@ func overrideK0sImages(cfg *k0sv1beta1.ClusterConfig, proxyRegistryDomain string
 		cfg.Spec.Images.MetricsServer.Image = Metadata.Images["metrics-server"].Repo
 		cfg.Spec.Images.KubeProxy.Image = Metadata.Images["kube-proxy"].Repo
 		cfg.Spec.Images.Pause.Image = Metadata.Images["pause"].Repo
+		cfg.Spec.Network.NodeLocalLoadBalancing.EnvoyProxy.Image.Image = Metadata.Images["envoy-distroless"].Repo
 	} else {
 		cfg.Spec.Images.CoreDNS.Image = strings.Replace(Metadata.Images["coredns"].Repo, "proxy.replicated.com", proxyRegistryDomain, 1)
 		cfg.Spec.Images.Calico.Node.Image = strings.Replace(Metadata.Images["calico-node"].Repo, "proxy.replicated.com", proxyRegistryDomain, 1)
@@ -69,6 +78,7 @@ func overrideK0sImages(cfg *k0sv1beta1.ClusterConfig, proxyRegistryDomain string
 		cfg.Spec.Images.MetricsServer.Image = strings.Replace(Metadata.Images["metrics-server"].Repo, "proxy.replicated.com", proxyRegistryDomain, 1)
 		cfg.Spec.Images.KubeProxy.Image = strings.Replace(Metadata.Images["kube-proxy"].Repo, "proxy.replicated.com", proxyRegistryDomain, 1)
 		cfg.Spec.Images.Pause.Image = strings.Replace(Metadata.Images["pause"].Repo, "proxy.replicated.com", proxyRegistryDomain, 1)
+		cfg.Spec.Network.NodeLocalLoadBalancing.EnvoyProxy.Image.Image = strings.Replace(Metadata.Images["envoy-distroless"].Repo, "proxy.replicated.com", proxyRegistryDomain, 1)
 	}
 
 	cfg.Spec.Images.CoreDNS.Version = Metadata.Images["coredns"].Tag[runtime.GOARCH]
@@ -78,4 +88,5 @@ func overrideK0sImages(cfg *k0sv1beta1.ClusterConfig, proxyRegistryDomain string
 	cfg.Spec.Images.MetricsServer.Version = Metadata.Images["metrics-server"].Tag[runtime.GOARCH]
 	cfg.Spec.Images.KubeProxy.Version = Metadata.Images["kube-proxy"].Tag[runtime.GOARCH]
 	cfg.Spec.Images.Pause.Version = Metadata.Images["pause"].Tag[runtime.GOARCH]
+	cfg.Spec.Network.NodeLocalLoadBalancing.EnvoyProxy.Image.Version = Metadata.Images["envoy-distroless"].Tag[runtime.GOARCH]
 }

--- a/pkg/config/images_test.go
+++ b/pkg/config/images_test.go
@@ -13,7 +13,7 @@ func TestListK0sImages(t *testing.T) {
 	if len(original) == 0 {
 		t.Errorf("airgap.GetImageURIs() = %v, want not empty", original)
 	}
-	var foundKubeRouter, foundCNINode, foundKonnectivity, foundEnvoy bool
+	var foundKubeRouter, foundCNINode, foundKonnectivity bool
 	for _, image := range original {
 		if strings.Contains(image, "kube-router") {
 			foundKubeRouter = true

--- a/pkg/config/images_test.go
+++ b/pkg/config/images_test.go
@@ -24,9 +24,6 @@ func TestListK0sImages(t *testing.T) {
 		if strings.Contains(image, "apiserver-network-proxy-agent") {
 			foundKonnectivity = true
 		}
-		if strings.Contains(image, "envoy-distroless") {
-			foundEnvoy = true
-		}
 	}
 	if !foundKubeRouter {
 		t.Errorf("airgap.GetImageURIs() = %v, want to contain kube-router", original)
@@ -36,9 +33,6 @@ func TestListK0sImages(t *testing.T) {
 	}
 	if !foundKonnectivity {
 		t.Errorf("airgap.GetImageURIs() = %v, want to contain apiserver-network-proxy-agent", original)
-	}
-	if !foundEnvoy {
-		t.Errorf("airgap.GetImageURIs() = %v, want to contain envoy-distroless", original)
 	}
 
 	filtered := ListK0sImages(RenderK0sConfig(runtimeconfig.DefaultProxyRegistryDomain))
@@ -77,9 +71,6 @@ func TestListK0sImages(t *testing.T) {
 		}
 		if strings.Contains(image, "apiserver-network-proxy-agent") {
 			t.Errorf("ListK0sImages() = %v, want not to contain apiserver-network-proxy-agent", filtered)
-		}
-		if strings.Contains(image, "envoy-distroless") {
-			t.Errorf("ListK0sImages() = %v, want not to contain envoy-distroless", filtered)
 		}
 	}
 }

--- a/pkg/config/static/metadata.yaml
+++ b/pkg/config/static/metadata.yaml
@@ -9,23 +9,28 @@ images:
     calico-cni:
         repo: proxy.replicated.com/anonymous/replicated/ec-calico-cni
         tag:
-            amd64: 3.28.2-r1-amd64@sha256:c56b30104e1472ed2673e8ab571ba198e8ea1153715208cf6124a9266f8f5c78
-            arm64: 3.28.2-r1-arm64@sha256:32548571114fd1c3a16177d4dde157fb230827d5b15809ea43332a3afbe3eb9c
+            amd64: 3.28.2-r1-amd64@sha256:2335ba80481c131e2f66abfa832d669f29c5ba19cb09331a1eba3b533e61f451
+            arm64: 3.28.2-r1-arm64@sha256:9dacc77342f589285677add8fc83910f1708e304b0a637638ba0c6d886976294
     calico-kube-controllers:
         repo: proxy.replicated.com/anonymous/replicated/ec-calico-kube-controllers
         tag:
-            amd64: 3.28.2-r1-amd64@sha256:7fb134965449733a6ea394c7ac9cf7f2b8c449fa40d3f78acda94fa4743b4eb5
-            arm64: 3.28.2-r1-arm64@sha256:15cc5473e1203ad76adaa0eb5c16ba088e30fe5103d27682b740539c5a0b2240
+            amd64: 3.28.2-r1-amd64@sha256:2235f7660a9d5132b1201a2edf43a4f0dd9f3dc18bcc005eadfdbe2b185d6667
+            arm64: 3.28.2-r1-arm64@sha256:09656679c25cf86fd575364ba146ca4d89a7be3e674fd268d16f016bc230a2f0
     calico-node:
         repo: proxy.replicated.com/anonymous/replicated/ec-calico-node
         tag:
-            amd64: 3.28.2-r1-amd64@sha256:5287da52e5d65f32707dedffea2cc7392e400c5d13d14cca426cd06d6182610d
-            arm64: 3.28.2-r1-arm64@sha256:45ed986bb0f2cdc4148bc8b00f3e19910bfb3ace2bf90a3d969940171a1509fa
+            amd64: 3.28.2-r1-amd64@sha256:3ed1476619f024924a7e1953b9736e79dcd5cc337b7ac83c1ebb360fb2353aaf
+            arm64: 3.28.2-r1-arm64@sha256:e66545a3e58dceeec3b93c6dad27d483787a7726ae6462bea52925c9e1881ad0
     coredns:
         repo: proxy.replicated.com/anonymous/replicated/ec-coredns
         tag:
-            amd64: 1.12.0-r7-amd64@sha256:3b33cc16f582ac4ad60b9f0733d7058c59719e4402bf85ca68bc2a41f1b9702b
-            arm64: 1.12.0-r7-arm64@sha256:8cd264719cdc6539f5a53f8d1d07137e897a7d24597f8d073935d53573cf985b
+            amd64: 1.12.0-r8-amd64@sha256:b66aa68194c2214e42b5abb513742e393d120d4363ad184ab6e3c5d173f98b48
+            arm64: 1.12.0-r8-arm64@sha256:122fc6b7ea9d11ac8ac8bac5d02510bd7493d4687b28fdad1c2888b7093ab269
+    envoy-distroless:
+        repo: proxy.replicated.com/anonymous/replicated/ec-envoy-distroless
+        tag:
+            amd64: 1.30.4-r0-amd64@sha256:5c63eda4aabad11633f66e4f47be677818288235344f8fa60b3219e2316563f0
+            arm64: 1.30.4-r0-arm64@sha256:63d18660379fbec4e652da9ea9f5ca5fef40abf0d1c02121307936b3ca7c2452
     kube-proxy:
         repo: proxy.replicated.com/anonymous/registry.k8s.io/kube-proxy
         tag:
@@ -34,8 +39,8 @@ images:
     metrics-server:
         repo: proxy.replicated.com/anonymous/replicated/ec-metrics-server
         tag:
-            amd64: 0.7.2-r9-amd64@sha256:e4173b019479a8dfb779205b440b0bf4a17f7ab41d0a326070f46504d24ea414
-            arm64: 0.7.2-r9-arm64@sha256:4d376627fda847aa5e4c4974bf8db6916ac42b7e700ba75e514a37dd62c05aca
+            amd64: 0.7.2-r10-amd64@sha256:ba6a69715a3d4616b299ebfcda9835b08a1599fb28f3add80255a6bc8d6b4b9d
+            arm64: 0.7.2-r10-arm64@sha256:51a5db49921f4b2a5e5b2411ba19d895b2b6364667eac64f3cf3ad3733892844
     pause:
         repo: proxy.replicated.com/anonymous/registry.k8s.io/pause
         tag:


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Adds no local load balancing support for new installations.

Upgrades are not supported from previous versions of EC.

According to the [k0s docs](https://docs.k0sproject.io/head/nllb/).

> The k0s worker process on worker nodes that are already running must be restarted for the new configuration to take effect.

Adds a test that resets the first controller node and checks that a pod will still start on a worker node.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
For new installations, the control plane is now set up as highly available within the cluster, enabling the removal of controller nodes from multi-node clusters without affecting pod scheduling.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
