### PR TITLE
feat: add control plane node affinity for upgrade job

### DIFF
--- a/operator/pkg/upgrade/job_test.go
+++ b/operator/pkg/upgrade/job_test.go
@@ -1,0 +1,85 @@
+package upgrade
+
+import (
+	"context"
+	"testing"
+
+	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"github.com/replicatedhq/embedded-cluster/kinds/types"
+	"github.com/replicatedhq/embedded-cluster/operator/pkg/release"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestCreateUpgradeJob_NodeAffinity(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, ecv1beta1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	// Version used for testing
+	testVersion := "1.2.3"
+
+	// Create a minimal installation CR
+	installation := &ecv1beta1.Installation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-installation",
+			Namespace: "default",
+		},
+		Spec: ecv1beta1.InstallationSpec{
+			BinaryName: "test-binary",
+			Config: &ecv1beta1.ConfigSpec{
+				Version: testVersion,
+				Domains: ecv1beta1.Domains{
+					ProxyRegistryDomain: "registry.example.com",
+				},
+			},
+		},
+	}
+
+	// Create a cached metadata for the test version
+	// This avoids having to properly create a ConfigMap
+	testMeta := types.ReleaseMetadata{
+		Images: []string{"registry.example.com/embedded-cluster-operator-image:1.2.3"},
+	}
+	release.CacheMeta(testVersion, testMeta)
+
+	// Create a fake client with the installation
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(installation).
+		Build()
+
+	// Call the function under test
+	err := CreateUpgradeJob(context.Background(), cli, installation, "", "1.2.2")
+	require.NoError(t, err)
+
+	// Get the job that was created
+	job := &batchv1.Job{}
+	err = cli.Get(context.Background(), client.ObjectKey{
+		Namespace: upgradeJobNamespace,
+		Name:      "embedded-cluster-upgrade-test-installation",
+	}, job)
+	require.NoError(t, err)
+
+	// Verify that the job has the expected node affinity
+	require.NotNil(t, job.Spec.Template.Spec.Affinity, "Job should have affinity set")
+	require.NotNil(t, job.Spec.Template.Spec.Affinity.NodeAffinity, "Job should have node affinity set")
+
+	// Verify the preferred scheduling term
+	preferredTerms := job.Spec.Template.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	require.NotEmpty(t, preferredTerms, "Job should have preferred scheduling terms")
+
+	// Verify the weight and key
+	assert.Equal(t, int32(100), preferredTerms[0].Weight, "Node affinity weight should be 100")
+	assert.Equal(t, "node-role.kubernetes.io/control-plane", preferredTerms[0].Preference.MatchExpressions[0].Key,
+		"Node affinity should target control-plane nodes")
+	assert.Equal(t, corev1.NodeSelectorOpExists, preferredTerms[0].Preference.MatchExpressions[0].Operator,
+		"Node affinity operator should be 'Exists'")
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Adds node affinity configuration to prefer scheduling upgrade jobs on control plane nodes, which are typically upgraded first in sequence. This reduces the likelihood of job failures when jobs get scheduled on nodes that haven't been upgraded yet, preventing the job from hitting its backoff limit and causing upgrades to fail.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue that can cause cluster upgrades to fail when the upgrade job is scheduled on nodes that have yet to be upgraded by prioritizing control plane nodes, which are typically upgraded first.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
