### PR TITLE
Changing the collapsed chevron to match Google Doc design pattern

### DIFF
--- a/web/src/components/wizard/setup/LinuxSetup.tsx
+++ b/web/src/components/wizard/setup/LinuxSetup.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import Input from "../../common/Input";
 import Select from "../../common/Select";
 import { useBranding } from "../../../contexts/BrandingContext";
-import { ChevronDown, ChevronUp } from "lucide-react";
+import { ChevronDown, ChevronRight } from "lucide-react";
 
 interface LinuxSetupProps {
   config: {
@@ -125,7 +125,7 @@ const LinuxSetup: React.FC<LinuxSetupProps> = ({
           className="flex items-center text-lg font-medium text-gray-900 mb-4"
           onClick={() => onShowAdvancedChange(!showAdvanced)}
         >
-          {showAdvanced ? <ChevronDown className="w-4 h-4 mr-1" /> : <ChevronUp className="w-4 h-4 mr-1" />}
+          {showAdvanced ? <ChevronDown className="w-4 h-4 mr-1" /> : <ChevronRight className="w-4 h-4 mr-1" />}
           Advanced Settings
         </button>
 


### PR DESCRIPTION
#### What this PR does / why we need it:
The collapse chevron points upwards when the section is collapsed. Following the design pattern seen in google docs, the chevron points to the right when a section is collapsed.

