### PR TITLE
Fix upgrade flakiness upon LAM restart

### DIFF
--- a/operator/pkg/artifacts/upgrade.go
+++ b/operator/pkg/artifacts/upgrade.go
@@ -89,6 +89,7 @@ var copyArtifactsJobCommandOnline = []string{
 	"/usr/local/bin/local-artifact-mirror pull binaries --data-dir /embedded-cluster " +
 		"--app-slug $APP_SLUG --channel-id $CHANNEL_ID --app-version $APP_VERSION " +
 		"$INSTALLATION_DATA; \n" +
+		"sleep 10; \n" + // wait for LAM to restart so k0s can pull from it. LAM restarts when it detects an EC binary update.
 		"echo 'done'",
 }
 
@@ -101,6 +102,7 @@ var copyArtifactsJobCommandAirgap = []string{
 		"/usr/local/bin/local-artifact-mirror pull helmcharts --data-dir /embedded-cluster $INSTALLATION_DATA; \n" +
 		"mv /embedded-cluster/bin/k0s /embedded-cluster/bin/k0s-upgrade; \n" +
 		"rm /embedded-cluster/images/images-amd64-* || true; \n" +
+		"sleep 10; \n" + // wait for LAM to restart so k0s can pull from it. LAM restarts when it detects an EC binary update.
 		"echo 'done'",
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Fixes an issue where k0s tries to pull images from LAM before it restarts on EC binary update which causes the upgrade to fail.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes an issue where upgrades could fail due to a race condition leading to errors that look like this: `msg=\"Waiting for container images to be uploaded...\"\nError: failed to upgrade: distribute artifacts: autopilot copy airgap artifacts: wait for autopilot plan: autopilot plan failed: Upgrade apply has failed\n"`
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE