### PR TITLE
chore(ci): ignore 143 exit code on node reset

### DIFF
--- a/e2e/cluster/lxd/cluster.go
+++ b/e2e/cluster/lxd/cluster.go
@@ -1077,6 +1077,11 @@ func (c *Cluster) RunCommandOnNode(node int, line []string, envs ...map[string]s
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
 	if err := Run(ctx, c.T, *cmd); err != nil {
+		// check if this is a reset-installation command that resulted in exit code 143
+		// as this is expected behavior when the node reboots and the api connection is lost
+		if strings.Contains(err.Error(), "143") && strings.Contains(strings.Join(line, " "), "reset-installation") {
+			return stdout.String(), stderr.String(), nil
+		}
 		c.T.Logf("stdout:\n%s", stdout.String())
 		c.T.Logf("stderr:\n%s", stderr.String())
 		return stdout.String(), stderr.String(), err


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

On node reset, the node is rebooted. The LXC container is [exiting](https://github.com/replicatedhq/embedded-cluster/actions/runs/14800575601/job/41586765525?pr=1363#step:4:744) before the reset-installation.sh script exits and is returning a 143 error. This change ignores the error and lets the test proceed.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
