### PR TITLE
feat: detect host ca bundle

### DIFF
--- a/cmd/installer/cli/ca.go
+++ b/cmd/installer/cli/ca.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+// findHostCABundle locates the system CA certificate bundle on the host.
+// It first checks the SSL_CERT_FILE environment variable, then searches
+// common file paths used by various Linux distributions.
+//
+// The search follows the same order as the Go standard library's crypto/x509 package.
+//
+// Returns the path to the first found CA certificate bundle and nil error on success.
+// Returns an empty string and error if SSL_CERT_FILE is set but inaccessible
+// or if no CA certificate bundle is found.
+func findHostCABundle() (string, error) {
+	// First check if SSL_CERT_FILE environment variable is set
+	if envFile := os.Getenv("SSL_CERT_FILE"); envFile != "" {
+		if _, err := os.Stat(envFile); err != nil {
+			return "", fmt.Errorf("SSL_CERT_FILE set to %s but file cannot be accessed: %w", envFile, err)
+		}
+		return envFile, nil
+	}
+
+	// From https://github.com/golang/go/blob/go1.24.3/src/crypto/x509/root_linux.go
+	certFiles := []string{
+		"/etc/ssl/certs/ca-certificates.crt",                // Debian/Ubuntu/Gentoo etc.
+		"/etc/pki/tls/certs/ca-bundle.crt",                  // Fedora/RHEL 6
+		"/etc/ssl/ca-bundle.pem",                            // OpenSUSE
+		"/etc/pki/tls/cacert.pem",                           // OpenELEC
+		"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", // CentOS/RHEL 7
+		"/etc/ssl/cert.pem",                                 // Alpine Linux
+	}
+
+	// Check each file in the order of preference returning the first found
+	for _, file := range certFiles {
+		if _, err := os.Stat(file); err == nil {
+			return file, nil
+		}
+	}
+
+	return "", errors.New("no CA certificate file found")
+}

--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -259,6 +259,12 @@ func preRunInstall(cmd *cobra.Command, flags *InstallCmdFlags) error {
 }
 
 func runInstall(ctx context.Context, name string, flags InstallCmdFlags, metricsReporter preflights.MetricsReporter) error {
+	hostCABundle, err := findHostCABundle()
+	if err != nil {
+		return fmt.Errorf("unable to find host CA bundle: %w", err)
+	}
+	logrus.Debugf("using host CA bundle: %s", hostCABundle)
+
 	if err := runInstallVerifyAndPrompt(ctx, name, &flags); err != nil {
 		return err
 	}
@@ -348,6 +354,7 @@ func runInstall(ctx context.Context, name string, flags InstallCmdFlags, metrics
 		License:                 flags.license,
 		IsAirgap:                flags.airgapBundle != "",
 		Proxy:                   flags.proxy,
+		HostCABundle:            hostCABundle,
 		PrivateCAs:              flags.privateCAs,
 		ServiceCIDR:             flags.cidrCfg.ServiceCIDR,
 		DisasterRecoveryEnabled: flags.license.Spec.IsDisasterRecoverySupported,

--- a/cmd/installer/cli/restore.go
+++ b/cmd/installer/cli/restore.go
@@ -364,6 +364,12 @@ func runRestoreStepNew(ctx context.Context, name string, flags InstallCmdFlags, 
 		}
 	}
 
+	hostCABundle, err := findHostCABundle()
+	if err != nil {
+		return fmt.Errorf("unable to find host CA bundle: %w", err)
+	}
+	logrus.Debugf("using host CA bundle: %s", hostCABundle)
+
 	logrus.Debugf("configuring sysctl")
 	if err := configutils.ConfigureSysctl(); err != nil {
 		logrus.Debugf("unable to configure sysctl: %v", err)
@@ -437,6 +443,7 @@ func runRestoreStepNew(ctx context.Context, name string, flags InstallCmdFlags, 
 	if err := addons.Install(ctx, hcli, addons.InstallOptions{
 		IsAirgap:           flags.airgapBundle != "",
 		Proxy:              flags.proxy,
+		HostCABundle:       hostCABundle,
 		PrivateCAs:         flags.privateCAs,
 		ServiceCIDR:        flags.cidrCfg.ServiceCIDR,
 		IsRestore:          true,

--- a/pkg/addons/install.go
+++ b/pkg/addons/install.go
@@ -23,6 +23,7 @@ type InstallOptions struct {
 	License                 *kotsv1beta1.License
 	IsAirgap                bool
 	Proxy                   *ecv1beta1.ProxySpec
+	HostCABundle            string
 	PrivateCAs              []string
 	ServiceCIDR             string
 	DisasterRecoveryEnabled bool


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

This is a precursor to deprecating the --private-ca flag and instead using the CA bundle from the host to inject into containers to support private CAs.

There is no functional change here and the product should continue to work as is.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
