### PR TITLE
Mount the EC data directory into the kots deployment

### DIFF
--- a/pkg/addons/adminconsole/values.go
+++ b/pkg/addons/adminconsole/values.go
@@ -31,6 +31,7 @@ func (a *AdminConsole) GenerateHelmValues(ctx context.Context, kcli client.Clien
 	}
 
 	copiedValues["embeddedClusterID"] = metrics.ClusterID().String()
+	copiedValues["embeddedClusterDataDir"] = runtimeconfig.EmbeddedClusterHomeDirectory()
 	copiedValues["isHA"] = a.IsHA
 	copiedValues["isMultiNodeEnabled"] = a.IsMultiNodeEnabled
 

--- a/tests/dryrun/install_test.go
+++ b/tests/dryrun/install_test.go
@@ -72,8 +72,9 @@ func testDefaultInstallationImpl(t *testing.T) {
 	adminConsoleOpts := hcli.Calls[3].Arguments[1].(helm.InstallOptions)
 	assert.Equal(t, "admin-console", adminConsoleOpts.ReleaseName)
 	assertHelmValues(t, adminConsoleOpts.Values, map[string]interface{}{
-		"isMultiNodeEnabled": true,
-		"kurlProxy.nodePort": float64(30000),
+		"isMultiNodeEnabled":     true,
+		"kurlProxy.nodePort":     float64(30000),
+		"embeddedClusterDataDir": "/var/lib/embedded-cluster",
 	})
 	assertHelmValuePrefixes(t, adminConsoleOpts.Values, map[string]string{
 		"images.kotsadm":    "fake-replicated-proxy.test.net/anonymous",
@@ -232,6 +233,9 @@ func TestCustomDataDir(t *testing.T) {
 	assert.Equal(t, "Install", hcli.Calls[3].Method)
 	adminConsoleOpts := hcli.Calls[3].Arguments[1].(helm.InstallOptions)
 	assert.Equal(t, "admin-console", adminConsoleOpts.ReleaseName)
+	assertHelmValues(t, adminConsoleOpts.Values, map[string]interface{}{
+		"embeddedClusterDataDir": "/custom/data/dir",
+	})
 
 	// --- validate os env --- //
 	assertEnv(t, dr.OSEnv, map[string]string{


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Mounts the EC data directory into the kots deployment.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-122562](https://app.shortcut.com/replicated/story/122562)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Yes

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE