### PR TITLE
chore: collect network interface statistics

### DIFF
--- a/cmd/installer/goods/support/host-support-bundle.tmpl.yaml
+++ b/cmd/installer/goods/support/host-support-bundle.tmpl.yaml
@@ -174,6 +174,10 @@ spec:
       command: "ip"
       args: ["route"]
   - run:
+      collectorName: "ip-address-stats"
+      command: "ip"
+      args: ["-s", "-s", "address"]
+  - run:
       collectorName: "sysctl"
       command: "sysctl"
       args: ["-a"]


### PR DESCRIPTION
#### What this PR does / why we need it:
Collect output of `ip -s -s address`

Example output
```
ip -s -s address | grep eth1: -A20
5: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc pfifo_fast state UP group default qlen 1000
    link/ether 18:7b:b3:1e:04:60 brd ff:ff:ff:ff:ff:ff
    inet 10.0.0.161/24 metric 100 brd 10.0.0.255 scope global dynamic eth1
       valid_lft 41901sec preferred_lft 41901sec
    inet6 fe80::1a7b:b3ff:fe1e:460/64 scope link
       valid_lft forever preferred_lft forever
    RX:  bytes packets errors dropped  missed   mcast
    1371687222  171289      0       0       0       0
    RX errors:  length    crc   frame    fifo overrun
                     0      0       0       0       0
    TX:  bytes packets errors dropped carrier collsns
       7715477  100950      0       0       0       0
    TX errors: aborted   fifo  window heartbt transns
                     0      0       0       0       2
```

#### Which issue(s) this PR fixes:
[sc-125168](https://app.shortcut.com/replicated/story/125168/collect-network-interface-statistics)

#### Does this PR require a test?
NONE

#### Does this PR require a release note?
NONE

#### Does this PR require documentation?
NONE