### PR TITLE
feat(ui): show install errors in the ui

### DIFF
--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -125,8 +125,7 @@ func InstallCmd(ctx context.Context, name string) *cobra.Command {
 				installReporter.ReportSignalAborted(ctx, sig)
 			})
 
-			err := runInstall(cmd.Context(), name, flags, rc, installReporter)
-			if err != nil {
+			if err := runInstall(cmd.Context(), name, flags, rc, installReporter); err != nil {
 				// Check if this is an interrupt error from the terminal
 				if errors.Is(err, terminal.InterruptErr) {
 					installReporter.ReportSignalAborted(ctx, syscall.SIGINT)
@@ -448,7 +447,7 @@ func runInstall(ctx context.Context, name string, flags InstallCmdFlags, rc runt
 	defer func() {
 		if flags.enableManagerExperience && finalErr != nil {
 			if err := markUIInstallComplete(flags.adminConsolePassword, flags.managerPort, finalErr); err != nil {
-				logrus.Errorf("Unable to mark ui install complete: %w", err)
+				logrus.Errorf("Unable to mark ui install complete: %v", err)
 			}
 		}
 	}()

--- a/web/src/components/wizard/InstallationStep.tsx
+++ b/web/src/components/wizard/InstallationStep.tsx
@@ -51,7 +51,7 @@ const InstallationStep: React.FC = () => {
       setShowAdminLink(true);
       setIsLoading(false);
     } else if (installStatus?.state === "Failed") {
-      setError("Installation failed");
+      setError(installStatus.description || "Installation failed");
       setIsLoading(false);
     }
   }, [installStatus]);


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Shows the installation error in the UI on failure.

![Screenshot 2025-06-09 at 1 22 26 PM](https://github.com/user-attachments/assets/013c81b9-6dd6-463a-9723-1c3b54b56d12)

https://github.com/user-attachments/assets/61519bf3-e9c2-4c8e-ad84-32be9560ce77

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
