### PR TITLE
Fix replicated-sdk chart image name

### DIFF
--- a/e2e/helm-charts/nginx-app/Chart.lock
+++ b/e2e/helm-charts/nginx-app/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: replicated
   repository: oci://registry.replicated.com/library
-  version: 1.2.0
-digest: sha256:e33bd5648e92533a9e0e43c0db252bc73da453cd59e643baa654b419ee3966b5
-generated: "2025-03-17T11:44:40.543758-04:00"
+  version: 1.5.1
+digest: sha256:34d7438335de667fde932992a7ac61c3237be12ac0794b4c64a0efc9420dcab2
+generated: "2025-04-17T06:54:24.758248-07:00"

--- a/e2e/kots-release-install-failing-preflights/nginx-app-helm-v1beta2.yaml
+++ b/e2e/kots-release-install-failing-preflights/nginx-app-helm-v1beta2.yaml
@@ -29,7 +29,7 @@ spec:
       enabled: true
       image:
         registry: repl{{ HasLocalRegistry | ternary LocalRegistryHost "ec-e2e-proxy.testcluster.net" }}
-        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/registry.staging.replicated.com/library" }}/replicated-sdk-image
+        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "anonymous/registry.replicated.com/library" }}/replicated-sdk-image
       imagePullSecrets:
         - name: '{{repl ImagePullSecretName }}'
   builder:

--- a/e2e/kots-release-install-failing-preflights/nginx-app-helm-v1beta2.yaml
+++ b/e2e/kots-release-install-failing-preflights/nginx-app-helm-v1beta2.yaml
@@ -29,7 +29,7 @@ spec:
       enabled: true
       image:
         registry: repl{{ HasLocalRegistry | ternary LocalRegistryHost "ec-e2e-proxy.testcluster.net" }}
-        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/registry.replicated.com/library" }}/replicated-sdk-image
+        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/registry.staging.replicated.com/library" }}/replicated-sdk-image
       imagePullSecrets:
         - name: '{{repl ImagePullSecretName }}'
   builder:

--- a/e2e/kots-release-install-failing-preflights/nginx-app-helm-v1beta2.yaml
+++ b/e2e/kots-release-install-failing-preflights/nginx-app-helm-v1beta2.yaml
@@ -29,7 +29,7 @@ spec:
       enabled: true
       image:
         registry: repl{{ HasLocalRegistry | ternary LocalRegistryHost "ec-e2e-proxy.testcluster.net" }}
-        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/replicated" }}/replicated-sdk
+        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/registry.replicated.com/library" }}/replicated-sdk-image
       imagePullSecrets:
         - name: '{{repl ImagePullSecretName }}'
   builder:

--- a/e2e/kots-release-install-legacydr/nginx-app-helm-v1beta2.yaml
+++ b/e2e/kots-release-install-legacydr/nginx-app-helm-v1beta2.yaml
@@ -32,7 +32,7 @@ spec:
       enabled: true
       image:
         registry: repl{{ HasLocalRegistry | ternary LocalRegistryHost "ec-e2e-proxy.testcluster.net" }}
-        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/registry.staging.replicated.com/library" }}/replicated-sdk-image
+        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "anonymous/registry.replicated.com/library" }}/replicated-sdk-image
       imagePullSecrets:
         - name: '{{repl ImagePullSecretName }}'
   builder:

--- a/e2e/kots-release-install-legacydr/nginx-app-helm-v1beta2.yaml
+++ b/e2e/kots-release-install-legacydr/nginx-app-helm-v1beta2.yaml
@@ -32,7 +32,7 @@ spec:
       enabled: true
       image:
         registry: repl{{ HasLocalRegistry | ternary LocalRegistryHost "ec-e2e-proxy.testcluster.net" }}
-        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/registry.replicated.com/library" }}/replicated-sdk-image
+        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/registry.staging.replicated.com/library" }}/replicated-sdk-image
       imagePullSecrets:
         - name: '{{repl ImagePullSecretName }}'
   builder:

--- a/e2e/kots-release-install-legacydr/nginx-app-helm-v1beta2.yaml
+++ b/e2e/kots-release-install-legacydr/nginx-app-helm-v1beta2.yaml
@@ -32,7 +32,7 @@ spec:
       enabled: true
       image:
         registry: repl{{ HasLocalRegistry | ternary LocalRegistryHost "ec-e2e-proxy.testcluster.net" }}
-        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/replicated" }}/replicated-sdk
+        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/registry.replicated.com/library" }}/replicated-sdk-image
       imagePullSecrets:
         - name: '{{repl ImagePullSecretName }}'
   builder:

--- a/e2e/kots-release-install-stable/nginx-app-helm-v1beta2.yaml
+++ b/e2e/kots-release-install-stable/nginx-app-helm-v1beta2.yaml
@@ -29,7 +29,7 @@ spec:
       enabled: true
       image:
         registry: repl{{ HasLocalRegistry | ternary LocalRegistryHost "ec-e2e-proxy.testcluster.net" }}
