### PR TITLE
Use IfNotPresent image pull policy so it works for airgap

### DIFF
--- a/operator/charts/embedded-cluster-operator/templates/embedded-cluster-lam-service-config.yaml
+++ b/operator/charts/embedded-cluster-operator/templates/embedded-cluster-lam-service-config.yaml
@@ -23,7 +23,7 @@ data:
             podSpec:
               containers:
               - image: {{ .Values.utilsImage }}
-                imagePullPolicy: Always
+                imagePullPolicy: IfNotPresent
                 args: ["chroot","/host","cat","/etc/systemd/system/local-artifact-mirror.service.d/embedded-cluster.conf"]
                 name: debugger
                 resources: {}

--- a/operator/charts/embedded-cluster-operator/templates/embedded-cluster-logs-collector.yaml
+++ b/operator/charts/embedded-cluster-operator/templates/embedded-cluster-logs-collector.yaml
@@ -23,7 +23,7 @@ data:
             podSpec:
               containers:
               - image: {{ .Values.utilsImage }}
-                imagePullPolicy: Always
+                imagePullPolicy: IfNotPresent
                 args: ["chroot","/host","journalctl","-u","k0scontroller","--no-pager","--since","2 days ago"]
                 name: debugger
                 resources: {}
@@ -52,7 +52,7 @@ data:
             podSpec:
               containers:
               - image: {{ .Values.utilsImage }}
-                imagePullPolicy: Always
+                imagePullPolicy: IfNotPresent
                 args: ["chroot","/host","journalctl","-u","k0sworker","--no-pager","--since","2 days ago"]
                 name: debugger
                 resources: {}
@@ -81,7 +81,7 @@ data:
             podSpec:
               containers:
               - image: {{ .Values.utilsImage }}
-                imagePullPolicy: Always
+                imagePullPolicy: IfNotPresent
                 args: ["chroot","/host","journalctl","-u","local-artifact-mirror","--no-pager","--since","2 days ago"]
                 name: debugger
                 resources: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Uses IfNotPresent image pull policy for support bundle spec images so it works for airgap.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes image pull errors for certain support bundle collectors in airgapped mode.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE