### PR TITLE
add -y alias for --yes

### DIFF
--- a/cmd/installer/cli/join.go
+++ b/cmd/installer/cli/join.go
@@ -122,7 +122,7 @@ func addJoinFlags(cmd *cobra.Command, flags *JoinCmdFlags) error {
 		return err
 	}
 
-	cmd.Flags().BoolVar(&flags.assumeYes, "yes", false, "Assume yes to all prompts.")
+	cmd.Flags().BoolVarP(&flags.assumeYes, "yes", "y", false, "Assume yes to all prompts.")
 	cmd.Flags().SetNormalizeFunc(normalizeNoPromptToYes)
 
 	return nil

--- a/cmd/installer/cli/reset.go
+++ b/cmd/installer/cli/reset.go
@@ -217,7 +217,7 @@ func ResetCmd(ctx context.Context, name string) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&force, "force", false, "Ignore errors encountered when resetting the node (implies ---yes)")
-	cmd.Flags().BoolVar(&assumeYes, "yes", false, "Assume yes to all prompts.")
+	cmd.Flags().BoolVarP(&assumeYes, "yes", "y", false, "Assume yes to all prompts.")
 	cmd.Flags().SetNormalizeFunc(normalizeNoPromptToYes)
 
 	cmd.AddCommand(ResetFirewalldCmd(ctx, name))


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
install already has this

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds `-y` as an alias for `--yes` in the `join` and `restore` commands.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