-        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/registry.staging.replicated.com/library" }}/replicated-sdk-image
+        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "anonymous/registry.replicated.com/library" }}/replicated-sdk-image
       imagePullSecrets:
         - name: '{{repl ImagePullSecretName }}'
   builder:

--- a/e2e/kots-release-install-stable/nginx-app-helm-v1beta2.yaml
+++ b/e2e/kots-release-install-stable/nginx-app-helm-v1beta2.yaml
@@ -29,7 +29,7 @@ spec:
       enabled: true
       image:
         registry: repl{{ HasLocalRegistry | ternary LocalRegistryHost "ec-e2e-proxy.testcluster.net" }}
-        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/registry.replicated.com/library" }}/replicated-sdk-image
+        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/registry.staging.replicated.com/library" }}/replicated-sdk-image
       imagePullSecrets:
         - name: '{{repl ImagePullSecretName }}'
   builder:

--- a/e2e/kots-release-install-stable/nginx-app-helm-v1beta2.yaml
+++ b/e2e/kots-release-install-stable/nginx-app-helm-v1beta2.yaml
@@ -29,7 +29,7 @@ spec:
       enabled: true
       image:
         registry: repl{{ HasLocalRegistry | ternary LocalRegistryHost "ec-e2e-proxy.testcluster.net" }}
-        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/replicated" }}/replicated-sdk
+        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/registry.replicated.com/library" }}/replicated-sdk-image
       imagePullSecrets:
         - name: '{{repl ImagePullSecretName }}'
   builder:

--- a/e2e/kots-release-install-warning-preflights/nginx-app-helm-v1beta2.yaml
+++ b/e2e/kots-release-install-warning-preflights/nginx-app-helm-v1beta2.yaml
@@ -29,7 +29,7 @@ spec:
       enabled: true
       image:
         registry: repl{{ HasLocalRegistry | ternary LocalRegistryHost "ec-e2e-proxy.testcluster.net" }}
-        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/registry.staging.replicated.com/library" }}/replicated-sdk-image
+        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "anonymous/registry.replicated.com/library" }}/replicated-sdk-image
       imagePullSecrets:
         - name: '{{repl ImagePullSecretName }}'
   builder:

--- a/e2e/kots-release-install-warning-preflights/nginx-app-helm-v1beta2.yaml
+++ b/e2e/kots-release-install-warning-preflights/nginx-app-helm-v1beta2.yaml
@@ -29,7 +29,7 @@ spec:
       enabled: true
       image:
         registry: repl{{ HasLocalRegistry | ternary LocalRegistryHost "ec-e2e-proxy.testcluster.net" }}
-        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/registry.replicated.com/library" }}/replicated-sdk-image
+        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/registry.staging.replicated.com/library" }}/replicated-sdk-image
       imagePullSecrets:
         - name: '{{repl ImagePullSecretName }}'
   builder:

--- a/e2e/kots-release-install-warning-preflights/nginx-app-helm-v1beta2.yaml
+++ b/e2e/kots-release-install-warning-preflights/nginx-app-helm-v1beta2.yaml
@@ -29,7 +29,7 @@ spec:
       enabled: true
       image:
         registry: repl{{ HasLocalRegistry | ternary LocalRegistryHost "ec-e2e-proxy.testcluster.net" }}
-        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/replicated" }}/replicated-sdk
+        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/registry.replicated.com/library" }}/replicated-sdk-image
       imagePullSecrets:
         - name: '{{repl ImagePullSecretName }}'
   builder:

--- a/e2e/kots-release-install/nginx-app-helm-v1beta2.yaml
+++ b/e2e/kots-release-install/nginx-app-helm-v1beta2.yaml
@@ -29,7 +29,7 @@ spec:
       enabled: true
       image:
         registry: repl{{ HasLocalRegistry | ternary LocalRegistryHost "ec-e2e-proxy.testcluster.net" }}
-        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/registry.staging.replicated.com/library" }}/replicated-sdk-image
+        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "anonymous/registry.replicated.com/library" }}/replicated-sdk-image
       imagePullSecrets:
         - name: '{{repl ImagePullSecretName }}'
   builder:

--- a/e2e/kots-release-install/nginx-app-helm-v1beta2.yaml
+++ b/e2e/kots-release-install/nginx-app-helm-v1beta2.yaml
@@ -29,7 +29,7 @@ spec:
       enabled: true
       image:
         registry: repl{{ HasLocalRegistry | ternary LocalRegistryHost "ec-e2e-proxy.testcluster.net" }}
-        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/registry.replicated.com/library" }}/replicated-sdk-image
+        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/registry.staging.replicated.com/library" }}/replicated-sdk-image
       imagePullSecrets:
         - name: '{{repl ImagePullSecretName }}'
   builder:

