### PR TITLE
Support custom domains for ECO's goldpinger support bundle spec

### DIFF
--- a/cmd/buildtools/embeddedclusteroperator.go
+++ b/cmd/buildtools/embeddedclusteroperator.go
@@ -21,6 +21,10 @@ var operatorImageComponents = map[string]addonComponent{
 	"docker.io/library/busybox": {
 		name: "utils",
 	},
+	"docker.io/bloomberg/goldpinger": {
+		name:             "goldpinger",
+		useUpstreamImage: true,
+	},
 }
 
 var updateOperatorAddonCommand = &cli.Command{
@@ -130,9 +134,9 @@ func updateOperatorAddonImages(ctx context.Context, hcli helm.Client, chartURL s
 		return fmt.Errorf("failed to get images from embedded cluster operator chart: %w", err)
 	}
 
-	// make sure we include the operator util image as it does not show up when rendering the helm
-	// chart.
+	// make sure we include the operator util and goldpinger images as they don't show up when rendering the helm chart.
 	images = append(images, "docker.io/library/busybox:latest")
+	images = append(images, "docker.io/bloomberg/goldpinger:latest")
 
 	metaImages, err := UpdateImages(ctx, operatorImageComponents, embeddedclusteroperator.Metadata.Images, images)
 	if err != nil {

--- a/operator/charts/embedded-cluster-operator/templates/embedded-cluster-troubleshoot-goldpinger.yaml
+++ b/operator/charts/embedded-cluster-operator/templates/embedded-cluster-troubleshoot-goldpinger.yaml
@@ -19,9 +19,9 @@ data:
       collectors:
       - goldpinger:
           namespace: goldpinger
-          image: proxy.replicated.com/anonymous/bloomberg/goldpinger@sha256:70416f19f1cbeedd344d37b08e64114779976b99905e0d018e71c437cde750dc
+          image: {{ .Values.goldpingerImage }}
           podLaunchOptions:
-            image: proxy.replicated.com/anonymous/library/busybox@sha256:768e5c6f5cb6db0794eec98dc7a967f40631746c32232b78a3105fb946f3ab83
+            image: {{ .Values.utilsImage }}
           exclude: {{ .Values.isAirgap }}
       analyzers:
       - goldpinger:

--- a/operator/charts/embedded-cluster-operator/values.yaml.tmpl
+++ b/operator/charts/embedded-cluster-operator/values.yaml.tmpl
@@ -13,6 +13,7 @@ image:
   pullPolicy: IfNotPresent
 
 utilsImage: busybox:latest
+goldpingerImage: bloomberg/goldpinger:latest
 
 extraEnv: []
 #  - name: HTTP_PROXY

--- a/pkg/addons/embeddedclusteroperator/static/metadata.yaml
+++ b/pkg/addons/embeddedclusteroperator/static/metadata.yaml
@@ -13,6 +13,11 @@ images:
         tag:
             amd64: v1.19.0-k8s-1.30
             arm64: v1.19.0-k8s-1.30
+    goldpinger:
+        repo: proxy.replicated.com/anonymous/bloomberg/goldpinger
+        tag:
+            amd64: latest
+            arm64: latest
     utils:
         repo: proxy.replicated.com/anonymous/replicated/ec-utils
         tag:

--- a/pkg/addons/embeddedclusteroperator/static/values.tpl.yaml
+++ b/pkg/addons/embeddedclusteroperator/static/values.tpl.yaml
@@ -7,4 +7,5 @@ image:
   repository: '{{ (index .Images "embedded-cluster-operator").Repo }}'
   tag: '{{ index (index .Images "embedded-cluster-operator").Tag .GOARCH }}'
 utilsImage: '{{ ImageString (index .Images "utils") }}'
+goldpingerImage: '{{ ImageString (index .Images "goldpinger") }}'
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Gets ECO's busybox and goldpinger images from Helm values so that custom domains get propagated to them.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE