### PR TITLE
chore(web): fix local web dev

### DIFF
--- a/web/static.go
+++ b/web/static.go
@@ -154,9 +154,7 @@ func (web *Web) rootHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (web *Web) RegisterRoutes(router *mux.Router) {
-	var webFS http.Handler
-	webFS = http.FileServer(http.FS(web.assets))
-
+	webFS := http.FileServer(http.FS(web.assets))
 	router.PathPrefix("/assets").Methods("GET").Handler(webFS)
 	router.PathPrefix("/").Methods("GET").HandlerFunc(web.rootHandler)
 }

--- a/web/static.go
+++ b/web/static.go
@@ -9,8 +9,6 @@ import (
 	"io/fs"
 	"net/http"
 	"os"
-	"path"
-	"runtime"
 
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
@@ -131,18 +129,11 @@ func (web *Web) RegisterRoutes(router *mux.Router) {
 
 	var webFS http.Handler
 	if os.Getenv("EC_DEV_ENV") == "true" {
-		webFS = http.FileServer(http.FS(os.DirFS(getDistPathInSource())))
+		webFS = http.FileServer(http.FS(os.DirFS("./web/dist")))
 	} else {
 		webFS = http.FileServer(http.FS(web.assets))
 	}
 
 	router.PathPrefix("/assets").Methods("GET").Handler(webFS)
 	router.PathPrefix("/").Methods("GET").HandlerFunc(web.rootHandler)
-}
-
-// getDistPathInSource is a utility method to get the path to the dist folder under this source code. This is relevant for local dev purposes.
-// We cannnot simply use "./web/dist" because "go test" will run in the root of the web package VS the root of project when running in prod.
-func getDistPathInSource() string {
-	_, filePath, _, _ := runtime.Caller(0)
-	return path.Join(path.Dir(filePath), "dist")
 }

--- a/web/static.go
+++ b/web/static.go
@@ -9,6 +9,8 @@ import (
 	"io/fs"
 	"net/http"
 	"os"
+	"path"
+	"runtime"
 
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
@@ -129,11 +131,18 @@ func (web *Web) RegisterRoutes(router *mux.Router) {
 
 	var webFS http.Handler
 	if os.Getenv("EC_DEV_ENV") == "true" {
-		webFS = http.FileServer(http.FS(os.DirFS("./dist")))
+		webFS = http.FileServer(http.FS(os.DirFS(getDistPathInSource())))
 	} else {
 		webFS = http.FileServer(http.FS(web.assets))
 	}
 
 	router.PathPrefix("/assets").Methods("GET").Handler(webFS)
 	router.PathPrefix("/").Methods("GET").HandlerFunc(web.rootHandler)
+}
+
+// getDistPathInSource is a utility method to get the path to the dist folder under this source code. This is relevant for local dev purposes.
+// We cannnot simply use "./web/dist" because "go test" will run in the root of the web package VS the root of project when running in prod.
+func getDistPathInSource() string {
+	_, filePath, _, _ := runtime.Caller(0)
+	return path.Join(path.Dir(filePath), "dist")
 }

--- a/web/static_test.go
+++ b/web/static_test.go
@@ -317,30 +317,26 @@ func TestRegisterRoutes(t *testing.T) {
 	})
 }
 func TestRegisterRoutesWithDevEnv(t *testing.T) {
-	// Create initial state
-	initialState := InitialState{
-		Title: "Test Title",
-		Icon:  "test-icon.png",
-	}
-
-	// Create a test logger
-	logger, _ := logtest.NewNullLogger()
-
-	// Create a new Web instance
-	web, err := New(initialState, WithLogger(logger), WithAssetsFS(createMockFS()))
-	require.NoError(t, err, "Failed to create Web instance")
-
 	// We need to change the current working directory because in `go test` this will be the package directory
 	// We want to mimic prod/local dev behaviour where cwd will be under the root of the project
 	_, filename, _, _ := runtime.Caller(0)
 	dir := path.Join(path.Dir(filename), "..")
-	err = os.Chdir(dir)
+	err := os.Chdir(dir)
 	if err != nil {
 		t.Fatalf("failed to change cwd to root of the project: %s", err)
 	}
 	defer os.Chdir(path.Dir(filename))
 
-	// Create temporary dist directory structure for development
+	// Create a test logger
+	logger, _ := logtest.NewNullLogger()
+	// Set the development environment variable
+	t.Setenv("EC_DEV_ENV", "true")
+
+	// Create a new Web instance
+	web, err := New(InitialState{}, WithLogger(logger))
+	require.NoError(t, err, "Failed to create Web instance")
+
+	// Create temporary dist directory structure to mimic what we use for development
 	err = os.MkdirAll("./web/dist/assets", 0755)
 	require.NoError(t, err, "Failed to create dist directory")
 	defer os.RemoveAll("./web/dist/assets") // Clean up after test
@@ -350,8 +346,6 @@ func TestRegisterRoutesWithDevEnv(t *testing.T) {
 	err = os.WriteFile("./web/dist/assets/test-file-dev-app.js", []byte(devFileContent), 0644)
 	require.NoError(t, err, "Failed to write dev file")
 
-	// Set the development environment variable
-	t.Setenv("EC_DEV_ENV", "true")
 	// Create router and register routes
 	router := mux.NewRouter()
 	web.RegisterRoutes(router)
@@ -368,6 +362,22 @@ func TestRegisterRoutesWithDevEnv(t *testing.T) {
 
 		// Check that the dev file content is served from local filesystem
 		assert.Equal(t, devFileContent, recorder.Body.String(), "Response should contain the dev file content from local filesystem")
+	})
+
+	t.Run("Changes to the file are reflected and served", func(t *testing.T) {
+		newDevFileContent := devFileContent + "console.log('such a change, very wow');"
+		err = os.WriteFile("./web/dist/assets/test-file-dev-app.js", []byte(newDevFileContent), 0644)
+		req := httptest.NewRequest("GET", "/assets/test-file-dev-app.js", nil)
+		recorder := httptest.NewRecorder()
+
+		// Serve the request
+		router.ServeHTTP(recorder, req)
+
+		// Check status code
+		assert.Equal(t, http.StatusOK, recorder.Code, "Should return status OK for dev file")
+
+		// Check that the new dev file content is served from local filesystem
+		assert.Equal(t, newDevFileContent, recorder.Body.String(), "Response should contain the dev file content from local filesystem")
 	})
 
 	t.Run("Non-existent File Returns 404", func(t *testing.T) {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Follow up to - https://github.com/replicatedhq/embedded-cluster/pull/2229. I was tricked by the cwd of `go test` which is the root of the package where the tests are running. This fix addresses it so that our tests still assert on the right thing and local dev works as expected.

Also run this locally using `EC_DEV_ENV=true` and without it.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
