### PR TITLE
add jobs to scan released images

### DIFF
--- a/.github/workflows/daily-container-scans.yml
+++ b/.github/workflows/daily-container-scans.yml
@@ -1,0 +1,78 @@
+# Container Security Scans
+# This workflow orchestrates security scanning of container images using Anchore scanner.
+# It runs nightly and can be triggered manually to scan various container images for vulnerabilities.
+name: Container Security Scans
+
+# Trigger configuration
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Runs nightly at midnight (UTC)
+  workflow_dispatch:      # Allows manual triggering through GitHub UI
+
+# Security hardening: Start with no permissions and grant only what's needed
+permissions: {}  # Remove all permissions by default
+
+# Prevent multiple workflow runs from interfering with each other
+# This ensures only one scan runs at a time and new triggers cancel old runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Get the latest release tag first
+  get-latest-tag:
+    name: Get Latest Release Tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read    # Needed to read releases
+    outputs:
+      tag_name: ${{ steps.get_release.outputs.tag_name }}
+    steps:
+      - name: Get latest release
+        id: get_release
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const release = await github.rest.repos.getLatestRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+            core.setOutput('tag_name', release.data.tag_name);
+  
+  # Scan operator image using latest release tag
+  scan-operator:
+    name: Scan Operator Image
+    needs: get-latest-tag  # Wait for tag to be fetched
+    uses: ./.github/workflows/scan-container-image.yml
+    # Grant required permissions to the reusable workflow
+    permissions:
+      contents: read        # Needed to read workflow files
+      security-events: write # Needed to upload SARIF results
+    with:
+      # Use the latest release tag from the previous job
+      image: replicated/embedded-cluster-operator-image:${{ needs.get-latest-tag.outputs.tag_name }}
+      # Report findings of medium severity or higher
+      severity-cutoff: medium
+      # Continue even if vulnerabilities are found
+      fail-build: false
+      # Specify platform to scan
+      platform: linux/amd64
+
+  # Scan local artifact mirror image using latest release tag
+  scan-registry:
+    name: Scan Registry Image
+    needs: get-latest-tag  # Wait for tag to be fetched
+    uses: ./.github/workflows/scan-container-image.yml
+    # Grant required permissions to the reusable workflow
+    permissions:
+      contents: read        # Needed to read workflow files
+      security-events: write # Needed to upload SARIF results
+    with:
+      # Use the latest release tag from the previous job
+      image: replicated/ec-registry:${{ needs.get-latest-tag.outputs.tag_name }}
+      # Report findings of medium severity or higher
+      severity-cutoff: medium
+      # Continue even if vulnerabilities are found
+      fail-build: false
+      # Specify platform to scan
+      platform: linux/amd64 

--- a/.github/workflows/daily-container-scans.yml
+++ b/.github/workflows/daily-container-scans.yml
@@ -58,9 +58,9 @@ jobs:
       # Specify platform to scan
       platform: linux/amd64
 
-  # Scan registry image using latest release tag
+  # Scan local artifact mirror image using latest release tag
   scan-registry:
-    name: Scan Registry Image
+    name: Scan Local Artifact Mirror Image
     needs: get-latest-tag  # Wait for tag to be fetched
     uses: ./.github/workflows/scan-container-image.yml
     # Grant required permissions to the reusable workflow
@@ -69,7 +69,7 @@ jobs:
       security-events: write # Needed to upload SARIF results
     with:
       # Use the latest release tag from the previous job
-      image: replicated/ec-registry:${{ needs.get-latest-tag.outputs.tag_name }}
+      image: replicated/embedded-cluster-local-artifact-mirror:${{ needs.get-latest-tag.outputs.tag_name }}
       # Report findings of medium severity or higher
       severity-cutoff: medium
       # Continue even if vulnerabilities are found

--- a/.github/workflows/daily-container-scans.yml
+++ b/.github/workflows/daily-container-scans.yml
@@ -58,7 +58,7 @@ jobs:
       # Specify platform to scan
       platform: linux/amd64
 
-  # Scan local artifact mirror image using latest release tag
+  # Scan registry image using latest release tag
   scan-registry:
     name: Scan Registry Image
     needs: get-latest-tag  # Wait for tag to be fetched

