### PR TITLE
add retries to leaveEtcdcluster

### DIFF
--- a/cmd/installer/cli/reset.go
+++ b/cmd/installer/cli/reset.go
@@ -375,7 +375,6 @@ func (h *hostInfo) leaveEtcdcluster() {
 
 	// If we get here, we failed to leave after retries
 	logrus.Warnf("Unable to leave etcd cluster after retries (this is often normal during reset): %v, %s", err, out)
-	return
 }
 
 var (

--- a/cmd/installer/cli/reset.go
+++ b/cmd/installer/cli/reset.go
@@ -330,25 +330,55 @@ type etcdMembers struct {
 
 // leaveEtcdcluster uses k0s to attempt to leave the etcd cluster
 func (h *hostInfo) leaveEtcdcluster() error {
+	// Try to list members with retries
+	var memberlist etcdMembers
+	var out string
+	var err error
 
-	// if we're the only etcd member we don't need to leave the cluster
-	out, err := helpers.RunCommand(k0sBinPath, "etcd", "member-list")
-	if err != nil {
-		return err
+	// Retry member list up to 3 times
+	for i := 0; i < 3; i++ {
+		out, err = helpers.RunCommand(k0sBinPath, "etcd", "member-list")
+		if err == nil {
+			err = json.Unmarshal([]byte(out), &memberlist)
+			if err == nil {
+				break
+			}
+		}
+		if i < 2 { // Don't sleep on last attempt
+			time.Sleep(2 * time.Second)
+		}
 	}
-	memberlist := etcdMembers{}
-	err = json.Unmarshal([]byte(out), &memberlist)
+
 	if err != nil {
-		return err
+		logrus.Warnf("Unable to list etcd members, continuing with reset: %v", err)
+		return nil
 	}
+
+	// If we're the only member, no need to leave
 	if len(memberlist.Members) == 1 && memberlist.Members[h.Hostname] != "" {
 		return nil
 	}
 
-	out, err = helpers.RunCommand(k0sBinPath, "etcd", "leave")
-	if err != nil {
-		return fmt.Errorf("unable to leave etcd cluster: %w, %s", err, out)
+	// Attempt to leave the cluster with retries
+	for i := 0; i < 3; i++ {
+		out, err = helpers.RunCommand(k0sBinPath, "etcd", "leave")
+		if err == nil {
+			return nil
+		}
+
+		// Check if the error is due to etcd being stopped
+		if strings.Contains(err.Error(), "etcdserver: server stopped") {
+			logrus.Warnf("Etcd server is stopped, continuing with reset")
+			return nil
+		}
+
+		if i < 2 { // Don't sleep on last attempt
+			time.Sleep(2 * time.Second)
+		}
 	}
+
+	// If we get here, we failed to leave after retries
+	logrus.Warnf("Unable to leave etcd cluster after retries (this is often normal during reset): %v, %s", err, out)
 	return nil
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

```
        error: unable to leave etcd cluster: exit status 1: {"level":"warn","ts":"2025-04-05T12:39:27.465388Z","logger":"etcd-client","caller":"v3@v3.5.17/retry_interceptor.go:63","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc000830000/127.0.0.1:2379","attempt":0,"error":"rpc error: code = Unavailable desc = etcdserver: server stopped"}
        time="2025-04-05 12:39:27" level=error msg="Failed to delete node from cluster" peerID=314ee8343a8b0c36 peerURL="https://172.17.0.4:2380"
        Error: etcdserver: server stopped
```

This isn't desirable.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
