### PR TITLE
chore: collect systemd k0scontroller service status in support bundle

### DIFF
--- a/cmd/installer/goods/support/host-support-bundle.tmpl.yaml
+++ b/cmd/installer/goods/support/host-support-bundle.tmpl.yaml
@@ -231,6 +231,10 @@ spec:
       command: "systemctl"
       args: ["cat", "k0scontroller.service"]
   - run:
+      collectorName: "systemctl-k0scontroller-status"
+      command: "systemctl"
+      args: ["status", "k0scontroller.service"]
+  - run:
       collectorName: "systemctl-cat-k0sworker"
       command: "systemctl"
       args: ["cat", "k0sworker.service"]


### PR DESCRIPTION
#### What this PR does / why we need it:
Add the output of systemctl status k0scontroller to the host support bundle

#### Which issue(s) this PR fixes:

[sc-124675](https://app.shortcut.com/replicated/story/124675/collect-k0s-systemd-service-status-in-host-support-bundle)

#### Does this PR require a test?
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Collect systemd k0scontroller service status in support bundle
```

#### Does this PR require documentation?
NONE
