### PR TITLE
feat(operator): Mount CA into Upgrade Artifacts Job Container

### DIFF
--- a/operator/charts/embedded-cluster-operator/values.yaml
+++ b/operator/charts/embedded-cluster-operator/values.yaml
@@ -71,7 +71,3 @@ serviceAccount:
   labels: {}
 
 terminationGracePeriodSeconds: 10
-
-privateCAs:
-  enabled: true
-  configmapName: "private-cas"

--- a/operator/charts/embedded-cluster-operator/values.yaml.tmpl
+++ b/operator/charts/embedded-cluster-operator/values.yaml.tmpl
@@ -73,7 +73,3 @@ serviceAccount:
   labels: {}
 
 terminationGracePeriodSeconds: 10
-
-privateCAs:
-  enabled: true
-  configmapName: "private-cas"


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds host CA bundle support to upgrade artifacts jobs, bringing them in line with the recent changes made to other components

**Changes:**
- **Removes hardcoded ConfigMap approach**: Eliminates the hardcoded "private-cas" volume, mount, and SSL_CERT_DIR environment variable from the `copyArtifactsJob` template
- **Adds conditional host CA bundle support**: When `Installation.Spec.RuntimeConfig.HostCABundlePath` is configured, artifacts jobs now dynamically add:
  - Host CA bundle volume (HostPath pointing to the configured path)
  - Volume mount at `/certs/ca-certificates.crt` 
  - `SSL_CERT_DIR=/certs` environment variable
- **Cleans up deprecated chart configuration**: Removes the `privateCAs` section from Helm chart values

**Why we need it:**
This aligns the artifacts upgrade functionality with the strategic direction of deprecating ConfigMap-based CA certificate management in favor of host CA bundles, providing a more flexible and consistent approach across all upgrade-related jobs.

#### Which issue(s) this PR fixes:

[SC-123412](https://app.shortcut.com/replicated/story/123412/mount-ca-into-upgrade-artifacts-job-container)

#### Does this PR require a test?

Yes - Added unit tests in `operator/pkg/artifacts/upgrade_test.go`:
- `TestGetArtifactJobForNode_HostCABundle/with_HostCABundlePath_set`: Verifies correct volume, mount, and environment variable configuration
- `TestGetArtifactJobForNode_HostCABundle/without_HostCABundlePath_set`: Verifies no CA configuration when path is not set

#### Does this PR require a release note?

```release-note
Upgrade artifacts jobs now automatically use CA certificates trusted by the host system instead of using the --private-ca CLI flag
```

#### Does this PR require documentation?