### PR TITLE
chore(e2e): make sure we log stderr output from the API

### DIFF
--- a/e2e/cluster/cmx/cluster.go
+++ b/e2e/cluster/cmx/cluster.go
@@ -89,7 +89,7 @@ func NewNetwork(in *ClusterInput) (*Network, error) {
 	name := fmt.Sprintf("ec-e2e-%s", uuid.New().String())
 	in.T.Logf("creating network %s", name)
 
-	output, err := exec.Command("replicated", "network", "create", "--name", name, "--wait", "5m", "-ojson").Output() // stderr can break json
+	output, err := exec.Command("replicated", "network", "create", "--name", name, "--wait", "5m", "-ojson").Output() // stderr can break json parsing
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return nil, fmt.Errorf("create network %s: %w: stderr: %s: stdout: %s", name, err, string(exitErr.Stderr), string(output))
@@ -136,7 +136,7 @@ func NewNode(in *ClusterInput, index int, networkID string) (*Node, error) {
 		args = append(args, "--ssh-public-key", key)
 	}
 
-	output, err := exec.Command("replicated", args...).Output() // stderr can break json
+	output, err := exec.Command("replicated", args...).Output() // stderr can break json parsing
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return nil, fmt.Errorf("create node %s: %w: stderr: %s: stdout: %s", nodeName, err, string(exitErr.Stderr), string(output))
@@ -463,7 +463,7 @@ func exposePort(node Node, port string) (string, error) {
 		return "", fmt.Errorf("expose port: %v: %s", err, string(output))
 	}
 
-	output, err = exec.Command("replicated", "vm", "port", "ls", node.ID, "-ojson").Output() // stderr can break json
+	output, err = exec.Command("replicated", "vm", "port", "ls", node.ID, "-ojson").Output() // stderr can break json parsing
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return "", fmt.Errorf("get port info: %w: stderr: %s: stdout: %s", err, string(exitErr.Stderr), string(output))

--- a/e2e/cluster/cmx/cluster.go
+++ b/e2e/cluster/cmx/cluster.go
@@ -89,9 +89,12 @@ func NewNetwork(in *ClusterInput) (*Network, error) {
 	name := fmt.Sprintf("ec-e2e-%s", uuid.New().String())
 	in.T.Logf("creating network %s", name)
 
-	output, err := execCommand("replicated", "network", "create", "--name", name, "--wait", "5m", "-ojson")
+	output, err := exec.Command("replicated", "network", "create", "--name", name, "--wait", "5m", "-ojson").Output()
 	if err != nil {
-		return nil, fmt.Errorf("create network %s: %v: %s", name, err, string(output))
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("create network %s: %w: stderr: %s: stdout: %s", name, err, string(exitErr.Stderr), string(output))
+		}
+		return nil, fmt.Errorf("create network %s: %w: stdout: %s", name, err, string(output))
 	}
 
 	var networks []Network
@@ -133,9 +136,12 @@ func NewNode(in *ClusterInput, index int, networkID string) (*Node, error) {
 		args = append(args, "--ssh-public-key", key)
 	}
 
-	output, err := execCommand("replicated", args...)
+	output, err := exec.Command("replicated", args...).Output()
 	if err != nil {
-		return nil, fmt.Errorf("create node %s: %v: %s", nodeName, err, string(output))
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("create node %s: %w: stderr: %s: stdout: %s", nodeName, err, string(exitErr.Stderr), string(output))
+		}
+		return nil, fmt.Errorf("create node %s: %w: stdout: %s", nodeName, err, string(output))
 	}
 
 	var nodes []Node
@@ -181,21 +187,6 @@ func NewNode(in *ClusterInput, index int, networkID string) (*Node, error) {
 	}
 
 	return &node, nil
-}
-
-// execCommand executes a command and returns the stdout output. If the command fails, it returns an error with the stderr output if any exists.
-func execCommand(command string, args ...string) ([]byte, error) {
-	cmd := exec.Command(command, args...)
-	// set Stderr to nil to force err to hold its output
-	cmd.Stderr = nil
-	output, err := cmd.Output()
-	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			return nil, fmt.Errorf("command %s: %w: stderr: %s: stdout: %s", cmd, err, string(exitErr.Stderr), string(output))
-		}
-		return nil, fmt.Errorf("command %s: %w: stdout: %s", cmd, err, string(output))
-	}
-	return output, nil
 }
 
 func discoverPrivateIP(node Node) (string, error) {
@@ -472,9 +463,12 @@ func exposePort(node Node, port string) (string, error) {
 		return "", fmt.Errorf("expose port: %v: %s", err, string(output))
 	}
 
-	output, err = execCommand("replicated", "vm", "port", "ls", node.ID, "-ojson")
+	output, err = exec.Command("replicated", "vm", "port", "ls", node.ID, "-ojson").Output()
 	if err != nil {
-		return "", fmt.Errorf("get port info: %v: %s", err, string(output))
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("get port info: %w: stderr: %s: stdout: %s", err, string(exitErr.Stderr), string(output))
+		}
+		return "", fmt.Errorf("get port info: %w: stdout: %s", err, string(output))
 	}
 
 	var ports []struct {

--- a/e2e/cluster/cmx/cluster.go
+++ b/e2e/cluster/cmx/cluster.go
@@ -191,9 +191,9 @@ func execCommand(command string, args ...string) ([]byte, error) {
 	output, err := cmd.Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			return nil, fmt.Errorf("command %s: err: %w stderr: %s stdout: %s", cmd, err, string(exitErr.Stderr), string(output))
+			return nil, fmt.Errorf("command %s: %w: stderr: %s: stdout: %s", cmd, err, string(exitErr.Stderr), string(output))
 		}
-		return nil, fmt.Errorf("command %s: err: %w  stdout: %s", cmd, err, string(output))
+		return nil, fmt.Errorf("command %s: %w: stdout: %s", cmd, err, string(output))
 	}
 	return output, nil
 }

--- a/e2e/cluster/cmx/cluster.go
+++ b/e2e/cluster/cmx/cluster.go
@@ -89,7 +89,7 @@ func NewNetwork(in *ClusterInput) (*Network, error) {
 	name := fmt.Sprintf("ec-e2e-%s", uuid.New().String())
 	in.T.Logf("creating network %s", name)
 
-	output, err := exec.Command("replicated", "network", "create", "--name", name, "--wait", "5m", "-ojson").Output()
+	output, err := exec.Command("replicated", "network", "create", "--name", name, "--wait", "5m", "-ojson").Output() // stderr can break json
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return nil, fmt.Errorf("create network %s: %w: stderr: %s: stdout: %s", name, err, string(exitErr.Stderr), string(output))
@@ -136,7 +136,7 @@ func NewNode(in *ClusterInput, index int, networkID string) (*Node, error) {
 		args = append(args, "--ssh-public-key", key)
 	}
 
-	output, err := exec.Command("replicated", args...).Output()
+	output, err := exec.Command("replicated", args...).Output() // stderr can break json
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return nil, fmt.Errorf("create node %s: %w: stderr: %s: stdout: %s", nodeName, err, string(exitErr.Stderr), string(output))
@@ -463,7 +463,7 @@ func exposePort(node Node, port string) (string, error) {
 		return "", fmt.Errorf("expose port: %v: %s", err, string(output))
 	}
 
-	output, err = exec.Command("replicated", "vm", "port", "ls", node.ID, "-ojson").Output()
+	output, err = exec.Command("replicated", "vm", "port", "ls", node.ID, "-ojson").Output() // stderr can break json
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return "", fmt.Errorf("get port info: %w: stderr: %s: stdout: %s", err, string(exitErr.Stderr), string(output))


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
With the change to `exec.Command(...).Output()` we stopped combining the `stderr` into the resulting output. That will be added to a field `Stderr` for the `ExitError` instead. This PR addresses that. Example output of an error now:

```
    cluster.go:82: failed to create nodes: create node 0: create node node0: exit status 1: stderr: Error: create vm: POST https://api.staging.replicated.com/vendor/v3/vm 500:
        : stdout:
```

Open to changing the format if y'all prefer something else.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
NA

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
