### PR TITLE
chore(ci): fix flakey test TestRegistry_EnableHAAirgap

### DIFF
--- a/pkg/dryrun/kubeutils.go
+++ b/pkg/dryrun/kubeutils.go
@@ -52,6 +52,10 @@ func (k *KubeUtils) WaitForPodComplete(ctx context.Context, cli client.Client, n
 	}, nil
 }
 
+func (k *KubeUtils) WaitForPodDeleted(ctx context.Context, cli client.Client, ns, name string, opts *kubeutils.WaitOptions) error {
+	return nil
+}
+
 func (k *KubeUtils) WaitForInstallation(ctx context.Context, cli client.Client, writer *spinner.MessageWriter) error {
 	return nil
 }

--- a/pkg/kubeutils/interface.go
+++ b/pkg/kubeutils/interface.go
@@ -30,6 +30,7 @@ type KubeUtilsInterface interface {
 	WaitForService(ctx context.Context, cli client.Client, ns, name string, opts *WaitOptions) error
 	WaitForJob(ctx context.Context, cli client.Client, ns, name string, completions int32, opts *WaitOptions) error
 	WaitForPodComplete(ctx context.Context, cli client.Client, ns, name string, opts *WaitOptions) (*corev1.Pod, error)
+	WaitForPodDeleted(ctx context.Context, cli client.Client, ns, name string, opts *WaitOptions) error
 	WaitForInstallation(ctx context.Context, cli client.Client, writer *spinner.MessageWriter) error
 	WaitForNodes(ctx context.Context, cli client.Client) error
 	WaitForNode(ctx context.Context, kcli client.Client, name string, isWorker bool) error
@@ -85,6 +86,10 @@ func WaitForJob(ctx context.Context, cli client.Client, ns, name string, complet
 
 func WaitForPodComplete(ctx context.Context, cli client.Client, ns, name string, opts *WaitOptions) (*corev1.Pod, error) {
 	return kb.WaitForPodComplete(ctx, cli, ns, name, opts)
+}
+
+func WaitForPodDeleted(ctx context.Context, cli client.Client, ns, name string, opts *WaitOptions) error {
+	return kb.WaitForPodDeleted(ctx, cli, ns, name, opts)
 }
 
 func WaitForInstallation(ctx context.Context, cli client.Client, writer *spinner.MessageWriter) error {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

https://github.com/replicatedhq/embedded-cluster/actions/runs/15541299543/job/43752497184?pr=2226

```
    ha_test.go:275: 2025-06-09 18:15:45 [spinner] ○  Migrating data for high availability
    ha_test.go:209: 
        	Error Trace:	/home/runner/work/embedded-cluster/embedded-cluster/tests/integration/kind/registry/ha_test.go:209
        	            				/home/runner/work/embedded-cluster/embedded-cluster/tests/integration/kind/registry/ha_test.go:134
        	Error:      	Target error should be in err chain:
        	            	expected: "context canceled"
        	            	in chain: "migrate registry data: run registry data migration: ensure pod: create pod: object is being deleted: pods \"registry-data-migration\" already exists"
        	            		"migrate registry data: run registry data migration: ensure pod: create pod: object is being deleted: pods \"registry-data-migration\" already exists"
        	            		"run registry data migration: ensure pod: create pod: object is being deleted: pods \"registry-data-migration\" already exists"
        	            		"run registry data migration: ensure pod: create pod: object is being deleted: pods \"registry-data-migration\" already exists"
        	            		"ensure pod: create pod: object is being deleted: pods \"registry-data-migration\" already exists"
        	            		"create pod: object is being deleted: pods \"registry-data-migration\" already exists"
        	            		"object is being deleted: pods \"registry-data-migration\" already exists"
        	Test:       	TestRegistry_EnableHAAirgap
        	Messages:   	expected context to be cancelled
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
