### PR TITLE
fix and test joining nodes with worker profiles after upgrading from previous EC versions

### DIFF
--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -648,16 +648,14 @@ func TestUpgradeEC18FromReplicatedApp(t *testing.T) {
 	}
 
 	// Join the additional nodes to the cluster
-	t.Logf("%s: joining controller node 2 to the cluster after upgrade", time.Now().Format(time.RFC3339))
+	t.Logf("%s: joining additional controller and worker node to the cluster after upgrade", time.Now().Format(time.RFC3339))
 	joinControllerNode(t, tc, 2)
-	t.Logf("%s: joining worker node 3 to the cluster after upgrade", time.Now().Format(time.RFC3339))
 	joinWorkerNode(t, tc, 3)
 
-	t.Logf("%s: waiting for all nodes to be ready after joining additional nodes", time.Now().Format(time.RFC3339))
-	waitForNodes(t, tc, 4, nil)
+	// wait for all nodes to report as ready
+	waitForNodes(t, tc, 4, withEnv)
 
 	// Check worker profiles for the joined nodes
-	t.Logf("%s: checking worker profiles for the joined nodes", time.Now().Format(time.RFC3339))
 	checkWorkerProfile(t, tc, 2)
 	checkWorkerProfile(t, tc, 3)
 
@@ -676,8 +674,7 @@ func TestUpgradeEC18FromReplicatedApp(t *testing.T) {
 	}
 
 	// wait for all nodes to report as ready after upgrade
-	t.Logf("%s: waiting for all nodes to be ready after upgrade", time.Now().Format(time.RFC3339))
-	waitForNodes(t, tc, 4, nil)
+	waitForNodes(t, tc, 4, withEnv)
 
 	// use upgraded binaries to run the reset command
 	// TODO: this is a temporary workaround and should eventually be a feature of EC

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -638,7 +638,7 @@ func TestUpgradeEC18FromReplicatedApp(t *testing.T) {
 	})
 
 	// Download embedded-cluster on additional nodes
-	t.Logf("%s: downloading embedded-cluster %s on additional nodes", appUpgradeVersion, time.Now().Format(time.RFC3339))
+	t.Logf("%s: downloading embedded-cluster %s on additional nodes", time.Now().Format(time.RFC3339), appUpgradeVersion)
 	line = []string{"vandoor-prepare.sh", appUpgradeVersion, os.Getenv("LICENSE_ID"), "false"}
 	if stdout, stderr, err := tc.RunCommandOnNode(2, line); err != nil {
 		t.Fatalf("fail to download embedded-cluster on node 2: %v: %s: %s", err, stdout, stderr)

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -647,49 +647,17 @@ func TestUpgradeEC18FromReplicatedApp(t *testing.T) {
 		t.Fatalf("fail to download embedded-cluster on node 3: %v: %s: %s", err, stdout, stderr)
 	}
 
-	// Join second controller node
-	t.Logf("%s: generating a new controller token command", time.Now().Format(time.RFC3339))
-	stdout, stderr, err = tc.RunPlaywrightTest("get-join-controller-command")
-	if err != nil {
-		t.Fatalf("fail to generate controller join token:\nstdout: %s\nstderr: %s", stdout, stderr)
-	}
-	controllerCommand, err := findJoinCommandInOutput(stdout)
-	if err != nil {
-		t.Fatalf("fail to find the join command in the output: %v: %s: %s", err, stdout, stderr)
-	}
-	t.Log("controller join token command:", controllerCommand)
-	t.Logf("%s: joining node 2 to the cluster as a controller", time.Now().Format(time.RFC3339))
-	if stdout, stderr, err := tc.RunCommandOnNode(2, strings.Split(controllerCommand, " ")); err != nil {
-		t.Fatalf("fail to join node 2 as a controller: %v: %s: %s", err, stdout, stderr)
-	}
-
-	// Join second worker node
-	t.Logf("%s: generating a new worker token command", time.Now().Format(time.RFC3339))
-	stdout, stderr, err = tc.RunPlaywrightTest("get-join-worker-command")
-	if err != nil {
-		t.Fatalf("fail to generate worker join token:\nstdout: %s\nstderr: %s", stdout, stderr)
-	}
-	workerCommand, err := findJoinCommandInOutput(stdout)
-	if err != nil {
-		t.Fatalf("fail to find the join command in the output: %v: %s: %s", err, stdout, stderr)
-	}
-	t.Log("worker join token command:", workerCommand)
-
-	t.Logf("%s: joining node 3 to the cluster as a worker", time.Now().Format(time.RFC3339))
-	if stdout, stderr, err := tc.RunCommandOnNode(3, strings.Split(workerCommand, " ")); err != nil {
-		t.Fatalf("fail to join node 3 as a worker: %v: %s: %s", err, stdout, stderr)
-	}
-
-	// wait for all nodes to report as ready
-	t.Logf("%s: all nodes joined, waiting for them to be ready", time.Now().Format(time.RFC3339))
-	stdout, stderr, err = tc.RunCommandOnNode(0, []string{"wait-for-ready-nodes.sh", "4"}, withEnv)
-	if err != nil {
-		t.Fatalf("fail to wait for ready nodes: %v: %s: %s", err, stdout, stderr)
-	}
-
+	// Join the additional nodes to the cluster
+	t.Logf("%s: joining controller node 2 to the cluster after upgrade", time.Now().Format(time.RFC3339))
+	joinControllerNode(t, tc, 2)
+	t.Logf("%s: joining worker node 3 to the cluster after upgrade", time.Now().Format(time.RFC3339))
+	joinWorkerNode(t, tc, 3)
 	// Check worker profiles for the joined nodes
 	checkWorkerProfile(t, tc, 2)
 	checkWorkerProfile(t, tc, 3)
+
+	// wait for the nodes to report as ready.
+	waitForNodes(t, tc, 4, nil)
 
 	appUpgradeVersion = fmt.Sprintf("appver-%s-upgrade", os.Getenv("SHORT_SHA"))
 	testArgs = []string{appUpgradeVersion}
@@ -707,10 +675,7 @@ func TestUpgradeEC18FromReplicatedApp(t *testing.T) {
 
 	// wait for all nodes to report as ready after upgrade
 	t.Logf("%s: waiting for all nodes to be ready after upgrade", time.Now().Format(time.RFC3339))
-	stdout, stderr, err = tc.RunCommandOnNode(0, []string{"wait-for-ready-nodes.sh", "4"}, withEnv)
-	if err != nil {
-		t.Fatalf("fail to wait for ready nodes after upgrade: %v: %s: %s", err, stdout, stderr)
-	}
+	waitForNodes(t, tc, 4, nil)
 
 	// use upgraded binaries to run the reset command
 	// TODO: this is a temporary workaround and should eventually be a feature of EC

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -652,12 +652,14 @@ func TestUpgradeEC18FromReplicatedApp(t *testing.T) {
 	joinControllerNode(t, tc, 2)
 	t.Logf("%s: joining worker node 3 to the cluster after upgrade", time.Now().Format(time.RFC3339))
 	joinWorkerNode(t, tc, 3)
+
+	t.Logf("%s: waiting for all nodes to be ready after joining additional nodes", time.Now().Format(time.RFC3339))
+	waitForNodes(t, tc, 4, nil)
+
 	// Check worker profiles for the joined nodes
+	t.Logf("%s: checking worker profiles for the joined nodes", time.Now().Format(time.RFC3339))
 	checkWorkerProfile(t, tc, 2)
 	checkWorkerProfile(t, tc, 3)
-
-	// wait for the nodes to report as ready.
-	waitForNodes(t, tc, 4, nil)
 
 	appUpgradeVersion = fmt.Sprintf("appver-%s-upgrade", os.Getenv("SHORT_SHA"))
 	testArgs = []string{appUpgradeVersion}

--- a/operator/pkg/upgrade/upgrade.go
+++ b/operator/pkg/upgrade/upgrade.go
@@ -204,15 +204,20 @@ func updateClusterConfig(ctx context.Context, cli client.Client, in *ecv1beta1.I
 
 	// Apply unsupported overrides from the installation
 	if (in.Spec.Config != nil && in.Spec.Config.UnsupportedOverrides.K0s != "") || in.Spec.EndUserK0sConfigOverrides != "" {
+		newCfg := currentCfg.DeepCopy()
 
-		newCfg, err := config.PatchK0sConfig(&currentCfg, in.Spec.Config.UnsupportedOverrides.K0s, true)
-		if err != nil {
-			return fmt.Errorf("apply vendor unsupported overrides: %w", err)
+		if in.Spec.Config != nil && in.Spec.Config.UnsupportedOverrides.K0s != "" {
+			newCfg, err = config.PatchK0sConfig(newCfg, in.Spec.Config.UnsupportedOverrides.K0s, true)
+			if err != nil {
+				return fmt.Errorf("apply vendor unsupported overrides: %w", err)
+			}
 		}
 
-		newCfg, err = config.PatchK0sConfig(newCfg, in.Spec.EndUserK0sConfigOverrides, true)
-		if err != nil {
-			return fmt.Errorf("apply end user unsupported overrides: %w", err)
+		if in.Spec.EndUserK0sConfigOverrides != "" {
+			newCfg, err = config.PatchK0sConfig(newCfg, in.Spec.EndUserK0sConfigOverrides, true)
+			if err != nil {
+				return fmt.Errorf("apply end user unsupported overrides: %w", err)
+			}
 		}
 
 		// check if the new config is different from the current config

--- a/operator/pkg/upgrade/upgrade.go
+++ b/operator/pkg/upgrade/upgrade.go
@@ -205,12 +205,12 @@ func updateClusterConfig(ctx context.Context, cli client.Client, in *ecv1beta1.I
 	// Apply unsupported overrides from the installation
 	if (in.Spec.Config != nil && in.Spec.Config.UnsupportedOverrides.K0s != "") || in.Spec.EndUserK0sConfigOverrides != "" {
 
-		newCfg, err := config.PatchK0sConfig(&currentCfg, in.Spec.Config.UnsupportedOverrides.K0s)
+		newCfg, err := config.PatchK0sConfig(&currentCfg, in.Spec.Config.UnsupportedOverrides.K0s, true)
 		if err != nil {
 			return fmt.Errorf("apply vendor unsupported overrides: %w", err)
 		}
 
-		newCfg, err = config.PatchK0sConfig(newCfg, in.Spec.EndUserK0sConfigOverrides)
+		newCfg, err = config.PatchK0sConfig(newCfg, in.Spec.EndUserK0sConfigOverrides, true)
 		if err != nil {
 			return fmt.Errorf("apply end user unsupported overrides: %w", err)
 		}

--- a/operator/pkg/upgrade/upgrade.go
+++ b/operator/pkg/upgrade/upgrade.go
@@ -202,6 +202,26 @@ func updateClusterConfig(ctx context.Context, cli client.Client, in *ecv1beta1.I
 		}
 	}
 
+	// Apply unsupported overrides from the installation
+	if (in.Spec.Config != nil && in.Spec.Config.UnsupportedOverrides.K0s != "") || in.Spec.EndUserK0sConfigOverrides != "" {
+
+		newCfg, err := config.PatchK0sConfig(&currentCfg, in.Spec.Config.UnsupportedOverrides.K0s)
+		if err != nil {
+			return fmt.Errorf("apply vendor unsupported overrides: %w", err)
+		}
+
+		newCfg, err = config.PatchK0sConfig(newCfg, in.Spec.EndUserK0sConfigOverrides)
+		if err != nil {
+			return fmt.Errorf("apply end user unsupported overrides: %w", err)
+		}
+
+		// check if the new config is different from the current config
+		if !reflect.DeepEqual(*newCfg, currentCfg) {
+			currentCfg = *newCfg
+			didUpdate = true
+		}
+	}
+
 	if !didUpdate {
 		return nil
 	}

--- a/operator/pkg/upgrade/upgrade_test.go
+++ b/operator/pkg/upgrade/upgrade_test.go
@@ -117,6 +117,102 @@ func TestUpdateClusterConfig(t *testing.T) {
 				assert.Contains(t, updatedConfig.Spec.Network.NodeLocalLoadBalancing.EnvoyProxy.Image.Image, "registry.com/")
 			},
 		},
+		{
+			name: "applies unsupported vendor k0s overrides",
+			currentConfig: &k0sv1beta1.ClusterConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "k0s",
+					Namespace: "kube-system",
+				},
+				Spec: &k0sv1beta1.ClusterSpec{
+					Network: &k0sv1beta1.Network{
+						ServiceCIDR: "10.96.0.0/12",
+					},
+					Telemetry: &k0sv1beta1.ClusterTelemetry{
+						Enabled: true,
+					},
+				},
+			},
+			installation: &ecv1beta1.Installation{
+				Spec: ecv1beta1.InstallationSpec{
+					Config: &ecv1beta1.ConfigSpec{
+						Domains: ecv1beta1.Domains{
+							ProxyRegistryDomain: "registry.com",
+						},
+						UnsupportedOverrides: ecv1beta1.UnsupportedOverrides{
+							K0s: `
+config:
+  spec:
+    telemetry:
+      enabled: false
+    workerProfiles:
+    - name: ip-forward
+      values:
+        allowedUnsafeSysctls:
+        - net.ipv4.ip_forward
+`,
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, updatedConfig *k0sv1beta1.ClusterConfig) {
+				// Verify that the unsupported override was applied to the telemetry config
+				assert.Equal(t, false, updatedConfig.Spec.Telemetry.Enabled)
+
+				// Verify that the unsupported override was applied to the worker profiles
+				require.Len(t, updatedConfig.Spec.WorkerProfiles, 1)
+				assert.Equal(t, "ip-forward", updatedConfig.Spec.WorkerProfiles[0].Name)
+				assert.Equal(t, &runtime.RawExtension{Raw: []byte(`{"allowedUnsafeSysctls":["net.ipv4.ip_forward"]}`)}, updatedConfig.Spec.WorkerProfiles[0].Config)
+
+				// Verify that other changes were not made
+				assert.Equal(t, "10.96.0.0/12", updatedConfig.Spec.Network.ServiceCIDR)
+				// Verify that supported changes (like image registries) are still applied
+				assert.Contains(t, updatedConfig.Spec.Images.CoreDNS.Image, "registry.com/")
+			},
+		},
+		{
+			name: "applies unsupported end user k0s overrides",
+			currentConfig: &k0sv1beta1.ClusterConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "k0s",
+					Namespace: "kube-system",
+				},
+				Spec: &k0sv1beta1.ClusterSpec{
+					Network: &k0sv1beta1.Network{
+						ServiceCIDR: "10.96.0.0/12",
+					},
+				},
+			},
+			installation: &ecv1beta1.Installation{
+				Spec: ecv1beta1.InstallationSpec{
+					Config: &ecv1beta1.ConfigSpec{
+						Domains: ecv1beta1.Domains{
+							ProxyRegistryDomain: "registry.com",
+						},
+					},
+					EndUserK0sConfigOverrides: `
+config:
+  spec:
+    workerProfiles:
+    - name: another-profile
+      values:
+        allowedUnsafeSysctls:
+        - net.ipv4.ip_forward
+`,
+				},
+			},
+			validate: func(t *testing.T, updatedConfig *k0sv1beta1.ClusterConfig) {
+				// Verify that the unsupported override was applied to the worker profiles
+				require.Len(t, updatedConfig.Spec.WorkerProfiles, 1)
+				assert.Equal(t, "another-profile", updatedConfig.Spec.WorkerProfiles[0].Name)
+				assert.Equal(t, &runtime.RawExtension{Raw: []byte(`{"allowedUnsafeSysctls":["net.ipv4.ip_forward"]}`)}, updatedConfig.Spec.WorkerProfiles[0].Config)
+
+				// Verify that other changes were not made
+				assert.Equal(t, "10.96.0.0/12", updatedConfig.Spec.Network.ServiceCIDR)
+				// Verify that supported changes (like image registries) are still applied
+				assert.Contains(t, updatedConfig.Spec.Images.CoreDNS.Image, "registry.com/")
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -43,10 +43,11 @@ func parseTestsYAML[T any](t *testing.T, prefix string) map[string]T {
 
 func TestPatchK0sConfig(t *testing.T) {
 	type test struct {
-		Name     string
-		Config   string `yaml:"config"`
-		Override string `yaml:"override"`
-		Expected string `yaml:"expected"`
+		Name                   string
+		Config                 string `yaml:"config"`
+		Override               string `yaml:"override"`
+		Expected               string `yaml:"expected"`
+		RespectImmutableFields bool   `yaml:"respectImmutableFields"`
 	}
 
 	for tname, tt := range parseTestsYAML[test](t, "override-") {
@@ -57,7 +58,7 @@ func TestPatchK0sConfig(t *testing.T) {
 			err := k8syaml.Unmarshal([]byte(tt.Config), &config)
 			req.NoError(err)
 
-			result, err := PatchK0sConfig(&config, tt.Override)
+			result, err := PatchK0sConfig(&config, tt.Override, tt.RespectImmutableFields)
 			req.NoError(err)
 
 			var expected k0sconfig.ClusterConfig
@@ -71,16 +72,17 @@ func TestPatchK0sConfig(t *testing.T) {
 
 func Test_extractK0sConfigPatch(t *testing.T) {
 	type test struct {
-		Name     string
-		Override string `yaml:"override"`
-		Expected string `yaml:"expected"`
+		Name                   string
+		Override               string `yaml:"override"`
+		Expected               string `yaml:"expected"`
+		RespectImmutableFields bool   `yaml:"respectImmutableFields"`
 	}
 
 	for tname, tt := range parseTestsYAML[test](t, "extract-") {
 		t.Run(tname, func(t *testing.T) {
 			req := require.New(t)
 
-			extracted, err := extractK0sConfigPatch(tt.Override)
+			extracted, err := extractK0sConfigPatch(tt.Override, tt.RespectImmutableFields)
 			req.NoError(err)
 
 			var actual map[string]interface{}

--- a/pkg/config/testdata/extract-respect-immutable-fields.yaml
+++ b/pkg/config/testdata/extract-respect-immutable-fields.yaml
@@ -1,0 +1,20 @@
+respectImmutableFields: true
+override: |-
+  config:
+    metadata:
+      name: foo
+    spec:
+      test:
+      - one
+      - two
+      emptyObject: {}
+      api:
+        address: 111.111.111.111
+      storage:
+        type: local
+expected: |-
+  spec:
+    test:
+    - one
+    - two
+    emptyObject: {}

--- a/pkg/config/testdata/override-respect-immutable-fields.yaml
+++ b/pkg/config/testdata/override-respect-immutable-fields.yaml
@@ -1,0 +1,36 @@
+respectImmutableFields: true
+config: |-
+  apiVersion: k0s.k0sproject.io/v1beta1
+  kind: ClusterConfig
+  metadata:
+    name: embedded-cluster
+  spec:
+    network:
+      provider: calico
+    telemetry:
+      enabled: false
+    api:
+      extraArgs:
+        service-node-port-range: 80-32767
+override: |-
+    config:
+      metadata:
+        name: foo
+      spec:
+        api:
+          address: 111.111.111.111
+        storage:
+          type: local
+expected: |-
+  apiVersion: k0s.k0sproject.io/v1beta1
+  kind: ClusterConfig
+  metadata:
+    name: embedded-cluster
+  spec:
+    api:
+      extraArgs:
+        service-node-port-range: 80-32767
+    network:
+      provider: calico
+    telemetry:
+      enabled: false

--- a/pkg/k0s/install.go
+++ b/pkg/k0s/install.go
@@ -127,7 +127,7 @@ func applyUnsupportedOverrides(cfg *k0sv1beta1.ClusterConfig, endUserOverridesPa
 		// Apply vendor k0s overrides
 		vendorOverrides := embcfg.Spec.UnsupportedOverrides.K0s
 		var err error
-		cfg, err = config.PatchK0sConfig(cfg, vendorOverrides)
+		cfg, err = config.PatchK0sConfig(cfg, vendorOverrides, false)
 		if err != nil {
 			return nil, fmt.Errorf("unable to patch k0s config: %w", err)
 		}
@@ -142,7 +142,7 @@ func applyUnsupportedOverrides(cfg *k0sv1beta1.ClusterConfig, endUserOverridesPa
 		// Apply end user k0s overrides
 		endUserOverrides := eucfg.Spec.UnsupportedOverrides.K0s
 		var err error
-		cfg, err = config.PatchK0sConfig(cfg, endUserOverrides)
+		cfg, err = config.PatchK0sConfig(cfg, endUserOverrides, false)
 		if err != nil {
 			return nil, fmt.Errorf("unable to apply overrides: %w", err)
 		}
@@ -169,7 +169,7 @@ func PatchK0sConfig(path string, patch string) error {
 			return fmt.Errorf("unable to unmarshal node config: %w", err)
 		}
 	}
-	result, err := config.PatchK0sConfig(finalcfg.DeepCopy(), patch)
+	result, err := config.PatchK0sConfig(finalcfg.DeepCopy(), patch, false)
 	if err != nil {
 		return fmt.Errorf("unable to patch node config: %w", err)
 	}

--- a/pkg/k0s/install.go
+++ b/pkg/k0s/install.go
@@ -121,28 +121,28 @@ func WriteK0sConfig(ctx context.Context, networkInterface string, airgapBundle s
 
 // applyUnsupportedOverrides applies overrides to the k0s configuration. Applies the
 // overrides embedded into the binary and then the ones provided by the user (--overrides).
-func applyUnsupportedOverrides(cfg *k0sv1beta1.ClusterConfig, overrides string) (*k0sv1beta1.ClusterConfig, error) {
+func applyUnsupportedOverrides(cfg *k0sv1beta1.ClusterConfig, endUserOverridesPath string) (*k0sv1beta1.ClusterConfig, error) {
 	embcfg := release.GetEmbeddedClusterConfig()
 	if embcfg != nil {
 		// Apply vendor k0s overrides
-		overrides := embcfg.Spec.UnsupportedOverrides.K0s
+		vendorOverrides := embcfg.Spec.UnsupportedOverrides.K0s
 		var err error
-		cfg, err = config.PatchK0sConfig(cfg, overrides)
+		cfg, err = config.PatchK0sConfig(cfg, vendorOverrides)
 		if err != nil {
 			return nil, fmt.Errorf("unable to patch k0s config: %w", err)
 		}
 	}
 
-	eucfg, err := helpers.ParseEndUserConfig(overrides)
+	eucfg, err := helpers.ParseEndUserConfig(endUserOverridesPath)
 	if err != nil {
 		return nil, fmt.Errorf("unable to process overrides file: %w", err)
 	}
 
 	if eucfg != nil {
 		// Apply end user k0s overrides
-		overrides := eucfg.Spec.UnsupportedOverrides.K0s
+		endUserOverrides := eucfg.Spec.UnsupportedOverrides.K0s
 		var err error
-		cfg, err = config.PatchK0sConfig(cfg, overrides)
+		cfg, err = config.PatchK0sConfig(cfg, endUserOverrides)
 		if err != nil {
 			return nil, fmt.Errorf("unable to apply overrides: %w", err)
 		}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

This updates the upgrade code to reapply unsupported k0s overrides on upgrade, and adds a test that ensures worker profiles are properly added when upgrading (via unsupported overrides).

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
