### PR TITLE
chore: add additional security tools check in support bundle

### DIFF
--- a/cmd/installer/goods/support/host-support-bundle.tmpl.yaml
+++ b/cmd/installer/goods/support/host-support-bundle.tmpl.yaml
@@ -644,7 +644,7 @@ spec:
       collectorName: security-tools-packages
       outcomes:
         - fail:
-            when: '{{ .IsInstalled }}'
+            when: '{{ "{{" }} .IsInstalled {{ "}}" }}'
             message: Package {{ .Name }} is installed. This tool can interfere with kubernetes operation. Ensure the tool is either disabled or configured to not interfere with kubernetes operation.
         - pass:
             message: Package {{ .Name }} is not installed

--- a/cmd/installer/goods/support/host-support-bundle.tmpl.yaml
+++ b/cmd/installer/goods/support/host-support-bundle.tmpl.yaml
@@ -299,6 +299,16 @@ spec:
       collectorName: "ps-detect-antivirus-and-security-tools"
       command: "sh"
       args: [-c, "ps -ef | grep -E 'clamav|sophos|esets_daemon|fsav|symantec|mfend|ds_agent|kav|bdagent|s1agent|falcon|illumio|xagt|wdavdaemon|mdatp' | grep -v grep"]
+  - systemPackages:
+      collectorName: security-tools-packages
+      ubuntu:
+        - sdcss-kmod
+        - sdcss
+        - sdcss-scripts
+      rhel:
+        - sdcss-kmod
+        - sdcss
+        - sdcss-scripts
   - filesystemPerformance:
         collectorName: filesystem-write-latency-etcd
         timeout: 5m
@@ -620,7 +630,7 @@ spec:
   - textAnalyze:
       checkName: "Detect Threat Management and Network Security Tools"
       fileName: host-collectors/run-host/ps-detect-antivirus-and-security-tools.txt
-      regex: '\b(clamav|sophos|esets_daemon|fsav|symantec|mfend|ds_agent|kav|bdagent|s1agent|falcon|illumio|xagt|wdavdaemon)\b'
+      regex: '\b(clamav|sophos|esets_daemon|fsav|symantec|mfend|ds_agent|kav|bdagent|s1agent|falcon|illumio|xagt|wdavdaemon|mdatp)\b'
       ignoreIfNoFiles: true
       outcomes:
         - fail:
@@ -629,6 +639,15 @@ spec:
         - pass:
             when: "false"
             message: "No antivirus or network security tools detected."
+  - systemPackages:
+      checkName: "Detected Security Packages"
+      collectorName: security-tools-packages
+      outcomes:
+        - fail:
+            when: '{{ .IsInstalled }}'
+            message: Package {{ .Name }} is installed. This tool can interfere with kubernetes operation. Ensure the tool is either disabled or configured to not interfere with kubernetes operation.
+        - pass:
+            message: Package {{ .Name }} is not installed
   - filesystemPerformance:
       checkName: Filesystem Write Latency
       collectorName: filesystem-write-latency-etcd

--- a/cmd/installer/goods/support/host-support-bundle.tmpl.yaml
+++ b/cmd/installer/goods/support/host-support-bundle.tmpl.yaml
@@ -645,9 +645,9 @@ spec:
       outcomes:
         - fail:
             when: '{{ "{{" }} .IsInstalled {{ "}}" }}'
-            message: Package {{ .Name }} is installed. This tool can interfere with kubernetes operation. Ensure the tool is either disabled or configured to not interfere with kubernetes operation.
+            message: Package {{ "{{" }} .Name {{ "}}" }} is installed. This tool can interfere with kubernetes operation. Ensure the tool is either disabled or configured to not interfere with kubernetes operation.
         - pass:
-            message: Package {{ .Name }} is not installed
+            message: Package {{ "{{" }} .Name {{ "}}" }} is not installed
   - filesystemPerformance:
       checkName: Filesystem Write Latency
       collectorName: filesystem-write-latency-etcd


### PR DESCRIPTION
#### What this PR does / why we need it:
**Enhancements to security tool detection:**

* Added a new collector `security-tools-packages` to detect specific security-related system packages for both Ubuntu and RHEL distributions.
* Extended the regex pattern in the `ps-detect-antivirus-and-security-tools` check to include `mdatp` for detecting additional security tools.

**Checks for installed security packages:**

* Introduced a new check `Detected Security Packages` to evaluate whether specific security packages are installed. Includes fail/pass outcomes with messages indicating potential interference with Kubernetes operation and recommending appropriate actions.

#### Which issue(s) this PR fixes:

https://app.shortcut.com/replicated/story/124367/additional-security-tools-check-in-support-bundle-analysis

#### Does this PR require a test?
NONE

#### Does this PR require a release note?
```release-note
Add additional security tools check in support bundle
```

#### Does this PR require documentation?
NONE
