### PR TITLE
fix(ci): enable required kernel modules

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -688,6 +688,12 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Free up runner disk space
         uses: ./.github/actions/free-disk-space
+      - name: Enable required kernel modules
+        run: |
+          sudo modprobe overlay
+          sudo modprobe ip_tables
+          sudo modprobe br_netfilter
+          sudo modprobe nf_conntrack
       - name: Run test
         env:
           SHORT_SHA: dev-${{ needs.git-sha.outputs.git_sha }}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Fixes host preflight failures on new actions runners

```
        ✗  2 host preflights failed
        
         •  Analyzer Failed: analyze: failed to analyze sysctl output: failed to evaluate outcomes: failed to compare net.bridge.bridge-nf-call-iptables == 
            0: kernel parameter "net.bridge.bridge-nf-call-iptables" does not exist on collected sysctl output                                              
         •  The 'br_netfilter' kernel module is not loaded or loadable 
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
