### PR TITLE
Use default CMX instance type to avoid quota limit

### DIFF
--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -998,7 +998,6 @@ func TestMultiNodeAirgapUpgradeSameK0s(t *testing.T) {
 		Nodes:        2,
 		Distribution: "ubuntu",
 		Version:      "22.04",
-		InstanceType: "r1.medium",
 	})
 	defer tc.Cleanup()
 
@@ -1074,7 +1073,6 @@ func TestMultiNodeAirgapUpgrade(t *testing.T) {
 		Nodes:        2,
 		Distribution: "ubuntu",
 		Version:      "22.04",
-		InstanceType: "r1.medium",
 	})
 	defer tc.Cleanup()
 
@@ -1157,7 +1155,6 @@ func TestMultiNodeAirgapUpgradePreviousStable(t *testing.T) {
 		Nodes:        2,
 		Distribution: "ubuntu",
 		Version:      "22.04",
-		InstanceType: "r1.medium",
 	})
 	defer tc.Cleanup(withEnv)
 
@@ -1346,7 +1343,6 @@ func TestMultiNodeAirgapHAInstallation(t *testing.T) {
 		Nodes:                  4,
 		Distribution:           "ubuntu",
 		Version:                "22.04",
-		InstanceType:           "r1.medium",
 		SupportBundleNodeIndex: 2,
 	})
 	defer tc.Cleanup()
@@ -1609,7 +1605,6 @@ func TestFiveNodesAirgapUpgrade(t *testing.T) {
 		Nodes:        5,
 		Distribution: "ubuntu",
 		Version:      "22.04",
-		InstanceType: "r1.medium",
 	})
 	defer tc.Cleanup()
 

--- a/e2e/restore_test.go
+++ b/e2e/restore_test.go
@@ -359,7 +359,6 @@ func TestSingleNodeAirgapDisasterRecovery(t *testing.T) {
 		Nodes:        1,
 		Distribution: "ubuntu",
 		Version:      "22.04",
-		InstanceType: "r1.medium",
 	})
 	defer tc.Cleanup()
 
@@ -642,7 +641,6 @@ func TestMultiNodeAirgapHADisasterRecovery(t *testing.T) {
 		Nodes:        3,
 		Distribution: "ubuntu",
 		Version:      "22.04",
-		InstanceType: "r1.medium",
 	})
 	defer tc.Cleanup(withEnv)
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Uses default small CMX instance type to avoid quota limit

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE