### PR TITLE
fix: empty tmp dir instead of removing it

### DIFF
--- a/pkg/runtimeconfig/cleanup_test.go
+++ b/pkg/runtimeconfig/cleanup_test.go
@@ -1,0 +1,71 @@
+package runtimeconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCleanup_EmptyTmpDir(t *testing.T) {
+	// Save original runtime config to restore after test
+	originalConfig := runtimeConfig
+	defer func() {
+		runtimeConfig = originalConfig
+	}()
+
+	// Create a test config with a temporary directory
+	testTmpParent := t.TempDir()
+	testConfig := &ecv1beta1.RuntimeConfigSpec{
+		DataDir: testTmpParent,
+	}
+	runtimeConfig = testConfig
+
+	// Get the tmp directory path that will be used
+	tmpDir := filepath.Join(testTmpParent, "tmp")
+
+	// Create the tmp directory
+	err := os.MkdirAll(tmpDir, 0755)
+	require.NoError(t, err, "Failed to create test tmp directory")
+
+	// Create test files and subdirectories
+	testFiles := []string{"file1.txt", "file2.log"}
+	testDirs := []string{"subdir1", "subdir2"}
+
+	for _, file := range testFiles {
+		path := filepath.Join(tmpDir, file)
+		err := os.WriteFile(path, []byte("test content"), 0644)
+		require.NoError(t, err, "Failed to create test file")
+	}
+
+	for _, dir := range testDirs {
+		path := filepath.Join(tmpDir, dir)
+		err := os.Mkdir(path, 0755)
+		require.NoError(t, err, "Failed to create test directory")
+
+		// Add a file in the subdirectory
+		subFile := filepath.Join(path, "subfile.txt")
+		err = os.WriteFile(subFile, []byte("subdir content"), 0644)
+		require.NoError(t, err, "Failed to create file in subdirectory")
+	}
+
+	// Verify test files and directories were created
+	entries, err := os.ReadDir(tmpDir)
+	require.NoError(t, err, "Failed to read test directory")
+	require.Len(t, entries, len(testFiles)+len(testDirs), "Incorrect number of test items created")
+
+	// Call the function under test
+	Cleanup()
+
+	// Verify the directory still exists
+	_, err = os.Stat(tmpDir)
+	assert.NoError(t, err, "The tmp directory should still exist")
+
+	// Verify the directory is empty
+	entries, err = os.ReadDir(tmpDir)
+	assert.NoError(t, err, "Failed to read tmp directory after cleanup")
+	assert.Empty(t, entries, "The tmp directory should be empty after cleanup")
+}

--- a/pkg/runtimeconfig/runtimeconfig.go
+++ b/pkg/runtimeconfig/runtimeconfig.go
@@ -27,7 +27,23 @@ func Get() *ecv1beta1.RuntimeConfigSpec {
 }
 
 func Cleanup() {
-	os.RemoveAll(EmbeddedClusterTmpSubDir())
+	emptyTmpDir()
+}
+
+func emptyTmpDir() {
+	tmpDir := EmbeddedClusterTmpSubDir()
+	entries, err := os.ReadDir(tmpDir)
+	if err != nil {
+		logrus.Errorf("error reading embedded-cluster tmp dir: %s", err)
+		return
+	}
+
+	for _, entry := range entries {
+		path := filepath.Join(tmpDir, entry.Name())
+		if err := os.RemoveAll(path); err != nil {
+			logrus.Errorf("error removing item %s: %s", path, err)
+		}
+	}
 }
 
 // EmbeddedClusterHomeDirectory returns the parent directory. Inside this parent directory we


### PR DESCRIPTION
#### What this PR does / why we need it:
The tmp directory is used for a number of things including when editig k8s resources using kubectl edit. Removing it after running commands will lead to failures in certain commands.

#### Which issue(s) this PR fixes:
[sc-124106](https://app.shortcut.com/replicated/story//collecting-a-support-bundle-deletes-tmp-directory-causing-failures-when-editing-k8s-resources-in-cli)

#### Does this PR require a test?
Unit test added

#### Does this PR require a release note?
```release-note
Empty <data-dir>/tmp dir instead of deleting in when cleaning up after running commands
```

#### Does this PR require documentation?
NONE
