### PR TITLE
Start moving airgap e2e tests to CMX

### DIFF
--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -25,6 +25,15 @@ inputs:
   version-specifier:
     description: 'the git sha or tag used to generate application version strings'
     required: true
+  github-token:
+    description: 'the ci github token used to install the replicated cli'
+    required: false # this is only needed for cmx-based tests
+  cmx-api-token:
+    description: 'the token used to access the replicated api for cmx'
+    required: false # this is only needed for cmx-based tests
+  cmx-ssh-private-key:
+    description: 'the private key used to access the cmx nodes'
+    required: false # this is only needed for cmx-based tests
   upgrade-target-ec-version:
     description: 'the embedded cluster version to expect after upgrades complete'
     required: false # this is only set by post-release testing
@@ -73,11 +82,28 @@ runs:
     with:
       go-version-file: go.mod
       cache-dependency-path: "**/*.sum"
+  - name: Install replicated CLI for CMX
+    if: ${{ inputs.cmx-api-token != '' }}
+    shell: bash
+    env:
+      GH_TOKEN: ${{ inputs.github-token }}
+    run: |
+      gh release download --repo replicatedhq/replicated --pattern '*_linux_amd64.tar.gz' --output /tmp/replicated.tar.gz --clobber
+      tar -xzf /tmp/replicated.tar.gz -C /tmp
+      mv /tmp/replicated /usr/local/bin/replicated
+  - name: Setup SSH for CMX
+    if: ${{ inputs.cmx-ssh-private-key != '' }}
+    shell: bash
+    run: |
+      mkdir -p ~/.ssh
+      echo "${{ inputs.cmx-ssh-private-key }}" > ~/.ssh/id_ed25519
+      chmod 600 ~/.ssh/id_ed25519
   - name: E2E
     shell: bash
     run: |
       export SHORT_SHA=${{ inputs.version-specifier }}
       echo "${SHORT_SHA}"
+      export REPLICATED_API_TOKEN=${{ inputs.cmx-api-token }}
       export DR_AWS_S3_ENDPOINT=https://s3.amazonaws.com
       export DR_AWS_S3_REGION=us-east-1
       export DR_AWS_S3_BUCKET=kots-testim-snapshots

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -739,8 +739,6 @@ jobs:
           - TestMultiNodeAirgapUpgradePreviousStable
           - TestAirgapUpgradeFromEC18
           - TestMultiNodeAirgapHAInstallation
-          # TODO NOW: remove this
-          - TestFiveNodesAirgapUpgrade
         include:
           - test: TestSingleNodeAirgapDisasterRecovery
             runner: embedded-cluster-2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -739,6 +739,8 @@ jobs:
           - TestMultiNodeAirgapUpgradePreviousStable
           - TestAirgapUpgradeFromEC18
           - TestMultiNodeAirgapHAInstallation
+          # TODO NOW: remove this
+          - TestFiveNodesAirgapUpgrade
         include:
           - test: TestSingleNodeAirgapDisasterRecovery
             runner: embedded-cluster-2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -734,18 +734,13 @@ jobs:
           - TestProxiedCustomCIDR
           - TestInstallWithPrivateCAs
           - TestInstallWithMITMProxy
+          - TestMultiNodeAirgapUpgrade
+          - TestMultiNodeAirgapUpgradeSameK0s
+          - TestMultiNodeAirgapUpgradePreviousStable
+          - TestAirgapUpgradeFromEC18
+          - TestMultiNodeAirgapHAInstallation
         include:
-          - test: TestMultiNodeAirgapUpgrade
-            runner: embedded-cluster-2
-          - test: TestMultiNodeAirgapUpgradeSameK0s
-            runner: embedded-cluster-2
-          - test: TestMultiNodeAirgapUpgradePreviousStable
-            runner: embedded-cluster-2
-          - test: TestAirgapUpgradeFromEC18
-            runner: embedded-cluster-2
           - test: TestSingleNodeAirgapDisasterRecovery
-            runner: embedded-cluster-2
-          - test: TestMultiNodeAirgapHAInstallation
             runner: embedded-cluster-2
           - test: TestMultiNodeAirgapHADisasterRecovery
             runner: embedded-cluster-2
@@ -768,9 +763,6 @@ jobs:
           k0s-version-previous: ${{ needs.build-previous-k0s.outputs.k0s_version }}
           k0s-version-previous-stable: ${{ needs.find-previous-stable.outputs.k0s_version }}
           version-specifier: ${{ needs.export-version-specifier.outputs.version_specifier }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          cmx-api-token: ${{ secrets.CMX_REPLICATED_API_TOKEN }}
-          cmx-ssh-private-key: ${{ secrets.CMX_SSH_PRIVATE_KEY }}
 
   e2e-main:
     name: E2E (on merge)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -737,9 +737,10 @@ jobs:
           - TestMultiNodeAirgapUpgrade
           - TestMultiNodeAirgapUpgradeSameK0s
           - TestMultiNodeAirgapUpgradePreviousStable
-          - TestAirgapUpgradeFromEC18
           - TestMultiNodeAirgapHAInstallation
         include:
+          - test: TestAirgapUpgradeFromEC18
+            runner: embedded-cluster-2
           - test: TestSingleNodeAirgapDisasterRecovery
             runner: embedded-cluster-2
           - test: TestMultiNodeAirgapHADisasterRecovery

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -763,6 +763,9 @@ jobs:
           k0s-version-previous: ${{ needs.build-previous-k0s.outputs.k0s_version }}
           k0s-version-previous-stable: ${{ needs.find-previous-stable.outputs.k0s_version }}
           version-specifier: ${{ needs.export-version-specifier.outputs.version_specifier }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cmx-api-token: ${{ secrets.CMX_REPLICATED_API_TOKEN }}
+          cmx-ssh-private-key: ${{ secrets.CMX_SSH_PRIVATE_KEY }}
 
   e2e-main:
     name: E2E (on merge)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -768,6 +768,9 @@ jobs:
           k0s-version-previous: ${{ needs.build-previous-k0s.outputs.k0s_version }}
           k0s-version-previous-stable: ${{ needs.find-previous-stable.outputs.k0s_version }}
           version-specifier: ${{ needs.export-version-specifier.outputs.version_specifier }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cmx-api-token: ${{ secrets.CMX_REPLICATED_API_TOKEN }}
+          cmx-ssh-private-key: ${{ secrets.CMX_SSH_PRIVATE_KEY }}
 
   e2e-main:
     name: E2E (on merge)

--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -563,18 +563,13 @@ jobs:
           - TestProxiedCustomCIDR
           - TestInstallWithPrivateCAs
           - TestInstallWithMITMProxy
+          - TestMultiNodeAirgapUpgrade
+          - TestMultiNodeAirgapUpgradeSameK0s
+          - TestMultiNodeAirgapUpgradePreviousStable
+          - TestAirgapUpgradeFromEC18
+          - TestMultiNodeAirgapHAInstallation
         include:
-          - test: TestMultiNodeAirgapUpgrade
-            runner: embedded-cluster-2
-          - test: TestMultiNodeAirgapUpgradeSameK0s
-            runner: embedded-cluster-2
-          - test: TestMultiNodeAirgapUpgradePreviousStable
-            runner: embedded-cluster-2
-          - test: TestAirgapUpgradeFromEC18
-            runner: embedded-cluster-2
           - test: TestSingleNodeAirgapDisasterRecovery
-            runner: embedded-cluster-2
-          - test: TestMultiNodeAirgapHAInstallation
             runner: embedded-cluster-2
           - test: TestMultiNodeAirgapHADisasterRecovery
             runner: embedded-cluster-2

--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -566,14 +566,13 @@ jobs:
           - TestMultiNodeAirgapUpgrade
           - TestMultiNodeAirgapUpgradeSameK0s
           - TestMultiNodeAirgapUpgradePreviousStable
-          - TestAirgapUpgradeFromEC18
           - TestMultiNodeAirgapHAInstallation
         include:
+          - test: TestAirgapUpgradeFromEC18
+            runner: embedded-cluster-2
           - test: TestSingleNodeAirgapDisasterRecovery
             runner: embedded-cluster-2
           - test: TestMultiNodeAirgapHADisasterRecovery
-            runner: embedded-cluster-2
-          - test: TestFiveNodesAirgapUpgrade
             runner: embedded-cluster-2
     steps:
       - name: Checkout

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,4 +1,59 @@
-## E2E tests
+## E2E Tests
+
+### Buildting the release for E2E tests
+
+```bash
+export ARCH=amd64
+export APP_VERSION="appver-dev-local-$USER"
+./scripts/build-and-release.sh
+```
+
+### Running individual CMX tests locally
+
+You can run a single test with:
+
+```bash
+export SHORT_SHA="dev-local-$USER"
+export LICENSE_ID="$EC_SMOKE_TEST_LICENSE_ID"
+make e2e-test TEST_NAME=TestSomething
+```
+
+TestSomething is the name of the test function you want to run.
+
+### Running individual Docker tests locally
+
+You can run a single test with:
+
+```bash
+export SHORT_SHA="dev-local-$USER"
+export LICENSE_ID="$EC_SMOKE_TEST_LICENSE_ID"
+make e2e-test TEST_NAME=TestSomething
+```
+
+TestSomething is the name of the test function you want to run.
+
+### Adding more tests
+
+Tests are added as Go tests in the e2e/ directory.
+Tests must be added to the ci.yaml and release-prod.yaml GitHub workflows to be run in CI.
+
+### Kots test application
+
+During end to end tests we embed a license for a smoke test kots app.
+This app can be found under the 'Replicated, Inc.' team on staging:
+
+https://vendor.staging.replicated.com/apps/embedded-cluster-smoke-test-staging-app
+
+New releases are created using the corresponding YAML files in the e2e/kots-release-* directories.
+
+### Playwright
+
+We use [Playwright](https://playwright.dev/) to run end to end tests on the UI.
+The tests live in the `playwright` directory.
+
+For more details on how to write tests with Playwright, refer to the [Playwright documentation](https://playwright.dev/docs/writing-tests).
+
+## DEPRECATED: E2E tests
 
 Integration tests depends on LXD. The following procedure shows
 how to get everything installed on Ubuntu 22.04.
@@ -31,45 +86,3 @@ Scripts inside the `scripts` directory are copied to all nodes.
 If you have a new test you want to add then start by creating a
 shell script to execute it and save it under the `scripts` dir.
 You can then call the script from your Go code.
-
-### Running all the tests
-
-You can run the tests from within this directory:
-
-```
-$ make e2e-tests
-```
-
-### Running individual tests
-
-You can run a single test with:
-
-```
-$ make e2e-test TEST_NAME=TestSomething
-```
-
-TestSomething is the name of the test function you want to run.
-
-### Adding more tests
-
-To add more tests you just need to create one inside this directory
-and then add it to the `.github/workflows/e2e.yaml` file.
-
-
-### Kots test application
-
-During end to end tests we embed a license for a smoke test kots app,
-this app can be found under the 'Replicated, Inc.' team on staging:
-
-https://vendor.staging.replicated.com/apps/embedded-cluster-smoke-test-staging-app
-
-Make sure to update the application yaml files under kots-release-onmerge
-and kots-release-onpr directories if you create a new release of the remote
-application.
-
-### Playwright
-
-We use [Playwright](https://playwright.dev/) to run end to end tests on the UI.
-The tests live in the `playwright` directory.
-
-For more details on how to write tests with Playwright, refer to the [Playwright documentation](https://playwright.dev/docs/writing-tests).

--- a/e2e/cluster/cmx/cluster.go
+++ b/e2e/cluster/cmx/cluster.go
@@ -292,14 +292,14 @@ func (c *Cluster) RunCommandOnNode(node int, line []string, envs ...map[string]s
 
 func runCommandOnNode(node Node, line []string, envs ...map[string]string) (string, string, error) {
 	line = append([]string{"sudo"}, line...)
-	cmd := exec.Command("ssh", append(sshArgs(), node.sshEndpoint, strings.Join(line, " "))...)
 
 	for _, env := range envs {
 		for k, v := range env {
-			cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
+			line = append([]string{fmt.Sprintf("%s=%s", k, v)}, line...)
 		}
 	}
 
+	cmd := exec.Command("ssh", append(sshArgs(), node.sshEndpoint, strings.Join(line, " "))...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/e2e/cluster/cmx/cluster.go
+++ b/e2e/cluster/cmx/cluster.go
@@ -291,13 +291,12 @@ func (c *Cluster) RunCommandOnNode(node int, line []string, envs ...map[string]s
 }
 
 func runCommandOnNode(node Node, line []string, envs ...map[string]string) (string, string, error) {
-	line = append([]string{"sudo"}, line...)
-
 	for _, env := range envs {
 		for k, v := range env {
 			line = append([]string{fmt.Sprintf("%s=%s", k, v)}, line...)
 		}
 	}
+	line = append([]string{"sudo"}, line...)
 
 	cmd := exec.Command("ssh", append(sshArgs(), node.sshEndpoint, strings.Join(line, " "))...)
 	var stdout, stderr bytes.Buffer

--- a/e2e/cluster/cmx/cluster.go
+++ b/e2e/cluster/cmx/cluster.go
@@ -1,0 +1,464 @@
+package cmx
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"golang.org/x/sync/errgroup"
+)
+
+type ClusterInput struct {
+	T                      *testing.T
+	Nodes                  int
+	Distribution           string
+	Version                string
+	InstanceType           string
+	DiskSize               int
+	SupportBundleNodeIndex int
+}
+
+type Cluster struct {
+	Nodes []Node
+
+	t                      *testing.T
+	network                *Network `json:"-"`
+	supportBundleNodeIndex int
+}
+
+type Node struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+
+	sshEndpoint     string `json:"-"`
+	adminConsoleURL string `json:"-"`
+}
+
+type Network struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func NewCluster(in *ClusterInput) *Cluster {
+	c := &Cluster{t: in.T, supportBundleNodeIndex: in.SupportBundleNodeIndex}
+	c.Nodes = make([]Node, in.Nodes)
+
+	network, err := NewNetwork(in)
+	if err != nil {
+		in.T.Fatalf("failed to create network: %v", err)
+	}
+	c.network = network
+
+	g := new(errgroup.Group)
+	var mu sync.Mutex
+
+	for i := range c.Nodes {
+		func(i int) {
+			g.Go(func() error {
+				node, err := NewNode(in, i, network.ID)
+				if err != nil {
+					return fmt.Errorf("failed to create node %d: %w", i, err)
+				}
+				mu.Lock()
+				c.Nodes[i] = *node
+				mu.Unlock()
+				return nil
+			})
+		}(i)
+	}
+
+	if err := g.Wait(); err != nil {
+		in.T.Fatalf("failed to create nodes: %v", err)
+	}
+
+	return c
+}
+
+func NewNetwork(in *ClusterInput) (*Network, error) {
+	name := fmt.Sprintf("ec-e2e-%s", uuid.New().String())
+	in.T.Logf("creating network %s", name)
+
+	output, err := exec.Command("replicated", "network", "create", "--name", name, "--wait", "5m", "-ojson").CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create network %s: %v: %s", name, err, string(output))
+	}
+
+	var networks []Network
+	if err := json.Unmarshal(output, &networks); err != nil {
+		return nil, fmt.Errorf("failed to parse networks output: %v", err)
+	}
+	if len(networks) != 1 {
+		return nil, fmt.Errorf("expected 1 network, got %d", len(networks))
+	}
+	return &networks[0], nil
+}
+
+func NewNode(in *ClusterInput, index int, networkID string) (*Node, error) {
+	nodeName := fmt.Sprintf("node%d", index)
+	in.T.Logf("creating node %s", nodeName)
+
+	args := []string{
+		"vm", "create",
+		"--name", nodeName,
+		"--network", networkID,
+		"--wait", "5m",
+		"-ojson",
+	}
+	if in.Distribution != "" {
+		args = append(args, "--distribution", in.Distribution)
+	}
+	if in.Version != "" {
+		args = append(args, "--version", in.Version)
+	}
+	if in.InstanceType != "" {
+		args = append(args, "--instance-type", in.InstanceType)
+	}
+	if in.DiskSize != 0 {
+		args = append(args, "--disk", strconv.Itoa(in.DiskSize))
+	}
+
+	output, err := exec.Command("replicated", args...).CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create node %s: %v: %s", nodeName, err, string(output))
+	}
+
+	var nodes []Node
+	if err := json.Unmarshal(output, &nodes); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal node: %v: %s", err, string(output))
+	}
+	if len(nodes) != 1 {
+		return nil, fmt.Errorf("expected 1 node, got %d", len(nodes))
+	}
+	node := nodes[0]
+
+	sshEndpoint, err := getSSHEndpoint(node.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ssh endpoint for node %s: %v", nodeName, err)
+	}
+	node.sshEndpoint = sshEndpoint
+
+	in.T.Logf("ensuring assets dir on node %s", node.Name)
+	if err := ensureAssetsDir(node); err != nil {
+		return nil, fmt.Errorf("failed to ensure assets dir on node %s: %v", node.Name, err)
+	}
+
+	in.T.Logf("copying scripts to node %s", node.Name)
+	if err := copyScriptsToNode(node); err != nil {
+		return nil, fmt.Errorf("failed to copy scripts to node %s: %v", node.Name, err)
+	}
+
+	if index == 0 {
+		in.T.Logf("exposing port 30003 on node %s", node.Name)
+		hostname, err := exposePort(node, "30003")
+		if err != nil {
+			return nil, fmt.Errorf("failed to expose port: %v", err)
+		}
+		node.adminConsoleURL = fmt.Sprintf("http://%s", hostname)
+	}
+
+	return &node, nil
+}
+
+func ensureAssetsDir(node Node) error {
+	stdout, stderr, err := runCommandOnNode(node, []string{"mkdir", "-p", "/assets"})
+	if err != nil {
+		return fmt.Errorf("failed to create directory: %v: %s: %s", err, stdout, stderr)
+	}
+	return nil
+}
+
+func copyScriptsToNode(node Node) error {
+	// Create a temporary directory for the archive
+	tempDir, err := os.MkdirTemp("", "scripts-archive")
+	if err != nil {
+		return fmt.Errorf("failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create the archive
+	archivePath := filepath.Join(tempDir, "scripts.tgz")
+	output, err := exec.Command("tar", "-czf", archivePath, "-C", "scripts", ".").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to create scripts archive: %v: %s", err, string(output))
+	}
+
+	// Copy the archive to the node
+	if err := copyFileToNode(node, archivePath, "/tmp/scripts.tgz"); err != nil {
+		return fmt.Errorf("failed to copy scripts archive to node: %v", err)
+	}
+
+	// Extract the archive in /usr/local/bin
+	_, stderr, err := runCommandOnNode(node, []string{"tar", "-xzf", "/tmp/scripts.tgz", "-C", "/usr/local/bin"})
+	if err != nil {
+		return fmt.Errorf("failed to extract scripts archive: %v: %s", err, stderr)
+	}
+
+	// Clean up the archive on the node
+	_, stderr, err = runCommandOnNode(node, []string{"rm", "-f", "/tmp/scripts.tgz"})
+	if err != nil {
+		return fmt.Errorf("failed to clean up scripts archive: %v: %s", err, stderr)
+	}
+
+	return nil
+}
+
+func getSSHEndpoint(nodeID string) (string, error) {
+	cmd := exec.Command("replicated", "vm", "ssh-endpoint", nodeID)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to get SSH endpoint for node %s: %v: %s", nodeID, err, string(output))
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func (c *Cluster) Airgap() error {
+	// Update network policy to airgap
+	cmd := exec.Command("replicated", "network", "update", "policy",
+		"--id", c.network.ID,
+		"--policy=airgap")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to update network policy: %v: %s", err, string(output))
+	}
+
+	// Wait until the nodes are airgapped
+	for node := range c.Nodes {
+		if err := c.waitUntilAirgapped(node); err != nil {
+			return fmt.Errorf("failed to wait until node %d is airgapped: %v", node, err)
+		}
+	}
+
+	return nil
+}
+
+func (c *Cluster) RefreshSSHEndpoints() error {
+	for i := range c.Nodes {
+		sshEndpoint, err := getSSHEndpoint(c.Nodes[i].ID)
+		if err != nil {
+			return fmt.Errorf("failed to get SSH endpoint for node %d: %v", i, err)
+		}
+		c.Nodes[i].sshEndpoint = sshEndpoint
+	}
+	return nil
+}
+
+func (c *Cluster) waitUntilAirgapped(node int) error {
+	timeout := time.After(2 * time.Minute)
+	tick := time.Tick(5 * time.Second)
+
+	for {
+		select {
+		case <-timeout:
+			return fmt.Errorf("timed out waiting for node to be airgapped after 1 minute")
+		case <-tick:
+			_, _, err := c.RunCommandOnNode(node, []string{"curl", "--connect-timeout", "5", "www.google.com"})
+			if err != nil {
+				c.t.Logf("node %d is airgapped successfully", node)
+				return nil
+			}
+			c.t.Logf("node %d is not airgapped yet", node)
+		}
+	}
+}
+
+func (c *Cluster) Cleanup(envs ...map[string]string) {
+	c.generateSupportBundle(envs...)
+	c.copyPlaywrightReport()
+	c.Destroy()
+}
+
+func (c *Cluster) Destroy() {
+	for _, node := range c.Nodes {
+		cmd := exec.Command("replicated", "vm", "rm", node.ID)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			c.t.Logf("failed to destroy node %s: %v: %s", node.Name, err, string(output))
+		}
+	}
+}
+
+func (c *Cluster) RunCommandOnNode(node int, line []string, envs ...map[string]string) (string, string, error) {
+	return runCommandOnNode(c.Nodes[node], line, envs...)
+}
+
+func runCommandOnNode(node Node, line []string, envs ...map[string]string) (string, string, error) {
+	line = append([]string{"sudo"}, line...)
+	cmd := exec.Command("ssh", append(sshArgs(), node.sshEndpoint, strings.Join(line, " "))...)
+
+	for _, env := range envs {
+		for k, v := range env {
+			cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
+		}
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+
+	if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 255 {
+		// check if this is a reset-installation command that resulted in exit code 255
+		// as this is expected behavior when the node reboots and the ssh connection is lost
+		if strings.Contains(strings.Join(line, " "), "reset-installation") {
+			return stdout.String(), stderr.String(), nil
+		}
+	}
+
+	return stdout.String(), stderr.String(), err
+}
+
+func (c *Cluster) SetupPlaywrightAndRunTest(testName string, args ...string) (string, string, error) {
+	if err := c.SetupPlaywright(); err != nil {
+		return "", "", fmt.Errorf("failed to setup playwright: %w", err)
+	}
+	return c.RunPlaywrightTest(testName, args...)
+}
+
+func (c *Cluster) SetupPlaywright(envs ...map[string]string) error {
+	c.t.Logf("%s: bypassing kurl-proxy", time.Now().Format(time.RFC3339))
+	_, stderr, err := c.RunCommandOnNode(0, []string{"bypass-kurl-proxy.sh"}, envs...)
+	if err != nil {
+		return fmt.Errorf("fail to bypass kurl-proxy: %v: %s", err, string(stderr))
+	}
+	c.t.Logf("%s: installing playwright", time.Now().Format(time.RFC3339))
+	cmd := exec.Command("sh", "-c", "cd playwright && npm ci && npx playwright install --with-deps")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("fail to install playwright: %v: %s", err, string(out))
+	}
+	return nil
+}
+
+func (c *Cluster) RunPlaywrightTest(testName string, args ...string) (string, string, error) {
+	c.t.Logf("%s: running playwright test %s", time.Now().Format(time.RFC3339), testName)
+	cmdArgs := []string{testName}
+	cmdArgs = append(cmdArgs, args...)
+	cmd := exec.Command("scripts/playwright.sh", cmdArgs...)
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, fmt.Sprintf("BASE_URL=%s", c.Nodes[0].adminConsoleURL))
+	cmd.Env = append(cmd.Env, "PLAYWRIGHT_DIR=./playwright")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return stdout.String(), stderr.String(), fmt.Errorf("fail to run playwright test %s: %v", testName, err)
+	}
+	return stdout.String(), stderr.String(), nil
+}
+
+func (c *Cluster) generateSupportBundle(envs ...map[string]string) {
+	wg := sync.WaitGroup{}
+	wg.Add(len(c.Nodes))
+
+	for i := range c.Nodes {
+		go func(i int, wg *sync.WaitGroup) {
+			defer wg.Done()
+			c.t.Logf("%s: generating host support bundle from node %d", time.Now().Format(time.RFC3339), i)
+			if stdout, stderr, err := c.RunCommandOnNode(i, []string{"collect-support-bundle-host.sh"}, envs...); err != nil {
+				c.t.Logf("stdout: %s", stdout)
+				c.t.Logf("stderr: %s", stderr)
+				c.t.Logf("fail to generate support from node %d bundle: %v", i, err)
+				return
+			}
+
+			c.t.Logf("%s: copying host support bundle from node %d to local machine", time.Now().Format(time.RFC3339), i)
+			src := "host.tar.gz"
+			dst := fmt.Sprintf("support-bundle-host-%d.tar.gz", i)
+			if err := copyFileFromNode(c.Nodes[i], src, dst); err != nil {
+				c.t.Logf("fail to copy support bundle from node %d: %v", i, err)
+				return
+			}
+		}(i, &wg)
+	}
+
+	c.t.Logf("%s: generating cluster support bundle from node %d", time.Now().Format(time.RFC3339), c.supportBundleNodeIndex)
+	if stdout, stderr, err := c.RunCommandOnNode(c.supportBundleNodeIndex, []string{"collect-support-bundle-cluster.sh"}, envs...); err != nil {
+		c.t.Logf("stdout: %s", stdout)
+		c.t.Logf("stderr: %s", stderr)
+		c.t.Logf("fail to generate cluster support from node %d bundle: %v", c.supportBundleNodeIndex, err)
+	} else {
+		c.t.Logf("%s: copying cluster support bundle from node %d to local machine", time.Now().Format(time.RFC3339), c.supportBundleNodeIndex)
+		src := "cluster.tar.gz"
+		dst := "support-bundle-cluster.tar.gz"
+		if err := copyFileFromNode(c.Nodes[c.supportBundleNodeIndex], src, dst); err != nil {
+			c.t.Logf("fail to copy cluster support bundle from node %d: %v", c.supportBundleNodeIndex, err)
+		}
+	}
+
+	wg.Wait()
+}
+
+func (c *Cluster) copyPlaywrightReport() {
+	c.t.Logf("%s: compressing playwright report", time.Now().Format(time.RFC3339))
+	cmd := exec.Command("tar", "-czf", "playwright-report.tar.gz", "-C", "./playwright/playwright-report", ".")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		c.t.Logf("fail to compress playwright report: %v: %s", err, string(out))
+	}
+}
+
+func exposePort(node Node, port string) (string, error) {
+	cmd := exec.Command("replicated", "vm", "port", "expose", node.ID, "--port", port)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to expose port: %v: %s", err, string(output))
+	}
+
+	cmd = exec.Command("replicated", "vm", "port", "ls", node.ID, "-ojson")
+	output, err = cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to get port info: %v: %s", err, string(output))
+	}
+
+	var ports []struct {
+		Hostname string `json:"hostname"`
+	}
+	if err := json.Unmarshal(output, &ports); err != nil {
+		return "", fmt.Errorf("failed to unmarshal port info: %v", err)
+	}
+
+	if len(ports) == 0 {
+		return "", fmt.Errorf("no ports found for node %s", node.ID)
+	}
+	return ports[0].Hostname, nil
+}
+
+func copyFileToNode(node Node, src, dst string) error {
+	scpEndpoint := strings.Replace(node.sshEndpoint, "ssh://", "scp://", 1)
+
+	cmd := exec.Command("scp", append(sshArgs(), src, fmt.Sprintf("%s/%s", scpEndpoint, dst))...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to copy file to node: %v: %s", err, string(output))
+	}
+	return nil
+}
+
+func copyFileFromNode(node Node, src, dst string) error {
+	scpEndpoint := strings.Replace(node.sshEndpoint, "ssh://", "scp://", 1)
+
+	cmd := exec.Command("scp", append(sshArgs(), fmt.Sprintf("%s/%s", scpEndpoint, src), dst)...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to copy file from node: %v: %s", err, string(output))
+	}
+	return nil
+}
+
+func sshArgs() []string {
+	return []string{
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "ServerAliveInterval=30",
+		"-o", "ServerAliveCountMax=10",
+	}
+}

--- a/e2e/cluster/interface.go
+++ b/e2e/cluster/interface.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"github.com/replicatedhq/embedded-cluster/e2e/cluster/cmx"
 	"github.com/replicatedhq/embedded-cluster/e2e/cluster/docker"
 	"github.com/replicatedhq/embedded-cluster/e2e/cluster/lxd"
 )
@@ -8,6 +9,7 @@ import (
 var (
 	_ Cluster = (*lxd.Cluster)(nil)
 	_ Cluster = (*docker.Cluster)(nil)
+	_ Cluster = (*cmx.Cluster)(nil)
 )
 
 type Cluster interface {

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -1599,11 +1599,9 @@ func TestMultiNodeAirgapHAInstallation(t *testing.T) {
 
 	checkPostUpgradeState(t, tc)
 
-	bin := "embedded-cluster"
-	t.Logf("%s: resetting controller node 0 with bin %q", time.Now().Format(time.RFC3339), bin)
-	stdout, stderr, err := tc.RunCommandOnNode(0, []string{bin, "reset", "--yes"})
+	stdout, stderr, err := resetInstallationWithError(t, tc, 0, resetInstallationOptions{})
 	if err != nil {
-		t.Fatalf("fail to remove controller node 0 %s: %s: %s", err, stdout, stderr)
+		t.Fatalf("fail to reset the installation on node 0: %v: %s: %s", err, stdout, stderr)
 	}
 	if !strings.Contains(stdout, "You must maintain at least three controller-test nodes in a high-availability cluster") {
 		t.Errorf("reset output does not contain the ha warning")

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -1009,6 +1009,10 @@ func TestAirgapUpgradeFromEC18(t *testing.T) {
 		func(t *testing.T) error {
 			return downloadAirgapBundleOnNode(t, tc, 0, upgrade2Version, AirgapUpgrade2BundlePath, AirgapLicenseID)
 		},
+		// versions < 2.4.0 required getting the binary from replicated.app
+		func(t *testing.T) error {
+			return downloadAirgapBundleOnNode(t, tc, 1, initialVersion, AirgapInstallBundlePath, AirgapLicenseID)
+		},
 	)
 
 	t.Logf("%s: airgapping cluster", time.Now().Format(time.RFC3339))
@@ -1323,6 +1327,11 @@ func TestMultiNodeAirgapUpgradePreviousStable(t *testing.T) {
 		func(t *testing.T) error {
 			return downloadAirgapBundleOnNode(t, tc, 0, upgrade2Version, AirgapUpgrade2BundlePath, AirgapLicenseID)
 		},
+		// TODO (@salah): remove this once we release 2.4.0 as it becomes the "previous stable"
+		// versions < 2.4.0 required getting the binary from replicated.app
+		func(t *testing.T) error {
+			return downloadAirgapBundleOnNode(t, tc, 1, initialVersion, AirgapInstallBundlePath, AirgapLicenseID)
+		},
 	)
 
 	t.Logf("%s: airgapping cluster", time.Now().Format(time.RFC3339))
@@ -1351,7 +1360,7 @@ func TestMultiNodeAirgapUpgradePreviousStable(t *testing.T) {
 		t.Fatalf("fail to run playwright test deploy-ec23-app: %v: %s: %s", err, stdout, stderr)
 	}
 
-	// TODO (@salah): use shared join function once we release 2.4.0 as it beomces the "previous stable"
+	// TODO (@salah): use shared join function once we release 2.4.0 as it becomes the "previous stable"
 	// generate worker node join command.
 	t.Logf("%s: generating a new worker token command", time.Now().Format(time.RFC3339))
 	stdout, stderr, err := tc.RunPlaywrightTest("get-ec23-join-worker-command")
@@ -1603,9 +1612,8 @@ func TestMultiNodeAirgapHAInstallation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("fail to reset the installation on node 0: %v: %s: %s", err, stdout, stderr)
 	}
-	if !strings.Contains(stdout, "You must maintain at least three controller-test nodes in a high-availability cluster") {
-		t.Errorf("reset output does not contain the ha warning")
-		t.Logf("stdout: %s\nstderr: %s", stdout, stderr)
+	if !strings.Contains(stdout, "High-availability is enabled and requires at least three controller-test nodes") {
+		t.Logf("reset output does not contain the ha warning: stdout: %s\nstderr: %s", stdout, stderr)
 	}
 
 	stdout, stderr, err = tc.RunCommandOnNode(2, []string{"check-nodes-removed.sh", "3"})

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -1565,11 +1565,12 @@ func TestMultiNodeAirgapHAInstallation(t *testing.T) {
 	RequireEnvVars(t, []string{"SHORT_SHA"})
 
 	tc := cmx.NewCluster(&cmx.ClusterInput{
-		T:            t,
-		Nodes:        4,
-		Distribution: "ubuntu",
-		Version:      "22.04",
-		InstanceType: "r1.medium",
+		T:                      t,
+		Nodes:                  4,
+		Distribution:           "ubuntu",
+		Version:                "22.04",
+		InstanceType:           "r1.medium",
+		SupportBundleNodeIndex: 2,
 	})
 	defer tc.Cleanup()
 

--- a/e2e/proxy_test.go
+++ b/e2e/proxy_test.go
@@ -103,11 +103,7 @@ func TestProxiedEnvironment(t *testing.T) {
 		t.Fatalf("fail to run playwright test deploy-app: %v", err)
 	}
 
-	t.Logf("%s: checking installation state after upgrade", time.Now().Format(time.RFC3339))
-	line = []string{"check-postupgrade-state.sh", k8sVersion(), ecUpgradeTargetVersion()}
-	if _, _, err := tc.RunCommandOnNode(0, line); err != nil {
-		t.Fatalf("fail to check postupgrade state: %v", err)
-	}
+	checkPostUpgradeState(t, tc)
 
 	t.Logf("%s: test complete", time.Now().Format(time.RFC3339))
 }
@@ -205,11 +201,7 @@ func TestProxiedCustomCIDR(t *testing.T) {
 		t.Fatalf("fail to run playwright test deploy-app: %v", err)
 	}
 
-	t.Logf("%s: checking installation state after upgrade", time.Now().Format(time.RFC3339))
-	line = []string{"check-postupgrade-state.sh", k8sVersion(), ecUpgradeTargetVersion()}
-	if _, _, err := tc.RunCommandOnNode(0, line); err != nil {
-		t.Fatalf("fail to check postupgrade state: %v", err)
-	}
+	checkPostUpgradeState(t, tc)
 
 	t.Logf("%s: test complete", time.Now().Format(time.RFC3339))
 }

--- a/e2e/restore_test.go
+++ b/e2e/restore_test.go
@@ -91,11 +91,7 @@ func TestSingleNodeDisasterRecovery(t *testing.T) {
 		t.Fatalf("fail to run playwright test deploy-upgrade: %v: %s: %s", err, stdout, stderr)
 	}
 
-	t.Logf("%s: checking installation state after upgrade", time.Now().Format(time.RFC3339))
-	line = []string{"check-postupgrade-state.sh", k8sVersion(), ecUpgradeTargetVersion()}
-	if stdout, stderr, err := tc.RunCommandOnNode(0, line); err != nil {
-		t.Fatalf("fail to check postupgrade state: %v: %s: %s", err, stdout, stderr)
-	}
+	checkPostUpgradeState(t, tc)
 
 	t.Logf("%s: test complete", time.Now().Format(time.RFC3339))
 }
@@ -483,11 +479,7 @@ func TestSingleNodeAirgapDisasterRecovery(t *testing.T) {
 		t.Fatalf("fail to run playwright test deploy-app: %v", err)
 	}
 
-	t.Logf("%s: checking installation state after upgrade", time.Now().Format(time.RFC3339))
-	line = []string{"check-postupgrade-state.sh", k8sVersion(), ecUpgradeTargetVersion()}
-	if _, _, err := tc.RunCommandOnNode(0, line); err != nil {
-		t.Fatalf("fail to check postupgrade state: %v", err)
-	}
+	checkPostUpgradeState(t, tc)
 
 	t.Logf("%s: test complete", time.Now().Format(time.RFC3339))
 }
@@ -616,11 +608,7 @@ func TestMultiNodeHADisasterRecovery(t *testing.T) {
 		t.Fatalf("fail to run playwright test deploy-app: %v: %s: %s", err, stdout, stderr)
 	}
 
-	t.Logf("%s: checking installation state after upgrade", time.Now().Format(time.RFC3339))
-	line = []string{"check-postupgrade-state.sh", k8sVersion(), ecUpgradeTargetVersion()}
-	if stdout, stderr, err := tc.RunCommandOnNode(0, line); err != nil {
-		t.Fatalf("fail to check postupgrade state: %v: %s: %s", err, stdout, stderr)
-	}
+	checkPostUpgradeState(t, tc)
 
 	t.Logf("%s: test complete", time.Now().Format(time.RFC3339))
 }
@@ -843,11 +831,9 @@ func TestMultiNodeAirgapHADisasterRecovery(t *testing.T) {
 		t.Fatalf("fail to run playwright test deploy-app: %v: %s: %s", err, stdout, stderr)
 	}
 
-	t.Logf("%s: checking installation state after upgrade", time.Now().Format(time.RFC3339))
-	line = []string{"check-postupgrade-state.sh", k8sVersion(), ecUpgradeTargetVersion()}
-	if stdout, stderr, err := tc.RunCommandOnNode(0, line, withEnv); err != nil {
-		t.Fatalf("fail to check postupgrade state: %v: %s: %s", err, stdout, stderr)
-	}
+	checkPostUpgradeStateWithOptions(t, tc, postUpgradeStateOptions{
+		withEnv: withEnv,
+	})
 
 	t.Logf("%s: test complete", time.Now().Format(time.RFC3339))
 }

--- a/e2e/restore_test.go
+++ b/e2e/restore_test.go
@@ -539,17 +539,23 @@ func TestMultiNodeHADisasterRecovery(t *testing.T) {
 	// reset the cluster
 	runInParallelOffset(t, time.Second*30,
 		func(t *testing.T) error {
-			return resetInstallationWithError(t, tc, 2, resetInstallationOptions{
-				force: true,
-			})
+			stdout, stderr, err := resetInstallationWithError(t, tc, 2, resetInstallationOptions{force: true})
+			if err != nil {
+				return fmt.Errorf("fail to reset the installation on node 2: %v: %s: %s", err, stdout, stderr)
+			}
+			return nil
 		}, func(t *testing.T) error {
-			return resetInstallationWithError(t, tc, 1, resetInstallationOptions{
-				force: true,
-			})
+			stdout, stderr, err := resetInstallationWithError(t, tc, 1, resetInstallationOptions{force: true})
+			if err != nil {
+				return fmt.Errorf("fail to reset the installation on node 1: %v: %s: %s", err, stdout, stderr)
+			}
+			return nil
 		}, func(t *testing.T) error {
-			return resetInstallationWithError(t, tc, 0, resetInstallationOptions{
-				force: true,
-			})
+			stdout, stderr, err := resetInstallationWithError(t, tc, 0, resetInstallationOptions{force: true})
+			if err != nil {
+				return fmt.Errorf("fail to reset the installation on node 0: %v: %s: %s", err, stdout, stderr)
+			}
+			return nil
 		},
 	)
 
@@ -713,20 +719,23 @@ func TestMultiNodeAirgapHADisasterRecovery(t *testing.T) {
 	// reset the cluster
 	runInParallelOffset(t, time.Second*30,
 		func(t *testing.T) error {
-			return resetInstallationWithError(t, tc, 2, resetInstallationOptions{
-				force:   true,
-				withEnv: withEnv,
-			})
+			stdout, stderr, err := resetInstallationWithError(t, tc, 2, resetInstallationOptions{force: true, withEnv: withEnv})
+			if err != nil {
+				return fmt.Errorf("fail to reset the installation on node 2: %v: %s: %s", err, stdout, stderr)
+			}
+			return nil
 		}, func(t *testing.T) error {
-			return resetInstallationWithError(t, tc, 1, resetInstallationOptions{
-				force:   true,
-				withEnv: withEnv,
-			})
+			stdout, stderr, err := resetInstallationWithError(t, tc, 1, resetInstallationOptions{force: true, withEnv: withEnv})
+			if err != nil {
+				return fmt.Errorf("fail to reset the installation on node 1: %v: %s: %s", err, stdout, stderr)
+			}
+			return nil
 		}, func(t *testing.T) error {
-			return resetInstallationWithError(t, tc, 0, resetInstallationOptions{
-				force:   true,
-				withEnv: withEnv,
-			})
+			stdout, stderr, err := resetInstallationWithError(t, tc, 0, resetInstallationOptions{force: true, withEnv: withEnv})
+			if err != nil {
+				return fmt.Errorf("fail to reset the installation on node 0: %v: %s: %s", err, stdout, stderr)
+			}
+			return nil
 		},
 	)
 

--- a/e2e/restore_test.go
+++ b/e2e/restore_test.go
@@ -537,7 +537,7 @@ func TestMultiNodeHADisasterRecovery(t *testing.T) {
 	}
 
 	// reset the cluster
-	runInParallel(t,
+	runInParallelOffset(t, time.Second*15,
 		func(t *testing.T) error {
 			return resetInstallationWithError(t, tc, 2, resetInstallationOptions{
 				force: true,
@@ -688,15 +688,13 @@ func TestMultiNodeAirgapHADisasterRecovery(t *testing.T) {
 
 	// join a controller
 	joinControllerNodeWithOptions(t, tc, 1, joinOptions{
-		keepAssets: true,
-		withEnv:    withEnv,
+		withEnv: withEnv,
 	})
 
 	// join another controller in HA mode
 	joinControllerNodeWithOptions(t, tc, 2, joinOptions{
-		isHA:       true,
-		keepAssets: true,
-		withEnv:    withEnv,
+		isHA:    true,
+		withEnv: withEnv,
 	})
 
 	// wait for the nodes to report as ready.
@@ -713,7 +711,7 @@ func TestMultiNodeAirgapHADisasterRecovery(t *testing.T) {
 	}
 
 	// reset the cluster
-	runInParallel(t,
+	runInParallelOffset(t, time.Second*15,
 		func(t *testing.T) error {
 			return resetInstallationWithError(t, tc, 2, resetInstallationOptions{
 				force:   true,

--- a/e2e/restore_test.go
+++ b/e2e/restore_test.go
@@ -717,27 +717,9 @@ func TestMultiNodeAirgapHADisasterRecovery(t *testing.T) {
 	}
 
 	// reset the cluster
-	runInParallelOffset(t, time.Second*30,
-		func(t *testing.T) error {
-			stdout, stderr, err := resetInstallationWithError(t, tc, 2, resetInstallationOptions{force: true, withEnv: withEnv})
-			if err != nil {
-				return fmt.Errorf("fail to reset the installation on node 2: %v: %s: %s", err, stdout, stderr)
-			}
-			return nil
-		}, func(t *testing.T) error {
-			stdout, stderr, err := resetInstallationWithError(t, tc, 1, resetInstallationOptions{force: true, withEnv: withEnv})
-			if err != nil {
-				return fmt.Errorf("fail to reset the installation on node 1: %v: %s: %s", err, stdout, stderr)
-			}
-			return nil
-		}, func(t *testing.T) error {
-			stdout, stderr, err := resetInstallationWithError(t, tc, 0, resetInstallationOptions{force: true, withEnv: withEnv})
-			if err != nil {
-				return fmt.Errorf("fail to reset the installation on node 0: %v: %s: %s", err, stdout, stderr)
-			}
-			return nil
-		},
-	)
+	resetInstallationWithOptions(t, tc, 2, resetInstallationOptions{force: true, withEnv: withEnv})
+	resetInstallationWithOptions(t, tc, 1, resetInstallationOptions{force: true, withEnv: withEnv})
+	resetInstallationWithOptions(t, tc, 0, resetInstallationOptions{force: true, withEnv: withEnv})
 
 	// wait for reboot
 	t.Logf("%s: waiting for nodes to reboot", time.Now().Format(time.RFC3339))

--- a/e2e/restore_test.go
+++ b/e2e/restore_test.go
@@ -537,7 +537,7 @@ func TestMultiNodeHADisasterRecovery(t *testing.T) {
 	}
 
 	// reset the cluster
-	runInParallelOffset(t, time.Second*15,
+	runInParallelOffset(t, time.Second*30,
 		func(t *testing.T) error {
 			return resetInstallationWithError(t, tc, 2, resetInstallationOptions{
 				force: true,
@@ -711,7 +711,7 @@ func TestMultiNodeAirgapHADisasterRecovery(t *testing.T) {
 	}
 
 	// reset the cluster
-	runInParallelOffset(t, time.Second*15,
+	runInParallelOffset(t, time.Second*30,
 		func(t *testing.T) error {
 			return resetInstallationWithError(t, tc, 2, resetInstallationOptions{
 				force:   true,

--- a/e2e/shared.go
+++ b/e2e/shared.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/replicatedhq/embedded-cluster/e2e/cluster"
-	"github.com/replicatedhq/embedded-cluster/e2e/cluster/docker"
+	"github.com/replicatedhq/embedded-cluster/e2e/cluster/lxd"
 )
 
 const (
@@ -79,11 +79,12 @@ func installSingleNodeWithOptions(t *testing.T, tc cluster.Cluster, opts install
 		line = append(line, "single-node-airgap-install.sh")
 	} else {
 		line = append(line, "single-node-install.sh")
-	}
-	if opts.viaCLI {
-		line = append(line, "cli")
-	} else {
-		line = append(line, "ui")
+		// the cli/ui option is currently only applicable for online installs
+		if opts.viaCLI {
+			line = append(line, "cli")
+		} else {
+			line = append(line, "ui")
+		}
 	}
 	if opts.version != "" {
 		line = append(line, opts.version)
@@ -187,10 +188,10 @@ func joinControllerNodeWithOptions(t *testing.T, tc cluster.Cluster, node int, o
 		// this is the join command
 		var joinCommand []string
 		if opts.isHA {
-			if _, ok := tc.(*docker.Cluster); ok {
-				joinCommand = []string{"join-ha.exp", fmt.Sprintf("'%s'", command)}
-			} else {
+			if _, ok := tc.(*lxd.Cluster); ok {
 				joinCommand = []string{"join-ha.exp", command}
+			} else {
+				joinCommand = []string{"join-ha.exp", fmt.Sprintf("'%s'", command)}
 			}
 		} else if opts.isRestore {
 			joinCommand = strings.Fields(command) // do not pass --no-ha as there should not be a prompt during a restore

--- a/e2e/shared.go
+++ b/e2e/shared.go
@@ -287,21 +287,19 @@ func resetInstallation(t *testing.T, tc cluster.Cluster, node int) {
 }
 
 func resetInstallationWithOptions(t *testing.T, tc cluster.Cluster, node int, opts resetInstallationOptions) {
-	if err := resetInstallationWithError(t, tc, node, opts); err != nil {
-		t.Fatal(err)
+	stdout, stderr, err := resetInstallationWithError(t, tc, node, opts)
+	if err != nil {
+		t.Fatalf("fail to reset the installation on node %d: %v: %s: %s", node, err, stdout, stderr)
 	}
 }
 
-func resetInstallationWithError(t *testing.T, tc cluster.Cluster, node int, opts resetInstallationOptions) error {
+func resetInstallationWithError(t *testing.T, tc cluster.Cluster, node int, opts resetInstallationOptions) (string, string, error) {
 	t.Logf("%s: resetting the installation on node %d", time.Now().Format(time.RFC3339), node)
 	line := []string{"reset-installation.sh"}
 	if opts.force {
 		line = append(line, "--force")
 	}
-	if stdout, stderr, err := tc.RunCommandOnNode(node, line, opts.withEnv); err != nil {
-		return fmt.Errorf("fail to reset the installation on node %d: %v: %s: %s", node, err, stdout, stderr)
-	}
-	return nil
+	return tc.RunCommandOnNode(node, line, opts.withEnv)
 }
 
 func checkPostUpgradeState(t *testing.T, tc cluster.Cluster) {

--- a/e2e/shared.go
+++ b/e2e/shared.go
@@ -46,10 +46,9 @@ type installationStateOptions struct {
 }
 
 type joinOptions struct {
-	isHA       bool
-	isRestore  bool
-	keepAssets bool
-	withEnv    map[string]string
+	isHA      bool
+	isRestore bool
+	withEnv   map[string]string
 }
 
 type downloadECReleaseOptions struct {

--- a/e2e/sudo_test.go
+++ b/e2e/sudo_test.go
@@ -34,7 +34,7 @@ func TestCommandsRequireSudo(t *testing.T) {
 		{"embedded-cluster", "reset", "--force"},
 		{"embedded-cluster", "node", "reset", "--force"},
 		{"embedded-cluster", "shell"},
-		{"embedded-cluster", "install", "--yes", "--license", "/assets/licenses/license.yaml"},
+		{"embedded-cluster", "install", "--yes", "--license", "/assets/license.yaml"},
 		{"embedded-cluster", "restore"},
 	} {
 		t.Logf("%s: running %q as regular user", time.Now().Format(time.RFC3339), "'"+strings.Join(cmd, " ")+"'")


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Moves these airgap tests to CMX:
- TestMultiNodeAirgapUpgrade
- TestSingleNodeAirgapUpgrade
- TestSingleNodeAirgapUpgradeCustomCIDR
- TestSingleNodeAirgapUpgradeConfigValues
- TestMultiNodeAirgapUpgradeSameK0s
- TestMultiNodeAirgapUpgradePreviousStable
- TestMultiNodeAirgapHAInstallation
- TestFiveNodesAirgapUpgrade

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[sc-122461](https://app.shortcut.com/replicated/story/122461)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Yes

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE