### PR TITLE
Fix prompts showing before required flag errors

### DIFF
--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -109,18 +109,14 @@ func InstallCmd(ctx context.Context, name string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install",
 		Short: fmt.Sprintf("Install %s", name),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := preRunInstall(cmd, &flags); err != nil {
-				return err
-			}
-
-			return nil
-		},
 		PostRun: func(cmd *cobra.Command, args []string) {
 			runtimeconfig.Cleanup()
 			cancel() // Cancel context when command completes
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := preRunInstall(cmd, &flags); err != nil {
+				return err
+			}
 			clusterID := metrics.ClusterID()
 			metricsReporter := NewInstallReporter(
 				replicatedAppURL(), clusterID, cmd.CalledAs(), flagsToStringSlice(cmd.Flags()),


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Currently, when users run the install command with missing required flags (like --license), they may be prompted for optional values (like creating an admin console password if one was not provided through the --admin-console-password flag) before seeing validation errors. This creates a frustrating experience where users complete prompts unnecessarily.

This PR moves the`preRunInstall` call from cobra's `PreRunE` to `RunE` to get the following order of execution and give precedence to required flag errors

**Current Behavior**
PreRunE
preRunInstall (prompts happen here)
Cobra's flag validation
RunE

**New Behavior**
~~PreRunE~~ (removed, preRunInstall was the only thing in it)
Cobra's flag validation
RunE
preRunInstall (prompts happen here)

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/124248/cli-install-command-shows-prompts-before-required-flag-validation-errors
#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE
#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```
#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE