### PR TITLE
bug: Remove lastUpdated timestamp and change CheckCircle icon color

### DIFF
--- a/web/src/components/wizard/InstallationStep.tsx
+++ b/web/src/components/wizard/InstallationStep.tsx
@@ -14,12 +14,13 @@ interface InstallStatus {
 }
 
 const InstallationStep: React.FC = () => {
-  const { config } = useConfig();
+  const { config, prototypeSettings } = useConfig();
   const { text } = useWizardMode();
   const [showAdminLink, setShowAdminLink] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const { token } = useAuth();
+  const themeColor = prototypeSettings.themeColor
 
   const { data: installStatus } = useQuery<InstallStatus, Error>({
     queryKey: ["installStatus"],
@@ -73,11 +74,6 @@ const InstallationStep: React.FC = () => {
               <p className="text-lg font-medium text-gray-900">Please wait while we complete the installation...</p>
               <p className="text-sm text-gray-500 mt-2">This may take a few minutes.</p>
               {installStatus?.description && <p className="text-sm text-gray-500 mt-2">{installStatus.description}</p>}
-              {installStatus?.lastUpdated && (
-                <p className="text-xs text-gray-400 mt-1">
-                  Last updated: {new Date(installStatus.lastUpdated).toLocaleString()}
-                </p>
-              )}
             </div>
           )}
 
@@ -91,7 +87,7 @@ const InstallationStep: React.FC = () => {
           {showAdminLink && (
             <div className="flex flex-col items-center justify-center mb-6">
               <div className="w-16 h-16 rounded-full flex items-center justify-center mb-6">
-                <CheckCircle className="w-10 h-10" style={{ color: "blue" }} />
+                <CheckCircle className="w-10 h-10" style={{ color: themeColor }}/>
               </div>
               <p className="text-gray-600 mt-4">
                 Visit the Admin Console to configure and install {text.installationTitle}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Changes the color of the Check Circle to match the blue of other elements
Removes the Last Updated timestamp

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/124799/checkmark-when-install-is-done-is-blue-but-not-the-right-blue

https://app.shortcut.com/replicated/story/124720/last-updated-date-in-installation-progress-page-shows-2-31-1-5-00-04-pm-timestamp

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
