### PR TITLE
skip LXD cleanup in e2e tests within CI

### DIFF
--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -113,6 +113,7 @@ runs:
       export EXPECT_K0S_VERSION_PREVIOUS=${{ inputs.k0s-version-previous }}
       export EXPECT_K0S_VERSION_PREVIOUS_STABLE=${{ inputs.k0s-version-previous-stable }}
       export EXPECT_EMBEDDED_CLUSTER_UPGRADE_TARGET_VERSION=${{ inputs.upgrade-target-ec-version }}
+      export SKIP_LXD_CLEANUP=true
       make e2e-test TEST_NAME=${{ inputs.test-name }}
   - name: Troubleshoot
     if: ${{ !cancelled() }}

--- a/e2e/cluster/lxd/cluster.go
+++ b/e2e/cluster/lxd/cluster.go
@@ -100,6 +100,11 @@ type Cluster struct {
 
 // Destroy destroys a cluster pointed by the id property.
 func (c *Cluster) Destroy() {
+	if os.Getenv("SKIP_LXD_CLEANUP") != "" {
+		c.T.Logf("Skipping LXD cleanup")
+		return
+	}
+
 	c.T.Logf("Destroying cluster %s", c.id)
 	client, err := lxd.ConnectLXDUnix(lxdSocket, nil)
 	if err != nil {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

This should speed up the 'e2e' tests by ~5 minutes

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
