### PR TITLE
show controller role name in prompts

### DIFF
--- a/cmd/installer/cli/join.go
+++ b/cmd/installer/cli/join.go
@@ -508,12 +508,22 @@ func maybeEnableHA(ctx context.Context, kcli client.Client, flags JoinCmdFlags, 
 	if !canEnableHA {
 		return nil
 	}
-
 	if !flags.assumeYes {
-		logrus.Info("")
-		logrus.Info("You can enable high availability when adding a third controller node or more. This will migrate data so that it is replicated across cluster nodes. Once enabled, you must maintain at least three controller nodes.")
-		logrus.Info("")
-		shouldEnableHA := prompts.New().Confirm("Do you want to enable high availability?", true)
+		if config.HasCustomRoles() {
+			controllerRoleName := config.GetControllerRoleName()
+			logrus.Info("")
+			logrus.Infof("You can enable high availability for clusters with three or more %s nodes.", controllerRoleName)
+			logrus.Infof("Data will be migrated so it is replicated across cluster nodes.")
+			logrus.Infof("When high availability is enabled, you must maintain at least three %s nodes.", controllerRoleName)
+			logrus.Info("")
+		} else {
+			logrus.Info("")
+			logrus.Info("You can enable high availability for clusters with three or more nodes.")
+			logrus.Info("Data will be migrated so it is replicated across cluster nodes.")
+			logrus.Info("When high availability is enabled, you must maintain at least three nodes.")
+			logrus.Info("")
+		}
+		shouldEnableHA := prompts.New().Confirm("Do you want to enable high availability?", false)
 		if !shouldEnableHA {
 			return nil
 		}

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -1801,7 +1801,7 @@ func TestMultiNodeHAInstallation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("fail to remove controller node 0: %v: %s: %s", err, stdout, stderr)
 	}
-	if !strings.Contains(stdout, "High-availability clusters must maintain at least three controller nodes") {
+	if !strings.Contains(stdout, "You must maintain at least three %s nodes in a high-availability cluster") {
 		t.Errorf("reset output does not contain the ha warning")
 		t.Logf("stdout: %s\nstderr: %s", stdout, stderr)
 	}
@@ -1951,7 +1951,7 @@ func TestMultiNodeAirgapHAInstallation(t *testing.T) {
 		t.Logf("stdout: %s\nstderr: %s", stdout, stderr)
 		t.Fatalf("fail to remove controller node 0 %s:", err)
 	}
-	if !strings.Contains(stdout, "High-availability clusters must maintain at least three controller nodes") {
+	if !strings.Contains(stdout, "You must maintain at least three %s nodes in a high-availability cluster") {
 		t.Errorf("reset output does not contain the ha warning")
 		t.Logf("stdout: %s\nstderr: %s", stdout, stderr)
 	}

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -1801,7 +1801,7 @@ func TestMultiNodeHAInstallation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("fail to remove controller node 0: %v: %s: %s", err, stdout, stderr)
 	}
-	if !strings.Contains(stdout, "You must maintain at least three %s nodes in a high-availability cluster") {
+	if !strings.Contains(stdout, "You must maintain at least three controller-test nodes in a high-availability cluster") {
 		t.Errorf("reset output does not contain the ha warning")
 		t.Logf("stdout: %s\nstderr: %s", stdout, stderr)
 	}
@@ -1951,7 +1951,7 @@ func TestMultiNodeAirgapHAInstallation(t *testing.T) {
 		t.Logf("stdout: %s\nstderr: %s", stdout, stderr)
 		t.Fatalf("fail to remove controller node 0 %s:", err)
 	}
-	if !strings.Contains(stdout, "You must maintain at least three %s nodes in a high-availability cluster") {
+	if !strings.Contains(stdout, "You must maintain at least three controller-test nodes in a high-availability cluster") {
 		t.Errorf("reset output does not contain the ha warning")
 		t.Logf("stdout: %s\nstderr: %s", stdout, stderr)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -139,6 +139,22 @@ func ProfileInstallFlag() (string, error) {
 	return "--profile=" + controllerProfile, nil
 }
 
+func GetControllerRoleName() string {
+	clusterConfig := release.GetEmbeddedClusterConfig()
+	controllerRoleName := "controller"
+	if clusterConfig != nil {
+		if clusterConfig.Spec.Roles.Controller.Name != "" {
+			controllerRoleName = clusterConfig.Spec.Roles.Controller.Name
+		}
+	}
+	return controllerRoleName
+}
+
+func HasCustomRoles() bool {
+	clusterConfig := release.GetEmbeddedClusterConfig()
+	return clusterConfig != nil && clusterConfig.Spec.Roles.Custom != nil && len(clusterConfig.Spec.Roles.Custom) > 0
+}
+
 // nodeLabels return a slice of string with labels (key=value format) for the node where we
 // are installing the k0s.
 func nodeLabels() []string {
@@ -151,20 +167,9 @@ func nodeLabels() []string {
 
 func controllerLabels() map[string]string {
 	lmap := additionalControllerLabels()
-	lmap["kots.io/embedded-cluster-role-0"] = getControllerRoleName()
+	lmap["kots.io/embedded-cluster-role-0"] = GetControllerRoleName()
 	lmap["kots.io/embedded-cluster-role"] = "total-1"
 	return lmap
-}
-
-func getControllerRoleName() string {
-	clusterConfig := release.GetEmbeddedClusterConfig()
-	controllerRoleName := "controller"
-	if clusterConfig != nil {
-		if clusterConfig.Spec.Roles.Controller.Name != "" {
-			controllerRoleName = clusterConfig.Spec.Roles.Controller.Name
-		}
-	}
-	return controllerRoleName
 }
 
 func additionalControllerLabels() map[string]string {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Today we say "controller node" when talking about HA clusters in the `join` and `reset` commands. Users won't know what a controller role is. This should either say the role name, if they're using roles, or just say "third node" if not.

`join` with node roles:

<img width="642" alt="Screenshot 2025-03-27 at 6 30 23 AM" src="https://github.com/user-attachments/assets/b0867d05-a5e4-4786-bc86-370203b9eb3f" />

`reset` with node roles:

<img width="941" alt="Screenshot 2025-03-27 at 6 31 04 AM" src="https://github.com/user-attachments/assets/dda22cc3-ace1-4eab-a1b0-a21e8d95c7aa" />

`join` without node roles:

<img width="539" alt="Screenshot 2025-03-27 at 9 03 26 AM" src="https://github.com/user-attachments/assets/a6a74f33-51bb-42cd-8721-bfa6af10eb5a" />

`reset` without node roles:

<img width="835" alt="Screenshot 2025-03-27 at 9 05 45 AM" src="https://github.com/user-attachments/assets/c87010ae-4f9b-4e2f-928f-78dc828668d0" />


#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/106752/better-ux-for-controller-role-name-when-prompting-about-ha

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Output from the `join` and `reset` commands no longer mentions "controller nodes," which is terminology users wouldn't be familiar with. The controller node role name is used if custom roles are defined in the Embedded Cluster Config.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE