### PR TITLE
Fix release pipeline for e2e docker tests by enabling kernel modules

### DIFF
--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -526,6 +526,12 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Free up runner disk space
         uses: ./.github/actions/free-disk-space
+      - name: Enable required kernel modules
+        run: |
+          sudo modprobe overlay
+          sudo modprobe ip_tables
+          sudo modprobe br_netfilter
+          sudo modprobe nf_conntrack
       - name: Run test
         env:
           SHORT_SHA: ${{ github.ref_name }}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Fixes release pipeline for e2e docker tests by enabling kernel modules

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE