### PR TITLE
bug: Fix brand icon appearing stretched

### DIFF
--- a/web/src/components/common/Logo.tsx
+++ b/web/src/components/common/Logo.tsx
@@ -11,7 +11,7 @@ export const AppIcon: React.FC<{ className?: string }> = ({ className = 'w-6 h-6
     <img
       src={icon}
       alt="App Icon"
-      className={className}
+      className={`object-contain ${className}`}
     />
   );
 };


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
This PR fixes the brand icon appearing stretched by preserving the aspect ratio of the image inside its container

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/124849/app-icon-displays-poorly

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE