### PR TITLE
Get charts and k0s images from KOTS and deprecate airgap bundle flag for node joins

### DIFF
--- a/cmd/installer/cli/join.go
+++ b/cmd/installer/cli/join.go
@@ -335,8 +335,8 @@ func materializeFilesForJoin(ctx context.Context, jcmd *join.JoinCommandResponse
 	}
 
 	if jcmd.InstallationSpec.AirGap {
-		if err := airgap.FetchAndWriteK0sImages(ctx, kotsAPIAddress); err != nil {
-			return fmt.Errorf("failed to fetch k0s images: %w", err)
+		if err := airgap.FetchAndWriteArtifacts(ctx, kotsAPIAddress); err != nil {
+			return fmt.Errorf("failed to fetch artifacts: %w", err)
 		}
 	}
 

--- a/cmd/installer/cli/join_runpreflights.go
+++ b/cmd/installer/cli/join_runpreflights.go
@@ -24,7 +24,7 @@ func JoinRunPreflightsCmd(ctx context.Context, name string) *cobra.Command {
 		Short: fmt.Sprintf("Run join host preflights for %s", name),
 		Args:  cobra.ExactArgs(2),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := preRunJoin(); err != nil {
+			if err := preRunJoin(&flags); err != nil {
 				return err
 			}
 

--- a/dev/dockerfiles/local-artifact-mirror/Dockerfile.ttlsh
+++ b/dev/dockerfiles/local-artifact-mirror/Dockerfile.ttlsh
@@ -1,4 +1,4 @@
-FROM golang:1.24 AS build
+FROM golang:1.24.2 AS build
 
 WORKDIR /app
 

--- a/dev/dockerfiles/operator/Dockerfile.local
+++ b/dev/dockerfiles/operator/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS build
+FROM golang:1.24.2-alpine AS build
 
 RUN apk add --no-cache ca-certificates curl git make bash
 

--- a/dev/dockerfiles/operator/Dockerfile.ttlsh
+++ b/dev/dockerfiles/operator/Dockerfile.ttlsh
@@ -1,4 +1,4 @@
-FROM golang:1.24 AS build
+FROM golang:1.24.2 AS build
 
 WORKDIR /app
 

--- a/pkg/addons/adminconsole/static/metadata.yaml
+++ b/pkg/addons/adminconsole/static/metadata.yaml
@@ -5,24 +5,24 @@
 # $ make buildtools
 # $ output/bin/buildtools update addon <addon name>
 #
-version: 1.124.15-ec.3
+version: 1.124.16-ec.0
 location: oci://proxy.replicated.com/anonymous/registry.replicated.com/library/admin-console
 images:
     kotsadm:
         repo: proxy.replicated.com/anonymous/kotsadm/kotsadm
         tag:
-            amd64: v1.124.15-ec.3-amd64@sha256:d5fb3ddb25580d36fab9baf0092217b9d40e922d294ec1d19af3551b30631ca8
-            arm64: v1.124.15-ec.3-arm64@sha256:e793322e706e64f6f3dcb4a6bdd4cc1f8d1d736d5f295d7f0a818e186610dffa
+            amd64: v1.124.16-ec.0-amd64@sha256:30bf71416ac4e28f343fc31b72e19fead80e3c833135b6175f6bf85f8a72916a
+            arm64: v1.124.16-ec.0-arm64@sha256:8b99803ed1ae94889f93646b61e991988293e5dbc253f76d7adf3185403c51af
     kotsadm-migrations:
         repo: proxy.replicated.com/anonymous/kotsadm/kotsadm-migrations
         tag:
-            amd64: v1.124.15-ec.3-amd64@sha256:94d83aedaf934bc86cfd7d831bd741632820fb1f2348f8ecef34fd88e389dc8c
-            arm64: v1.124.15-ec.3-arm64@sha256:ea2fec69f0465127f20bceefc60a45726472b516db77fc892e94611910d0caee
+            amd64: v1.124.16-ec.0-amd64@sha256:a9f0a7313e43579f33a2cf776d4a6096e4f942545cda4b0fe2a4fd48de81ffcc
+            arm64: v1.124.16-ec.0-arm64@sha256:0cdab3221eeb9aedf7a70e915b2adfad72d484b4dd147401ee563fc8959cd530
     kurl-proxy:
         repo: proxy.replicated.com/anonymous/kotsadm/kurl-proxy
         tag:
-            amd64: v1.124.15-ec.3-amd64@sha256:ca0656e13d244ecf40e5ca5ffd93b77064616ebe2b8dbb18932b27f556ed9f9c
-            arm64: v1.124.15-ec.3-arm64@sha256:3fb5a6da34d9dd00580cbcd2eadeb0a907017b9bbb91659b46aa96bbc80b5aeb
+            amd64: v1.124.16-ec.0-amd64@sha256:67555f18b467d96c886aee8b868acb3ba719ad0ff9562d3fb87aaa093338adcd
+            arm64: v1.124.16-ec.0-arm64@sha256:677d752ce90e1831f58868c618322720affe21443c5c638d2d4b416860828402
     rqlite:
         repo: proxy.replicated.com/anonymous/kotsadm/rqlite
         tag:

--- a/pkg/addons/adminconsole/static/metadata.yaml
+++ b/pkg/addons/adminconsole/static/metadata.yaml
@@ -5,24 +5,24 @@
 # $ make buildtools
 # $ output/bin/buildtools update addon <addon name>
 #
-version: 1.124.15-ec.2
+version: 1.124.15-ec.3
 location: oci://proxy.replicated.com/anonymous/registry.replicated.com/library/admin-console
 images:
     kotsadm:
         repo: proxy.replicated.com/anonymous/kotsadm/kotsadm
         tag:
-            amd64: v1.124.15-ec.2-amd64@sha256:55647c859506b1462cac40078d2279bb5ea284a39d7b8ab5c8caceea8cf57382
-            arm64: v1.124.15-ec.2-arm64@sha256:bc4608169f30250d2b997a28fbd59711cdf975766332110776c52b4d87563db5
+            amd64: v1.124.15-ec.3-amd64@sha256:d5fb3ddb25580d36fab9baf0092217b9d40e922d294ec1d19af3551b30631ca8
+            arm64: v1.124.15-ec.3-arm64@sha256:e793322e706e64f6f3dcb4a6bdd4cc1f8d1d736d5f295d7f0a818e186610dffa
     kotsadm-migrations:
         repo: proxy.replicated.com/anonymous/kotsadm/kotsadm-migrations
         tag:
-            amd64: v1.124.15-ec.2-amd64@sha256:8563ebe149f917e6030737e5e8b58b8a7796f47638ff87546d1d33c26bb27c80
-            arm64: v1.124.15-ec.2-arm64@sha256:4d72708542edfc5956aa815fe106e7172aee98550cc51e90dad8eb34300b55f5
+            amd64: v1.124.15-ec.3-amd64@sha256:94d83aedaf934bc86cfd7d831bd741632820fb1f2348f8ecef34fd88e389dc8c
+            arm64: v1.124.15-ec.3-arm64@sha256:ea2fec69f0465127f20bceefc60a45726472b516db77fc892e94611910d0caee
     kurl-proxy:
         repo: proxy.replicated.com/anonymous/kotsadm/kurl-proxy
         tag:
-            amd64: v1.124.15-ec.2-amd64@sha256:0dc979da23442b7e4ae53fa46fbbbb1835c4f186b2e9d4d1f11000431a6dd6ad
-            arm64: v1.124.15-ec.2-arm64@sha256:4d369bee17c270991f5daee2b01762be7caee1dd2882b8a320902e910cbd05cc
+            amd64: v1.124.15-ec.3-amd64@sha256:ca0656e13d244ecf40e5ca5ffd93b77064616ebe2b8dbb18932b27f556ed9f9c
+            arm64: v1.124.15-ec.3-arm64@sha256:3fb5a6da34d9dd00580cbcd2eadeb0a907017b9bbb91659b46aa96bbc80b5aeb
     rqlite:
         repo: proxy.replicated.com/anonymous/kotsadm/rqlite
         tag:

--- a/pkg/dryrun/kotsadm.go
+++ b/pkg/dryrun/kotsadm.go
@@ -3,6 +3,7 @@ package dryrun
 import (
 	"context"
 	"fmt"
+	"io"
 	"reflect"
 	"strings"
 
@@ -45,9 +46,9 @@ func (c *Kotsadm) setResponse(resp interface{}, err error, methodName string, ar
 	return nil
 }
 
-// SetGetJoinTokenResponse sets the response for the GetJoinToken method, based on the provided address and shortToken.
-func (c *Kotsadm) SetGetJoinTokenResponse(address, shortToken string, resp *join.JoinCommandResponse, err error) {
-	mockErr := c.setResponse(resp, err, "GetJoinToken", address, shortToken)
+// SetGetJoinTokenResponse sets the response for the GetJoinToken method, based on the provided kotsAPIAddress and shortToken.
+func (c *Kotsadm) SetGetJoinTokenResponse(kotsAPIAddress, shortToken string, resp *join.JoinCommandResponse, err error) {
+	mockErr := c.setResponse(resp, err, "GetJoinToken", kotsAPIAddress, shortToken)
 	if mockErr != nil {
 		panic(mockErr)
 	}
@@ -55,11 +56,29 @@ func (c *Kotsadm) SetGetJoinTokenResponse(address, shortToken string, resp *join
 
 // GetJoinToken issues a request to the kots api to get the actual join command
 // based on the short token provided by the user.
-func (c *Kotsadm) GetJoinToken(ctx context.Context, address, shortToken string) (*join.JoinCommandResponse, error) {
-	key := strings.Join([]string{"GetJoinToken", address, shortToken}, ":")
+func (c *Kotsadm) GetJoinToken(ctx context.Context, kotsAPIAddress, shortToken string) (*join.JoinCommandResponse, error) {
+	key := strings.Join([]string{"GetJoinToken", kotsAPIAddress, shortToken}, ":")
 	if handler, ok := c.mockHandlers[key]; ok {
 		return handler.resp.(*join.JoinCommandResponse), handler.err
 	} else {
-		return nil, fmt.Errorf("no response set for GetJoinToken, address: %s, shortToken: %s", address, shortToken)
+		return nil, fmt.Errorf("no response set for GetJoinToken, kotsAPIAddress: %s, shortToken: %s", kotsAPIAddress, shortToken)
+	}
+}
+
+func (c *Kotsadm) SetGetK0sImagesFileResponse(kotsAPIAddress string, resp io.ReadCloser, err error) {
+	mockErr := c.setResponse(resp, err, "GetK0sImagesFile", kotsAPIAddress)
+	if mockErr != nil {
+		panic(mockErr)
+	}
+}
+
+// GetK0sImagesFile fetches the k0s images file from the KOTS API.
+// caller is responsible for closing the response body.
+func (c *Kotsadm) GetK0sImagesFile(ctx context.Context, kotsAPIAddress string) (io.ReadCloser, error) {
+	key := strings.Join([]string{"GetK0sImagesFile", kotsAPIAddress}, ":")
+	if handler, ok := c.mockHandlers[key]; ok {
+		return handler.resp.(io.ReadCloser), handler.err
+	} else {
+		return nil, fmt.Errorf("no response set for GetK0sImagesFile, kotsAPIAddress: %s", kotsAPIAddress)
 	}
 }

--- a/pkg/dryrun/kotsadm.go
+++ b/pkg/dryrun/kotsadm.go
@@ -82,3 +82,21 @@ func (c *Kotsadm) GetK0sImagesFile(ctx context.Context, kotsAPIAddress string) (
 		return nil, fmt.Errorf("no response set for GetK0sImagesFile, kotsAPIAddress: %s", kotsAPIAddress)
 	}
 }
+
+func (c *Kotsadm) SetGetECChartsResponse(kotsAPIAddress string, resp io.ReadCloser, err error) {
+	mockErr := c.setResponse(resp, err, "GetECCharts", kotsAPIAddress)
+	if mockErr != nil {
+		panic(mockErr)
+	}
+}
+
+// GetECCharts fetches the Helm charts file from the KOTS API.
+// caller is responsible for closing the response body.
+func (c *Kotsadm) GetECCharts(ctx context.Context, kotsAPIAddress string) (io.ReadCloser, error) {
+	key := strings.Join([]string{"GetECCharts", kotsAPIAddress}, ":")
+	if handler, ok := c.mockHandlers[key]; ok {
+		return handler.resp.(io.ReadCloser), handler.err
+	} else {
+		return nil, fmt.Errorf("no response set for GetECCharts, kotsAPIAddress: %s", kotsAPIAddress)
+	}
+}

--- a/pkg/kotsadm/client.go
+++ b/pkg/kotsadm/client.go
@@ -34,6 +34,7 @@ func (c *Client) GetJoinToken(ctx context.Context, kotsAPIAddress, shortToken st
 		return nil, fmt.Errorf("unable to get join token: %w", err)
 	}
 	defer resp.Body.Close()
+
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
@@ -62,6 +63,7 @@ func (c *Client) GetK0sImagesFile(ctx context.Context, kotsAPIAddress string) (i
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		_ = resp.Body.Close()
 		return nil, fmt.Errorf("unexpected status code fetching k0s images: %d", resp.StatusCode)
 	}
 	return resp.Body, nil
@@ -85,6 +87,7 @@ func (c *Client) GetECCharts(ctx context.Context, kotsAPIAddress string) (io.Rea
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		_ = resp.Body.Close()
 		return nil, fmt.Errorf("unexpected status code fetching charts: %d", resp.StatusCode)
 	}
 	return resp.Body, nil

--- a/pkg/kotsadm/client.go
+++ b/pkg/kotsadm/client.go
@@ -66,3 +66,26 @@ func (c *Client) GetK0sImagesFile(ctx context.Context, kotsAPIAddress string) (i
 	}
 	return resp.Body, nil
 }
+
+// GetECCharts fetches the helm charts file from the KOTS API.
+// caller is responsible for closing the response body.
+func (c *Client) GetECCharts(ctx context.Context, kotsAPIAddress string) (io.ReadCloser, error) {
+	url := fmt.Sprintf("http://%s/api/v1/embedded-cluster/charts", kotsAPIAddress)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create request: %w", err)
+	}
+
+	// this will generally be a self-signed certificate created by kurl-proxy
+	insecureClient := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
+	resp, err := insecureClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch charts: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code fetching charts: %d", resp.StatusCode)
+	}
+	return resp.Body, nil
+}

--- a/pkg/kotsadm/client.go
+++ b/pkg/kotsadm/client.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -17,8 +18,8 @@ type Client struct{}
 
 // GetJoinToken issues a request to the kots api to get the actual join command
 // based on the short token provided by the user.
-func (c *Client) GetJoinToken(ctx context.Context, address, shortToken string) (*join.JoinCommandResponse, error) {
-	url := fmt.Sprintf("https://%s/api/v1/embedded-cluster/join?token=%s", address, shortToken)
+func (c *Client) GetJoinToken(ctx context.Context, kotsAPIAddress, shortToken string) (*join.JoinCommandResponse, error) {
+	url := fmt.Sprintf("https://%s/api/v1/embedded-cluster/join?token=%s", kotsAPIAddress, shortToken)
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -41,4 +42,27 @@ func (c *Client) GetJoinToken(ctx context.Context, address, shortToken string) (
 		return nil, fmt.Errorf("unable to decode response: %w", err)
 	}
 	return &command, nil
+}
+
+// GetK0sImagesFile fetches the k0s images file from the KOTS API.
+// caller is responsible for closing the response body.
+func (c *Client) GetK0sImagesFile(ctx context.Context, kotsAPIAddress string) (io.ReadCloser, error) {
+	url := fmt.Sprintf("http://%s/api/v1/embedded-cluster/k0s-images", kotsAPIAddress)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create request: %w", err)
+	}
+
+	// this will generally be a self-signed certificate created by kurl-proxy
+	insecureClient := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
+	resp, err := insecureClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch k0s images: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code fetching k0s images: %d", resp.StatusCode)
+	}
+	return resp.Body, nil
 }

--- a/pkg/kotsadm/interface.go
+++ b/pkg/kotsadm/interface.go
@@ -2,6 +2,7 @@ package kotsadm
 
 import (
 	"context"
+	"io"
 
 	"github.com/replicatedhq/embedded-cluster/kinds/types/join"
 )
@@ -19,13 +20,20 @@ func Set(kotsadm ClientInterface) {
 }
 
 type ClientInterface interface {
-	GetJoinToken(ctx context.Context, address, shortToken string) (*join.JoinCommandResponse, error)
+	GetJoinToken(ctx context.Context, kotsAPIAddress, shortToken string) (*join.JoinCommandResponse, error)
+	GetK0sImagesFile(ctx context.Context, kotsAPIAddress string) (io.ReadCloser, error)
 }
 
 // Convenience functions
 
 // GetJoinToken is a helper function that issues a request to the kots api to get the actual join command
 // based on the short token provided by the user.
-func GetJoinToken(ctx context.Context, address, shortToken string) (*join.JoinCommandResponse, error) {
-	return _kotsadm.GetJoinToken(ctx, address, shortToken)
+func GetJoinToken(ctx context.Context, kotsAPIAddress, shortToken string) (*join.JoinCommandResponse, error) {
+	return _kotsadm.GetJoinToken(ctx, kotsAPIAddress, shortToken)
+}
+
+// GetK0sImagesFile is a helper function that fetches the k0s images file from the KOTS API.
+// caller is responsible for closing the response body.
+func GetK0sImagesFile(ctx context.Context, kotsAPIAddress string) (io.ReadCloser, error) {
+	return _kotsadm.GetK0sImagesFile(ctx, kotsAPIAddress)
 }

--- a/pkg/kotsadm/interface.go
+++ b/pkg/kotsadm/interface.go
@@ -22,6 +22,7 @@ func Set(kotsadm ClientInterface) {
 type ClientInterface interface {
 	GetJoinToken(ctx context.Context, kotsAPIAddress, shortToken string) (*join.JoinCommandResponse, error)
 	GetK0sImagesFile(ctx context.Context, kotsAPIAddress string) (io.ReadCloser, error)
+	GetECCharts(ctx context.Context, kotsAPIAddress string) (io.ReadCloser, error)
 }
 
 // Convenience functions
@@ -36,4 +37,10 @@ func GetJoinToken(ctx context.Context, kotsAPIAddress, shortToken string) (*join
 // caller is responsible for closing the response body.
 func GetK0sImagesFile(ctx context.Context, kotsAPIAddress string) (io.ReadCloser, error) {
 	return _kotsadm.GetK0sImagesFile(ctx, kotsAPIAddress)
+}
+
+// GetECCharts is a helper function that fetches the Helm charts file from the KOTS API.
+// caller is responsible for closing the response body.
+func GetECCharts(ctx context.Context, kotsAPIAddress string) (io.ReadCloser, error) {
+	return _kotsadm.GetECCharts(ctx, kotsAPIAddress)
 }

--- a/tests/dryrun/Dockerfile
+++ b/tests/dryrun/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS build
+FROM golang:1.24.2-alpine AS build
 
 RUN apk add --no-cache ca-certificates curl git make bash
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Gets k0s images from KOTS and deprecates airgap bundle flag for node joins

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-122569](https://app.shortcut.com/replicated/story/122569)
[SC-122796](https://app.shortcut.com/replicated/story/122796)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Yes

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
TBD
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE