### PR TITLE
use save_image_name in sarif upload category

### DIFF
--- a/.github/actions/scan-image/action.yml
+++ b/.github/actions/scan-image/action.yml
@@ -55,10 +55,13 @@ runs:
         IMAGE_TAG=$(echo "${{ inputs.image-ref }}" | cut -d':' -f2 | cut -d'@' -f1)
         [[ "$IMAGE_TAG" == "$IMAGE_NAME" ]] && IMAGE_TAG="latest"
         SAFE_NAME=$(echo "${IMAGE_NAME}-${IMAGE_TAG}" | sed 's/[\/:]/-/g')
+        SAFE_IMAGE_NAME=$(echo "${IMAGE_NAME}" | sed 's/[\/:]/-/g')
         {
           echo "image_name=${IMAGE_NAME}"
           echo "image_tag=${IMAGE_TAG}"
           echo "safe_name=${SAFE_NAME}"
+          echo "safe_image_name=${SAFE_IMAGE_NAME}"
+
         } >> "$GITHUB_OUTPUT"
 
     - name: Scan image with Grype
@@ -122,7 +125,8 @@ runs:
       uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: ${{ inputs.output-file }}
-        category: '${{ inputs.category-prefix }}${{ steps.image-id.outputs.image_id }}'
+        category: '${{ inputs.category-prefix }}${{ steps.image_details.outputs.safe_image_name }}'
+
 
     - name: Archive scan results
       if: ${{ !cancelled() && inputs.upload-sarif == 'true' }}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
- For sarif upload, use the image base name as the category instead of the full name and version
- THis will ensure gtihub can correctly manage the scan results over different image versions

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
NONE

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE