### PR TITLE
chore(local-dev): gitgnore and operator makefile improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,10 @@ hack/release
 
 # helm charts dependencies
 *.tgz
+
+# test coverage files
+cover.out
+
+# e2e test runs locally
+e2e/playwright*.tar.gz
+e2e/support-bundle*.tar.gz

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -126,7 +126,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 
 .PHONY: schemas
 schemas: fmt controller-gen
-	go build ${LDFLAGS} -o bin/schemagen ./schemagen
+	go build -ldflags="$(LD_FLAGS)" -o bin/schemagen ./schemagen
 	./bin/schemagen --output-dir ./schemas
 
 .PHONY: envtest

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -126,7 +126,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 
 .PHONY: schemas
 schemas: fmt controller-gen
-	go build -ldflags="$(LD_FLAGS)" -o bin/schemagen ./schemagen
+	go build -o bin/schemagen ./schemagen
 	./bin/schemagen --output-dir ./schemas
 
 .PHONY: envtest


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Some local dev quality of life improvements:
- Adding some files created during tests to `.gitignore`
- Fixing `LD_FLAGS` usage in the operator Makefile

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