--- a/e2e/kots-release-install/nginx-app-helm-v1beta2.yaml
+++ b/e2e/kots-release-install/nginx-app-helm-v1beta2.yaml
@@ -29,7 +29,7 @@ spec:
       enabled: true
       image:
         registry: repl{{ HasLocalRegistry | ternary LocalRegistryHost "ec-e2e-proxy.testcluster.net" }}
-        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/replicated" }}/replicated-sdk
+        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/registry.replicated.com/library" }}/replicated-sdk-image
       imagePullSecrets:
         - name: '{{repl ImagePullSecretName }}'
   builder:

--- a/e2e/kots-release-unsupported-overrides/nginx-app-helm-v1beta2.yaml
+++ b/e2e/kots-release-unsupported-overrides/nginx-app-helm-v1beta2.yaml
@@ -29,7 +29,7 @@ spec:
       enabled: true
       image:
         registry: repl{{ HasLocalRegistry | ternary LocalRegistryHost "ec-e2e-proxy.testcluster.net" }}
-        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/registry.staging.replicated.com/library" }}/replicated-sdk-image
+        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "anonymous/registry.replicated.com/library" }}/replicated-sdk-image
       imagePullSecrets:
         - name: '{{repl ImagePullSecretName }}'
   builder:

--- a/e2e/kots-release-unsupported-overrides/nginx-app-helm-v1beta2.yaml
+++ b/e2e/kots-release-unsupported-overrides/nginx-app-helm-v1beta2.yaml
@@ -29,7 +29,7 @@ spec:
       enabled: true
       image:
         registry: repl{{ HasLocalRegistry | ternary LocalRegistryHost "ec-e2e-proxy.testcluster.net" }}
-        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/registry.replicated.com/library" }}/replicated-sdk-image
+        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/registry.staging.replicated.com/library" }}/replicated-sdk-image
       imagePullSecrets:
         - name: '{{repl ImagePullSecretName }}'
   builder:

--- a/e2e/kots-release-unsupported-overrides/nginx-app-helm-v1beta2.yaml
+++ b/e2e/kots-release-unsupported-overrides/nginx-app-helm-v1beta2.yaml
@@ -29,7 +29,7 @@ spec:
       enabled: true
       image:
         registry: repl{{ HasLocalRegistry | ternary LocalRegistryHost "ec-e2e-proxy.testcluster.net" }}
-        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/replicated" }}/replicated-sdk
+        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/registry.replicated.com/library" }}/replicated-sdk-image
       imagePullSecrets:
         - name: '{{repl ImagePullSecretName }}'
   builder:

--- a/e2e/kots-release-upgrade/nginx-app-helm-v1beta2.yaml
+++ b/e2e/kots-release-upgrade/nginx-app-helm-v1beta2.yaml
@@ -29,7 +29,7 @@ spec:
       enabled: true
       image:
         registry: repl{{ HasLocalRegistry | ternary LocalRegistryHost "ec-e2e-proxy.testcluster.net" }}
-        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/registry.staging.replicated.com/library" }}/replicated-sdk-image
+        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "anonymous/registry.replicated.com/library" }}/replicated-sdk-image
       imagePullSecrets:
         - name: '{{repl ImagePullSecretName }}'
   builder:

--- a/e2e/kots-release-upgrade/nginx-app-helm-v1beta2.yaml
+++ b/e2e/kots-release-upgrade/nginx-app-helm-v1beta2.yaml
@@ -29,7 +29,7 @@ spec:
       enabled: true
       image:
         registry: repl{{ HasLocalRegistry | ternary LocalRegistryHost "ec-e2e-proxy.testcluster.net" }}
-        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/registry.replicated.com/library" }}/replicated-sdk-image
+        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/registry.staging.replicated.com/library" }}/replicated-sdk-image
       imagePullSecrets:
         - name: '{{repl ImagePullSecretName }}'
   builder:

--- a/e2e/kots-release-upgrade/nginx-app-helm-v1beta2.yaml
+++ b/e2e/kots-release-upgrade/nginx-app-helm-v1beta2.yaml
@@ -29,7 +29,7 @@ spec:
       enabled: true
       image:
         registry: repl{{ HasLocalRegistry | ternary LocalRegistryHost "ec-e2e-proxy.testcluster.net" }}
-        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/replicated" }}/replicated-sdk
+        repository: repl{{ HasLocalRegistry | ternary LocalRegistryNamespace "proxy/embedded-cluster-smoke-test-staging-app/registry.replicated.com/library" }}/replicated-sdk-image
       imagePullSecrets:
         - name: '{{repl ImagePullSecretName }}'
   builder:


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

the default replicated sdk image name / location changed to `registry.replicated.com/library/replicated-sdk-image`

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
