### PR TITLE
Increase CMX create nodes timeout to 10m

### DIFF
--- a/e2e/cluster/cmx/cluster.go
+++ b/e2e/cluster/cmx/cluster.go
@@ -68,7 +68,7 @@ func NewNodes(in *ClusterInput) ([]Node, error) {
 		"vm", "create",
 		"--name", "ec-test-suite",
 		"--count", strconv.Itoa(in.Nodes),
-		"--wait", "5m",
+		"--wait", "10m",
 		"-ojson",
 	}
 	if in.Distribution != "" {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Sometimes it takes more than 5 minutes to create 4 nodes. This hopefully makes the tests less flaky.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE