### PR TITLE
fix: handle ctrl+c in prompts

### DIFF
--- a/cmd/installer/cli/adminconsole_resetpassword.go
+++ b/cmd/installer/cli/adminconsole_resetpassword.go
@@ -37,8 +37,14 @@ func AdminConsoleResetPasswordCmd(ctx context.Context, name string) *cobra.Comma
 			} else {
 				maxTries := 3
 				for i := 0; i < maxTries; i++ {
-					promptA := prompts.New().Password(fmt.Sprintf("Set the Admin Console password (minimum %d characters):", minAdminPasswordLength))
-					promptB := prompts.New().Password("Confirm the Admin Console password:")
+					promptA, err := prompts.New().Password(fmt.Sprintf("Set the Admin Console password (minimum %d characters):", minAdminPasswordLength))
+					if err != nil {
+						return fmt.Errorf("failed to get password: %w", err)
+					}
+					promptB, err := prompts.New().Password("Confirm the Admin Console password:")
+					if err != nil {
+						return fmt.Errorf("failed to get password: %w", err)
+					}
 
 					if validateAdminConsolePassword(promptA, promptB) {
 						password = promptA

--- a/cmd/installer/cli/adminconsole_resetpassword.go
+++ b/cmd/installer/cli/adminconsole_resetpassword.go
@@ -43,7 +43,7 @@ func AdminConsoleResetPasswordCmd(ctx context.Context, name string) *cobra.Comma
 					}
 					promptB, err := prompts.New().Password("Confirm the Admin Console password:")
 					if err != nil {
-						return fmt.Errorf("failed to get password: %w", err)
+						return fmt.Errorf("failed to get password confirmation: %w", err)
 					}
 
 					if validateAdminConsolePassword(promptA, promptB) {

--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/gosimple/slug"
 	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/cmd/installer/goods"
@@ -111,7 +112,12 @@ func InstallCmd(ctx context.Context, name string) *cobra.Command {
 			})
 
 			if err := runInstall(cmd.Context(), name, flags, metricsReporter); err != nil {
-				metricsReporter.ReportInstallationFailed(ctx, err)
+				// Check if this is an interrupt error from the terminal
+				if errors.Is(err, terminal.InterruptErr) {
+					metricsReporter.ReportSignalAborted(ctx, syscall.SIGINT)
+				} else {
+					metricsReporter.ReportInstallationFailed(ctx, err)
+				}
 				return err
 			}
 			metricsReporter.ReportInstallationSucceeded(ctx)
@@ -463,8 +469,15 @@ func ensureAdminConsolePassword(flags *InstallCmdFlags) error {
 		} else {
 			maxTries := 3
 			for i := 0; i < maxTries; i++ {
-				promptA := prompts.New().Password(fmt.Sprintf("Set the Admin Console password (minimum %d characters):", minAdminPasswordLength))
-				promptB := prompts.New().Password("Confirm the Admin Console password:")
+				promptA, err := prompts.New().Password(fmt.Sprintf("Set the Admin Console password (minimum %d characters):", minAdminPasswordLength))
+				if err != nil {
+					return fmt.Errorf("failed to get password: %w", err)
+				}
+
+				promptB, err := prompts.New().Password("Confirm the Admin Console password:")
+				if err != nil {
+					return fmt.Errorf("failed to get password confirmation: %w", err)
+				}
 
 				if validateAdminConsolePassword(promptA, promptB) {
 					flags.adminConsolePassword = promptA
@@ -566,7 +579,11 @@ func verifyChannelRelease(cmdName string, isAirgap bool, assumeYes bool) error {
 	if channelRelease != nil && channelRelease.Airgap && !isAirgap && !assumeYes {
 		logrus.Warnf("You downloaded an air gap bundle but didn't provide it with --airgap-bundle.")
 		logrus.Warnf("If you continue, the %s will not use an air gap bundle and will connect to the internet.", cmdName)
-		if !prompts.New().Confirm(fmt.Sprintf("Do you want to proceed with an online %s?", cmdName), false) {
+		confirmed, err := prompts.New().Confirm(fmt.Sprintf("Do you want to proceed with an online %s?", cmdName), false)
+		if err != nil {
+			return fmt.Errorf("failed to get confirmation: %w", err)
+		}
+		if !confirmed {
 			// TODO: send aborted metrics event
 			return NewErrorNothingElseToAdd(errors.New("user aborted: air gap bundle downloaded but flag not provided"))
 		}
@@ -770,7 +787,11 @@ func maybePromptForAppUpdate(ctx context.Context, prompt prompts.Prompt, license
 	}
 
 	text := fmt.Sprintf("Do you want to continue installing %s anyway?", channelRelease.VersionLabel)
-	if !prompt.Confirm(text, true) {
+	confirmed, err := prompt.Confirm(text, true)
+	if err != nil {
+		return fmt.Errorf("failed to get confirmation: %w", err)
+	}
+	if !confirmed {
 		// TODO: send aborted metrics event
 		return NewErrorNothingElseToAdd(errors.New("user aborted: app not up-to-date"))
 	}

--- a/cmd/installer/cli/join.go
+++ b/cmd/installer/cli/join.go
@@ -84,7 +84,6 @@ func JoinCmd(ctx context.Context, name string) *cobra.Command {
 				// Check if this is an interrupt error from the terminal
 				if errors.Is(err, terminal.InterruptErr) {
 					metricsReporter.ReportSignalAborted(ctx, syscall.SIGINT)
-					return err
 				} else {
 					metricsReporter.ReportJoinFailed(ctx, err)
 				}

--- a/cmd/installer/cli/join.go
+++ b/cmd/installer/cli/join.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/AlecAivazis/survey/v2/terminal"
 	k0sconfig "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons"
@@ -80,7 +81,13 @@ func JoinCmd(ctx context.Context, name string) *cobra.Command {
 			})
 
 			if err := runJoin(cmd.Context(), name, flags, jcmd, metricsReporter); err != nil {
-				metricsReporter.ReportJoinFailed(ctx, err)
+				// Check if this is an interrupt error from the terminal
+				if errors.Is(err, terminal.InterruptErr) {
+					metricsReporter.ReportSignalAborted(ctx, syscall.SIGINT)
+					return err
+				} else {
+					metricsReporter.ReportJoinFailed(ctx, err)
+				}
 				return err
 			}
 
@@ -533,7 +540,10 @@ func maybeEnableHA(ctx context.Context, kcli client.Client, flags JoinCmdFlags, 
 			logrus.Info("When high availability is enabled, you must maintain at least three nodes.")
 			logrus.Info("")
 		}
-		shouldEnableHA := prompts.New().Confirm("Do you want to enable high availability?", false)
+		shouldEnableHA, err := prompts.New().Confirm("Do you want to enable high availability?", false)
+		if err != nil {
+			return fmt.Errorf("failed to get confirmation: %w", err)
+		}
 		if !shouldEnableHA {
 			return nil
 		}

--- a/cmd/installer/cli/reset.go
+++ b/cmd/installer/cli/reset.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/AlecAivazis/survey/v2/terminal"
 	autopilot "github.com/k0sproject/k0s/pkg/apis/autopilot/v1beta2"
 	"github.com/k0sproject/k0s/pkg/etcd"
 	"github.com/replicatedhq/embedded-cluster/pkg/config"
@@ -241,7 +242,9 @@ func checkErrPrompt(noPrompt bool, force bool, err error) bool {
 	}
 	logrus.Info("Continuing may leave the cluster in an unexpected state.")
 	confirmed, err := prompts.New().Confirm("Do you want to continue anyway?", false)
-	if err != nil {
+	if errors.Is(err, terminal.InterruptErr) {
+		panic(err)
+	} else if err != nil {
 		logrus.Errorf("failed to get confirmation: %v", err)
 		return false
 	}

--- a/cmd/installer/cli/reset.go
+++ b/cmd/installer/cli/reset.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/AlecAivazis/survey/v2/terminal"
 	autopilot "github.com/k0sproject/k0s/pkg/apis/autopilot/v1beta2"
 	"github.com/k0sproject/k0s/pkg/etcd"
 	"github.com/replicatedhq/embedded-cluster/pkg/config"
@@ -242,9 +241,7 @@ func checkErrPrompt(noPrompt bool, force bool, err error) bool {
 	}
 	logrus.Info("Continuing may leave the cluster in an unexpected state.")
 	confirmed, err := prompts.New().Confirm("Do you want to continue anyway?", false)
-	if errors.Is(err, terminal.InterruptErr) {
-		panic(err)
-	} else if err != nil {
+	if err != nil {
 		logrus.Errorf("failed to get confirmation: %v", err)
 		return false
 	}

--- a/cmd/installer/cli/restore.go
+++ b/cmd/installer/cli/restore.go
@@ -142,7 +142,7 @@ func runRestore(ctx context.Context, name string, flags InstallCmdFlags, s3Store
 	if state != ecRestoreStateNew {
 		shouldResume, err := prompts.New().Confirm("A previous restore operation was detected. Would you like to resume?", true)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to get confirmation: %w", err)
 		}
 		logrus.Info("")
 		if !shouldResume {
@@ -352,7 +352,7 @@ func runRestoreStepNew(ctx context.Context, name string, flags InstallCmdFlags, 
 		logrus.Info("Enter information to configure access to your backup storage location.\n")
 
 		if err := promptForS3BackupStore(s3Store); err != nil {
-			return err
+			return fmt.Errorf("failed to prompt for backup store: %w", err)
 		}
 	}
 	s3Store.prefix = strings.TrimPrefix(s3Store.prefix, "/")
@@ -1590,7 +1590,7 @@ func waitForAdditionalNodes(ctx context.Context, highAvailability bool, networkI
 	for {
 		p, err := prompts.New().Input("Type 'continue' when you are done adding nodes:", "", false)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to get confirmation: %w", err)
 		}
 		if p != "continue" {
 			logrus.Info("Please type 'continue' to proceed")

--- a/cmd/installer/cli/restore.go
+++ b/cmd/installer/cli/restore.go
@@ -140,7 +140,10 @@ func runRestore(ctx context.Context, name string, flags InstallCmdFlags, s3Store
 	logrus.Debugf("restore state is: %q", state)
 
 	if state != ecRestoreStateNew {
-		shouldResume := prompts.New().Confirm("A previous restore operation was detected. Would you like to resume?", true)
+		shouldResume, err := prompts.New().Confirm("A previous restore operation was detected. Would you like to resume?", true)
+		if err != nil {
+			return err
+		}
 		logrus.Info("")
 		if !shouldResume {
 			state = ecRestoreStateNew
@@ -348,7 +351,9 @@ func runRestoreStepNew(ctx context.Context, name string, flags InstallCmdFlags, 
 		logrus.Infof("You'll be guided through the process of restoring %s from a backup.\n", name)
 		logrus.Info("Enter information to configure access to your backup storage location.\n")
 
-		promptForS3BackupStore(s3Store)
+		if err := promptForS3BackupStore(s3Store); err != nil {
+			return err
+		}
 	}
 	s3Store.prefix = strings.TrimPrefix(s3Store.prefix, "/")
 
@@ -479,7 +484,10 @@ func runRestoreStepConfirmBackup(ctx context.Context, flags InstallCmdFlags) (*d
 
 	logrus.Info("")
 	completionTimestamp := backupToRestore.GetCompletionTimestamp().Format("2006-01-02 15:04:05 UTC")
-	shouldRestore := prompts.New().Confirm(fmt.Sprintf("Restore from backup %q (%s)?", backupToRestore.GetName(), completionTimestamp), true)
+	shouldRestore, err := prompts.New().Confirm(fmt.Sprintf("Restore from backup %q (%s)?", backupToRestore.GetName(), completionTimestamp), true)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to get confirmation: %w", err)
+	}
 	logrus.Info("")
 	if !shouldRestore {
 		logrus.Infof("Aborting restore...")
@@ -866,22 +874,51 @@ func s3BackupStoreHasData(store *s3BackupStore) bool {
 }
 
 // promptForS3BackupStore prompts the user for S3 backup store configuration.
-func promptForS3BackupStore(store *s3BackupStore) {
+func promptForS3BackupStore(store *s3BackupStore) error {
 	for {
-		store.endpoint = strings.TrimSpace(prompts.New().Input("S3 endpoint:", store.endpoint, true))
+		input, err := prompts.New().Input("S3 endpoint:", store.endpoint, true)
+		if err != nil {
+			return fmt.Errorf("failed to get input: %w", err)
+		}
+		store.endpoint = strings.TrimSpace(input)
 		if strings.HasPrefix(store.endpoint, "http://") || strings.HasPrefix(store.endpoint, "https://") {
 			break
 		}
 		logrus.Info("Endpoint must start with http:// or https://")
 	}
 
-	store.region = strings.TrimSpace(prompts.New().Input("Region:", store.region, true))
-	store.bucket = strings.TrimSpace(prompts.New().Input("Bucket:", store.bucket, true))
-	store.prefix = strings.TrimSpace(prompts.New().Input("Prefix (press Enter to skip):", store.prefix, false))
-	store.accessKeyID = strings.TrimSpace(prompts.New().Input("Access key ID:", store.accessKeyID, true))
-	store.secretAccessKey = strings.TrimSpace(prompts.New().Password("Secret access key:"))
+	input, err := prompts.New().Input("Region:", store.region, true)
+	if err != nil {
+		return fmt.Errorf("failed to get input: %w", err)
+	}
+	store.region = strings.TrimSpace(input)
+
+	input, err = prompts.New().Input("Bucket:", store.bucket, true)
+	if err != nil {
+		return fmt.Errorf("failed to get input: %w", err)
+	}
+	store.bucket = strings.TrimSpace(input)
+
+	input, err = prompts.New().Input("Prefix (press Enter to skip):", store.prefix, false)
+	if err != nil {
+		return fmt.Errorf("failed to get input: %w", err)
+	}
+	store.prefix = strings.TrimSpace(input)
+
+	input, err = prompts.New().Input("Access key ID:", store.accessKeyID, true)
+	if err != nil {
+		return fmt.Errorf("failed to get input: %w", err)
+	}
+	store.accessKeyID = strings.TrimSpace(input)
+
+	password, err := prompts.New().Password("Secret access key:")
+	if err != nil {
+		return fmt.Errorf("failed to get password: %w", err)
+	}
+	store.secretAccessKey = strings.TrimSpace(password)
 
 	logrus.Info("")
+	return nil
 }
 
 // validateS3BackupStore validates the S3 backup store configuration.
@@ -1551,7 +1588,10 @@ func waitForAdditionalNodes(ctx context.Context, highAvailability bool, networkI
 	logrus.Info(joinNodesMsg)
 
 	for {
-		p := prompts.New().Input("Type 'continue' when you are done adding nodes:", "", false)
+		p, err := prompts.New().Input("Type 'continue' when you are done adding nodes:", "", false)
+		if err != nil {
+			return err
+		}
 		if p != "continue" {
 			logrus.Info("Please type 'continue' to proceed")
 			continue

--- a/pkg/preflights/run.go
+++ b/pkg/preflights/run.go
@@ -158,7 +158,11 @@ func runHostPreflights(ctx context.Context, hpf *v1beta2.HostPreflightSpec, opts
 				}
 				return nil
 			}
-			if prompts.New().Confirm("Are you sure you want to ignore these failures and continue installing?", false) {
+			confirmed, err := prompts.New().Confirm("Are you sure you want to ignore these failures and continue installing?", false)
+			if err != nil {
+				return fmt.Errorf("failed to get confirmation: %w", err)
+			}
+			if confirmed {
 				if opts.MetricsReporter != nil {
 					opts.MetricsReporter.ReportPreflightsFailed(ctx, *output, true)
 				}
@@ -200,7 +204,11 @@ func runHostPreflights(ctx context.Context, hpf *v1beta2.HostPreflightSpec, opts
 		pb.Close()
 		output.PrintTableWithoutInfo()
 
-		if !prompts.New().Confirm("Do you want to continue?", false) {
+		confirmed, err := prompts.New().Confirm("Do you want to continue?", false)
+		if err != nil {
+			return fmt.Errorf("failed to get confirmation: %w", err)
+		}
+		if !confirmed {
 			if opts.MetricsReporter != nil {
 				opts.MetricsReporter.ReportPreflightsFailed(ctx, *output, false)
 			}

--- a/pkg/prompts/decorative/decorative.go
+++ b/pkg/prompts/decorative/decorative.go
@@ -2,8 +2,6 @@
 package decorative
 
 import (
-	"fmt"
-
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/sirupsen/logrus"
 )
@@ -21,7 +19,7 @@ func (d Decorative) Confirm(msg string, defvalue bool) (bool, error) {
 	var response bool
 	var confirm = &survey.Confirm{Message: msg, Default: defvalue}
 	if err := survey.AskOne(confirm, &response); err != nil {
-		return false, fmt.Errorf("unable to confirm: %w", err)
+		return false, err
 	}
 	return response, nil
 }
@@ -31,7 +29,7 @@ func (d Decorative) PressEnter(msg string) error {
 	var i string
 	in := &survey.Input{Message: msg}
 	if err := survey.AskOne(in, &i); err != nil {
-		return fmt.Errorf("unable to ask for input: %w", err)
+		return err
 	}
 	return nil
 }
@@ -42,7 +40,7 @@ func (d Decorative) Password(msg string) (string, error) {
 	for pass == "" {
 		question := &survey.Password{Message: msg}
 		if err := survey.AskOne(question, &pass); err != nil {
-			return "", fmt.Errorf("unable to ask for input: %w", err)
+			return "", err
 		} else if pass == "" {
 			logrus.Error("Password cannot be empty")
 		}
@@ -59,7 +57,7 @@ func (d Decorative) Select(msg string, options []string, defvalue string) (strin
 	}
 	var response string
 	if err := survey.AskOne(question, &response); err != nil {
-		return "", fmt.Errorf("unable to ask for input: %w", err)
+		return "", err
 	}
 	return response, nil
 }
@@ -71,7 +69,7 @@ func (d Decorative) Input(msg string, defvalue string, required bool) (string, e
 	for response == "" {
 		question := &survey.Input{Message: msg, Default: defvalue}
 		if err := survey.AskOne(question, &response); err != nil {
-			return "", fmt.Errorf("unable to ask for input: %w", err)
+			return "", err
 		} else if !required || response != "" {
 			break
 		}

--- a/pkg/prompts/decorative/decorative.go
+++ b/pkg/prompts/decorative/decorative.go
@@ -2,6 +2,8 @@
 package decorative
 
 import (
+	"fmt"
+
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/sirupsen/logrus"
 )
@@ -15,40 +17,41 @@ func New() Decorative {
 
 // Confirm asks for user for a "Yes" or "No" response. The default value
 // is used if the user presses enter without typing anything.
-func (d Decorative) Confirm(msg string, defvalue bool) bool {
+func (d Decorative) Confirm(msg string, defvalue bool) (bool, error) {
 	var response bool
 	var confirm = &survey.Confirm{Message: msg, Default: defvalue}
 	if err := survey.AskOne(confirm, &response); err != nil {
-		logrus.Fatalf("unable to confirm: %v", err)
+		return false, fmt.Errorf("unable to confirm: %w", err)
 	}
-	return response
+	return response, nil
 }
 
 // PressEnter asks the user to press enter to continue.
-func (d Decorative) PressEnter(msg string) {
+func (d Decorative) PressEnter(msg string) error {
 	var i string
 	in := &survey.Input{Message: msg}
 	if err := survey.AskOne(in, &i); err != nil {
-		logrus.Fatalf("unable to ask for input: %v", err)
+		return fmt.Errorf("unable to ask for input: %w", err)
 	}
+	return nil
 }
 
 // Password asks the user for a password. Password can't be empty.
-func (d Decorative) Password(msg string) string {
+func (d Decorative) Password(msg string) (string, error) {
 	var pass string
 	for pass == "" {
 		question := &survey.Password{Message: msg}
 		if err := survey.AskOne(question, &pass); err != nil {
-			logrus.Fatalf("unable to ask for input: %v", err)
+			return "", fmt.Errorf("unable to ask for input: %w", err)
 		} else if pass == "" {
 			logrus.Error("Password cannot be empty")
 		}
 	}
-	return pass
+	return pass, nil
 }
 
 // Select asks the user to select one of the provided options.
-func (d Decorative) Select(msg string, options []string, defvalue string) string {
+func (d Decorative) Select(msg string, options []string, defvalue string) (string, error) {
 	question := &survey.Select{
 		Message: msg,
 		Options: options,
@@ -56,23 +59,23 @@ func (d Decorative) Select(msg string, options []string, defvalue string) string
 	}
 	var response string
 	if err := survey.AskOne(question, &response); err != nil {
-		logrus.Fatalf("unable to ask for input: %v", err)
+		return "", fmt.Errorf("unable to ask for input: %w", err)
 	}
-	return response
+	return response, nil
 }
 
 // Input asks the user for a string. If required is true then
 // the string cannot be empty.
-func (d Decorative) Input(msg string, defvalue string, required bool) string {
+func (d Decorative) Input(msg string, defvalue string, required bool) (string, error) {
 	var response string
 	for response == "" {
 		question := &survey.Input{Message: msg, Default: defvalue}
 		if err := survey.AskOne(question, &response); err != nil {
-			logrus.Fatalf("unable to ask for input: %v", err)
+			return "", fmt.Errorf("unable to ask for input: %w", err)
 		} else if !required || response != "" {
 			break
 		}
 		logrus.Error("Input cannot be empty")
 	}
-	return response
+	return response, nil
 }

--- a/pkg/prompts/plain/plain.go
+++ b/pkg/prompts/plain/plain.go
@@ -47,7 +47,7 @@ func WithOut(out io.Writer) Option {
 
 // Confirm asks for user for a "Yes" or "No" response. The default value
 // is used if the user presses enter without typing neither Y nor N.
-func (p Plain) Confirm(msg string, defvalue bool) bool {
+func (p Plain) Confirm(msg string, defvalue bool) (bool, error) {
 	options := " [y/N]"
 	if defvalue {
 		options = " [Y/n]"
@@ -57,16 +57,16 @@ func (p Plain) Confirm(msg string, defvalue bool) bool {
 		fmt.Fprintf(p.out, "%s %s: ", msg, options)
 		input, err := reader.ReadString('\n')
 		if err != nil {
-			logrus.Fatalf("unable to read input: %v", err)
+			return false, fmt.Errorf("unable to read input: %w", err)
 		}
 		input = strings.ToLower(strings.TrimSpace(input))
 		switch input {
 		case "y", "yes":
-			return true
+			return true, nil
 		case "n", "no":
-			return false
+			return false, nil
 		case "":
-			return defvalue
+			return defvalue, nil
 		default:
 			logrus.Errorf("Invalid input: %s", input)
 		}
@@ -74,22 +74,23 @@ func (p Plain) Confirm(msg string, defvalue bool) bool {
 }
 
 // PressEnter asks the user to press enter to continue.
-func (p Plain) PressEnter(msg string) {
+func (p Plain) PressEnter(msg string) error {
 	fmt.Fprintf(p.out, "%s ", msg)
 	reader := bufio.NewReader(p.in)
 	if _, err := reader.ReadString('\n'); err != nil {
-		logrus.Fatalf("unable to read input: %v", err)
+		return fmt.Errorf("unable to read input: %w", err)
 	}
+	return nil
 }
 
 // Password asks the user for a password. We just forward the call to Input
 // with required set to true.
-func (p Plain) Password(msg string) string {
+func (p Plain) Password(msg string) (string, error) {
 	return p.Input(msg, "", true)
 }
 
 // Select asks the user to select one of the provided options.
-func (p Plain) Select(msg string, options []string, _ string) string {
+func (p Plain) Select(msg string, options []string, _ string) (string, error) {
 	reader := bufio.NewReader(p.in)
 	for {
 		fmt.Println(msg)
@@ -99,14 +100,14 @@ func (p Plain) Select(msg string, options []string, _ string) string {
 		fmt.Fprintf(p.out, "Type one of the options above: ")
 		input, err := reader.ReadString('\n')
 		if err != nil {
-			logrus.Fatalf("unable to read input: %v", err)
+			return "", fmt.Errorf("unable to read input: %w", err)
 		}
 		input = strings.TrimSuffix(input, "\n")
 		for _, option := range options {
 			if input != option {
 				continue
 			}
-			return input
+			return input, nil
 		}
 		logrus.Errorf("Invalid option %q", input)
 	}
@@ -114,14 +115,14 @@ func (p Plain) Select(msg string, options []string, _ string) string {
 
 // Input asks the user for a string. If required is true then
 // the string cannot be empty.
-func (p Plain) Input(msg string, _ string, required bool) string {
+func (p Plain) Input(msg string, defvalue string, required bool) (string, error) {
 	reader := bufio.NewReader(p.in)
 	for {
 		fmt.Fprintf(p.out, "%s ", msg)
 		if input, err := reader.ReadString('\n'); err != nil {
-			logrus.Fatalf("unable to read input: %v", err)
+			return "", fmt.Errorf("unable to read input: %w", err)
 		} else if !required || input != "" {
-			return strings.TrimSuffix(input, "\n")
+			return strings.TrimSuffix(input, "\n"), nil
 		}
 		logrus.Error("Input cannot be empty")
 	}

--- a/pkg/prompts/plain/plain.go
+++ b/pkg/prompts/plain/plain.go
@@ -57,7 +57,7 @@ func (p Plain) Confirm(msg string, defvalue bool) (bool, error) {
 		fmt.Fprintf(p.out, "%s %s: ", msg, options)
 		input, err := reader.ReadString('\n')
 		if err != nil {
-			return false, fmt.Errorf("unable to read input: %w", err)
+			return false, fmt.Errorf("read input: %w", err)
 		}
 		input = strings.ToLower(strings.TrimSpace(input))
 		switch input {
@@ -78,7 +78,7 @@ func (p Plain) PressEnter(msg string) error {
 	fmt.Fprintf(p.out, "%s ", msg)
 	reader := bufio.NewReader(p.in)
 	if _, err := reader.ReadString('\n'); err != nil {
-		return fmt.Errorf("unable to read input: %w", err)
+		return fmt.Errorf("read input: %w", err)
 	}
 	return nil
 }
@@ -100,7 +100,7 @@ func (p Plain) Select(msg string, options []string, _ string) (string, error) {
 		fmt.Fprintf(p.out, "Type one of the options above: ")
 		input, err := reader.ReadString('\n')
 		if err != nil {
-			return "", fmt.Errorf("unable to read input: %w", err)
+			return "", fmt.Errorf("read input: %w", err)
 		}
 		input = strings.TrimSuffix(input, "\n")
 		for _, option := range options {
@@ -120,7 +120,7 @@ func (p Plain) Input(msg string, defvalue string, required bool) (string, error)
 	for {
 		fmt.Fprintf(p.out, "%s ", msg)
 		if input, err := reader.ReadString('\n'); err != nil {
-			return "", fmt.Errorf("unable to read input: %w", err)
+			return "", fmt.Errorf("read input: %w", err)
 		} else if !required || input != "" {
 			return strings.TrimSuffix(input, "\n"), nil
 		}

--- a/pkg/prompts/prompts.go
+++ b/pkg/prompts/prompts.go
@@ -23,15 +23,15 @@ func SetTerminal(isTerminal bool) {
 type Prompt interface {
 	// Confirm asks for user for a "Yes" or "No" response. The default value is used if the user
 	// presses enter without typing anything.
-	Confirm(msg string, defvalue bool) bool
+	Confirm(msg string, defvalue bool) (bool, error)
 	// PressEnter asks the user to press enter to continue.
-	PressEnter(msg string)
+	PressEnter(msg string) error
 	// Password asks the user for a password. Password can't be empty.
-	Password(msg string) string
+	Password(msg string) (string, error)
 	// Select asks the user to select one of the provided options.
-	Select(msg string, options []string, defvalue string) string
+	Select(msg string, options []string, defvalue string) (string, error)
 	// Input asks the user for a string. If required is true then the string cannot be empty.
-	Input(msg string, defvalue string, required bool) string
+	Input(msg string, defvalue string, required bool) (string, error)
 }
 
 // New returns a new Prompt.


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

> Ordinarily, when you type Ctrl-C, the terminal recognizes this as the QUIT button and delivers a SIGINT signal to the process, which terminates it. However, Survey temporarily configures the terminal to deliver control codes as ordinary input bytes. When Survey reads a ^C byte (ASCII \x03, "end of text"), it interrupts the current survey and returns a github.com/AlecAivazis/survey/v2/terminal.InterruptErr from Ask or AskOne. If you want to stop the process, handle the returned error in your code:

https://github.com/AlecAivazis/survey?tab=readme-ov-file#why-isnt-ctrl-c-working

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
