### PR TITLE
chore(e2e): create multiple VMs in one go through the CLI

### DIFF
--- a/e2e/cluster/cmx/cluster.go
+++ b/e2e/cluster/cmx/cluster.go
@@ -125,7 +125,7 @@ func NewNodes(in *ClusterInput) ([]Node, error) {
 			return nil, fmt.Errorf("copy scripts to node %s: %v", nodes[i].ID, err)
 		}
 
-		if in.Nodes == 1 {
+		if i == 0 {
 			in.T.Logf("exposing port 30003 on node %s", nodes[i].ID)
 			hostname, err := exposePort(nodes[i], "30003")
 			if err != nil {

--- a/e2e/cluster/cmx/cluster.go
+++ b/e2e/cluster/cmx/cluster.go
@@ -299,7 +299,7 @@ func (c *Cluster) Destroy() {
 func (c *Cluster) removeNode(node Node) {
 	output, err := exec.Command("replicated", "vm", "rm", node.ID).CombinedOutput()
 	if err != nil {
-		c.t.Logf("failed to destroy node %s: %v: %s", node.Name, err, string(output))
+		c.t.Logf("failed to destroy node %s: %v: %s", node.ID, err, string(output))
 	}
 }
 

--- a/e2e/cluster/cmx/cluster.go
+++ b/e2e/cluster/cmx/cluster.go
@@ -12,8 +12,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 type ClusterInput struct {
@@ -35,8 +33,9 @@ type Cluster struct {
 }
 
 type Node struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	NetworkID string `json:"network_id"`
 
 	privateIP       string `json:"-"`
 	sshEndpoint     string `json:"-"`
@@ -44,68 +43,31 @@ type Node struct {
 }
 
 type Network struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
+	ID string `json:"id"`
 }
 
 func NewCluster(in *ClusterInput) *Cluster {
 	c := &Cluster{t: in.T, supportBundleNodeIndex: in.SupportBundleNodeIndex}
 	c.t.Cleanup(c.Destroy)
 
-	c.Nodes = make([]Node, in.Nodes)
-
-	network, err := NewNetwork(in)
+	nodes, err := NewNodes(in)
 	if err != nil {
-		in.T.Fatalf("failed to create network: %v", err)
+		in.T.Fatalf("failed to create nodes: %v", err)
 	}
-	c.network = network
-
-	for i := range c.Nodes {
-		node, err := NewNode(in, i, network.ID)
-		if node != nil {
-			c.Nodes[i] = *node
-		}
-		if err != nil {
-			in.T.Fatalf("create node %d: %v", i, err)
-		}
-		in.T.Logf("node%d created with ID %s", i, node.ID)
-	}
+	in.T.Logf("cluster created with network ID %s", nodes[0].NetworkID)
+	c.Nodes = nodes
+	c.network = &Network{ID: nodes[0].NetworkID}
 
 	return c
 }
 
-func NewNetwork(in *ClusterInput) (*Network, error) {
-	name := fmt.Sprintf("ec-e2e-%s", uuid.New().String())
-	in.T.Logf("creating network %s", name)
-
-	output, err := exec.Command("replicated", "network", "create", "--name", name, "--wait", "5m", "-ojson").Output() // stderr can break json parsing
-	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			return nil, fmt.Errorf("create network %s: %w: stderr: %s: stdout: %s", name, err, string(exitErr.Stderr), string(output))
-		}
-		return nil, fmt.Errorf("create network %s: %w: stdout: %s", name, err, string(output))
-	}
-
-	var networks []Network
-	if err := json.Unmarshal(output, &networks); err != nil {
-		return nil, fmt.Errorf("parse networks output: %v: %s", err, string(output))
-	}
-	if len(networks) != 1 {
-		return nil, fmt.Errorf("expected 1 network, got %d", len(networks))
-	}
-	network := &networks[0]
-	in.T.Logf("Network created with ID %s", network.ID)
-	return network, nil
-}
-
-func NewNode(in *ClusterInput, index int, networkID string) (node *Node, err error) {
-	nodeName := fmt.Sprintf("node%d", index)
-	in.T.Logf("creating node %s", nodeName)
+func NewNodes(in *ClusterInput) ([]Node, error) {
+	in.T.Logf("creating %s nodes", strconv.Itoa(in.Nodes))
 
 	args := []string{
 		"vm", "create",
-		"--name", nodeName,
-		"--network", networkID,
+		"--name", "ec-test-suite",
+		"--count", strconv.Itoa(in.Nodes),
 		"--wait", "5m",
 		"-ojson",
 	}
@@ -128,54 +90,54 @@ func NewNode(in *ClusterInput, index int, networkID string) (node *Node, err err
 	output, err := exec.Command("replicated", args...).Output() // stderr can break json parsing
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			return nil, fmt.Errorf("create node %s: %w: stderr: %s: stdout: %s", nodeName, err, string(exitErr.Stderr), string(output))
+			return nil, fmt.Errorf("create nodes: %w: stderr: %s: stdout: %s", err, string(exitErr.Stderr), string(output))
 		}
-		return nil, fmt.Errorf("create node %s: %w: stdout: %s", nodeName, err, string(output))
+		return nil, fmt.Errorf("create nodes: %w: stdout: %s", err, string(output))
 	}
 
 	var nodes []Node
 	if err := json.Unmarshal(output, &nodes); err != nil {
 		return nil, fmt.Errorf("unmarshal node: %v: %s", err, string(output))
 	}
-	if len(nodes) != 1 {
-		return nil, fmt.Errorf("expected 1 node, got %d", len(nodes))
-	}
-	node = &nodes[0]
 
 	// TODO (@salah): remove this once the bug is fixed in CMX
 	// note: the vm gets marked as ready before the services are actually running
 	time.Sleep(30 * time.Second)
 
-	sshEndpoint, err := getSSHEndpoint(node.ID)
-	if err != nil {
-		return node, fmt.Errorf("get ssh endpoint for node %s: %v", nodeName, err)
-	}
-	node.sshEndpoint = sshEndpoint
-
-	privateIP, err := discoverPrivateIP(*node)
-	if err != nil {
-		return node, fmt.Errorf("discover node private IP: %v", err)
-	}
-	node.privateIP = privateIP
-
-	if err := ensureAssetsDir(*node); err != nil {
-		return node, fmt.Errorf("ensure assets dir on node %s: %v", node.Name, err)
-	}
-
-	if err := copyScriptsToNode(*node); err != nil {
-		return node, fmt.Errorf("copy scripts to node %s: %v", node.Name, err)
-	}
-
-	if index == 0 {
-		in.T.Logf("exposing port 30003 on node %s", node.Name)
-		hostname, err := exposePort(*node, "30003")
+	for i := range nodes {
+		sshEndpoint, err := getSSHEndpoint(nodes[i].ID)
 		if err != nil {
-			return node, fmt.Errorf("expose port: %v", err)
+			return nil, fmt.Errorf("get ssh endpoint for node %s: %v", nodes[i].ID, err)
 		}
-		node.adminConsoleURL = fmt.Sprintf("http://%s", hostname)
+		nodes[i].sshEndpoint = sshEndpoint
+
+		privateIP, err := discoverPrivateIP(nodes[i])
+		if err != nil {
+			return nil, fmt.Errorf("discover node private IP: %v", err)
+		}
+		nodes[i].privateIP = privateIP
+
+		if err := ensureAssetsDir(nodes[i]); err != nil {
+			return nil, fmt.Errorf("ensure assets dir on node %s: %v", nodes[i].ID, err)
+		}
+
+		if err := copyScriptsToNode(nodes[i]); err != nil {
+			return nil, fmt.Errorf("copy scripts to node %s: %v", nodes[i].ID, err)
+		}
+
+		if in.Nodes == 1 {
+			in.T.Logf("exposing port 30003 on node %s", nodes[i].ID)
+			hostname, err := exposePort(nodes[i], "30003")
+			if err != nil {
+				return nil, fmt.Errorf("expose port: %v", err)
+			}
+			nodes[i].adminConsoleURL = fmt.Sprintf("http://%s", hostname)
+		}
+
+		in.T.Logf("node %d created with ID %s and private IP %s", i, nodes[i].ID, nodes[i].privateIP)
 	}
 
-	return node, nil
+	return nodes, nil
 }
 
 func discoverPrivateIP(node Node) (string, error) {
@@ -344,7 +306,7 @@ func (c *Cluster) removeNode(node Node) {
 func (c *Cluster) removeNetwork(network Network) {
 	output, err := exec.Command("replicated", "network", "rm", network.ID).CombinedOutput()
 	if err != nil {
-		c.t.Logf("failed to destroy network %s: %v: %s", network.Name, err, string(output))
+		c.t.Logf("failed to destroy network %s: %v: %s", network.ID, err, string(output))
 	}
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Based on the following thread:
- https://replicated.slack.com/archives/C04T9AAMJUS/p1747707927071029

Seems like a lot of the E2E test flakiness and errors we've been getting with CMX can be addressed if instead of manually creating the network and each node in parallel we leverage the VM API and create all the required VMs in one go (which will be under the same network by default).

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
NA

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE
#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE