### PR TITLE
chore: include the embedded cluster and k0s versions in the debug logs

### DIFF
--- a/cmd/installer/cli/logging.go
+++ b/cmd/installer/cli/logging.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
+	"github.com/replicatedhq/embedded-cluster/pkg/versions"
 	"github.com/sirupsen/logrus"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -117,6 +118,7 @@ func SetupLogging() {
 	logrus.SetOutput(logfile)
 	logrus.AddHook(&StdoutLogger{})
 	logrus.Debugf("command line: %v", os.Args)
+	logrus.Debugf("Embedded Cluster: %s, k0s: %s", versions.Version, versions.K0sVersion)
 
 	setupCtrlLogging(logfile)
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

I was reading the debug logs for an install and noticed we don't log the version. We should log the version.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Debug logs of the installation will now include the Embedded Cluster and k0s versions.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
