### PR TITLE
Update host-preflight.yaml

### DIFF
--- a/pkg/preflights/host-preflight.yaml
+++ b/pkg/preflights/host-preflight.yaml
@@ -443,8 +443,7 @@ spec:
                 Ensure your firewall is properly configured, and use --http-proxy,
                 --https-proxy, and --no-proxy if there is a proxy server.
                 The static IP addresses for {{ .ProxyRegistryURL }} are
-                162.159.137.43 and 162.159.138.43. If you provided a CA certificate,
-                make sure it is trusted by the system.
+                162.159.137.43 and 162.159.138.43. 
           - pass:
               when: 'statusCode == 401'
               message: 'Connected to {{ .ProxyRegistryURL }}'


### PR DESCRIPTION
Removing unnecessary information about trusting the ca on the host.

#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
