### PR TITLE
Remove Back button from Setup page

### DIFF
--- a/web/src/components/wizard/SetupStep.tsx
+++ b/web/src/components/wizard/SetupStep.tsx
@@ -147,10 +147,7 @@ const SetupStep: React.FC<SetupStepProps> = ({ onNext, onBack }) => {
         )}
       </Card>
 
-      <div className="flex justify-between">
-        <Button variant="outline" onClick={onBack} icon={<ChevronLeft className="w-5 h-5" />}>
-          Back
-        </Button>
+      <div className="flex justify-end">
         <Button onClick={handleNext} icon={<ChevronRight className="w-5 h-5" />}>
           Next: Validate Host
         </Button>

--- a/web/src/components/wizard/SetupStep.tsx
+++ b/web/src/components/wizard/SetupStep.tsx
@@ -3,14 +3,13 @@ import Card from "../common/Card";
 import Button from "../common/Button";
 import { useConfig } from "../../contexts/ConfigContext";
 import { useWizardMode } from "../../contexts/WizardModeContext";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronRight } from "lucide-react";
 import LinuxSetup from "./setup/LinuxSetup";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { useAuth } from "../../contexts/AuthContext";
 
 interface SetupStepProps {
   onNext: () => void;
-  onBack: () => void;
 }
 
 interface Status {
@@ -22,7 +21,7 @@ interface ConfigError extends Error {
   errors?: { field: string; message: string }[];
 }
 
-const SetupStep: React.FC<SetupStepProps> = ({ onNext, onBack }) => {
+const SetupStep: React.FC<SetupStepProps> = ({ onNext }) => {
   const { config, updateConfig, prototypeSettings } = useConfig();
   const { text } = useWizardMode();
   const [showAdvanced, setShowAdvanced] = useState(true);


### PR DESCRIPTION
You can't go back to the Welcome step because it just proceeds you to the Setup step if you're already logged in. So the button didn't do anything.

<img width="1291" alt="Screenshot 2025-06-13 at 2 39 01 PM" src="https://github.com/user-attachments/assets/9cac4c09-d532-4513-a581-cc35faa0b1c1" />
