### PR TITLE
ToLower() hostnames where it'll be used to address nodes

### DIFF
--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -983,7 +983,8 @@ func waitForNode(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("get hostname: %w", err)
 	}
-	if err := kubeutils.WaitForNode(ctx, kcli, hostname, false); err != nil {
+	nodename := strings.ToLower(hostname)
+	if err := kubeutils.WaitForNode(ctx, kcli, nodename, false); err != nil {
 		return fmt.Errorf("wait for node: %w", err)
 	}
 	return nil

--- a/cmd/installer/cli/join.go
+++ b/cmd/installer/cli/join.go
@@ -188,7 +188,8 @@ func runJoin(ctx context.Context, name string, flags JoinCmdFlags, jcmd *kotsadm
 	}
 
 	logrus.Debugf("waiting for node to join cluster")
-	if err := waitForNodeToJoin(ctx, kcli, hostname, isWorker); err != nil {
+	nodename := strings.ToLower(hostname)
+	if err := waitForNodeToJoin(ctx, kcli, nodename, isWorker); err != nil {
 		return fmt.Errorf("unable to wait for node: %w", err)
 	}
 

--- a/cmd/installer/cli/reset.go
+++ b/cmd/installer/cli/reset.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 	"time"
 
 	autopilot "github.com/k0sproject/k0s/pkg/apis/autopilot/v1beta2"
@@ -386,7 +387,7 @@ func (h *hostInfo) getHostName() error {
 	if err != nil {
 		return fmt.Errorf("unable to get hostname: %w", err)
 	}
-	h.Hostname = hostname
+	h.Hostname = strings.ToLower(hostname)
 	return nil
 }
 

--- a/e2e/cluster/lxd/cluster.go
+++ b/e2e/cluster/lxd/cluster.go
@@ -815,7 +815,7 @@ func CreateNode(in *ClusterInput, i int) (string, string) {
 	if err != nil {
 		in.T.Fatalf("Failed to connect to LXD: %v", err)
 	}
-	name := fmt.Sprintf("node-%s-%02d", in.id, i)
+	name := fmt.Sprintf("Node-%s-%02d", in.id, i)
 	profile := fmt.Sprintf("profile-%s", in.id)
 	net := fmt.Sprintf("internal-%s", in.id)
 	request := api.InstancesPost{

--- a/e2e/cluster/lxd/cluster.go
+++ b/e2e/cluster/lxd/cluster.go
@@ -379,7 +379,7 @@ func ConfigureProxy(in *ClusterInput) {
 	// http requests using the proxy. we also copy the squid ca to the nodes and make
 	// them trust it.
 	for i := 0; i < in.Nodes; i++ {
-		name := fmt.Sprintf("node-%s-%02d", in.id, i)
+		name := fmt.Sprintf("Node-%s-%02d", in.id, i)
 		RunCommand(in, []string{"mkdir", "-p", "/usr/local/share/ca-certificates/proxy"}, name)
 
 		CopyFileToNode(in, name, File{

--- a/e2e/cluster/lxd/cluster.go
+++ b/e2e/cluster/lxd/cluster.go
@@ -71,6 +71,7 @@ type ClusterInput struct {
 	id                                string
 	AdditionalFiles                   []File
 	SupportBundleNodeIndex            int
+	LowercaseNodeNames                bool
 }
 
 // File holds information about a file that must be uploaded to a node.
@@ -380,6 +381,9 @@ func ConfigureProxy(in *ClusterInput) {
 	// them trust it.
 	for i := 0; i < in.Nodes; i++ {
 		name := fmt.Sprintf("Node-%s-%02d", in.id, i)
+		if in.LowercaseNodeNames {
+			name = strings.ToLower(name)
+		}
 		RunCommand(in, []string{"mkdir", "-p", "/usr/local/share/ca-certificates/proxy"}, name)
 
 		CopyFileToNode(in, name, File{
@@ -816,6 +820,9 @@ func CreateNode(in *ClusterInput, i int) (string, string) {
 		in.T.Fatalf("Failed to connect to LXD: %v", err)
 	}
 	name := fmt.Sprintf("Node-%s-%02d", in.id, i)
+	if in.LowercaseNodeNames {
+		name = strings.ToLower(name)
+	}
 	profile := fmt.Sprintf("profile-%s", in.id)
 	net := fmt.Sprintf("internal-%s", in.id)
 	request := api.InstancesPost{

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -1081,6 +1081,7 @@ func TestAirgapUpgradeFromEC18(t *testing.T) {
 		AirgapInstallBundlePath:  airgapInstallBundlePath,
 		AirgapUpgradeBundlePath:  airgapUpgradeBundlePath,
 		AirgapUpgrade2BundlePath: airgapUpgrade2BundlePath,
+		LowercaseNodeNames:       true,
 	})
 	defer tc.Cleanup(withEnv)
 
@@ -1588,6 +1589,7 @@ func TestMultiNodeAirgapUpgradePreviousStable(t *testing.T) {
 		AirgapInstallBundlePath:  airgapInstallBundlePath,
 		AirgapUpgradeBundlePath:  airgapUpgradeBundlePath,
 		AirgapUpgrade2BundlePath: airgapUpgrade2BundlePath,
+		LowercaseNodeNames:       true,
 	})
 	defer tc.Cleanup()
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

If a host has a mixed case hostname, k0s will normalise the case to lowercase for the kubernetes node name, but we still check for the node by it's mixed-case name in several places. 

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Allow running clusters on nodes with hostnames that include uppercase letters.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
