### PR TITLE
warn about joining controllers in parallel

### DIFF
--- a/cmd/installer/cli/join.go
+++ b/cmd/installer/cli/join.go
@@ -129,6 +129,12 @@ func addJoinFlags(cmd *cobra.Command, flags *JoinCmdFlags) error {
 }
 
 func runJoin(ctx context.Context, name string, flags JoinCmdFlags, jcmd *kotsadm.JoinCommandResponse, metricsReporter preflights.MetricsReporter) error {
+	// both controller and worker nodes will have 'worker' in the join command
+	isWorker := !strings.Contains(jcmd.K0sJoinCommand, "controller")
+	if !isWorker {
+		logrus.Warnf("Do not join another node until this join is complete.")
+	}
+
 	if err := runJoinVerifyAndPrompt(name, flags, jcmd); err != nil {
 		return err
 	}
@@ -172,11 +178,11 @@ func runJoin(ctx context.Context, name string, flags JoinCmdFlags, jcmd *kotsadm
 	}
 
 	logrus.Debugf("installing and joining cluster")
-	if err := installAndJoinCluster(ctx, jcmd, name, flags); err != nil {
+	if err := installAndJoinCluster(ctx, jcmd, name, flags, isWorker); err != nil {
 		return err
 	}
 
-	if !strings.Contains(jcmd.K0sJoinCommand, "controller") {
+	if isWorker {
 		logrus.Debugf("worker node join finished")
 		return nil
 	}
@@ -296,7 +302,7 @@ func getJoinCIDRConfig(jcmd *kotsadm.JoinCommandResponse) (*CIDRConfig, error) {
 	}, nil
 }
 
-func installAndJoinCluster(ctx context.Context, jcmd *kotsadm.JoinCommandResponse, name string, flags JoinCmdFlags) error {
+func installAndJoinCluster(ctx context.Context, jcmd *kotsadm.JoinCommandResponse, name string, flags JoinCmdFlags, isWorker bool) error {
 	logrus.Debugf("saving token to disk")
 	if err := saveTokenToDisk(jcmd.K0sToken); err != nil {
 		return fmt.Errorf("unable to save token to disk: %w", err)
@@ -314,8 +320,6 @@ func installAndJoinCluster(ctx context.Context, jcmd *kotsadm.JoinCommandRespons
 	}
 
 	logrus.Debugf("creating systemd unit files")
-	// both controller and worker nodes will have 'worker' in the join command
-	isWorker := !strings.Contains(jcmd.K0sJoinCommand, "controller")
 	if err := createSystemdUnitFiles(ctx, isWorker, jcmd.InstallationSpec.Proxy); err != nil {
 		return fmt.Errorf("unable to create systemd unit files: %w", err)
 	}

--- a/cmd/installer/cli/reset.go
+++ b/cmd/installer/cli/reset.go
@@ -70,8 +70,8 @@ func ResetCmd(ctx context.Context, name string) *cobra.Command {
 				return err
 			}
 
-			logrus.Info("This will remove this node from the cluster and completely reset it, removing all data stored on the node.")
-			logrus.Info("This node will also reboot. Do not reset another node until this is complete.")
+			logrus.Warn("This will remove this node from the cluster and completely reset it, removing all data stored on the node.")
+			logrus.Warn("This node will also reboot. Do not reset another node until this is complete.")
 			if !force && !assumeYes && !prompts.New().Confirm("Do you want to continue?", false) {
 				return fmt.Errorf("Aborting")
 			}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Warn that you shouldn't join another node when a controller is being joined.

Also update other warns to use `logrus.Warn`.

<img width="1025" alt="Screenshot 2025-03-24 at 2 44 41 PM" src="https://github.com/user-attachments/assets/2c5e741a-aa8e-4848-a53b-7a0c258ac00b" />

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/106755/warn-that-you-should-only-join-one-node-at-a-time

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
When joining a controller node, warn that the user shouldn't join another node until the controller joins successfully.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
https://github.com/replicatedhq/replicated-docs/pull/3126