### PR TITLE
feat: [sc-121571] respect env vars for http proxy, https proxy, and no proxy

### DIFF
--- a/cmd/installer/cli/proxy.go
+++ b/cmd/installer/cli/proxy.go
@@ -56,24 +56,30 @@ func getProxySpec(cmd *cobra.Command) (*ecv1beta1.ProxySpec, error) {
 	// If flags aren't set, look for environment variables (lowercase takes precedence)
 	if httpProxy == "" {
 		if envValue := os.Getenv("http_proxy"); envValue != "" {
+			logrus.Debug("got http_proxy from http_proxy env var")
 			httpProxy = envValue
 		} else if envValue := os.Getenv("HTTP_PROXY"); envValue != "" {
+			logrus.Debug("got http_proxy from HTTP_PROXY env var")
 			httpProxy = envValue
 		}
 	}
 
 	if httpsProxy == "" {
 		if envValue := os.Getenv("https_proxy"); envValue != "" {
+			logrus.Debug("got https_proxy from https_proxy env var")
 			httpsProxy = envValue
 		} else if envValue := os.Getenv("HTTPS_PROXY"); envValue != "" {
+			logrus.Debug("got https_proxy from HTTPS_PROXY env var")
 			httpsProxy = envValue
 		}
 	}
 
 	if noProxy == "" {
 		if envValue := os.Getenv("no_proxy"); envValue != "" {
+			logrus.Debug("got no_proxy from no_proxy env var")
 			noProxy = envValue
 		} else if envValue := os.Getenv("NO_PROXY"); envValue != "" {
+			logrus.Debug("got no_proxy from NO_PROXY env var")
 			noProxy = envValue
 		}
 	}

--- a/cmd/installer/cli/proxy_test.go
+++ b/cmd/installer/cli/proxy_test.go
@@ -16,109 +16,126 @@ func Test_getProxySpecFromFlags(t *testing.T) {
 		want *ecv1beta1.ProxySpec
 	}{
 		{
-			name: "no flags set should not set proxy",
+			name: "no flags set and no env vars should not set proxy",
 			init: func(t *testing.T, flagSet *pflag.FlagSet) {
-				t.Setenv("HTTP_PROXY", "http://proxy")
-				t.Setenv("HTTPS_PROXY", "https://proxy")
-				t.Setenv("NO_PROXY", "no-proxy-1,no-proxy-2")
+				// No env vars, no flags
 			},
 			want: nil,
 		},
 		{
-			name: "proxy from env flag set should set proxy",
+			name: "lowercase env vars should be used when no flags set",
 			init: func(t *testing.T, flagSet *pflag.FlagSet) {
-				t.Setenv("HTTP_PROXY", "http://proxy")
-				t.Setenv("HTTPS_PROXY", "https://proxy")
-				t.Setenv("NO_PROXY", "no-proxy-1,no-proxy-2")
-
-				flagSet.Set("proxy", "true")
+				t.Setenv("http_proxy", "http://lower-proxy")
+				t.Setenv("https_proxy", "https://lower-proxy")
+				t.Setenv("no_proxy", "lower-no-proxy-1,lower-no-proxy-2")
 			},
 			want: &ecv1beta1.ProxySpec{
-				HTTPProxy:       "http://proxy",
-				HTTPSProxy:      "https://proxy",
-				ProvidedNoProxy: "no-proxy-1,no-proxy-2",
-				NoProxy:         "localhost,127.0.0.1,.cluster.local,.svc,169.254.169.254,no-proxy-1,no-proxy-2,10.244.0.0/17,10.244.128.0/17",
+				HTTPProxy:       "http://lower-proxy",
+				HTTPSProxy:      "https://lower-proxy",
+				ProvidedNoProxy: "lower-no-proxy-1,lower-no-proxy-2",
+				NoProxy:         "localhost,127.0.0.1,.cluster.local,.svc,169.254.169.254,lower-no-proxy-1,lower-no-proxy-2,10.244.0.0/17,10.244.128.0/17",
 			},
 		},
 		{
-			name: "proxy from env flag set should not set proxy for lowercase env vars",
+			name: "uppercase env vars should be used when no flags set and no lowercase vars",
 			init: func(t *testing.T, flagSet *pflag.FlagSet) {
-				t.Setenv("http_proxy", "http://proxy")
-				t.Setenv("https_proxy", "https://proxy")
-				t.Setenv("no_proxy", "no-proxy-1,no-proxy-2")
-
-				flagSet.Set("proxy", "true")
-			},
-			want: nil,
-		},
-		{
-			name: "proxy flags set should set proxy",
-			init: func(t *testing.T, flagSet *pflag.FlagSet) {
-				t.Setenv("HTTP_PROXY", "http://proxy")
-				t.Setenv("HTTPS_PROXY", "https://proxy")
-				t.Setenv("NO_PROXY", "no-proxy-1,no-proxy-2")
-
-				flagSet.Set("http-proxy", "http://other-proxy")
-				flagSet.Set("https-proxy", "https://other-proxy")
-				flagSet.Set("no-proxy", "other-no-proxy-1,other-no-proxy-2")
+				t.Setenv("HTTP_PROXY", "http://upper-proxy")
+				t.Setenv("HTTPS_PROXY", "https://upper-proxy")
+				t.Setenv("NO_PROXY", "upper-no-proxy-1,upper-no-proxy-2")
 			},
 			want: &ecv1beta1.ProxySpec{
-				HTTPProxy:       "http://other-proxy",
-				HTTPSProxy:      "https://other-proxy",
-				ProvidedNoProxy: "other-no-proxy-1,other-no-proxy-2",
-				NoProxy:         "localhost,127.0.0.1,.cluster.local,.svc,169.254.169.254,other-no-proxy-1,other-no-proxy-2,10.244.0.0/17,10.244.128.0/17",
+				HTTPProxy:       "http://upper-proxy",
+				HTTPSProxy:      "https://upper-proxy",
+				ProvidedNoProxy: "upper-no-proxy-1,upper-no-proxy-2",
+				NoProxy:         "localhost,127.0.0.1,.cluster.local,.svc,169.254.169.254,upper-no-proxy-1,upper-no-proxy-2,10.244.0.0/17,10.244.128.0/17",
 			},
 		},
 		{
-			name: "proxy flags should override proxy from env, but merge no-proxy",
+			name: "lowercase should take precedence over uppercase",
 			init: func(t *testing.T, flagSet *pflag.FlagSet) {
-				t.Setenv("HTTP_PROXY", "http://proxy")
-				t.Setenv("HTTPS_PROXY", "https://proxy")
-				t.Setenv("NO_PROXY", "no-proxy-1,no-proxy-2")
-
-				flagSet.Set("proxy", "true")
-				flagSet.Set("http-proxy", "http://other-proxy")
-				flagSet.Set("https-proxy", "https://other-proxy")
-				flagSet.Set("no-proxy", "other-no-proxy-1,other-no-proxy-2")
+				t.Setenv("http_proxy", "http://lower-proxy")
+				t.Setenv("https_proxy", "https://lower-proxy")
+				t.Setenv("no_proxy", "lower-no-proxy-1,lower-no-proxy-2")
+				t.Setenv("HTTP_PROXY", "http://upper-proxy")
+				t.Setenv("HTTPS_PROXY", "https://upper-proxy")
+				t.Setenv("NO_PROXY", "upper-no-proxy-1,upper-no-proxy-2")
 			},
 			want: &ecv1beta1.ProxySpec{
-				HTTPProxy:       "http://other-proxy",
-				HTTPSProxy:      "https://other-proxy",
-				ProvidedNoProxy: "no-proxy-1,no-proxy-2,other-no-proxy-1,other-no-proxy-2",
-				NoProxy:         "localhost,127.0.0.1,.cluster.local,.svc,169.254.169.254,no-proxy-1,no-proxy-2,other-no-proxy-1,other-no-proxy-2,10.244.0.0/17,10.244.128.0/17",
+				HTTPProxy:       "http://lower-proxy",
+				HTTPSProxy:      "https://lower-proxy",
+				ProvidedNoProxy: "lower-no-proxy-1,lower-no-proxy-2",
+				NoProxy:         "localhost,127.0.0.1,.cluster.local,.svc,169.254.169.254,lower-no-proxy-1,lower-no-proxy-2,10.244.0.0/17,10.244.128.0/17",
+			},
+		},
+		{
+			name: "proxy flags should override env vars",
+			init: func(t *testing.T, flagSet *pflag.FlagSet) {
+				t.Setenv("http_proxy", "http://lower-proxy")
+				t.Setenv("https_proxy", "https://lower-proxy")
+				t.Setenv("no_proxy", "lower-no-proxy-1,lower-no-proxy-2")
+				t.Setenv("HTTP_PROXY", "http://upper-proxy")
+				t.Setenv("HTTPS_PROXY", "https://upper-proxy")
+				t.Setenv("NO_PROXY", "upper-no-proxy-1,upper-no-proxy-2")
+
+				flagSet.Set("http-proxy", "http://flag-proxy")
+				flagSet.Set("https-proxy", "https://flag-proxy")
+				flagSet.Set("no-proxy", "flag-no-proxy-1,flag-no-proxy-2")
+			},
+			want: &ecv1beta1.ProxySpec{
+				HTTPProxy:       "http://flag-proxy",
+				HTTPSProxy:      "https://flag-proxy",
+				ProvidedNoProxy: "flag-no-proxy-1,flag-no-proxy-2",
+				NoProxy:         "localhost,127.0.0.1,.cluster.local,.svc,169.254.169.254,flag-no-proxy-1,flag-no-proxy-2,10.244.0.0/17,10.244.128.0/17",
 			},
 		},
 		{
 			name: "pod and service CIDR should override default no proxy",
 			init: func(t *testing.T, flagSet *pflag.FlagSet) {
-				flagSet.Set("http-proxy", "http://other-proxy")
-				flagSet.Set("https-proxy", "https://other-proxy")
-				flagSet.Set("no-proxy", "other-no-proxy-1,other-no-proxy-2")
+				flagSet.Set("http-proxy", "http://flag-proxy")
+				flagSet.Set("https-proxy", "https://flag-proxy")
+				flagSet.Set("no-proxy", "flag-no-proxy-1,flag-no-proxy-2")
 
 				flagSet.Set("pod-cidr", "1.1.1.1/24")
 				flagSet.Set("service-cidr", "2.2.2.2/24")
 			},
 			want: &ecv1beta1.ProxySpec{
-				HTTPProxy:       "http://other-proxy",
-				HTTPSProxy:      "https://other-proxy",
-				ProvidedNoProxy: "other-no-proxy-1,other-no-proxy-2",
-				NoProxy:         "localhost,127.0.0.1,.cluster.local,.svc,169.254.169.254,other-no-proxy-1,other-no-proxy-2,1.1.1.1/24,2.2.2.2/24",
+				HTTPProxy:       "http://flag-proxy",
+				HTTPSProxy:      "https://flag-proxy",
+				ProvidedNoProxy: "flag-no-proxy-1,flag-no-proxy-2",
+				NoProxy:         "localhost,127.0.0.1,.cluster.local,.svc,169.254.169.254,flag-no-proxy-1,flag-no-proxy-2,1.1.1.1/24,2.2.2.2/24",
 			},
 		},
 		{
 			name: "custom --cidr should be present in the no-proxy",
 			init: func(t *testing.T, flagSet *pflag.FlagSet) {
-				flagSet.Set("http-proxy", "http://other-proxy")
-				flagSet.Set("https-proxy", "https://other-proxy")
-				flagSet.Set("no-proxy", "other-no-proxy-1,other-no-proxy-2")
+				flagSet.Set("http-proxy", "http://flag-proxy")
+				flagSet.Set("https-proxy", "https://flag-proxy")
+				flagSet.Set("no-proxy", "flag-no-proxy-1,flag-no-proxy-2")
 
 				flagSet.Set("cidr", "10.0.0.0/16")
 			},
 			want: &ecv1beta1.ProxySpec{
-				HTTPProxy:       "http://other-proxy",
-				HTTPSProxy:      "https://other-proxy",
-				ProvidedNoProxy: "other-no-proxy-1,other-no-proxy-2",
-				NoProxy:         "localhost,127.0.0.1,.cluster.local,.svc,169.254.169.254,other-no-proxy-1,other-no-proxy-2,10.0.0.0/17,10.0.128.0/17",
+				HTTPProxy:       "http://flag-proxy",
+				HTTPSProxy:      "https://flag-proxy",
+				ProvidedNoProxy: "flag-no-proxy-1,flag-no-proxy-2",
+				NoProxy:         "localhost,127.0.0.1,.cluster.local,.svc,169.254.169.254,flag-no-proxy-1,flag-no-proxy-2,10.0.0.0/17,10.0.128.0/17",
+			},
+		},
+		{
+			name: "partial env vars with partial flag vars",
+			init: func(t *testing.T, flagSet *pflag.FlagSet) {
+				t.Setenv("http_proxy", "http://lower-proxy")
+				// No https_proxy set
+				t.Setenv("no_proxy", "lower-no-proxy-1,lower-no-proxy-2")
+
+				// Only set https-proxy flag
+				flagSet.Set("https-proxy", "https://flag-proxy")
+			},
+			want: &ecv1beta1.ProxySpec{
+				HTTPProxy:       "http://lower-proxy",
+				HTTPSProxy:      "https://flag-proxy",
+				ProvidedNoProxy: "lower-no-proxy-1,lower-no-proxy-2",
+				NoProxy:         "localhost,127.0.0.1,.cluster.local,.svc,169.254.169.254,lower-no-proxy-1,lower-no-proxy-2,10.244.0.0/17,10.244.128.0/17",
 			},
 		},
 	}
@@ -133,7 +150,7 @@ func Test_getProxySpecFromFlags(t *testing.T) {
 				tt.init(t, flagSet)
 			}
 
-			got, err := getProxySpecFromFlags(cmd)
+			got, err := getProxySpec(cmd)
 			assert.NoError(t, err, "unexpected error received")
 			assert.Equal(t, tt.want, got)
 		})

