### PR TITLE
fix(adminconsole): loads old ui after upgrade

### DIFF
--- a/pkg/addons/adminconsole/static/metadata.yaml
+++ b/pkg/addons/adminconsole/static/metadata.yaml
@@ -5,7 +5,7 @@
 # $ make buildtools
 # $ output/bin/buildtools update addon <addon name>
 #
-version: 1.124.11
+version: 1.124.11-build.0
 location: oci://proxy.replicated.com/anonymous/registry.replicated.com/library/admin-console
 images:
     kotsadm:


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Updates from older versions are not showing the updated version as the current version in the ui. The ui in the e2e test screenshots after upgrade shows the old kots version.

What seems to happen is the reload happens before the new kotsadm deployment has rolled out

```
{"type":"resource-snapshot","snapshot":{"_frameref":"frame@5441e467a7cf5ac3316a41031f3638c2","_monotonicTime":321817.372,"startedDateTime":"2025-03-30T12:36:43.905Z","time":135.644,"request":{"method":"GET","url":"http://localhost:30003/main.685f6df444999cd96e8f.js",...
```

```
          {
            "type": "Progressing",
            "status": "True",
            "lastUpdateTime": "2025-03-30T12:36:57Z",
            "lastTransitionTime": "2025-03-30T12:27:01Z",
            "reason": "NewReplicaSetAvailable",
            "message": "ReplicaSet \"kotsadm-86c7b98874\" has successfully progressed."
          }
```

This updates kots helm chart to use strategy.type Recreate rather than RollingUpdate in an attempt to fix the issue.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where the UI continues to display the old Admin Console after an upgrade, which results in the previous version of the application showing as the currently deployed version.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
