### PR TITLE
chore: add Microsoft Defender Antivirus to the list of security tools

### DIFF
--- a/cmd/installer/goods/support/host-support-bundle.tmpl.yaml
+++ b/cmd/installer/goods/support/host-support-bundle.tmpl.yaml
@@ -298,7 +298,7 @@ spec:
   - run:
       collectorName: "ps-detect-antivirus-and-security-tools"
       command: "sh"
-      args: [-c, "ps -ef | grep -E 'clamav|sophos|esets_daemon|fsav|symantec|mfend|ds_agent|kav|bdagent|s1agent|falcon|illumio|xagt|wdavdaemon' | grep -v grep"]
+      args: [-c, "ps -ef | grep -E 'clamav|sophos|esets_daemon|fsav|symantec|mfend|ds_agent|kav|bdagent|s1agent|falcon|illumio|xagt|wdavdaemon|mdatp' | grep -v grep"]
   - filesystemPerformance:
         collectorName: filesystem-write-latency-etcd
         timeout: 5m


### PR DESCRIPTION
#### What this PR does / why we need it:
Ensure Microsoft Defender Antivirus security tool is detected by the support bundle analysis.

#### Which issue(s) this PR fixes:

#### Does this PR require a test?
NONE

#### Does this PR require a release note?
```release-note
Ensure Microsoft Defender Antivirus security tool is detected by the support bundle analysis.
```

#### Does this PR require documentation?
NONE