### PR TITLE
preflight pass wording and enable HA by default

### DIFF
--- a/cmd/installer/cli/join.go
+++ b/cmd/installer/cli/join.go
@@ -576,7 +576,7 @@ func maybeEnableHA(ctx context.Context, kcli client.Client, flags JoinCmdFlags, 
 	}
 
 	if !flags.assumeYes {
-		shouldEnableHA, err := prompts.New().Confirm("Do you want to enable high availability?", false)
+		shouldEnableHA, err := prompts.New().Confirm("Do you want to enable high availability?", true)
 		if err != nil {
 			return fmt.Errorf("failed to get confirmation: %w", err)
 		}

--- a/cmd/installer/cli/join.go
+++ b/cmd/installer/cli/join.go
@@ -552,7 +552,7 @@ func maybeEnableHA(ctx context.Context, kcli client.Client, flags JoinCmdFlags, 
 			logrus.Info("When high availability is enabled, you must maintain at least three nodes.")
 			logrus.Info("")
 		}
-		shouldEnableHA, err := prompts.New().Confirm("Do you want to enable high availability?", false)
+		shouldEnableHA, err := prompts.New().Confirm("Do you want to enable high availability?", true)
 		if err != nil {
 			return fmt.Errorf("failed to get confirmation: %w", err)
 		}

--- a/pkg/preflights/run.go
+++ b/pkg/preflights/run.go
@@ -220,8 +220,8 @@ func runHostPreflights(ctx context.Context, hpf *v1beta2.HostPreflightSpec, opts
 	}
 
 	// No failures or warnings
-	pb.Infof("Host preflights passed")
-	pb.Close()
+	spinner.Infof("Host preflights passed")
+	spinner.Close()
 
 	return nil
 }

--- a/pkg/preflights/run.go
+++ b/pkg/preflights/run.go
@@ -223,7 +223,7 @@ func runHostPreflights(ctx context.Context, hpf *v1beta2.HostPreflightSpec, opts
 	}
 
 	// No failures or warnings
-	pb.Infof("Host preflights succeeded!")
+	pb.Infof("Host preflights passed")
 	pb.Close()
 
 	return nil


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Say "preflights passed" instead of "succeeded" because that's the terminology we usually use for Troubleshoot.

When prompting about HA while joining nodes, default answer is now yes.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
When prompted to enable high availability while joining a third or more controller node, the default response is now yes to encourage users to enable high availability.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
