### PR TITLE
Set SSL Cert ConfigMap in KOTS and Improve Detection of Unhealthy Pods in Tests

### DIFF
--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -1457,6 +1457,9 @@ func TestMultiNodeAirgapHAInstallation(t *testing.T) {
 
 	checkPostUpgradeStateWithOptions(t, tc, postUpgradeStateOptions{
 		node: 2,
+		withEnv: map[string]string{
+			"ALLOW_PENDING_PODS": "true",
+		},
 	})
 
 	t.Logf("%s: test complete", time.Now().Format(time.RFC3339))

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -1328,6 +1328,9 @@ func TestMultiNodeHAInstallation(t *testing.T) {
 
 	checkPostUpgradeStateWithOptions(t, tc, postUpgradeStateOptions{
 		node: 2,
+		withEnv: map[string]string{
+			"ALLOW_PENDING_PODS": "true",
+		},
 	})
 
 	t.Logf("%s: test complete", time.Now().Format(time.RFC3339))

--- a/e2e/scripts/check-airgap-installation-state.sh
+++ b/e2e/scripts/check-airgap-installation-state.sh
@@ -43,7 +43,7 @@ main() {
         exit 1
     fi
 
-    validate_no_pods_in_crashloop
+    validate_all_pods_healthy
 }
 
 main "$@"

--- a/e2e/scripts/check-airgap-post-ha-state.sh
+++ b/e2e/scripts/check-airgap-post-ha-state.sh
@@ -81,7 +81,7 @@ main() {
     # scale the second deployment back down so that they aren't restored in the DR test
     kubectl scale -n "$APP_NAMESPACE" deployment/second --replicas=0
 
-    validate_no_pods_in_crashloop
+    validate_all_pods_healthy
 }
 
 main "$@"

--- a/e2e/scripts/check-installation-state.sh
+++ b/e2e/scripts/check-installation-state.sh
@@ -49,7 +49,7 @@ main() {
         validate_data_dirs
     fi
 
-    validate_no_pods_in_crashloop
+    validate_all_pods_healthy
 }
 
 main "$@"

--- a/e2e/scripts/check-post-ha-state.sh
+++ b/e2e/scripts/check-post-ha-state.sh
@@ -61,7 +61,7 @@ main() {
         exit 1
     fi
 
-    validate_no_pods_in_crashloop
+    validate_all_pods_healthy
 }
 
 main "$@"

--- a/e2e/scripts/check-postupgrade-state.sh
+++ b/e2e/scripts/check-postupgrade-state.sh
@@ -111,7 +111,7 @@ main() {
 
     validate_data_dirs
 
-    validate_no_pods_in_crashloop
+    validate_all_pods_healthy
 }
 
 main "$@"

--- a/e2e/scripts/common.sh
+++ b/e2e/scripts/common.sh
@@ -455,12 +455,19 @@ validate_data_dirs() {
     fi
 }
 
-validate_no_pods_in_crashloop() {
-    if kubectl get pods -A | grep CrashLoopBackOff -q ; then
-        echo "found pods in CrashLoopBackOff state"
-        kubectl get pods -A | grep CrashLoopBackOff
+validate_all_pods_healthy() {
+    local unhealthy_pods
+    unhealthy_pods=$(kubectl get pods -A --no-headers | awk '$4 != "Running" && $4 != "Completed" && $4 != "Succeeded" { print $0 }')
+    
+    if [ -n "$unhealthy_pods" ]; then
+        echo "found pods in unhealthy state:"
+        echo "$unhealthy_pods"
+        echo ""
+        echo "All pod statuses:"
+        kubectl get pods -A
         exit 1
     fi
+    echo "All pods are healthy (Running, Completed, or Succeeded)"
 }
 
 validate_worker_profile() {

--- a/e2e/scripts/common.sh
+++ b/e2e/scripts/common.sh
@@ -457,16 +457,25 @@ validate_data_dirs() {
 
 validate_non_job_pods_healthy() {
     local unhealthy_pods
-    # Get pods that are NOT owned by Jobs and check their health
-    unhealthy_pods=$(kubectl get pods -A --no-headers -o custom-columns="NAMESPACE:.metadata.namespace,NAME:.metadata.name,STATUS:.status.phase,OWNER:.metadata.ownerReferences[0].kind" | \
-        awk '$4 != "Job" && ($3 != "Running" && $3 != "Completed" && $3 != "Succeeded") { print $1 "/" $2 " (" $3 ")" }')
+    
+    # Check for environment variable override (used by specific tests)
+    if [ "$ALLOW_PENDING_PODS" = "true" ]; then
+        # Allow Running, Completed, Succeeded, Pending
+        unhealthy_pods=$(kubectl get pods -A --no-headers -o custom-columns="NAMESPACE:.metadata.namespace,NAME:.metadata.name,STATUS:.status.phase,OWNER:.metadata.ownerReferences[0].kind" | \
+            awk '$4 != "Job" && ($3 != "Running" && $3 != "Completed" && $3 != "Succeeded" && $3 != "Pending") { print $1 "/" $2 " (" $3 ")" }')
+        echo "All non-Job pods are healthy (allowing Pending pods)"
+    else
+        # Default: only allow Running, Completed, Succeeded  
+        unhealthy_pods=$(kubectl get pods -A --no-headers -o custom-columns="NAMESPACE:.metadata.namespace,NAME:.metadata.name,STATUS:.status.phase,OWNER:.metadata.ownerReferences[0].kind" | \
+            awk '$4 != "Job" && ($3 != "Running" && $3 != "Completed" && $3 != "Succeeded") { print $1 "/" $2 " (" $3 ")" }')
+        echo "All non-Job pods are healthy"
+    fi
     
     if [ -n "$unhealthy_pods" ]; then
         echo "found non-Job pods in unhealthy state:"
         echo "$unhealthy_pods"
         return 1
     fi
-    echo "All non-Job pods are healthy"
     return 0
 }
 
@@ -496,7 +505,12 @@ validate_all_pods_healthy() {
     local elapsed_time
     start_time=$(date +%s)
     
-    echo "Validating pod and job health..."
+    # Show what mode we're in
+    if [ "$ALLOW_PENDING_PODS" = "true" ]; then
+        echo "Validating pod and job health (allowing Pending pods)..."
+    else
+        echo "Validating pod and job health (default: Running, Completed, Succeeded)..."
+    fi
     
     while true; do
         current_time=$(date +%s)

--- a/e2e/scripts/common.sh
+++ b/e2e/scripts/common.sh
@@ -459,7 +459,7 @@ validate_non_job_pods_healthy() {
     local unhealthy_pods
     
     # Check for environment variable override (used by specific tests)
-    if [ "$ALLOW_PENDING_PODS" = "true" ]; then
+    if [ "${ALLOW_PENDING_PODS:-}" = "true" ]; then
         # Allow Running, Completed, Succeeded, Pending
         unhealthy_pods=$(kubectl get pods -A --no-headers -o custom-columns="NAMESPACE:.metadata.namespace,NAME:.metadata.name,STATUS:.status.phase,OWNER:.metadata.ownerReferences[0].kind" | \
             awk '$4 != "Job" && ($3 != "Running" && $3 != "Completed" && $3 != "Succeeded" && $3 != "Pending") { print $1 "/" $2 " (" $3 ")" }')
@@ -506,7 +506,7 @@ validate_all_pods_healthy() {
     start_time=$(date +%s)
     
     # Show what mode we're in
-    if [ "$ALLOW_PENDING_PODS" = "true" ]; then
+    if [ "${ALLOW_PENDING_PODS:-}" = "true" ]; then
         echo "Validating pod and job health (allowing Pending pods)..."
     else
         echo "Validating pod and job health (default: Running, Completed, Succeeded)..."

--- a/pkg/addons/adminconsole/static/values.tpl.yaml
+++ b/pkg/addons/adminconsole/static/values.tpl.yaml
@@ -19,3 +19,6 @@ passwordSecretRef:
     name: kotsadm-password
 service:
     enabled: false
+privateCAs:
+    enabled: true
+    configmapName: "kotsadm-private-cas"

--- a/pkg/addons/adminconsole/static/values.tpl.yaml
+++ b/pkg/addons/adminconsole/static/values.tpl.yaml
@@ -19,6 +19,6 @@ passwordSecretRef:
     name: kotsadm-password
 service:
     enabled: false
-privateCAs:
-    enabled: true
-    configmapName: "kotsadm-private-cas"
+extraEnv:
+  - name: SSL_CERT_CONFIGMAP
+    value: "kotsadm-private-cas"

--- a/pkg/addons/adminconsole/values.go
+++ b/pkg/addons/adminconsole/values.go
@@ -57,6 +57,10 @@ func (a *AdminConsole) GenerateHelmValues(ctx context.Context, kcli client.Clien
 			"name":  "ENABLE_IMPROVED_DR",
 			"value": "true",
 		},
+		{
+			"name":  "SSL_CERT_CONFIGMAP",
+			"value": "kotsadm-private-cas",
+		},
 	}
 
 	if a.Proxy != nil {

--- a/tests/dryrun/install_test.go
+++ b/tests/dryrun/install_test.go
@@ -723,6 +723,10 @@ func TestHTTPProxyWithCABundleConfiguration(t *testing.T) {
 				"value": "true",
 			},
 			{
+				"name":  "SSL_CERT_CONFIGMAP",
+				"value": "kotsadm-private-cas",
+			},
+			{
 				"name":  "HTTP_PROXY",
 				"value": "http://localhost:3128",
 			},


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Set `SSL_CERT_CONFIGMAP` so KOTS knows what configmap to use for the Replicated SDK. See here - https://github.com/replicatedhq/kots-helm/blob/main/templates/kotsadm-deployment.yaml#L108-L113. Without this, the SDK  doesn't work in proxied environments.

Also in this PR is an adjustment to our function which validates if there are unhealthy pods. Right now it doesn't account for pods which are stuck in `0/1 Running` like the SDK is currently in proxied environments

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
