### PR TITLE
Wait for a bit after creating VM and before getting SSH endpoint

### DIFF
--- a/e2e/cluster/cmx/cluster.go
+++ b/e2e/cluster/cmx/cluster.go
@@ -144,6 +144,10 @@ func NewNode(in *ClusterInput, index int, networkID string) (*Node, error) {
 	}
 	node := nodes[0]
 
+	// TODO (@salah): remove this once the bug is fixed in CMX
+	// note: the vm gets marked as ready before the services are actually running
+	time.Sleep(30 * time.Second)
+
 	sshEndpoint, err := getSSHEndpoint(node.ID)
 	if err != nil {
 		return nil, fmt.Errorf("get ssh endpoint for node %s: %v", nodeName, err)


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

The CMX VM gets marked as ready right after cloud-init scripts but it can take time after that for the services to start. This adds a wait until an actual fix is implemented in CMX.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE