### PR TITLE
chore(log): suppress the tls warning logs in the console

### DIFF
--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"os"
@@ -446,6 +447,8 @@ func runInstallAPI(ctx context.Context, listener net.Listener, cert tls.Certific
 	router.PathPrefix("/").Methods("GET").Handler(webFs)
 
 	server := &http.Server{
+		// ErrorLog outputs TLS errors and warnings to the console, we want to make sure we use the same logrus logger for them
+		ErrorLog:  log.New(logger.WithField("http-server", "std-log").Writer(), "", 0),
 		Handler:   router,
 		TLSConfig: tlsutils.GetTLSConfig(cert),
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

This should suppress the tls warnings that show up in the console:
```
? Set the Admin Console password (minimum 6 characters): ******
? Confirm the Admin Console password: ******

Visit https://localhost:30080 to configure your cluster
2025/05/27 11:18:20 http: TLS handshake error from 192.168.65.1:24546: remote error: tls: unknown certificate authority
2025/05/27 13:33:47 http: TLS handshake error from 192.168.65.1:34099: remote error: tls: unknown certificate
2025/05/27 13:33:47 http: TLS handshake error from 192.168.65.1:51200: remote error: tls: unknown certificate
^C
```

While making sure we use the same logger for consistency.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
