### PR TITLE
feat(adminconsle): support for HostCABundlePath template function

### DIFF
--- a/pkg/addons/adminconsole/integration/hostcabundle_test.go
+++ b/pkg/addons/adminconsole/integration/hostcabundle_test.go
@@ -76,4 +76,15 @@ func TestHostCABundle(t *testing.T) {
 	if assert.NotNil(t, sslCertDirEnv, "Admin Console SSL_CERT_DIR environment variable should not be nil") {
 		assert.Equal(t, sslCertDirEnv.Value, "/certs")
 	}
+
+	// Check for HOST_CA_BUNDLE_PATH environment variable
+	var hostCABundlePathEnv *corev1.EnvVar
+	for _, env := range adminDeployment.Spec.Template.Spec.Containers[0].Env {
+		if env.Name == "HOST_CA_BUNDLE_PATH" {
+			hostCABundlePathEnv = &env
+		}
+	}
+	if assert.NotNil(t, hostCABundlePathEnv, "Admin Console HOST_CA_BUNDLE_PATH environment variable should not be nil") {
+		assert.Equal(t, hostCABundlePathEnv.Value, "/etc/ssl/certs/ca-certificates.crt")
+	}
 }

--- a/pkg/addons/adminconsole/values.go
+++ b/pkg/addons/adminconsole/values.go
@@ -97,6 +97,11 @@ func (a *AdminConsole) GenerateHelmValues(ctx context.Context, kcli client.Clien
 			"name":  "SSL_CERT_DIR",
 			"value": "/certs",
 		})
+
+		extraEnv = append(extraEnv, map[string]interface{}{
+			"name":  "HOST_CA_BUNDLE_PATH",
+			"value": a.HostCABundlePath,
+		})
 	}
 
 	copiedValues["extraEnv"] = extraEnv

--- a/pkg/addons/adminconsole/values_test.go
+++ b/pkg/addons/adminconsole/values_test.go
@@ -54,6 +54,17 @@ func TestGenerateHelmValues_HostCABundlePath(t *testing.T) {
 			}
 		}
 		assert.True(t, foundSSLCertDir, "SSL_CERT_DIR environment variable should be set")
+
+		// Verify HOST_CA_BUNDLE_PATH environment variable
+		var foundHostCABundlePath bool
+		for _, env := range extraEnv {
+			if env["name"] == "HOST_CA_BUNDLE_PATH" {
+				foundHostCABundlePath = true
+				assert.Equal(t, "/etc/ssl/certs/ca-certificates.crt", env["value"])
+				break
+			}
+		}
+		assert.True(t, foundHostCABundlePath, "HOST_CA_BUNDLE_PATH environment variable should be set")
 	})
 
 	t.Run("without host CA bundle path", func(t *testing.T) {
@@ -77,6 +88,7 @@ func TestGenerateHelmValues_HostCABundlePath(t *testing.T) {
 		extraEnv := values["extraEnv"].([]map[string]interface{})
 		for _, env := range extraEnv {
 			assert.NotEqual(t, "SSL_CERT_DIR", env["name"], "SSL_CERT_DIR environment variable should not be set")
+			assert.NotEqual(t, "HOST_CA_BUNDLE_PATH", env["name"], "HOST_CA_BUNDLE_PATH environment variable should not be set")
 		}
 	})
 }

--- a/tests/dryrun/install_test.go
+++ b/tests/dryrun/install_test.go
@@ -709,6 +709,10 @@ func TestHTTPProxyWithCABundleConfiguration(t *testing.T) {
 				"name":  "SSL_CERT_DIR",
 				"value": "/certs",
 			},
+			{
+				"name":  "HOST_CA_BUNDLE_PATH",
+				"value": hostCABundle,
+			},
 		},
 		"extraVolumes": []map[string]any{{
 			"name": "host-ca-bundle",


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

In addition to the existing [PrivateCACert](https://github.com/replicatedhq/kots/blob/main/pkg/template/static_context.go#L113) template function which exposes the CA in a ConfigMap, another template function HostCABundlePath will be added so that vendors can mount the cert directly as a hostPath volume and receive realtime updates.

This adds an environment variable in the kotsadm container via extraEnv in the values file HOST_CA_BUNDLE_PATH so that kots can know the path to the CA bundle on the host.

Related:
- https://github.com/replicatedhq/kots/pull/5337
- https://github.com/replicatedhq/replicated-docs/pull/3274

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