--- a/.github/workflows/scan-container-image.yml
+++ b/.github/workflows/scan-container-image.yml
@@ -1,0 +1,113 @@
+# This is a reusable workflow for scanning container images using Anchore's vulnerability scanner.
+# It can be called from other workflows to scan any container image and report findings to GitHub Security tab.
+name: Scan Container Image
+
+# Define this as a reusable workflow that other workflows can call
+on:
+  workflow_call:
+    # Define the inputs that callers must/can provide
+    inputs:
+      image:
+        required: true
+        type: string
+        description: 'Container image to scan (format: image:tag)'
+      severity-cutoff:
+        required: false
+        type: string
+        default: 'medium'
+        description: 'Minimum severity to report (critical, high, medium, low, negligible)'
+      fail-build:
+        required: false
+        type: boolean
+        default: false
+        description: 'Fail the workflow if vulnerabilities are found'
+      platform:
+        required: false
+        type: string
+        default: 'linux/amd64'
+        description: 'Platform to scan (e.g., linux/amd64, linux/arm64)'
+
+permissions: {}  # Remove all permissions by default
+
+jobs:
+  scan:
+    name: Scan Image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30  # Default timeout for the job
+    # Permissions required for security scanning and reporting
+    permissions:
+      security-events: write  # Needed to upload SARIF results
+      contents: read         # Needed to read workflow files
+    
+    steps:
+      # Extract and normalize image details for use in later steps
+      # Handles cases where tag might be missing (defaults to 'latest')
+      # Creates a safe name for use in filenames and categories
+      - name: Extract image details
+        id: image_details
+        run: |
+          IMAGE_NAME=$(echo "${{ inputs.image }}" | cut -d':' -f1)
+          IMAGE_TAG=$(echo "${{ inputs.image }}" | cut -d':' -f2)
+          [[ "$IMAGE_TAG" == "$IMAGE_NAME" ]] && IMAGE_TAG="latest"
+          SAFE_NAME=$(echo "${IMAGE_NAME}-${IMAGE_TAG}" | sed 's/[\/:]/-/g')
+          echo "image_name=${IMAGE_NAME}" >> $GITHUB_OUTPUT
+          echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "safe_name=${SAFE_NAME}" >> $GITHUB_OUTPUT
+      
+      # Run Anchore vulnerability scanner on the specified image
+      # Outputs findings in SARIF format for GitHub security dashboard
+      - name: Scan image with Anchore
+        uses: anchore/scan-action@v3
+        id: scan
+        with:
+          image: "${{ inputs.image }}"
+          fail-build: ${{ inputs.fail-build }}
+          severity-cutoff: ${{ inputs.severity-cutoff }}
+          output-format: sarif
+          platform: ${{ inputs.platform }}
+      
+      # Enrich the SARIF output with additional metadata about the scanned image
+      # This helps with tracking and identifying scan results in GitHub Security tab
+      - name: Enrich SARIF with image metadata
+        run: |
+          # Install jq for JSON processing
+          sudo apt-get update && sudo apt-get install -y jq
+          
+          # Add metadata to SARIF using jq
+          # This includes image details, scan time, and repository information
+          jq --arg imageRef "${{ inputs.image }}" \
+             --arg repo "${{ steps.image_details.outputs.image_name }}" \
+             --arg name "${{ steps.image_details.outputs.image_name }}" \
+             --arg tag "${{ steps.image_details.outputs.image_tag }}" \
+             --arg scanTime "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+             --arg platform "${{ inputs.platform }}" \
+             '.runs[0].properties = {
+                "imageRef": $imageRef,
+                "repository": $repo,
+                "scanTime": $scanTime,
+                "platform": $platform,
+                "imageMetadata": {
+                  "name": $name,
+                  "tag": $tag
+                }
+              }' results.sarif > enriched-results.sarif
+          
+          mv enriched-results.sarif results.sarif
+      
+      # Upload the SARIF results to GitHub Security tab
+      # Note: This uploads to the repository where the workflow runs, not the image source
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+          # Create a unique category for each image to separate findings
+          category: "container-scan-${{ steps.image_details.outputs.safe_name }}"
+      
+      # Archive the SARIF results as an artifact for later reference
+      # Useful for debugging or historical analysis
+      - name: Archive scan results
+        uses: actions/upload-artifact@v4
+        with:
+          name: "sarif-${{ steps.image_details.outputs.safe_name }}"
+          path: results.sarif
+          retention-days: 365 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

- Adds new image scanning process
- Scan the actual public image on dockerhub
- Use Grype as the scanner
- Use Sarif format as attachment to the repo so it gets added to the code scan results
- Enrich the Sarif with properties we use for reporting purposes
- To determine the image tag we use the release version from this repo
- We scan the public image to ensure we are scanning what people are using. If we were to build the image and scan, we would actually be scanning a new image instead of the current release.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
None

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
None
#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
No