### PR TITLE
fix(install): keep a single instance of runtime config within the API context

### DIFF
--- a/api/controllers/install/controller.go
+++ b/api/controllers/install/controller.go
@@ -125,7 +125,6 @@ func NewInstallController(opts ...InstallControllerOption) (*InstallController, 
 
 	if controller.installationManager == nil {
 		controller.installationManager = installation.NewInstallationManager(
-			installation.WithRuntimeConfig(controller.rc),
 			installation.WithLogger(controller.logger),
 			installation.WithInstallation(controller.install.Steps.Installation),
 			installation.WithLicenseFile(controller.licenseFile),
@@ -136,7 +135,6 @@ func NewInstallController(opts ...InstallControllerOption) (*InstallController, 
 
 	if controller.hostPreflightManager == nil {
 		controller.hostPreflightManager = preflight.NewHostPreflightManager(
-			preflight.WithRuntimeConfig(controller.rc),
 			preflight.WithLogger(controller.logger),
 			preflight.WithMetricsReporter(controller.metricsReporter),
 			preflight.WithHostPreflight(controller.install.Steps.HostPreflight),

--- a/api/controllers/install/hostpreflight.go
+++ b/api/controllers/install/hostpreflight.go
@@ -22,6 +22,7 @@ func (c *InstallController) RunHostPreflights(ctx context.Context) error {
 
 	// Prepare host preflights
 	hpf, proxy, err := c.hostPreflightManager.PrepareHostPreflights(ctx, preflight.PrepareHostPreflightOptions{
+		RuntimeConfig:         c.rc,
 		InstallationConfig:    config,
 		ReplicatedAppURL:      netutils.MaybeAddHTTPS(ecDomains.ReplicatedAppDomain),
 		ProxyRegistryURL:      netutils.MaybeAddHTTPS(ecDomains.ProxyRegistryDomain),
@@ -35,6 +36,7 @@ func (c *InstallController) RunHostPreflights(ctx context.Context) error {
 
 	// Run host preflights
 	return c.hostPreflightManager.RunHostPreflights(ctx, preflight.RunHostPreflightOptions{
+		RuntimeConfig:     c.rc,
 		HostPreflightSpec: hpf,
 		Proxy:             proxy,
 	})

--- a/api/controllers/install/installation.go
+++ b/api/controllers/install/installation.go
@@ -48,7 +48,7 @@ func (c *InstallController) ConfigureInstallation(ctx context.Context, config *t
 	c.rc.SetLocalArtifactMirrorPort(config.LocalArtifactMirrorPort)
 	c.rc.SetAdminConsolePort(config.AdminConsolePort)
 
-	if err := c.installationManager.ConfigureForInstall(ctx, config); err != nil {
+	if err := c.installationManager.ConfigureForInstall(ctx, config, c.rc); err != nil {
 		return fmt.Errorf("configure: %w", err)
 	}
 

--- a/api/internal/managers/installation/config_test.go
+++ b/api/internal/managers/installation/config_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/replicatedhq/embedded-cluster/api/types"
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg-new/hostutils"
+	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 )
 
 func TestValidateConfig(t *testing.T) {
@@ -382,7 +383,7 @@ func TestConfigureForInstall(t *testing.T) {
 			)
 
 			// Run the test
-			err := manager.ConfigureForInstall(context.Background(), tt.config)
+			err := manager.ConfigureForInstall(context.Background(), tt.config, runtimeconfig.New(nil))
 
 			// Assertions
 			if tt.expectedErr {

--- a/api/internal/managers/installation/manager.go
+++ b/api/internal/managers/installation/manager.go
@@ -22,14 +22,13 @@ type InstallationManager interface {
 	SetStatus(status types.Status) error
 	ValidateConfig(config *types.InstallationConfig) error
 	SetConfigDefaults(config *types.InstallationConfig) error
-	ConfigureForInstall(ctx context.Context, config *types.InstallationConfig) error
+	ConfigureForInstall(ctx context.Context, config *types.InstallationConfig, rc runtimeconfig.RuntimeConfig) error
 }
 
 // installationManager is an implementation of the InstallationManager interface
 type installationManager struct {
 	installation      *types.Installation
 	installationStore InstallationStore
-	rc                runtimeconfig.RuntimeConfig
 	licenseFile       string
 	airgapBundle      string
 	netUtils          utils.NetUtils
@@ -39,12 +38,6 @@ type installationManager struct {
 }
 
 type InstallationManagerOption func(*installationManager)
-
-func WithRuntimeConfig(rc runtimeconfig.RuntimeConfig) InstallationManagerOption {
-	return func(c *installationManager) {
-		c.rc = rc
-	}
-}
 
 func WithLogger(logger logrus.FieldLogger) InstallationManagerOption {
 	return func(c *installationManager) {
@@ -94,10 +87,6 @@ func NewInstallationManager(opts ...InstallationManagerOption) *installationMana
 
 	for _, opt := range opts {
 		opt(manager)
-	}
-
-	if manager.rc == nil {
-		manager.rc = runtimeconfig.New(nil)
 	}
 
 	if manager.logger == nil {

--- a/api/internal/managers/installation/manager_mock.go
+++ b/api/internal/managers/installation/manager_mock.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/replicatedhq/embedded-cluster/api/types"
+	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -57,7 +58,7 @@ func (m *MockInstallationManager) SetConfigDefaults(config *types.InstallationCo
 }
 
 // ConfigureForInstall mocks the ConfigureForInstall method
-func (m *MockInstallationManager) ConfigureForInstall(ctx context.Context, config *types.InstallationConfig) error {
-	args := m.Called(ctx, config)
+func (m *MockInstallationManager) ConfigureForInstall(ctx context.Context, config *types.InstallationConfig, rc runtimeconfig.RuntimeConfig) error {
+	args := m.Called(ctx, config, rc)
 	return args.Error(0)
 }

--- a/api/internal/managers/preflight/manager.go
+++ b/api/internal/managers/preflight/manager.go
@@ -8,7 +8,6 @@ import (
 	"github.com/replicatedhq/embedded-cluster/api/types"
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg/metrics"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"github.com/sirupsen/logrus"
 )
@@ -25,19 +24,12 @@ type HostPreflightManager interface {
 type hostPreflightManager struct {
 	hostPreflight      *types.HostPreflight
 	hostPreflightStore HostPreflightStore
-	rc                 runtimeconfig.RuntimeConfig
 	logger             logrus.FieldLogger
 	metricsReporter    metrics.ReporterInterface
 	mu                 sync.RWMutex
 }
 
 type HostPreflightManagerOption func(*hostPreflightManager)
-
-func WithRuntimeConfig(rc runtimeconfig.RuntimeConfig) HostPreflightManagerOption {
-	return func(m *hostPreflightManager) {
-		m.rc = rc
-	}
-}
 
 func WithLogger(logger logrus.FieldLogger) HostPreflightManagerOption {
 	return func(m *hostPreflightManager) {
@@ -69,10 +61,6 @@ func NewHostPreflightManager(opts ...HostPreflightManagerOption) HostPreflightMa
 
 	for _, opt := range opts {
 		opt(manager)
-	}
-
-	if manager.rc == nil {
-		manager.rc = runtimeconfig.New(nil)
 	}
 
 	if manager.logger == nil {

--- a/pkg-new/hostutils/mock.go
+++ b/pkg-new/hostutils/mock.go
@@ -16,7 +16,7 @@ type MockHostUtils struct {
 
 // ConfigureForInstall mocks the ConfigureForInstall method
 func (m *MockHostUtils) ConfigureForInstall(ctx context.Context, rc runtimeconfig.RuntimeConfig, opts InitForInstallOptions) error {
-	args := m.Called(ctx, opts)
+	args := m.Called(ctx, rc, opts)
 	return args.Error(0)
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
This PR addresses something that came up once I rebased - https://github.com/replicatedhq/embedded-cluster/pull/2226
See the failure:
- https://github.com/replicatedhq/embedded-cluster/actions/runs/15537684440/job/43740622893?pr=2226#step:4:1401

This failure is a consequence of how we're currently passing around the runtime config between controller, managers, etc. This doesn't surface in production because we let the install controller instantiate everything, however I'm worried we might run into this in the future with the way we have our structs wired up. The idea here is that instead of keeping a runtime config property in multiple places that can lead to a disconnect between which instance is being used, we keep one copy of it at the controller level and pass it around to all the manager methods when they need it. We could eventually look into either keeping the runtime config in a specific manager (Installation?) or creating its dedicated manager (overkill?) but I believe that for now this should suffice.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Updated

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
