### PR TITLE
feat(operator): improved private ca support from host

### DIFF
--- a/operator/charts/embedded-cluster-operator/templates/embedded-cluster-operator-deployment.yaml
+++ b/operator/charts/embedded-cluster-operator/templates/embedded-cluster-operator-deployment.yaml
@@ -64,10 +64,6 @@ spec:
           value: {{ .Values.utilsImage }}
         - name: EMBEDDEDCLUSTER_IMAGE
           value: {{ printf "%s:%s" .Values.image.repository .Values.image.tag | quote }}
-{{- if .Values.privateCAs.enabled }}
-        - name: SSL_CERT_DIR
-          value: /certs
-{{- end }}
         name: manager
 {{- if .Values.livenessProbe }}
         livenessProbe:
@@ -77,11 +73,10 @@ spec:
         readinessProbe:
 {{ toYaml .Values.readinessProbe | indent 10 }}
 {{- end }}
-{{- if .Values.privateCAs.enabled }}
+        {{- if .Values.extraVolumeMounts }}
         volumeMounts:
-        - mountPath: /certs
-          name: private-cas
-{{- end }}
+        {{- toYaml .Values.extraVolumeMounts | nindent 8 }}
+        {{- end }}
 {{- if .Values.resources }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
@@ -95,10 +90,7 @@ spec:
         runAsNonRoot: true
       serviceAccountName: {{ include "embedded-cluster-operator.serviceAccountName" $ | trunc 63 | trimAll "-"}}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
-{{- if .Values.privateCAs.enabled }}
+      {{- if .Values.extraVolumes }}
       volumes:
-      - configMap:
-          name: "{{ .Values.privateCAs.configmapName }}"
-          optional: true
-        name: private-cas
-{{- end }}
+      {{- toYaml .Values.extraVolumes | nindent 6 }}
+      {{- end }}

--- a/pkg/addons/embeddedclusteroperator/embeddedclusteroperator.go
+++ b/pkg/addons/embeddedclusteroperator/embeddedclusteroperator.go
@@ -6,21 +6,44 @@ import (
 
 	"github.com/pkg/errors"
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"github.com/replicatedhq/embedded-cluster/pkg/kubeutils"
 	"github.com/replicatedhq/embedded-cluster/pkg/release"
 	"github.com/replicatedhq/embedded-cluster/pkg/versions"
 	"gopkg.in/yaml.v3"
+	"k8s.io/apimachinery/pkg/runtime"
+	jsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
+var (
+	serializer runtime.Serializer
+)
+
+func init() {
+	scheme := kubeutils.Scheme
+	serializer = jsonserializer.NewSerializerWithOptions(jsonserializer.DefaultMetaFactory, scheme, scheme, jsonserializer.SerializerOptions{
+		Yaml: true,
+	})
+}
+
 type EmbeddedClusterOperator struct {
-	IsAirgap              bool
-	Proxy                 *ecv1beta1.ProxySpec
+	IsAirgap bool
+	Proxy    *ecv1beta1.ProxySpec
+	// Deprecated: use HostCABundlePath instead
 	PrivateCAs            []string
+	HostCABundlePath      string
 	ChartLocationOverride string
 	ChartVersionOverride  string
 	ImageRepoOverride     string
 	ImageTagOverride      string
 	UtilsImageOverride    string
 	ProxyRegistryDomain   string
+
+	// DryRun is a flag to enable dry-run mode for Velero.
+	// If true, Velero will only render the helm template and additional manifests, but not install
+	// the release.
+	DryRun bool
+
+	dryRunManifests [][]byte
 }
 
 const (
@@ -86,6 +109,10 @@ func (e *EmbeddedClusterOperator) ChartVersion() string {
 		return e.ChartVersionOverride
 	}
 	return Metadata.Version
+}
+
+func (v *EmbeddedClusterOperator) DryRunManifests() [][]byte {
+	return v.dryRunManifests
 }
 
 func getBackupLabels() map[string]string {

--- a/pkg/addons/embeddedclusteroperator/install_test.go
+++ b/pkg/addons/embeddedclusteroperator/install_test.go
@@ -67,11 +67,13 @@ func Test_installEnsureCAConfigmap(t *testing.T) {
 			cli := builder.Build()
 
 			// Call the function under test
-			privateCAs := []string{
-				filepath.Join(tmpDir, "ca_0.crt"),
-				filepath.Join(tmpDir, "ca_1.crt"),
+			e := &EmbeddedClusterOperator{
+				PrivateCAs: []string{
+					filepath.Join(tmpDir, "ca_0.crt"),
+					filepath.Join(tmpDir, "ca_1.crt"),
+				},
 			}
-			err := installEnsureCAConfigmap(context.Background(), cli, privateCAs)
+			err := e.installEnsureCAConfigmap(context.Background(), cli)
 
 			// Check error expectations
 			if tt.expectError {

--- a/pkg/addons/embeddedclusteroperator/integration/hostcabundle_test.go
+++ b/pkg/addons/embeddedclusteroperator/integration/hostcabundle_test.go
@@ -1,0 +1,82 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/replicatedhq/embedded-cluster/pkg/addons/embeddedclusteroperator"
+	"github.com/replicatedhq/embedded-cluster/pkg/helm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/yaml"
+)
+
+func TestHostCABundle(t *testing.T) {
+	chartLocation, err := filepath.Abs("../../../../operator/charts/embedded-cluster-operator")
+	require.NoError(t, err, "Failed to get chart location")
+
+	addon := &embeddedclusteroperator.EmbeddedClusterOperator{
+		DryRun:                true,
+		ChartLocationOverride: chartLocation,
+		HostCABundlePath:      "/etc/ssl/certs/ca-certificates.crt",
+	}
+
+	fmt.Println(addon.ChartLocation())
+
+	hcli, err := helm.NewClient(helm.HelmOptions{})
+	require.NoError(t, err, "NewClient should not return an error")
+
+	err = addon.Install(context.Background(), nil, hcli, nil, nil)
+	require.NoError(t, err, "embeddedclusteroperator.Install should not return an error")
+
+	manifests := addon.DryRunManifests()
+	require.NotEmpty(t, manifests, "DryRunManifests should not be empty")
+
+	var deployment *appsv1.Deployment
+	for _, manifest := range manifests {
+		if strings.Contains(string(manifest), "# Source: embedded-cluster-operator/templates/embedded-cluster-operator-deployment.yaml") {
+			err := yaml.Unmarshal(manifest, &deployment)
+			require.NoError(t, err, "Failed to unmarshal EmbeddedClusterOperator deployment")
+		}
+	}
+
+	require.NotNil(t, deployment, "EmbeddedClusterOperator deployment should not be nil")
+
+	var volume *corev1.Volume
+	for _, v := range deployment.Spec.Template.Spec.Volumes {
+		if v.Name == "host-ca-bundle" {
+			volume = &v
+		}
+	}
+	if assert.NotNil(t, volume, "EmbeddedClusterOperator host-ca-bundle volume should not be nil") {
+		assert.Equal(t, volume.VolumeSource.HostPath.Path, "/etc/ssl/certs/ca-certificates.crt")
+		assert.Equal(t, volume.VolumeSource.HostPath.Type, ptr.To(corev1.HostPathFileOrCreate))
+	}
+
+	var volumeMount *corev1.VolumeMount
+	for _, v := range deployment.Spec.Template.Spec.Containers[0].VolumeMounts {
+		if v.Name == "host-ca-bundle" {
+			volumeMount = &v
+		}
+	}
+	if assert.NotNil(t, volumeMount, "EmbeddedClusterOperator host-ca-bundle volume mount should not be nil") {
+		assert.Equal(t, volumeMount.MountPath, "/certs/ca-certificates.crt")
+	}
+
+	// Check the SSL_CERT_DIR environment variable is set correctly
+	var sslCertDirEnv *corev1.EnvVar
+	for _, env := range deployment.Spec.Template.Spec.Containers[0].Env {
+		if env.Name == "SSL_CERT_DIR" {
+			sslCertDirEnv = &env
+		}
+	}
+	if assert.NotNil(t, sslCertDirEnv, "SSL_CERT_DIR environment variable should not be nil") {
+		assert.Equal(t, sslCertDirEnv.Value, "/certs")
+	}
+}

--- a/pkg/addons/embeddedclusteroperator/upgrade.go
+++ b/pkg/addons/embeddedclusteroperator/upgrade.go
@@ -66,5 +66,6 @@ func UpgradeEnsureCAConfigmap(ctx context.Context, kcli client.Client) error {
 		return errors.Wrap(err, "get kotsadm-private-cas configmap")
 	}
 
-	return ensureCAConfigmap(ctx, kcli, cm.Data)
+	addon := &EmbeddedClusterOperator{}
+	return addon.ensureCAConfigmap(ctx, kcli, cm.Data)
 }

--- a/pkg/addons/embeddedclusteroperator/values.go
+++ b/pkg/addons/embeddedclusteroperator/values.go
@@ -43,8 +43,12 @@ func (e *EmbeddedClusterOperator) GenerateHelmValues(ctx context.Context, kcli c
 		copiedValues["isAirgap"] = "true"
 	}
 
+	extraEnvVars := []map[string]any{}
+	extraVolumes := []map[string]any{}
+	extraVolumeMounts := []map[string]any{}
+
 	if e.Proxy != nil {
-		copiedValues["extraEnv"] = []map[string]interface{}{
+		extraEnvVars = append(extraEnvVars, []map[string]any{
 			{
 				"name":  "HTTP_PROXY",
 				"value": e.Proxy.HTTPProxy,
@@ -57,10 +61,32 @@ func (e *EmbeddedClusterOperator) GenerateHelmValues(ctx context.Context, kcli c
 				"name":  "NO_PROXY",
 				"value": e.Proxy.NoProxy,
 			},
-		}
-	} else {
-		delete(copiedValues, "extraEnv")
+		}...)
 	}
+
+	if e.HostCABundlePath != "" {
+		extraVolumes = append(extraVolumes, map[string]any{
+			"name": "host-ca-bundle",
+			"hostPath": map[string]any{
+				"path": e.HostCABundlePath,
+				"type": "FileOrCreate",
+			},
+		})
+
+		extraVolumeMounts = append(extraVolumeMounts, map[string]any{
+			"name":      "host-ca-bundle",
+			"mountPath": "/certs/ca-certificates.crt",
+		})
+
+		extraEnvVars = append(extraEnvVars, map[string]any{
+			"name":  "SSL_CERT_DIR",
+			"value": "/certs",
+		})
+	}
+
+	copiedValues["extraEnv"] = extraEnvVars
+	copiedValues["extraVolumes"] = extraVolumes
+	copiedValues["extraVolumeMounts"] = extraVolumeMounts
 
 	for _, override := range overrides {
 		var err error

--- a/pkg/addons/embeddedclusteroperator/values_test.go
+++ b/pkg/addons/embeddedclusteroperator/values_test.go
@@ -1,0 +1,51 @@
+package embeddedclusteroperator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateHelmValues_HostCABundlePath(t *testing.T) {
+	e := &EmbeddedClusterOperator{
+		HostCABundlePath: "/etc/ssl/certs/ca-certificates.crt",
+	}
+
+	values, err := e.GenerateHelmValues(context.Background(), nil, nil)
+	require.NoError(t, err, "GenerateHelmValues should not return an error")
+
+	require.NotEmpty(t, values["extraVolumes"])
+	require.IsType(t, []map[string]any{}, values["extraVolumes"])
+	require.Len(t, values["extraVolumes"], 1)
+
+	require.NotEmpty(t, values["extraVolumeMounts"])
+	require.IsType(t, []map[string]any{}, values["extraVolumeMounts"])
+	require.Len(t, values["extraVolumeMounts"], 1)
+
+	require.NotEmpty(t, values["extraEnv"])
+	require.IsType(t, []map[string]any{}, values["extraEnv"])
+
+	// Find the SSL_CERT_DIR environment variable
+	var sslCertDirFound bool
+	for _, env := range values["extraEnv"].([]map[string]any) {
+		if env["name"] == "SSL_CERT_DIR" {
+			assert.Equal(t, "/certs", env["value"])
+			sslCertDirFound = true
+			break
+		}
+	}
+	assert.True(t, sslCertDirFound, "SSL_CERT_DIR environment variable should be present")
+
+	extraVolume := values["extraVolumes"].([]map[string]any)[0]
+	assert.Equal(t, "host-ca-bundle", extraVolume["name"])
+	if assert.NotNil(t, extraVolume["hostPath"]) {
+		assert.Equal(t, "/etc/ssl/certs/ca-certificates.crt", extraVolume["hostPath"].(map[string]any)["path"])
+		assert.Equal(t, "FileOrCreate", extraVolume["hostPath"].(map[string]any)["type"])
+	}
+
+	extraVolumeMount := values["extraVolumeMounts"].([]map[string]any)[0]
+	assert.Equal(t, "host-ca-bundle", extraVolumeMount["name"])
+	assert.Equal(t, "/certs/ca-certificates.crt", extraVolumeMount["mountPath"])
+}

--- a/pkg/addons/install.go
+++ b/pkg/addons/install.go
@@ -74,6 +74,7 @@ func getAddOnsForInstall(opts InstallOptions) []types.AddOn {
 			IsAirgap:            opts.IsAirgap,
 			Proxy:               opts.Proxy,
 			PrivateCAs:          opts.PrivateCAs,
+			HostCABundlePath:    opts.HostCABundlePath,
 		},
 	}
 

--- a/pkg/addons/upgrade.go
+++ b/pkg/addons/upgrade.go
@@ -82,6 +82,7 @@ func getAddOnsForUpgrade(in *ecv1beta1.Installation, meta *ectypes.ReleaseMetada
 		ImageTagOverride:      ecoImageTag,
 		UtilsImageOverride:    ecoUtilsImage,
 		ProxyRegistryDomain:   domains.ProxyRegistryDomain,
+		HostCABundlePath:      hostCABundlePath,
 	})
 
 	if in.Spec.AirGap {

--- a/tests/dryrun/install_test.go
+++ b/tests/dryrun/install_test.go
@@ -638,9 +638,23 @@ func TestInstall_HTTPProxy(t *testing.T) {
 				"name":  "NO_PROXY",
 				"value": noProxy,
 			},
+			{
+				"name":  "SSL_CERT_DIR",
+				"value": "/certs",
+			},
 		},
+		"extraVolumes": []map[string]any{{
+			"name": "host-ca-bundle",
+			"hostPath": map[string]any{
+				"path": hostCABundle,
+				"type": "FileOrCreate",
+			},
+		}},
+		"extraVolumeMounts": []map[string]any{{
+			"mountPath": "/certs/ca-certificates.crt",
+			"name":      "host-ca-bundle",
+		}},
 	})
-	// TODO: CA
 
 	// velero
 	assert.Equal(t, "Install", hcli.Calls[2].Method)
@@ -723,7 +737,6 @@ func TestInstall_HTTPProxy(t *testing.T) {
 
 	// TODO: CA
 	// assertConfigMapExists(t, kcli, "private-cas", "kotsadm")
-	// assertConfigMapExists(t, kcli, "kotsadm-private-cas", "embedded-cluster")
 
 	// --- validate installation object --- //
 	in, err := kubeutils.GetLatestInstallation(context.TODO(), kcli)


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Pass the ca bundle detected from the host to the operator chart.

Mounts the CA into the operator container at path /certs/ca-certificates.crt and sets the SSL_CERT_DIR env var so that golang will use the certificate.

Adds extraVolumes and extraVolumeMounts keys to the helm values file to pass through to the operator deployment similar to the [velero helm chart](https://github.com/vmware-tanzu/helm-charts/blob/main/charts/velero/templates/node-agent-daemonset.yaml#L86-L89).

Related https://github.com/replicatedhq/embedded-cluster/pull/2168

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
