### PR TITLE
Build LAM and operator in parallel

### DIFF
--- a/scripts/ci-build-deps.sh
+++ b/scripts/ci-build-deps.sh
@@ -17,22 +17,29 @@ function init_vars() {
 }
 
 function local_artifact_mirror() {
-    make -C local-artifact-mirror build-ttl.sh
+    make -C local-artifact-mirror build-ttl.sh 2>&1 | prefix_output "LAM"
     cp local-artifact-mirror/build/image "local-artifact-mirror/build/image-$EC_VERSION"
 }
 
 function operator() {
     make -C operator build-ttl.sh build-chart-ttl.sh \
         PACKAGE_VERSION="$EC_VERSION" \
-        VERSION="$EC_VERSION"
+        VERSION="$EC_VERSION" 2>&1 | prefix_output "OPERATOR"
     cp operator/build/image "operator/build/image-$EC_VERSION"
     cp operator/build/chart "operator/build/chart-$EC_VERSION"
 }
 
 function main() {
     init_vars
-    local_artifact_mirror
-    operator
+    
+    local_artifact_mirror &
+    lam_pid=$!
+    
+    operator &
+    operator_pid=$!
+    
+    wait $lam_pid
+    wait $operator_pid
 }
 
 main "$@"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -9,6 +9,11 @@ function fail() {
     exit 1
 }
 
+function prefix_output() {
+    local prefix=$1
+    sed "s/^/[$prefix] /"
+}
+
 function require() {
     if [ -z "$2" ]; then
         fail "validation failed: $1 unset"


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Speeds up builds by building the operator and LAM images in parallel.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE