### PR TITLE
Fix "new version available" prompt appearing after manager experience URL

### DIFF
--- a/cmd/installer/cli/install_runpreflights.go
+++ b/cmd/installer/cli/install_runpreflights.go
@@ -58,7 +58,7 @@ func InstallRunPreflightsCmd(ctx context.Context, name string) *cobra.Command {
 }
 
 func runInstallRunPreflights(ctx context.Context, name string, flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig) error {
-	if err := runInstallVerifyAndPrompt(ctx, name, flags, prompts.New()); err != nil {
+	if err := verifyAndPrompt(ctx, name, flags, prompts.New()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
User sees the prompt about a new available version after the prompt to go to the UI. 
This PR fixes that behavior and reorganizes similar prompts and checks to enhance the user experience.

New priority Order
1. Cobra's required flag validation (e.g. missing --license)
2. Prompts and checks on installation state, license file, airgap bundles, and releases
    - Existing k0s installation (reinstall detected)
    - Airgap bundle downloaded but not provided via CLI
    - License/release version mismatch
    - Airgap bundle/release version mismatch
    - Outdated release version available
3. Proxy configuration prompt (HTTP proxy set without HTTPS)
4. Admin console password prompt
5. Display URL to the Manager Experience UI

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/124485/user-sees-the-prompt-about-a-new-available-version-after-the-prompt-to-go-to-the-ui
#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
