### PR TITLE
 chore(test): actually wait for the os exit signal function to be called before asserting

### DIFF
--- a/cmd/installer/cli/signal_test.go
+++ b/cmd/installer/cli/signal_test.go
@@ -40,8 +40,6 @@ func Test_signalHandler_Signal(t *testing.T) {
 	exitCode := int32(0)
 	osExit = func(code int) {
 		atomic.StoreInt32(&exitCode, int32(code))
-		// Check that the context is done
-		assert.Equal(t, context.Canceled, ctx.Err())
 		// Resume the waitgroup to allow the test to complete
 		wg.Done()
 	}
@@ -77,6 +75,8 @@ func Test_signalHandler_Signal(t *testing.T) {
 
 	// Verify cleanup was called with the expected error
 	assert.True(t, cleanupCalled, "Cleanup function should have been called")
+	// Check that the context was cancelled
+	assert.Equal(t, context.Canceled, ctx.Err())
 	assert.Equal(t, syscall.SIGINT, cleanupSignal, "Cleanup should be called with SIGINT")
 	assert.Equal(t, int32(1), atomic.LoadInt32(&exitCode), "Exit code should be 1")
 }

--- a/cmd/installer/cli/signal_test.go
+++ b/cmd/installer/cli/signal_test.go
@@ -31,7 +31,6 @@ func Test_signalHandler_Signal(t *testing.T) {
 		if sig != nil {
 			cleanupSignal = sig
 		}
-		wg.Done()
 	}
 
 	// Save original os.Exit and restore after test
@@ -41,8 +40,10 @@ func Test_signalHandler_Signal(t *testing.T) {
 	exitCode := int32(0)
 	osExit = func(code int) {
 		atomic.StoreInt32(&exitCode, int32(code))
-		// Instead of exiting, just cancel the context
-		cancel()
+		// Check that the context is done
+		assert.Equal(t, context.Canceled, ctx.Err())
+		// Resume the waitgroup to allow the test to complete
+		wg.Done()
 	}
 
 	// Set up the signal handler


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

See - https://github.com/replicatedhq/embedded-cluster/actions/runs/15614228889/job/43982767244?pr=2292#step:4:988 - we need to wait for the os exit function to have been called before making assertions on the state.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
NA

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
It's a test fix

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
