### PR TITLE
feat(lam): support for pull binaries command in online mode

### DIFF
--- a/cmd/local-artifact-mirror/main.go
+++ b/cmd/local-artifact-mirror/main.go
@@ -2,14 +2,18 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"os/signal"
 	"path"
 	"syscall"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
 func main() {
+	logrus.SetOutput(os.Stdout)
+
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
@@ -20,14 +24,7 @@ func main() {
 	// we do this before calling cli.InitAndExecute so that it is set before the process forks
 	_ = syscall.Umask(0o022)
 
-	InitAndExecute(ctx, name)
-}
-
-func InitAndExecute(ctx context.Context, name string) {
 	cli := NewCLI(name)
 	err := RootCmd(cli).ExecuteContext(ctx)
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
+	cobra.CheckErr(err)
 }

--- a/cmd/local-artifact-mirror/pull.go
+++ b/cmd/local-artifact-mirror/pull.go
@@ -37,7 +37,7 @@ func PullCmd(cli *CLI) *cobra.Command {
 
 // fetchAndValidateInstallation fetches an Installation object from its name or directly decodes it
 // and checks if it is valid for an airgap cluster deployment.
-func fetchAndValidateInstallation(ctx context.Context, kcli client.Client, iname string) (*ecv1beta1.Installation, error) {
+func fetchAndValidateInstallation(ctx context.Context, kcli client.Client, iname string, isAirgap bool) (*ecv1beta1.Installation, error) {
 	in, err := decodeInstallation(ctx, iname)
 	if err != nil {
 		in, err = kubeutils.GetInstallation(ctx, kcli, iname)
@@ -46,10 +46,12 @@ func fetchAndValidateInstallation(ctx context.Context, kcli client.Client, iname
 		}
 	}
 
-	if !in.Spec.AirGap {
-		return nil, fmt.Errorf("installation is not airgapped")
-	} else if in.Spec.Artifacts == nil {
-		return nil, fmt.Errorf("installation has no artifacts")
+	if isAirgap {
+		if !in.Spec.AirGap {
+			return nil, fmt.Errorf("installation is not airgapped")
+		} else if in.Spec.Artifacts == nil {
+			return nil, fmt.Errorf("installation has no artifacts")
+		}
 	}
 
 	return in, nil

--- a/cmd/local-artifact-mirror/pull.go
+++ b/cmd/local-artifact-mirror/pull.go
@@ -37,7 +37,7 @@ func PullCmd(cli *CLI) *cobra.Command {
 
 // fetchAndValidateInstallation fetches an Installation object from its name or directly decodes it
 // and checks if it is valid for an airgap cluster deployment.
-func fetchAndValidateInstallation(ctx context.Context, kcli client.Client, iname string, isAirgap bool) (*ecv1beta1.Installation, error) {
+func fetchAndValidateInstallation(ctx context.Context, kcli client.Client, iname string) (*ecv1beta1.Installation, error) {
 	in, err := decodeInstallation(ctx, iname)
 	if err != nil {
 		in, err = kubeutils.GetInstallation(ctx, kcli, iname)
@@ -46,12 +46,8 @@ func fetchAndValidateInstallation(ctx context.Context, kcli client.Client, iname
 		}
 	}
 
-	if isAirgap {
-		if !in.Spec.AirGap {
-			return nil, fmt.Errorf("installation is not airgapped")
-		} else if in.Spec.Artifacts == nil {
-			return nil, fmt.Errorf("installation has no artifacts")
-		}
+	if in.Spec.AirGap && in.Spec.Artifacts == nil {
+		return nil, fmt.Errorf("airgap installation has no artifacts")
 	}
 
 	return in, nil

--- a/cmd/local-artifact-mirror/pull_binaries.go
+++ b/cmd/local-artifact-mirror/pull_binaries.go
@@ -137,7 +137,8 @@ func PullBinariesCmd(cli *CLI) *cobra.Command {
 }
 
 // fetchBinaryWithLicense downloads the binary from the Replicated app using basic auth with license ID
-func fetchBinaryWithLicense(url, licenseID, binaryName string) (string, error) { // Create a temporary directory to store the binary
+func fetchBinaryWithLicense(url, licenseID, binaryName string) (string, error) {
+	// Create a temporary directory to store the binary
 	tmpdir, err := os.MkdirTemp("", "lam-artifact-*")
 	if err != nil {
 		return "", fmt.Errorf("create temp dir: %w", err)

--- a/cmd/local-artifact-mirror/pull_binaries.go
+++ b/cmd/local-artifact-mirror/pull_binaries.go
@@ -56,7 +56,8 @@ func PullBinariesCmd(cli *CLI) *cobra.Command {
 				return fmt.Errorf("unable to create kube client: %w", err)
 			}
 
-			in, err := fetchAndValidateInstallation(ctx, kcli, args[0], licenseID == "")
+			isAirgap := licenseID == ""
+			in, err := fetchAndValidateInstallation(ctx, kcli, args[0], isAirgap)
 			if err != nil {
 				return err
 			}

--- a/cmd/local-artifact-mirror/pull_binaries.go
+++ b/cmd/local-artifact-mirror/pull_binaries.go
@@ -1,8 +1,11 @@
 package main
 
 import (
-	"bytes"
+	"archive/tar"
+	"compress/gzip"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,15 +15,39 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// binariesCommands pulls the binary artifact from the registry running in the cluster and stores
-// it locally. This command is used during cluster upgrades when we want to fetch the most up to
-// date binaries. The binaries are stored in the /usr/local/bin directory and they overwrite the
-// existing binaries.
+// PullBinariesCmd pulls the binary artifact and stores it locally. This command is used during
+// joins as well as cluster upgrades when we want to fetch the most up to date binaries. The
+// binaries are stored in the /usr/local/bin directory and they overwrite the existing binaries.
+//
+// When using --license-id flag along with --app-slug and --channel-slug, the command will
+// fetch the binary directly from the Replicated app endpoint (online mode).
+// Without these flags, it will fetch the binary from the artifact path in the installation
+// spec (airgap mode).
 func PullBinariesCmd(cli *CLI) *cobra.Command {
+	var licenseID string
+	var appSlug string
+	var channelSlug string
+	var appVersion string
+
 	cmd := &cobra.Command{
 		Use:   "binaries INSTALLATION",
-		Short: "Pull binaries artifacts for an airgap installation",
+		Short: "Pull binaries artifacts for online or airgap installations",
 		Args:  cobra.ExactArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			// If license-id is set, app-slug and channel-slug are required
+			if licenseID != "" {
+				if appSlug == "" {
+					return fmt.Errorf("--app-slug is required when --license-id is set")
+				}
+				if channelSlug == "" {
+					return fmt.Errorf("--channel-slug is required when --license-id is set")
+				}
+				if appVersion == "" {
+					return fmt.Errorf("--app-version is required when --license-id is set")
+				}
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
@@ -29,22 +56,53 @@ func PullBinariesCmd(cli *CLI) *cobra.Command {
 				return fmt.Errorf("unable to create kube client: %w", err)
 			}
 
-			in, err := fetchAndValidateInstallation(ctx, kcli, args[0])
+			in, err := fetchAndValidateInstallation(ctx, kcli, args[0], licenseID == "")
 			if err != nil {
 				return err
 			}
 
-			from := in.Spec.Artifacts.EmbeddedClusterBinary
-			logrus.Infof("fetching embedded cluster binary artifact from %s", from)
-			location, err := cli.PullArtifact(ctx, kcli, from)
-			if err != nil {
-				return fmt.Errorf("unable to fetch artifact: %w", err)
+			var location string
+			if licenseID != "" {
+				// For online, fetch from Replicated app using license ID
+				u := releaseURL(in.Spec.MetricsBaseURL, appSlug, channelSlug, appVersion)
+				logrus.Infof("fetching embedded cluster binary from %s using license ID", u)
+
+				location, err = fetchBinaryWithLicense(u, licenseID, in.Spec.BinaryName)
+				if err != nil {
+					return fmt.Errorf("unable to fetch binary from Replicated app: %w", err)
+				}
+				logrus.Infof("successfully downloaded binary from Replicated app")
+			} else {
+				// For airgap, fetch from artifact path in installation spec
+				from := in.Spec.Artifacts.EmbeddedClusterBinary
+				logrus.Infof("fetching embedded cluster binary artifact from %s", from)
+
+				location, err = cli.PullArtifact(ctx, kcli, from)
+				if err != nil {
+					return fmt.Errorf("unable to fetch artifact: %w", err)
+				}
+				logrus.Infof("successfully downloaded binary from artifact path")
 			}
+
 			defer func() {
 				logrus.Infof("removing temporary directory %s", location)
-				os.RemoveAll(location)
+				_ = os.RemoveAll(location)
 			}()
+
 			bin := filepath.Join(location, EmbeddedClusterBinaryArtifactName)
+
+			// Verify the binary file exists and has content
+			binInfo, err := os.Stat(bin)
+			if err != nil {
+				return fmt.Errorf("binary file verification failed: %w", err)
+			}
+
+			if binInfo.Size() == 0 {
+				return fmt.Errorf("binary file is empty")
+			}
+
+			logrus.Infof("binary file size: %d bytes", binInfo.Size())
+
 			namedBin := filepath.Join(location, in.Spec.BinaryName)
 			if err := os.Rename(bin, namedBin); err != nil {
 				return fmt.Errorf("unable to rename binary: %w", err)
@@ -54,16 +112,12 @@ func PullBinariesCmd(cli *CLI) *cobra.Command {
 				return fmt.Errorf("unable to change permissions on %s: %w", bin, err)
 			}
 
-			out := bytes.NewBuffer(nil)
-
 			materializeCmdArgs := []string{"materialize", "--data-dir", runtimeconfig.EmbeddedClusterHomeDirectory()}
 			materializeCmd := exec.Command(namedBin, materializeCmdArgs...)
-			materializeCmd.Stdout = out
-			materializeCmd.Stderr = out
 
 			logrus.Infof("running command: %s with args: %v", namedBin, materializeCmdArgs)
-			if err := materializeCmd.Run(); err != nil {
-				logrus.Error(out.String())
+			if out, err := materializeCmd.CombinedOutput(); err != nil {
+				logrus.Errorf("error running command:\n%s", out)
 				return err
 			}
 
@@ -73,5 +127,103 @@ func PullBinariesCmd(cli *CLI) *cobra.Command {
 		},
 	}
 
+	cmd.Flags().StringVar(&licenseID, "license-id", "", "License ID to use for fetching binary from Replicated app")
+	cmd.Flags().StringVar(&appSlug, "app-slug", "", "Application slug (required when using --license-id)")
+	cmd.Flags().StringVar(&channelSlug, "channel-slug", "", "Channel slug (required when using --license-id)")
+	cmd.Flags().StringVar(&appVersion, "app-version", "", "Application version (required when using --license-id)")
+
 	return cmd
+}
+
+// fetchBinaryWithLicense downloads the binary from the Replicated app using basic auth with license ID
+func fetchBinaryWithLicense(url, licenseID, binaryName string) (tmpdir string, err error) {
+	defer func() {
+		if err != nil && tmpdir != "" {
+			_ = os.RemoveAll(tmpdir)
+		}
+	}()
+
+	// Create a temporary directory to store the binary
+	tmpdir, err = os.MkdirTemp("", "lam-artifact-*")
+	if err != nil {
+		return tmpdir, fmt.Errorf("create temp dir: %w", err)
+	}
+
+	logrus.Debugf("Created temporary directory %s for binary download", tmpdir)
+
+	// Create HTTP request with basic auth
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return tmpdir, fmt.Errorf("create request: %w", err)
+	}
+
+	logrus.Debugf("Requesting release tarball from %s using license ID auth", url)
+
+	// Set basic auth with license ID
+	req.SetBasicAuth(licenseID, "")
+
+	// Make the request
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return tmpdir, fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		// Read response body for error details
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr == nil && len(body) > 0 {
+			return tmpdir, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+		}
+
+		return tmpdir, fmt.Errorf("API request failed with status %d", resp.StatusCode)
+	}
+
+	logrus.Debugf("Successfully received tarball, extracting contents")
+
+	// Stream extraction directly from response body
+	gzr, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		return tmpdir, fmt.Errorf("create gzip reader: %w", err)
+	}
+	defer gzr.Close()
+
+	tr := tar.NewReader(gzr)
+
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			return tmpdir, fmt.Errorf("could not find binary file (%s) in extracted contents", binaryName)
+		} else if err != nil {
+			return tmpdir, err
+		}
+
+		// Skip non-regular files or files that don't match the expected binary name
+		if header.Typeflag != tar.TypeReg || header.Name != binaryName {
+			logrus.Debugf("Skipping file %s of type %d", header.Name, header.Typeflag)
+			continue
+		}
+
+		logrus.Infof("Found binary %s", header.Name)
+
+		// Copy the binary to the expected location
+		destPath := filepath.Join(tmpdir, EmbeddedClusterBinaryArtifactName)
+
+		outFile, err := os.Create(destPath)
+		if err != nil {
+			return tmpdir, fmt.Errorf("create output file: %w", err)
+		}
+		defer outFile.Close()
+
+		if _, err := io.Copy(outFile, tr); err != nil {
+			return tmpdir, fmt.Errorf("stream binary to file: %w", err)
+		}
+
+		logrus.Debugf("Successfully extracted binary to %s", destPath)
+		return tmpdir, nil
+	}
+}
+
+func releaseURL(metricsBaseURL, appSlug, channelSlug, appVersion string) string {
+	return fmt.Sprintf("%s/embedded/%s/%s/%s", metricsBaseURL, appSlug, channelSlug, appVersion)
 }

--- a/cmd/local-artifact-mirror/pull_binaries.go
+++ b/cmd/local-artifact-mirror/pull_binaries.go
@@ -56,14 +56,17 @@ func PullBinariesCmd(cli *CLI) *cobra.Command {
 				return fmt.Errorf("unable to create kube client: %w", err)
 			}
 
-			isAirgap := licenseID == ""
-			in, err := fetchAndValidateInstallation(ctx, kcli, args[0], isAirgap)
+			in, err := fetchAndValidateInstallation(ctx, kcli, args[0])
 			if err != nil {
 				return err
 			}
 
+			if !in.Spec.AirGap && licenseID == "" {
+				return fmt.Errorf("license ID is required for online installations")
+			}
+
 			var location string
-			if !isAirgap {
+			if !in.Spec.AirGap {
 				// For online, fetch from Replicated app using license ID
 				u := releaseURL(in.Spec.MetricsBaseURL, appSlug, channelSlug, appVersion)
 				logrus.Infof("fetching embedded cluster binary from %s using license ID", u)

--- a/cmd/local-artifact-mirror/pull_binaries.go
+++ b/cmd/local-artifact-mirror/pull_binaries.go
@@ -63,7 +63,7 @@ func PullBinariesCmd(cli *CLI) *cobra.Command {
 			}
 
 			var location string
-			if licenseID != "" {
+			if !isAirgap {
 				// For online, fetch from Replicated app using license ID
 				u := releaseURL(in.Spec.MetricsBaseURL, appSlug, channelSlug, appVersion)
 				logrus.Infof("fetching embedded cluster binary from %s using license ID", u)

--- a/cmd/local-artifact-mirror/pull_binaries.go
+++ b/cmd/local-artifact-mirror/pull_binaries.go
@@ -34,7 +34,7 @@ func PullBinariesCmd(cli *CLI) *cobra.Command {
 		Short: "Pull binaries artifacts for online or airgap installations",
 		Args:  cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			// If license-id is set, app-slug and channel-slug are required
+			// If license-id is set, app-slug, channel-slug, and app-version are required
 			if licenseID != "" {
 				if appSlug == "" {
 					return fmt.Errorf("--app-slug is required when --license-id is set")

--- a/cmd/local-artifact-mirror/pull_binaries_test.go
+++ b/cmd/local-artifact-mirror/pull_binaries_test.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -19,6 +18,24 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var (
+	testBinaryContent = []byte(`#!/bin/bash
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    '--data-dir')
+       shift
+       echo "--data-dir = $1"
+       echo "Hello, world!" > "$1/some-file"
+       exit 0
+       ;;
+  esac
+  shift
+done
+echo "did not find --data-dir"
+exit 1
+`)
 )
 
 func TestPullBinariesCmd_Online(t *testing.T) {
@@ -44,10 +61,6 @@ func TestPullBinariesCmd_Online(t *testing.T) {
 		var buf bytes.Buffer
 		gzWriter := gzip.NewWriter(&buf)
 		tarWriter := tar.NewWriter(gzWriter)
-
-		testBinaryContent := []byte(fmt.Sprintf(`#!/bin/bash
-printf "Hello, world!" > "%s/some-file"
-`, dataDir))
 
 		// Add the test binary to the archive with the expected name
 		header := &tar.Header{
@@ -164,7 +177,7 @@ printf "Hello, world!" > "%s/some-file"
 				// Verify file content
 				content, err := os.ReadFile(expectedDst)
 				assert.NoError(t, err)
-				assert.Equal(t, "Hello, world!", string(content))
+				assert.Equal(t, "Hello, world!\n", string(content))
 			}
 		})
 	}

--- a/cmd/local-artifact-mirror/pull_binaries_test.go
+++ b/cmd/local-artifact-mirror/pull_binaries_test.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var (
+	testBinaryContent = []byte(`#!/bin/bash
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    '--data-dir')
+       shift
+       echo "--data-dir = $1"
+       echo "Hello, world!" > "$1/some-file"
+       exit 0
+       ;;
+  esac
+  shift
+done
+echo "did not find --data-dir"
+exit 1
+`)
+)
+
+func TestPullBinariesCmd_Online(t *testing.T) {
+	// Create temporary directory for test
+	dataDir := t.TempDir()
+	t.Setenv("TMPDIR", dataDir) // hack as the cli sets TMPDIR, this will reset it after the test
+
+	// Create a test server that serves the test release archive
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check basic auth
+		username, _, ok := r.BasicAuth()
+		if !ok || username != "valid-license" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		// Set headers
+		w.Header().Set("Content-Disposition", "attachment; filename=my-app.tgz")
+		w.Header().Set("Content-Type", "application/gzip")
+		w.WriteHeader(http.StatusOK)
+
+		// Create a tar.gz archive with the test binary
+		var buf bytes.Buffer
+		gzWriter := gzip.NewWriter(&buf)
+		tarWriter := tar.NewWriter(gzWriter)
+
+		// Add the test binary to the archive with the expected name
+		header := &tar.Header{
+			Name: "my-app",
+			Mode: 0755,
+			Size: int64(len(testBinaryContent)),
+		}
+		err := tarWriter.WriteHeader(header)
+		if err != nil {
+			t.Fatalf("Failed to write tar header: %v", err)
+		}
+
+		_, err = tarWriter.Write(testBinaryContent)
+		if err != nil {
+			t.Fatalf("Failed to write tar content: %v", err)
+		}
+
+		// Close writers
+		tarWriter.Close()
+		gzWriter.Close()
+
+		// Write the archive to the response
+		w.Write(buf.Bytes())
+	}))
+	defer server.Close()
+
+	// Create a fake client with test Installation
+	scheme := runtime.NewScheme()
+	err := ecv1beta1.AddToScheme(scheme)
+	require.NoError(t, err)
+
+	// Create a test installation
+	installation := &ecv1beta1.Installation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-installation",
+		},
+		Spec: ecv1beta1.InstallationSpec{
+			AirGap:         false,
+			BinaryName:     "my-app",
+			MetricsBaseURL: "https://api.replicated.com",
+		},
+	}
+
+	installation.Spec.MetricsBaseURL = server.URL
+
+	// Create fake client
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(installation).
+		Build()
+
+	testCases := []struct {
+		name          string
+		setupEnv      func(t *testing.T)
+		args          []string
+		mock          *mockPuller
+		expectedError string
+	}{
+		{
+			name: "successful online pull with license ID",
+			args: []string{
+				"test-installation",
+				"--license-id", "valid-license",
+				"--app-slug", "my-app",
+				"--channel-slug", "stable",
+				"--app-version", "1.0.0",
+			},
+			setupEnv: func(t *testing.T) {
+				t.Setenv("LOCAL_ARTIFACT_MIRROR_DATA_DIR", dataDir)
+			},
+			mock: func() *mockPuller {
+				m := &mockPuller{}
+				// No need to mock PullArtifact for online mode
+				return m
+			}(),
+			expectedError: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup environment for test
+			if tc.setupEnv != nil {
+				tc.setupEnv(t)
+			}
+
+			// Create the command
+			cli := &CLI{
+				Name: "local-artifact-mirror",
+				V:    viper.New(),
+				KCLIGetter: func() (client.Client, error) {
+					return fakeClient, nil
+				},
+				PullArtifact: tc.mock.PullArtifact,
+			}
+			root := RootCmd(cli)
+
+			// Execute command
+			_, _, err := testExecuteCommandC(t.Context(), root, append([]string{"pull", "binaries"}, tc.args...)...)
+
+			tc.mock.AssertExpectations(t)
+
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedError)
+			} else {
+				require.NoError(t, err)
+
+				// Check that the destination file exists
+				expectedDst := filepath.Join(dataDir, "some-file")
+				_, err := os.Stat(expectedDst)
+				assert.NoError(t, err, "Expected destination file to exist")
+
+				// Verify file content
+				content, err := os.ReadFile(expectedDst)
+				assert.NoError(t, err)
+				assert.Equal(t, "Hello, world!\n", string(content))
+			}
+		})
+	}
+}

--- a/cmd/local-artifact-mirror/pull_helmcharts.go
+++ b/cmd/local-artifact-mirror/pull_helmcharts.go
@@ -28,7 +28,7 @@ func PullHelmChartsCmd(cli *CLI) *cobra.Command {
 				return fmt.Errorf("unable to create kube client: %w", err)
 			}
 
-			in, err := fetchAndValidateInstallation(ctx, kcli, args[0])
+			in, err := fetchAndValidateInstallation(ctx, kcli, args[0], true)
 			if err != nil {
 				return err
 			}

--- a/cmd/local-artifact-mirror/pull_helmcharts.go
+++ b/cmd/local-artifact-mirror/pull_helmcharts.go
@@ -28,9 +28,13 @@ func PullHelmChartsCmd(cli *CLI) *cobra.Command {
 				return fmt.Errorf("unable to create kube client: %w", err)
 			}
 
-			in, err := fetchAndValidateInstallation(ctx, kcli, args[0], true)
+			in, err := fetchAndValidateInstallation(ctx, kcli, args[0])
 			if err != nil {
 				return err
+			}
+
+			if !in.Spec.AirGap {
+				return fmt.Errorf("pulling helm charts is not supported for online installations")
 			}
 
 			from := in.Spec.Artifacts.HelmCharts

--- a/cmd/local-artifact-mirror/pull_images.go
+++ b/cmd/local-artifact-mirror/pull_images.go
@@ -28,9 +28,13 @@ func PullImagesCmd(cli *CLI) *cobra.Command {
 				return fmt.Errorf("unable to create kube client: %w", err)
 			}
 
-			in, err := fetchAndValidateInstallation(ctx, kcli, args[0], true)
+			in, err := fetchAndValidateInstallation(ctx, kcli, args[0])
 			if err != nil {
 				return err
+			}
+
+			if !in.Spec.AirGap {
+				return fmt.Errorf("pulling images is not supported for online installations")
 			}
 
 			from := in.Spec.Artifacts.Images

--- a/cmd/local-artifact-mirror/pull_images.go
+++ b/cmd/local-artifact-mirror/pull_images.go
@@ -28,7 +28,7 @@ func PullImagesCmd(cli *CLI) *cobra.Command {
 				return fmt.Errorf("unable to create kube client: %w", err)
 			}
 
-			in, err := fetchAndValidateInstallation(ctx, kcli, args[0])
+			in, err := fetchAndValidateInstallation(ctx, kcli, args[0], true)
 			if err != nil {
 				return err
 			}

--- a/cmd/local-artifact-mirror/pull_images_test.go
+++ b/cmd/local-artifact-mirror/pull_images_test.go
@@ -151,7 +151,7 @@ func TestPullImagesCmd(t *testing.T) {
 				m := &mockPuller{}
 				return m
 			}(),
-			expectedError: "installation is not airgapped",
+			expectedError: "pulling images is not supported for online installations",
 		},
 	}
 

--- a/operator/pkg/artifacts/upgrade.go
+++ b/operator/pkg/artifacts/upgrade.go
@@ -176,7 +176,7 @@ func HashForAirgapConfig(in *clusterv1beta1.Installation) (string, error) {
 }
 
 func ensureArtifactsJobForNode(ctx context.Context, cli client.Client, in *clusterv1beta1.Installation, node corev1.Node, localArtifactMirrorImage, cfghash string) (*batchv1.Job, error) {
-	job, err := getArtifactJobForNode(ctx, cli, in, node, localArtifactMirrorImage)
+	job, err := getArtifactJobForNode(cli, in, node, localArtifactMirrorImage)
 	if err != nil {
 		return nil, fmt.Errorf("get job for node: %w", err)
 	}
@@ -200,7 +200,7 @@ func ensureArtifactsJobForNode(ctx context.Context, cli client.Client, in *clust
 	return job, nil
 }
 
-func getArtifactJobForNode(ctx context.Context, cli client.Client, in *clusterv1beta1.Installation, node corev1.Node, localArtifactMirrorImage string) (*batchv1.Job, error) {
+func getArtifactJobForNode(cli client.Client, in *clusterv1beta1.Installation, node corev1.Node, localArtifactMirrorImage string) (*batchv1.Job, error) {
 	hash, err := HashForAirgapConfig(in)
 	if err != nil {
 		return nil, fmt.Errorf("failed to hash airgap config: %w", err)


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

In preparation for a better join experience, run the LAM jobs in online mode to update the binaries and artifacts on the host similar to how we do it for airgap.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
