### PR TITLE
chore(e2e): add additional logging around waitForSSH, set SSH `ConnectTimeout` to 5 sec

### DIFF
--- a/e2e/cluster/cmx/cluster.go
+++ b/e2e/cluster/cmx/cluster.go
@@ -62,7 +62,7 @@ func NewCluster(in *ClusterInput) *Cluster {
 }
 
 func NewNodes(in *ClusterInput) ([]Node, error) {
-	in.T.Logf("creating %s nodes", strconv.Itoa(in.Nodes))
+	in.T.Logf("%s: creating %s nodes", time.Now().Format(time.RFC3339), strconv.Itoa(in.Nodes))
 
 	args := []string{
 		"vm", "create",
@@ -222,11 +222,11 @@ func waitForSSH(node Node, t *testing.T) error {
 		case <-timeout:
 			return fmt.Errorf("timed out after 5 minutes: last error: %w", lastErr)
 		case <-tick:
-			t.Logf("%s: checking SSH connectivity to node %s", time.Now().Format(time.RFC3339), node.ID)
+			t.Logf("%s: checking SSH connectivity to node ID: %s", time.Now().Format(time.RFC3339), node.ID)
 			stdout, stderr, err := runCommandOnNode(node, []string{"uptime"})
 			t.Logf("%s: SSH attempt - stdout: %s, stderr: %s, err: %v", time.Now().Format(time.RFC3339), stdout, stderr, err)
 			if err == nil {
-				t.Logf("%s: SSH connection successful to node %s", time.Now().Format(time.RFC3339), node.ID)
+				t.Logf("%s: SSH connection successful to node ID: %s", time.Now().Format(time.RFC3339), node.ID)
 				return nil
 			}
 			lastErr = fmt.Errorf("%w: stdout: %s: stderr: %s", err, stdout, stderr)
@@ -506,5 +506,7 @@ func sshArgs() []string {
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "ServerAliveInterval=30",
 		"-o", "ServerAliveCountMax=10",
+		"-o", "ConnectTimeout=5",
+		"-o", "BatchMode=yes",
 	}
 }


### PR DESCRIPTION
This adds extra logging around the `waitForSSH` phase to get timestamps and VM IDs to help try to associate issues with SSH connections in production logs to help get to the bottom of SSH issues against CMX.

This also changes the SSH `ConnectTimeout` to 5 sec to match the ticker timer used by `waitForSSH`.  The default `ConnectTimeout` for SSH is the equivalent of the host TCP timeout which could be quite a long time, for example here's where I saw some transient behavior in the tests:

```
   cluster.go:108: 2025-06-09T16:19:24-07:00: getting ssh endpoint for node ID: 17ac480e
    cluster.go:225: 2025-06-09T16:19:30-07:00: checking SSH connectivity to node 17ac480e
    cluster.go:227: 2025-06-09T16:21:42-07:00: SSH attempt - stdout: , stderr: Connection closed by 135.181.113.41 port 38879
        , err: exit status 255
    cluster.go:225: 2025-06-09T16:21:42-07:00: checking SSH connectivity to node 17ac480e
    cluster.go:227: 2025-06-09T16:21:51-07:00: SSH attempt - stdout:  23:21:51 up 8 min,  0 users,  load average: 0.00, 0.00, 0.00
        , stderr: Warning: Permanently added '[135.181.113.41]:38879' (ED25519) to the list of known hosts.
        , err: <nil>
    cluster.go:229: 2025-06-09T16:21:51-07:00: SSH connection successful to node 17ac480e
```

The behavior eventually clears but we don't make a follow-up attempt to this node until more than 2 min later because it takes that time for us to give up on the connection.

This also adds `BatchMode=yes` which is typically used in scripts to help prevent SSH interactivity from breaking the connection, just an extra fail-fast bool.