--- a/e2e/restore_test.go
+++ b/e2e/restore_test.go
@@ -421,7 +421,7 @@ func TestSingleNodeAirgapDisasterRecovery(t *testing.T) {
 		t.Fatalf("fail to prepare airgap files on node %s: %v", tc.Nodes[0], err)
 	}
 	t.Logf("%s: installing embedded-cluster on node 0", time.Now().Format(time.RFC3339))
-	line = []string{"single-node-airgap-install.sh", os.Getenv("SHORT_SHA"), "--proxy"}
+	line = []string{"single-node-airgap-install.sh", os.Getenv("SHORT_SHA")}
 	line = append(line, "--pod-cidr", "10.128.0.0/20")
 	line = append(line, "--service-cidr", "10.129.0.0/20")
 	if _, _, err := tc.RunCommandOnNode(0, line, lxd.WithProxyEnv(tc.IPs)); err != nil {
@@ -714,7 +714,7 @@ func TestMultiNodeAirgapHADisasterRecovery(t *testing.T) {
 	}
 
 	t.Logf("%s: installing embedded-cluster on node 0", time.Now().Format(time.RFC3339))
-	line = []string{"single-node-airgap-install.sh", os.Getenv("SHORT_SHA"), "--proxy", "--data-dir", "/var/lib/ec"}
+	line = []string{"single-node-airgap-install.sh", os.Getenv("SHORT_SHA"), "--data-dir", "/var/lib/ec"}
 	if _, _, err := tc.RunCommandOnNode(0, line, withEnv, lxd.WithProxyEnv(tc.IPs)); err != nil {
 		t.Fatalf("fail to install embedded-cluster on node %s: %v", tc.Nodes[0], err)
 	}

--- a/e2e/scripts/restore-installation-airgap.exp
+++ b/e2e/scripts/restore-installation-airgap.exp
@@ -20,7 +20,7 @@ if {$num_args > 6} {
   set additional_args [lrange $argv 6 end]
 }
 
-set cmd [concat embedded-cluster restore --airgap-bundle /assets/release.airgap --proxy $additional_args]
+set cmd [concat embedded-cluster restore --airgap-bundle /assets/release.airgap $additional_args]
 eval spawn $cmd
 
 expect {

--- a/e2e/scripts/restore-multi-node-airgap-phase1.exp
+++ b/e2e/scripts/restore-multi-node-airgap-phase1.exp
@@ -9,7 +9,7 @@ set dr_aws_s3_prefix [lindex $argv 3]
 set dr_aws_access_key_id [lindex $argv 4]
 set dr_aws_secret_access_key [lindex $argv 5]
 
-spawn embedded-cluster restore --airgap-bundle /assets/release.airgap --proxy --local-artifact-mirror-port 50001 --data-dir /var/lib/ec
+spawn embedded-cluster restore --airgap-bundle /assets/release.airgap --local-artifact-mirror-port 50001 --data-dir /var/lib/ec
 
 expect {
     "Enter information to configure access to your backup storage location." {}

--- a/e2e/scripts/restore-multi-node-airgap-phase2.exp
+++ b/e2e/scripts/restore-multi-node-airgap-phase2.exp
@@ -2,7 +2,7 @@
 
 source /usr/local/bin/env.exp
 
-spawn embedded-cluster restore --airgap-bundle /assets/release.airgap --proxy --local-artifact-mirror-port 50001 --data-dir /var/lib/ec
+spawn embedded-cluster restore --airgap-bundle /assets/release.airgap --local-artifact-mirror-port 50001 --data-dir /var/lib/ec
 
 expect {
     "A previous restore operation was detected. Would you like to resume?" {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Tools like `curl` use proxy env vars, but EC doesn't. This has led to confusion when a curl command worked but EC didn't.

<img width="1355" alt="Screenshot 2025-04-08 at 11 21 05 AM" src="https://github.com/user-attachments/assets/b6df0ce0-59fa-4275-8a89-c935b3c1ecc1" />

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/121571/respect-env-vars-for-http-proxy-https-proxy-and-no-proxy

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Updated current tests

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Proxy information can be set with the `http_proxy`, `https_proxy`, and `no_proxy` environment variables. The corresponding CLI flags (e.g., `--http-proxy`) take precedence. Environment variables can be lowercase (`http_proxy`) or uppercase (`HTTP_PROXY`), but lowercase takes precedence.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
Yes, tbd