### PR TITLE
fix(openebs): disable loki components

### DIFF
--- a/pkg/addons/openebs/static/values.tpl.yaml
+++ b/pkg/addons/openebs/static/values.tpl.yaml
@@ -50,3 +50,5 @@ zfs-localpv:
   enabled: false
 alloy:
   enabled: false
+loki:
+  enabled: false

--- a/pkg/addons/openebs/static/values.tpl.yaml
+++ b/pkg/addons/openebs/static/values.tpl.yaml
@@ -48,3 +48,5 @@ preUpgradeHook:
 {{- end }}
 zfs-localpv:
   enabled: false
+alloy:
+  enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

New loki components should be disabled and is causing automation to fail to update openebs.

https://github.com/replicatedhq/embedded-cluster/actions/runs/15616993264/job/43992314591

```
failed to update openebs images: failed to update images: no component found for image docker.io/grafana/alloy:v1.8.1
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
