### PR TITLE
feat: add prompt to proceed if http proxy is set and https proxy unset

### DIFF
--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -722,7 +722,7 @@ func runInstallVerifyAndPrompt(ctx context.Context, name string, flags *InstallC
 		}
 	}
 
-	if err := promptProceedWithPartialProxyConfig(flags.proxy, prompt); err != nil {
+	if err := verifyProxyConfig(flags.proxy, prompt, flags.assumeYes); err != nil {
 		return err
 	}
 	logrus.Debug("User confirmed prompt to proceed installing with `http_proxy` set and `https_proxy` unset")
@@ -1112,10 +1112,10 @@ func maybePromptForAppUpdate(ctx context.Context, prompt prompts.Prompt, license
 	return nil
 }
 
-// promptProceedWithPartialProxyConfig prompts for confirmation when HTTP proxy is set without HTTPS proxy,
+// verifyProxyConfig prompts for confirmation when HTTP proxy is set without HTTPS proxy,
 // returning an error if the user declines to proceed.
-func promptProceedWithPartialProxyConfig(proxy *ecv1beta1.ProxySpec, prompt prompts.Prompt) error {
-	if proxy != nil && proxy.HTTPProxy != "" && proxy.HTTPSProxy == "" {
+func verifyProxyConfig(proxy *ecv1beta1.ProxySpec, prompt prompts.Prompt, assumeYes bool) error {
+	if proxy != nil && proxy.HTTPProxy != "" && proxy.HTTPSProxy == "" && !assumeYes {
 		message := "Typically --https-proxy should be set if --http-proxy is set. Installation failures are likely otherwise. Do you want to continue anyway?"
 		confirmed, err := prompt.Confirm(message, false)
 		if err != nil {

--- a/cmd/installer/cli/install_runpreflights.go
+++ b/cmd/installer/cli/install_runpreflights.go
@@ -8,6 +8,7 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/configutils"
 	"github.com/replicatedhq/embedded-cluster/pkg/netutils"
 	"github.com/replicatedhq/embedded-cluster/pkg/preflights"
+	"github.com/replicatedhq/embedded-cluster/pkg/prompts"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -50,7 +51,7 @@ func InstallRunPreflightsCmd(ctx context.Context, name string) *cobra.Command {
 }
 
 func runInstallRunPreflights(ctx context.Context, name string, flags InstallCmdFlags) error {
-	if err := runInstallVerifyAndPrompt(ctx, name, &flags); err != nil {
+	if err := runInstallVerifyAndPrompt(ctx, name, &flags, prompts.New()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Installation fails if `--http-proxy` is set and `--https-proxy` is not set.
This PR adds the following confirmation prompt before proceeding with the installation:
```
"Typically --https-proxy should be set if --http-proxy is set. Installation failures are likely otherwise. Do you want to continue anyway?"
```
#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/121629/prompt-if-http-proxy-is-set-but-not-https-proxy
#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Unit tests have been added to verify:
- no proxy set
- `http_proxy` set without `https_proxy` and user **confirms** (inputs y) proceeding with installation
- `http_proxy` set without `https_proxy` and user **declines** (inputs n) proceeding with installation
- `http_proxy` set without `https_proxy` and `assumeYes` is true
- both proxy set
#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Added confirmation prompt to prevent installation failures when `--http-proxy` is set but `--https-proxy` is not set.
```
#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
