### PR TITLE
[bug] don't set profiles flag if no profiles

### DIFF
--- a/e2e/kots-release-install-stable/cluster-config.yaml
+++ b/e2e/kots-release-install-stable/cluster-config.yaml
@@ -38,6 +38,11 @@ spec:
         spec:
           telemetry:
             enabled: false
+          workerProfiles:
+          - name: ip-forward
+            values:
+              allowedUnsafeSysctls:
+              - net.ipv4.ip_forward
   extensions:
     helm:
       repositories:

--- a/e2e/kots-release-install-stable/cluster-config.yaml
+++ b/e2e/kots-release-install-stable/cluster-config.yaml
@@ -38,11 +38,6 @@ spec:
         spec:
           telemetry:
             enabled: false
-          workerProfiles:
-          - name: ip-forward
-            values:
-              allowedUnsafeSysctls:
-              - net.ipv4.ip_forward
   extensions:
     helm:
       repositories:

--- a/e2e/kots-release-unsupported-overrides/cluster-config.yaml
+++ b/e2e/kots-release-unsupported-overrides/cluster-config.yaml
@@ -27,8 +27,3 @@ spec:
         spec:
           telemetry:
             enabled: true
-          workerProfiles:
-          - name: ip-forward
-            values:
-              allowedUnsafeSysctls:
-              - net.ipv4.ip_forward

--- a/e2e/scripts/unsupported-overrides.sh
+++ b/e2e/scripts/unsupported-overrides.sh
@@ -16,11 +16,6 @@ override_applied() {
       cat "$K0SCONFIG"
       return 1
     fi
-    if ! grep "net.ipv4.ip_forward" "$K0SCONFIG"; then
-      echo "override not applied, expected worker profile not found, actual config:"
-      cat "$K0SCONFIG"
-      return 1
-    fi
 }
 
 main() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -136,6 +136,9 @@ func ProfileInstallFlag() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("unable to get controller worker profile: %w", err)
 	}
+	if controllerProfile == "" {
+		return "", nil
+	}
 	return "--profile=" + controllerProfile, nil
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,9 @@ const (
 	DefaultVendorChartOrder     = 10
 )
 
+// k0sConfigPathOverride is used during tests to override the path to the k0s config file.
+var k0sConfigPathOverride string
+
 // RenderK0sConfig renders a k0s cluster configuration.
 func RenderK0sConfig(proxyRegistryDomain string) *k0sconfig.ClusterConfig {
 	cfg := k0sconfig.DefaultClusterConfig()
@@ -109,7 +112,9 @@ func InstallFlags(nodeIP string) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to get profile install flag: %w", err)
 	}
-	flags = append(flags, profile)
+	if profile != "" {
+		flags = append(flags, profile)
+	}
 	flags = append(flags, AdditionalInstallFlags(nodeIP)...)
 	flags = append(flags, AdditionalInstallFlagsController()...)
 	return flags, nil
@@ -187,7 +192,12 @@ func additionalControllerLabels() map[string]string {
 
 func controllerWorkerProfile() (string, error) {
 	// Read the k0s config file
-	data, err := os.ReadFile(runtimeconfig.PathToK0sConfig())
+	k0sPath := runtimeconfig.PathToK0sConfig()
+	if k0sConfigPathOverride != "" {
+		k0sPath = k0sConfigPathOverride
+	}
+
+	data, err := os.ReadFile(k0sPath)
 	if err != nil {
 		return "", fmt.Errorf("unable to read k0s config: %w", err)
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2,11 +2,13 @@ package config
 
 import (
 	"embed"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	k0sconfig "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+	"github.com/replicatedhq/embedded-cluster/pkg/release"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -100,4 +102,123 @@ func TestRenderK0sConfig(t *testing.T) {
 	assert.Equal(t, "calico", cfg.Spec.Network.Provider)
 	assert.Equal(t, DefaultServiceNodePortRange, cfg.Spec.API.ExtraArgs["service-node-port-range"])
 	assert.Contains(t, cfg.Spec.API.SANs, "kubernetes.default.svc.cluster.local")
+}
+
+func TestInstallFlags(t *testing.T) {
+	// Create a pair of temporary k0s config files
+	k0sCfg := k0sconfig.DefaultClusterConfig()
+	k0sDefaultConfigBytes, err := k8syaml.Marshal(k0sCfg)
+	require.NoError(t, err)
+
+	defaultTmpFile, err := os.CreateTemp("", "k0s-*.yaml")
+	require.NoError(t, err)
+	defer os.Remove(defaultTmpFile.Name())
+
+	err = os.WriteFile(defaultTmpFile.Name(), k0sDefaultConfigBytes, 0644)
+	require.NoError(t, err)
+
+	k0sCfg.Spec.WorkerProfiles = []k0sconfig.WorkerProfile{
+		{
+			Name: "test-profile",
+		},
+	}
+	k0sProfileConfigBytes, err := k8syaml.Marshal(k0sCfg)
+	require.NoError(t, err)
+
+	profileTmpFile, err := os.CreateTemp("", "k0s-*.yaml")
+	require.NoError(t, err)
+	defer os.Remove(profileTmpFile.Name())
+
+	err = os.WriteFile(profileTmpFile.Name(), k0sProfileConfigBytes, 0644)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name           string
+		nodeIP         string
+		releaseData    map[string][]byte
+		expectedFlags  []string
+		expectedError  bool
+		expectedErrMsg string
+		k0sConfigPath  string
+	}{
+		{
+			name:          "default configuration",
+			nodeIP:        "192.168.1.10",
+			k0sConfigPath: defaultTmpFile.Name(),
+			releaseData:   map[string][]byte{},
+			expectedFlags: []string{
+				"install",
+				"controller",
+				"--labels", "kots.io/embedded-cluster-role-0=controller,kots.io/embedded-cluster-role=total-1",
+				"--enable-worker",
+				"--no-taints",
+				"-c", runtimeconfig.PathToK0sConfig(),
+				"--kubelet-extra-args", "--node-ip=192.168.1.10",
+				"--data-dir", runtimeconfig.EmbeddedClusterK0sSubDir(),
+				"--disable-components", "konnectivity-server",
+				"--enable-dynamic-config",
+			},
+			expectedError: false,
+		},
+		{
+			name:          "custom controller role name with worker profile",
+			nodeIP:        "192.168.1.10",
+			k0sConfigPath: profileTmpFile.Name(),
+			releaseData: map[string][]byte{
+				"cluster-config.yaml": []byte(`
+apiVersion: embeddedcluster.replicated.com/v1beta1
+kind: Config
+metadata:
+  name: embedded-cluster
+spec:
+  roles:
+    controller:
+      name: custom-controller
+      labels:
+        environment: test
+`),
+			},
+			expectedFlags: []string{
+				"install",
+				"controller",
+				"--labels", "environment=test,kots.io/embedded-cluster-role-0=custom-controller,kots.io/embedded-cluster-role=total-1",
+				"--enable-worker",
+				"--no-taints",
+				"-c", runtimeconfig.PathToK0sConfig(),
+				"--profile=test-profile",
+				"--kubelet-extra-args", "--node-ip=192.168.1.10",
+				"--data-dir", runtimeconfig.EmbeddedClusterK0sSubDir(),
+				"--disable-components", "konnectivity-server",
+				"--enable-dynamic-config",
+			},
+			expectedError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup test data
+			err := release.SetReleaseDataForTests(tt.releaseData)
+			require.NoError(t, err)
+
+			// Set the override for the k0s config path
+			k0sConfigPathOverride = tt.k0sConfigPath
+
+			// Cleanup after test
+			t.Cleanup(func() {
+				release.SetReleaseDataForTests(nil)
+				k0sConfigPathOverride = ""
+			})
+
+			// Run test
+			flags, err := InstallFlags(tt.nodeIP)
+			if tt.expectedError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErrMsg)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedFlags, flags)
+			}
+		})
+	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

if no worker profiles are set, the profile flag still gets applied but is empty. this causes some problems

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
