### PR TITLE
St0rmz1/chore/grype migration

### DIFF
--- a/.github/actions/scan-image/action.yml
+++ b/.github/actions/scan-image/action.yml
@@ -113,7 +113,7 @@ runs:
       uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: ${{ inputs.output-file }}
-        category: 'image-scan:${{ steps.image-id.outputs.image_id }}'
+        category: '${{ inputs.category-prefix }}${{ steps.image-id.outputs.image_id }}'
 
     - name: Archive scan results
       if: ${{ !cancelled() && inputs.upload-sarif == 'true' }}

--- a/.github/actions/scan-image/action.yml
+++ b/.github/actions/scan-image/action.yml
@@ -96,13 +96,26 @@ runs:
            --arg name "${{ steps.image_details.outputs.image_name }}" \
            --arg tag "${{ steps.image_details.outputs.image_tag }}" \
            --arg scanTime "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+           --arg digest "$(echo "${{ inputs.image-ref }}" | grep -o '@sha256:[a-f0-9]*' || true)" \
            '.runs[0].properties = {
               "imageRef": $imageRef,
               "repository": $repo,
               "scanTime": $scanTime,
               "imageMetadata": {
                 "name": $name,
-                "tag": $tag
+                "tag": $tag,
+                "digest": ($digest | if . == "" then null else . end),
+                "repoDigest": ($imageRef | if contains("@sha256:") then . else null end),
+                "labels": {},
+                "annotations": {
+                  "scanTime": $scanTime,
+                  "tool": "grype",
+                  "toolVersion": "latest"
+                }
+              },
+              "partialFingerprints": {
+                "scanTargetFingerprint": ($imageRef | sub("@sha256:[a-f0-9]+$"; "")),
+                "scanTimeFingerprint": $scanTime
               }
             }' ${{ inputs.output-file }} > enriched-results.sarif
 

--- a/.github/actions/scan-image/action.yml
+++ b/.github/actions/scan-image/action.yml
@@ -52,7 +52,7 @@ runs:
       shell: bash
       run: |
         IMAGE_NAME=$(echo "${{ inputs.image-ref }}" | cut -d':' -f1)
-        IMAGE_TAG=$(echo "${{ inputs.image-ref }}" | cut -d':' -f2)
+        IMAGE_TAG=$(echo "${{ inputs.image-ref }}" | cut -d':' -f2 | cut -d'@' -f1)
         [[ "$IMAGE_TAG" == "$IMAGE_NAME" ]] && IMAGE_TAG="latest"
         SAFE_NAME=$(echo "${IMAGE_NAME}-${IMAGE_TAG}" | sed 's/[\/:]/-/g')
         {
@@ -92,20 +92,20 @@ runs:
         fi
 
         jq --arg imageRef "${{ inputs.image-ref }}" \
-           --arg repo "${{ steps.image_details.outputs.image_name }}" \
+           --arg repo "replicatedhq/embedded-cluster" \
            --arg name "${{ steps.image_details.outputs.image_name }}" \
            --arg tag "${{ steps.image_details.outputs.image_tag }}" \
            --arg scanTime "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
-           --arg digest "$(echo "${{ inputs.image-ref }}" | grep -o '@sha256:[a-f0-9]*' || true)" \
+           --arg digest "$(echo "${{ inputs.image-ref }}" | grep -o 'sha256:[a-f0-9]*' || true)" \
            '.runs[0].properties = {
-              "imageRef": $imageRef,
+              "imageRef": ($imageRef | sub("proxy\\.replicated\\.com/anonymous/replicated/"; "")),
               "repository": $repo,
               "scanTime": $scanTime,
               "imageMetadata": {
-                "name": $name,
+                "name": ($name | sub("proxy\\.replicated\\.com/anonymous/replicated/"; "")),
                 "tag": $tag,
                 "digest": ($digest | if . == "" then null else . end),
-                "repoDigest": ($imageRef | if contains("@sha256:") then . else null end),
+                "repoDigest": ($imageRef | sub("proxy\\.replicated\\.com/anonymous/replicated/"; "") | if contains("@sha256:") then . else null end),
                 "labels": {},
                 "annotations": {
                   "scanTime": $scanTime,

--- a/.github/actions/scan-image/action.yml
+++ b/.github/actions/scan-image/action.yml
@@ -1,4 +1,4 @@
-name: Scan image
+name: Scan Container Image Grype SARIF
 description: 'Scan a container image for vulnerabilities and optionally upload the results for GitHub code scanning'
 inputs:
   image-ref:
@@ -7,7 +7,35 @@ inputs:
   upload-sarif:
     description: 'Whether to upload the scan results as a SARIF file'
     required: false
-    default: 'false'
+    default: 'true'
+  severity-cutoff:
+    description: 'Minimum severity to report (critical, high, medium, low, negligible)'
+    required: false
+    default: 'medium'
+  fail-build:
+    description: 'Fail the workflow if vulnerabilities are found'
+    required: false
+    default: 'true'
+  output-file:
+    description: 'Output file name for SARIF results'
+    required: false
+    default: 'results.sarif'
+  timeout-minutes:
+    description: 'Maximum time in minutes to wait for the scan to complete'
+    required: false
+    default: '30'
+  retention-days:
+    description: 'Number of days to retain the scan results artifact'
+    required: false
+    default: '90'
+  category-prefix:
+    description: 'Prefix to use for the SARIF category name'
+    required: false
+    default: 'image-scan-'
+  only-fixed:
+    description: 'Only report vulnerabilities that have a fix available'
+    required: false
+    default: 'true'
 
 runs:
   using: composite
@@ -18,29 +46,79 @@ runs:
       run: |
         image_id=$(${{github.action_path}}/image_id.sh '${{ inputs.image-ref }}')
         echo "image_id=$image_id" >> $GITHUB_OUTPUT
+    
+    - name: Extract image details
+      id: image_details
+      shell: bash
+      run: |
+        IMAGE_NAME=$(echo "${{ inputs.image-ref }}" | cut -d':' -f1)
+        IMAGE_TAG=$(echo "${{ inputs.image-ref }}" | cut -d':' -f2)
+        [[ "$IMAGE_TAG" == "$IMAGE_NAME" ]] && IMAGE_TAG="latest"
+        SAFE_NAME=$(echo "${IMAGE_NAME}-${IMAGE_TAG}" | sed 's/[\/:]/-/g')
+        {
+          echo "image_name=${IMAGE_NAME}"
+          echo "image_tag=${IMAGE_TAG}"
+          echo "safe_name=${SAFE_NAME}"
+        } >> "$GITHUB_OUTPUT"
 
-    - name: Scan image
-      uses: aquasecurity/trivy-action@0.24.0
+    - name: Scan image with Grype
+      uses: anchore/scan-action@v6
+      id: scan
+      continue-on-error: ${{ inputs.fail-build != 'true' }}
       with:
-        image-ref: '${{ inputs.image-ref }}'
-        ignore-unfixed: true
-        severity: CRITICAL,HIGH,MEDIUM
-        exit-code: 1
-        trivyignores: .trivyignore
+        image: "${{ inputs.image-ref }}"
+        fail-build: "${{ inputs.fail-build }}"
+        severity-cutoff: "${{ inputs.severity-cutoff }}"
+        output-format: sarif
+        output-file: "${{ inputs.output-file }}"
+        by-cve: true
+        only-fixed: "${{ inputs.only-fixed }}"
 
-    - name: Output sarif
-      uses: aquasecurity/trivy-action@0.24.0
+    - name: Check scan status
+      if: steps.scan.outcome == 'failure' && inputs.fail-build == 'true'
+      shell: bash
+      run: |
+        echo "::error::Scan failed for image ${{ inputs.image-ref }}"
+        echo "Please check the scan logs above for details"
+        exit 1
+
+    - name: Enrich or generate SARIF
       if: ${{ !cancelled() && inputs.upload-sarif == 'true' }}
-      with:
-        image-ref: '${{ matrix.image }}'
-        format: sarif
-        output: trivy-results.sarif
-        ignore-unfixed: true
-        severity: CRITICAL,HIGH,MEDIUM
+      shell: bash
+      run: |
+        if [ ! -f ${{ inputs.output-file }} ]; then
+          echo "No SARIF file found — creating minimal empty SARIF"
+          echo '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"Anchore Grype","informationUri":"https://github.com/anchore/grype","rules":[]}},"results":[],"properties":{"isFallbackSarif":true}}]}' > ${{ inputs.output-file }}
+        fi
 
-    - name: Upload sarif
+        jq --arg imageRef "${{ inputs.image-ref }}" \
+           --arg repo "${{ steps.image_details.outputs.image_name }}" \
+           --arg name "${{ steps.image_details.outputs.image_name }}" \
+           --arg tag "${{ steps.image_details.outputs.image_tag }}" \
+           --arg scanTime "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+           '.runs[0].properties = {
+              "imageRef": $imageRef,
+              "repository": $repo,
+              "scanTime": $scanTime,
+              "imageMetadata": {
+                "name": $name,
+                "tag": $tag
+              }
+            }' ${{ inputs.output-file }} > enriched-results.sarif
+
+        mv enriched-results.sarif ${{ inputs.output-file }}
+
+    - name: Upload SARIF file
       if: ${{ !cancelled() && inputs.upload-sarif == 'true' }}
       uses: github/codeql-action/upload-sarif@v3
       with:
-        sarif_file: trivy-results.sarif
+        sarif_file: ${{ inputs.output-file }}
         category: 'image-scan:${{ steps.image-id.outputs.image_id }}'
+
+    - name: Archive scan results
+      if: ${{ !cancelled() && inputs.upload-sarif == 'true' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: "sarif-${{ steps.image_details.outputs.safe_name }}"
+        path: ${{ inputs.output-file }}
+        retention-days: ${{ inputs.retention-days }}

--- a/.github/actions/scan-image/action.yml
+++ b/.github/actions/scan-image/action.yml
@@ -98,14 +98,14 @@ runs:
            --arg scanTime "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
            --arg digest "$(echo "${{ inputs.image-ref }}" | grep -o 'sha256:[a-f0-9]*' || true)" \
            '.runs[0].properties = {
-              "imageRef": ($imageRef | sub("proxy\\.replicated\\.com/anonymous/replicated/"; "")),
+              "imageRef": ($name | sub("proxy\\.replicated\\.com/anonymous/replicated/"; "replicatedhq/embedded-cluster/")) + ":" + $tag + if $digest != "" then "@" + $digest else "" end,
               "repository": $repo,
               "scanTime": $scanTime,
               "imageMetadata": {
-                "name": ($name | sub("proxy\\.replicated\\.com/anonymous/replicated/"; "")),
+                "name": ($name | sub("proxy\\.replicated\\.com/anonymous/replicated/"; "replicatedhq/embedded-cluster/")),
                 "tag": $tag,
                 "digest": ($digest | if . == "" then null else . end),
-                "repoDigest": ($name | sub("proxy\\.replicated\\.com/anonymous/replicated/"; "") | . + "@" + ($digest | if . == "" then null else . end)),
+                "repoDigest": ($name | sub("proxy\\.replicated\\.com/anonymous/replicated/"; "replicatedhq/embedded-cluster/")) + "@" + ($digest | if . == "" then null else . end),
                 "labels": {},
                 "annotations": {
                   "scanTime": $scanTime,

--- a/.github/actions/scan-image/action.yml
+++ b/.github/actions/scan-image/action.yml
@@ -98,14 +98,14 @@ runs:
            --arg scanTime "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
            --arg digest "$(echo "${{ inputs.image-ref }}" | grep -o 'sha256:[a-f0-9]*' || true)" \
            '.runs[0].properties = {
-              "imageRef": ($name | sub("proxy\\.replicated\\.com/anonymous/replicated/"; "replicatedhq/embedded-cluster/")) + ":" + $tag + if $digest != "" then "@" + $digest else "" end,
+              "imageRef": (($name | sub("proxy\\.replicated\\.com/anonymous/replicated/"; "replicatedhq/embedded-cluster/")) + ":" + $tag + (if $digest != "" then "@" + $digest else "" end)),
               "repository": $repo,
               "scanTime": $scanTime,
               "imageMetadata": {
                 "name": ($name | sub("proxy\\.replicated\\.com/anonymous/replicated/"; "replicatedhq/embedded-cluster/")),
                 "tag": $tag,
                 "digest": ($digest | if . == "" then null else . end),
-                "repoDigest": ($name | sub("proxy\\.replicated\\.com/anonymous/replicated/"; "replicatedhq/embedded-cluster/")) + "@" + ($digest | if . == "" then null else . end),
+                "repoDigest": (($name | sub("proxy\\.replicated\\.com/anonymous/replicated/"; "replicatedhq/embedded-cluster/")) + "@" + ($digest | if . == "" then null else . end)),
                 "labels": {},
                 "annotations": {
                   "scanTime": $scanTime,

--- a/.github/actions/scan-image/action.yml
+++ b/.github/actions/scan-image/action.yml
@@ -98,14 +98,14 @@ runs:
            --arg scanTime "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
            --arg digest "$(echo "${{ inputs.image-ref }}" | grep -o 'sha256:[a-f0-9]*' || true)" \
            '.runs[0].properties = {
-              "imageRef": (($name | sub("proxy\\.replicated\\.com/anonymous/replicated/"; "replicatedhq/embedded-cluster/")) + ":" + $tag + (if $digest != "" then "@" + $digest else "" end)),
+              "imageRef": (if ($name | startswith("replicatedhq/embedded-cluster/")) then $name else ($name | sub("proxy\\.replicated\\.com/anonymous/(?:ttl\\.sh/runner/|registry\\.k8s\\.io/|kotsadm/|ttl\\.sh/replicated/|replicated/)"; "replicatedhq/embedded-cluster/")) end + ":" + $tag + (if $digest != "" then "@" + $digest else "" end)),
               "repository": $repo,
               "scanTime": $scanTime,
               "imageMetadata": {
-                "name": ($name | sub("proxy\\.replicated\\.com/anonymous/replicated/"; "replicatedhq/embedded-cluster/")),
+                "name": (if ($name | startswith("replicatedhq/embedded-cluster/")) then $name else ($name | sub("proxy\\.replicated\\.com/anonymous/(?:ttl\\.sh/runner/|registry\\.k8s\\.io/|kotsadm/|ttl\\.sh/replicated/|replicated/)"; "replicatedhq/embedded-cluster/")) end),
                 "tag": $tag,
                 "digest": ($digest | if . == "" then null else . end),
-                "repoDigest": (($name | sub("proxy\\.replicated\\.com/anonymous/replicated/"; "replicatedhq/embedded-cluster/")) + "@" + ($digest | if . == "" then null else . end)),
+                "repoDigest": (if ($name | startswith("replicatedhq/embedded-cluster/")) then $name else ($name | sub("proxy\\.replicated\\.com/anonymous/(?:ttl\\.sh/runner/|registry\\.k8s\\.io/|kotsadm/|ttl\\.sh/replicated/|replicated/)"; "replicatedhq/embedded-cluster/")) end + "@" + ($digest | if . == "" then null else . end)),
                 "labels": {},
                 "annotations": {
                   "scanTime": $scanTime,

--- a/.github/actions/scan-image/action.yml
+++ b/.github/actions/scan-image/action.yml
@@ -105,17 +105,13 @@ runs:
                 "name": ($name | sub("proxy\\.replicated\\.com/anonymous/replicated/"; "")),
                 "tag": $tag,
                 "digest": ($digest | if . == "" then null else . end),
-                "repoDigest": ($imageRef | sub("proxy\\.replicated\\.com/anonymous/replicated/"; "") | if contains("@sha256:") then . else null end),
+                "repoDigest": ($name | sub("proxy\\.replicated\\.com/anonymous/replicated/"; "") | . + "@" + ($digest | if . == "" then null else . end)),
                 "labels": {},
                 "annotations": {
                   "scanTime": $scanTime,
                   "tool": "grype",
                   "toolVersion": "latest"
                 }
-              },
-              "partialFingerprints": {
-                "scanTargetFingerprint": ($imageRef | sub("@sha256:[a-f0-9]+$"; "")),
-                "scanTimeFingerprint": $scanTime
               }
             }' ${{ inputs.output-file }} > enriched-results.sarif
 

--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -134,9 +134,8 @@ jobs:
       - uses: ./.github/actions/scan-image
         with:
           image-ref: '${{ matrix.image }}'
-          # upload-sarif: ${{ github.ref == 'refs/heads/main' }}
-          upload-sarif: 'true'
-          fail-build: 'false'
+          upload-sarif: ${{ github.ref == 'refs/heads/main' }}
+          fail-build: 'true'
           severity-cutoff: 'medium'
           output-file: 'results.sarif'
           retention-days: '90'

--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -134,7 +134,8 @@ jobs:
       - uses: ./.github/actions/scan-image
         with:
           image-ref: '${{ matrix.image }}'
-          upload-sarif: ${{ github.ref == 'refs/heads/main' }}
+          # upload-sarif: ${{ github.ref == 'refs/heads/main' }}
+          upload-sarif: 'true'
           fail-build: 'false'
           severity-cutoff: 'medium'
           output-file: 'results.sarif'

--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -135,3 +135,9 @@ jobs:
         with:
           image-ref: '${{ matrix.image }}'
           upload-sarif: ${{ github.ref == 'refs/heads/main' }}
+          fail-build: 'false'
+          severity-cutoff: 'medium'
+          output-file: 'results.sarif'
+          retention-days: '90'
+          category-prefix: 'image-scan-'
+          only-fixed: 'true'

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,27 @@
+# Grype configuration file
+# See: https://github.com/anchore/grype#configuration
+
+# Ignore rules for vulnerabilities
+# Each rule can specify criteria for vulnerabilities to ignore
+ignore:
+  # Ignore CVE-2023-47108 which has been accepted upstream in Kubernetes
+  # Reference: https://github.com/kubernetes/kubernetes/pull/121842
+  # This vulnerability is not in the code path and has been fixed upstream
+  - vulnerability: CVE-2023-47108
+    # You can add additional criteria if needed:
+    # fix-state: fixed  # since it's fixed upstream
+    # package:
+    #   type: go  # if you want to specifically target Go packages
+    #   name: k8s.io/kubernetes  # if you want to target specific k8s packages
+
+# Default configuration options below
+# Uncomment and modify as needed
+
+# output: table
+# fail-on-severity: medium
+# file: ""
+# exclude: []
+# db:
+#   cache-dir: ""
+#   update-url: "https://grype.anchore.io/databases"
+#   auto-update: true 

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -8,11 +8,29 @@ ignore:
   # Reference: https://github.com/kubernetes/kubernetes/pull/121842
   # This vulnerability is not in the code path and has been fixed upstream
   - vulnerability: CVE-2023-47108
-    # You can add additional criteria if needed:
-    # fix-state: fixed  # since it's fixed upstream
-    # package:
-    #   type: go  # if you want to specifically target Go packages
-    #   name: k8s.io/kubernetes  # if you want to target specific k8s packages
+
+# Match Trivy's configuration
+fail-on-severity: medium  # Equivalent to Trivy's CRITICAL,HIGH,MEDIUM setting
+output: table  # Default output format (will be overridden by action for SARIF)
+
+# Database configuration
+db:
+  auto-update: true  # Ensure vulnerability database is up to date, like Trivy
+
+# Search configuration to match Trivy's behavior
+search:
+  scope: "squashed"  # Similar to Trivy's default behavior
+  indexed-archives: true
+  unindexed-archives: true  # Ensure we don't miss vulnerabilities in archives
+
+# Registry configuration (similar to Trivy's behavior)
+registry:
+  insecure-skip-tls-verify: false
+  insecure-use-http: false
+
+# Logging configuration
+log:
+  level: "warn"  # Similar to Trivy's default
 
 # Default configuration options below
 # Uncomment and modify as needed


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

- Migrating scan jobs to use grype instead of trivy
- Maintaining the same functionality and results and filenames
- Enrich the sarif using jq to add custom properties used by tracking tools


#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
NONE

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
