### PR TITLE
Install extension on upgrade if doesn't exist

### DIFF
--- a/dev/dockerfiles/local-artifact-mirror/Dockerfile.ttlsh
+++ b/dev/dockerfiles/local-artifact-mirror/Dockerfile.ttlsh
@@ -22,6 +22,3 @@ FROM debian:bookworm-slim
 
 COPY --from=build /app/local-artifact-mirror/bin/local-artifact-mirror /usr/bin/local-artifact-mirror
 RUN ln -s /usr/bin/local-artifact-mirror /usr/local/bin/local-artifact-mirror
-
-RUN groupadd -r lam && useradd -r -u 1000 -g lam lam
-USER 1000


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Installs extension on upgrade if Helm release doesn't exist in the cluster.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-122672](https://app.shortcut.com/replicated/story/122672)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Yes

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Improves Helm extension upgrade behavior to automatically install extensions if they don't exist during an upgrade operation.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE