### PR TITLE
chore: runtime config as argument

### DIFF
--- a/api/client/install.go
+++ b/api/client/install.go
@@ -35,8 +35,8 @@ func (c *client) GetInstallationConfig() (*types.InstallationConfig, error) {
 	return &config, nil
 }
 
-func (c *client) ConfigureInstallation(cfg *types.InstallationConfig) (*types.Status, error) {
-	b, err := json.Marshal(cfg)
+func (c *client) ConfigureInstallation(config *types.InstallationConfig) (*types.Status, error) {
+	b, err := json.Marshal(config)
 	if err != nil {
 		return nil, err
 	}

--- a/api/controllers/install/controller.go
+++ b/api/controllers/install/controller.go
@@ -173,7 +173,6 @@ func NewInstallController(opts ...InstallControllerOption) (*InstallController, 
 
 	if controller.installationManager == nil {
 		controller.installationManager = installation.NewInstallationManager(
-			installation.WithRuntimeConfig(controller.rc),
 			installation.WithLogger(controller.logger),
 			installation.WithInstallation(controller.install.Steps.Installation),
 			installation.WithLicenseFile(controller.licenseFile),
@@ -185,7 +184,6 @@ func NewInstallController(opts ...InstallControllerOption) (*InstallController, 
 
 	if controller.hostPreflightManager == nil {
 		controller.hostPreflightManager = preflight.NewHostPreflightManager(
-			preflight.WithRuntimeConfig(controller.rc),
 			preflight.WithLogger(controller.logger),
 			preflight.WithMetricsReporter(controller.metricsReporter),
 			preflight.WithHostPreflightStore(preflight.NewMemoryStore(controller.install.Steps.HostPreflight)),
@@ -195,7 +193,6 @@ func NewInstallController(opts ...InstallControllerOption) (*InstallController, 
 
 	if controller.infraManager == nil {
 		controller.infraManager = infra.NewInfraManager(
-			infra.WithRuntimeConfig(controller.rc),
 			infra.WithLogger(controller.logger),
 			infra.WithInfra(controller.install.Steps.Infra),
 			infra.WithPassword(controller.password),

--- a/api/controllers/install/controller_test.go
+++ b/api/controllers/install/controller_test.go
@@ -37,7 +37,7 @@ func TestGetInstallationConfig(t *testing.T) {
 				mock.InOrder(
 					m.On("GetConfig").Return(config, nil),
 					m.On("SetConfigDefaults", config).Return(nil),
-					m.On("ValidateConfig", config).Return(nil),
+					m.On("ValidateConfig", config, 9001).Return(nil),
 				)
 			},
 			expectedErr: false,
@@ -73,7 +73,7 @@ func TestGetInstallationConfig(t *testing.T) {
 				mock.InOrder(
 					m.On("GetConfig").Return(config, nil),
 					m.On("SetConfigDefaults", config).Return(nil),
-					m.On("ValidateConfig", config).Return(errors.New("validation error")),
+					m.On("ValidateConfig", config, 9001).Return(errors.New("validation error")),
 				)
 			},
 			expectedErr:   true,
@@ -85,6 +85,7 @@ func TestGetInstallationConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			rc := runtimeconfig.New(nil, runtimeconfig.WithEnvSetter(&testEnvSetter{}))
 			rc.SetDataDir(t.TempDir())
+			rc.SetManagerPort(9001)
 
 			mockManager := &installation.MockInstallationManager{}
 			tt.setupMock(mockManager)
@@ -114,7 +115,7 @@ func TestConfigureInstallation(t *testing.T) {
 	tests := []struct {
 		name        string
 		config      *types.InstallationConfig
-		setupMock   func(*installation.MockInstallationManager, *types.InstallationConfig)
+		setupMock   func(*installation.MockInstallationManager, runtimeconfig.RuntimeConfig, *types.InstallationConfig)
 		expectedErr bool
 	}{
 		{
@@ -123,11 +124,11 @@ func TestConfigureInstallation(t *testing.T) {
 				LocalArtifactMirrorPort: 9000,
 				DataDirectory:           t.TempDir(),
 			},
-			setupMock: func(m *installation.MockInstallationManager, config *types.InstallationConfig) {
+			setupMock: func(m *installation.MockInstallationManager, rc runtimeconfig.RuntimeConfig, config *types.InstallationConfig) {
 				mock.InOrder(
-					m.On("ValidateConfig", config).Return(nil),
+					m.On("ValidateConfig", config, 9001).Return(nil),
 					m.On("SetConfig", *config).Return(nil),
-					m.On("ConfigureHost", t.Context()).Return(nil),
+					m.On("ConfigureHost", t.Context(), rc).Return(nil),
 				)
 			},
 			expectedErr: false,
@@ -135,17 +136,17 @@ func TestConfigureInstallation(t *testing.T) {
 		{
 			name:   "validate error",
 			config: &types.InstallationConfig{},
-			setupMock: func(m *installation.MockInstallationManager, config *types.InstallationConfig) {
-				m.On("ValidateConfig", config).Return(errors.New("validation error"))
+			setupMock: func(m *installation.MockInstallationManager, rc runtimeconfig.RuntimeConfig, config *types.InstallationConfig) {
+				m.On("ValidateConfig", config, 9001).Return(errors.New("validation error"))
 			},
 			expectedErr: true,
 		},
 		{
 			name:   "set config error",
 			config: &types.InstallationConfig{},
-			setupMock: func(m *installation.MockInstallationManager, config *types.InstallationConfig) {
+			setupMock: func(m *installation.MockInstallationManager, rc runtimeconfig.RuntimeConfig, config *types.InstallationConfig) {
 				mock.InOrder(
-					m.On("ValidateConfig", config).Return(nil),
+					m.On("ValidateConfig", config, 9001).Return(nil),
 					m.On("SetConfig", *config).Return(errors.New("set config error")),
 				)
 			},
@@ -157,16 +158,16 @@ func TestConfigureInstallation(t *testing.T) {
 				GlobalCIDR:    "10.0.0.0/16",
 				DataDirectory: t.TempDir(),
 			},
-			setupMock: func(m *installation.MockInstallationManager, config *types.InstallationConfig) {
+			setupMock: func(m *installation.MockInstallationManager, rc runtimeconfig.RuntimeConfig, config *types.InstallationConfig) {
 				// Create a copy with expected CIDR values after computation
 				configWithCIDRs := *config
 				configWithCIDRs.PodCIDR = "10.0.0.0/17"
 				configWithCIDRs.ServiceCIDR = "10.0.128.0/17"
 
 				mock.InOrder(
-					m.On("ValidateConfig", config).Return(nil),
+					m.On("ValidateConfig", config, 9001).Return(nil),
 					m.On("SetConfig", configWithCIDRs).Return(nil),
-					m.On("ConfigureHost", t.Context()).Return(nil),
+					m.On("ConfigureHost", t.Context(), rc).Return(nil),
 				)
 			},
 			expectedErr: false,
@@ -177,13 +178,14 @@ func TestConfigureInstallation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			rc := runtimeconfig.New(nil, runtimeconfig.WithEnvSetter(&testEnvSetter{}))
 			rc.SetDataDir(t.TempDir())
+			rc.SetManagerPort(9001)
 
 			mockManager := &installation.MockInstallationManager{}
 
 			// Create a copy of the config to avoid modifying the original
 			configCopy := *tt.config
 
-			tt.setupMock(mockManager, &configCopy)
+			tt.setupMock(mockManager, rc, &configCopy)
 
 			controller, err := NewInstallController(
 				WithRuntimeConfig(rc),
@@ -273,15 +275,15 @@ func TestRunHostPreflights(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		setupMocks  func(*preflight.MockHostPreflightManager)
+		setupMocks  func(*preflight.MockHostPreflightManager, runtimeconfig.RuntimeConfig)
 		expectedErr bool
 	}{
 		{
 			name: "successful run preflights",
-			setupMocks: func(pm *preflight.MockHostPreflightManager) {
+			setupMocks: func(pm *preflight.MockHostPreflightManager, rc runtimeconfig.RuntimeConfig) {
 				mock.InOrder(
-					pm.On("PrepareHostPreflights", t.Context(), mock.Anything).Return(expectedHPF, nil),
-					pm.On("RunHostPreflights", t.Context(), mock.MatchedBy(func(opts preflight.RunHostPreflightOptions) bool {
+					pm.On("PrepareHostPreflights", t.Context(), rc, mock.Anything).Return(expectedHPF, nil),
+					pm.On("RunHostPreflights", t.Context(), rc, mock.MatchedBy(func(opts preflight.RunHostPreflightOptions) bool {
 						return expectedHPF == opts.HostPreflightSpec
 					})).Return(nil),
 				)
@@ -290,19 +292,19 @@ func TestRunHostPreflights(t *testing.T) {
 		},
 		{
 			name: "prepare preflights error",
-			setupMocks: func(pm *preflight.MockHostPreflightManager) {
+			setupMocks: func(pm *preflight.MockHostPreflightManager, rc runtimeconfig.RuntimeConfig) {
 				mock.InOrder(
-					pm.On("PrepareHostPreflights", t.Context(), mock.Anything).Return(nil, errors.New("prepare error")),
+					pm.On("PrepareHostPreflights", t.Context(), rc, mock.Anything).Return(nil, errors.New("prepare error")),
 				)
 			},
 			expectedErr: true,
 		},
 		{
 			name: "run preflights error",
-			setupMocks: func(pm *preflight.MockHostPreflightManager) {
+			setupMocks: func(pm *preflight.MockHostPreflightManager, rc runtimeconfig.RuntimeConfig) {
 				mock.InOrder(
-					pm.On("PrepareHostPreflights", t.Context(), mock.Anything).Return(expectedHPF, nil),
-					pm.On("RunHostPreflights", t.Context(), mock.MatchedBy(func(opts preflight.RunHostPreflightOptions) bool {
+					pm.On("PrepareHostPreflights", t.Context(), rc, mock.Anything).Return(expectedHPF, nil),
+					pm.On("RunHostPreflights", t.Context(), rc, mock.MatchedBy(func(opts preflight.RunHostPreflightOptions) bool {
 						return expectedHPF == opts.HostPreflightSpec
 					})).Return(errors.New("run preflights error")),
 				)
@@ -313,9 +315,6 @@ func TestRunHostPreflights(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockPreflightManager := &preflight.MockHostPreflightManager{}
-			tt.setupMocks(mockPreflightManager)
-
 			rc := runtimeconfig.New(nil)
 			rc.SetDataDir(t.TempDir())
 			rc.SetProxySpec(&ecv1beta1.ProxySpec{
@@ -324,6 +323,9 @@ func TestRunHostPreflights(t *testing.T) {
 				ProvidedNoProxy: "provided-proxy.com",
 				NoProxy:         "no-proxy.com",
 			})
+
+			mockPreflightManager := &preflight.MockHostPreflightManager{}
+			tt.setupMocks(mockPreflightManager, rc)
 
 			controller, err := NewInstallController(
 				WithRuntimeConfig(rc),
@@ -566,25 +568,25 @@ func TestGetInstallationStatus(t *testing.T) {
 func TestSetupInfra(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupMocks  func(*preflight.MockHostPreflightManager, *installation.MockInstallationManager, *infra.MockInfraManager, *metrics.MockReporter)
+		setupMocks  func(runtimeconfig.RuntimeConfig, *preflight.MockHostPreflightManager, *installation.MockInstallationManager, *infra.MockInfraManager, *metrics.MockReporter)
 		expectedErr bool
 	}{
 		{
 			name: "successful setup with passed preflights",
-			setupMocks: func(pm *preflight.MockHostPreflightManager, im *installation.MockInstallationManager, fm *infra.MockInfraManager, r *metrics.MockReporter) {
+			setupMocks: func(rc runtimeconfig.RuntimeConfig, pm *preflight.MockHostPreflightManager, im *installation.MockInstallationManager, fm *infra.MockInfraManager, r *metrics.MockReporter) {
 				preflightStatus := &types.Status{
 					State: types.StateSucceeded,
 				}
 				mock.InOrder(
 					pm.On("GetHostPreflightStatus", t.Context()).Return(preflightStatus, nil),
-					fm.On("Install", t.Context()).Return(nil),
+					fm.On("Install", t.Context(), rc).Return(nil),
 				)
 			},
 			expectedErr: false,
 		},
 		{
 			name: "successful setup with failed preflights",
-			setupMocks: func(pm *preflight.MockHostPreflightManager, im *installation.MockInstallationManager, fm *infra.MockInfraManager, r *metrics.MockReporter) {
+			setupMocks: func(rc runtimeconfig.RuntimeConfig, pm *preflight.MockHostPreflightManager, im *installation.MockInstallationManager, fm *infra.MockInfraManager, r *metrics.MockReporter) {
 				preflightStatus := &types.Status{
 					State: types.StateFailed,
 				}
@@ -600,21 +602,21 @@ func TestSetupInfra(t *testing.T) {
 					pm.On("GetHostPreflightStatus", t.Context()).Return(preflightStatus, nil),
 					pm.On("GetHostPreflightOutput", t.Context()).Return(preflightOutput, nil),
 					r.On("ReportPreflightsFailed", t.Context(), preflightOutput).Return(nil),
-					fm.On("Install", t.Context()).Return(nil),
+					fm.On("Install", t.Context(), rc).Return(nil),
 				)
 			},
 			expectedErr: false,
 		},
 		{
 			name: "preflight status error",
-			setupMocks: func(pm *preflight.MockHostPreflightManager, im *installation.MockInstallationManager, fm *infra.MockInfraManager, r *metrics.MockReporter) {
+			setupMocks: func(rc runtimeconfig.RuntimeConfig, pm *preflight.MockHostPreflightManager, im *installation.MockInstallationManager, fm *infra.MockInfraManager, r *metrics.MockReporter) {
 				pm.On("GetHostPreflightStatus", t.Context()).Return(nil, errors.New("get preflight status error"))
 			},
 			expectedErr: true,
 		},
 		{
 			name: "preflight not completed",
-			setupMocks: func(pm *preflight.MockHostPreflightManager, im *installation.MockInstallationManager, fm *infra.MockInfraManager, r *metrics.MockReporter) {
+			setupMocks: func(rc runtimeconfig.RuntimeConfig, pm *preflight.MockHostPreflightManager, im *installation.MockInstallationManager, fm *infra.MockInfraManager, r *metrics.MockReporter) {
 				preflightStatus := &types.Status{
 					State: types.StateRunning,
 				}
@@ -624,7 +626,7 @@ func TestSetupInfra(t *testing.T) {
 		},
 		{
 			name: "preflight output error",
-			setupMocks: func(pm *preflight.MockHostPreflightManager, im *installation.MockInstallationManager, fm *infra.MockInfraManager, r *metrics.MockReporter) {
+			setupMocks: func(rc runtimeconfig.RuntimeConfig, pm *preflight.MockHostPreflightManager, im *installation.MockInstallationManager, fm *infra.MockInfraManager, r *metrics.MockReporter) {
 				preflightStatus := &types.Status{
 					State: types.StateFailed,
 				}
@@ -637,13 +639,13 @@ func TestSetupInfra(t *testing.T) {
 		},
 		{
 			name: "install infra error",
-			setupMocks: func(pm *preflight.MockHostPreflightManager, im *installation.MockInstallationManager, fm *infra.MockInfraManager, r *metrics.MockReporter) {
+			setupMocks: func(rc runtimeconfig.RuntimeConfig, pm *preflight.MockHostPreflightManager, im *installation.MockInstallationManager, fm *infra.MockInfraManager, r *metrics.MockReporter) {
 				preflightStatus := &types.Status{
 					State: types.StateSucceeded,
 				}
 				mock.InOrder(
 					pm.On("GetHostPreflightStatus", t.Context()).Return(preflightStatus, nil),
-					fm.On("Install", t.Context()).Return(errors.New("install error")),
+					fm.On("Install", t.Context(), rc).Return(errors.New("install error")),
 				)
 			},
 			expectedErr: true,
@@ -652,13 +654,18 @@ func TestSetupInfra(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			rc := runtimeconfig.New(nil)
+			rc.SetDataDir(t.TempDir())
+			rc.SetManagerPort(9001)
+
 			mockPreflightManager := &preflight.MockHostPreflightManager{}
 			mockInstallationManager := &installation.MockInstallationManager{}
 			mockInfraManager := &infra.MockInfraManager{}
 			mockMetricsReporter := &metrics.MockReporter{}
-			tt.setupMocks(mockPreflightManager, mockInstallationManager, mockInfraManager, mockMetricsReporter)
+			tt.setupMocks(rc, mockPreflightManager, mockInstallationManager, mockInfraManager, mockMetricsReporter)
 
 			controller, err := NewInstallController(
+				WithRuntimeConfig(rc),
 				WithHostPreflightManager(mockPreflightManager),
 				WithInstallationManager(mockInstallationManager),
 				WithInfraManager(mockInfraManager),

--- a/api/controllers/install/controller_test.go
+++ b/api/controllers/install/controller_test.go
@@ -575,13 +575,9 @@ func TestSetupInfra(t *testing.T) {
 				preflightStatus := &types.Status{
 					State: types.StateSucceeded,
 				}
-				config := &types.InstallationConfig{
-					AdminConsolePort: 8000,
-				}
 				mock.InOrder(
 					pm.On("GetHostPreflightStatus", t.Context()).Return(preflightStatus, nil),
-					im.On("GetConfig").Return(config, nil),
-					fm.On("Install", t.Context(), config).Return(nil),
+					fm.On("Install", t.Context()).Return(nil),
 				)
 			},
 			expectedErr: false,
@@ -600,15 +596,11 @@ func TestSetupInfra(t *testing.T) {
 						},
 					},
 				}
-				config := &types.InstallationConfig{
-					AdminConsolePort: 8000,
-				}
 				mock.InOrder(
 					pm.On("GetHostPreflightStatus", t.Context()).Return(preflightStatus, nil),
 					pm.On("GetHostPreflightOutput", t.Context()).Return(preflightOutput, nil),
 					r.On("ReportPreflightsFailed", t.Context(), preflightOutput).Return(nil),
-					im.On("GetConfig").Return(config, nil),
-					fm.On("Install", t.Context(), config).Return(nil),
+					fm.On("Install", t.Context()).Return(nil),
 				)
 			},
 			expectedErr: false,
@@ -644,31 +636,14 @@ func TestSetupInfra(t *testing.T) {
 			expectedErr: true,
 		},
 		{
-			name: "get config error",
-			setupMocks: func(pm *preflight.MockHostPreflightManager, im *installation.MockInstallationManager, fm *infra.MockInfraManager, r *metrics.MockReporter) {
-				preflightStatus := &types.Status{
-					State: types.StateSucceeded,
-				}
-				mock.InOrder(
-					pm.On("GetHostPreflightStatus", t.Context()).Return(preflightStatus, nil),
-					im.On("GetConfig").Return(nil, errors.New("get config error")),
-				)
-			},
-			expectedErr: true,
-		},
-		{
 			name: "install infra error",
 			setupMocks: func(pm *preflight.MockHostPreflightManager, im *installation.MockInstallationManager, fm *infra.MockInfraManager, r *metrics.MockReporter) {
 				preflightStatus := &types.Status{
 					State: types.StateSucceeded,
 				}
-				config := &types.InstallationConfig{
-					AdminConsolePort: 8000,
-				}
 				mock.InOrder(
 					pm.On("GetHostPreflightStatus", t.Context()).Return(preflightStatus, nil),
-					im.On("GetConfig").Return(config, nil),
-					fm.On("Install", t.Context(), config).Return(errors.New("install error")),
+					fm.On("Install", t.Context()).Return(errors.New("install error")),
 				)
 			},
 			expectedErr: true,

--- a/api/controllers/install/hostpreflight.go
+++ b/api/controllers/install/hostpreflight.go
@@ -15,7 +15,7 @@ func (c *InstallController) RunHostPreflights(ctx context.Context, opts RunHostP
 	ecDomains := utils.GetDomains(c.releaseData)
 
 	// Prepare host preflights
-	hpf, err := c.hostPreflightManager.PrepareHostPreflights(ctx, preflight.PrepareHostPreflightOptions{
+	hpf, err := c.hostPreflightManager.PrepareHostPreflights(ctx, c.rc, preflight.PrepareHostPreflightOptions{
 		ReplicatedAppURL:      netutils.MaybeAddHTTPS(ecDomains.ReplicatedAppDomain),
 		ProxyRegistryURL:      netutils.MaybeAddHTTPS(ecDomains.ProxyRegistryDomain),
 		HostPreflightSpec:     c.releaseData.HostPreflights,
@@ -28,7 +28,7 @@ func (c *InstallController) RunHostPreflights(ctx context.Context, opts RunHostP
 	}
 
 	// Run host preflights
-	return c.hostPreflightManager.RunHostPreflights(ctx, preflight.RunHostPreflightOptions{
+	return c.hostPreflightManager.RunHostPreflights(ctx, c.rc, preflight.RunHostPreflightOptions{
 		HostPreflightSpec: hpf,
 	})
 }

--- a/api/controllers/install/infra.go
+++ b/api/controllers/install/infra.go
@@ -27,13 +27,7 @@ func (c *InstallController) SetupInfra(ctx context.Context) error {
 		}
 	}
 
-	// Get current installation config
-	config, err := c.installationManager.GetConfig()
-	if err != nil {
-		return fmt.Errorf("failed to read installation config: %w", err)
-	}
-
-	if err := c.infraManager.Install(ctx, config); err != nil {
+	if err := c.infraManager.Install(ctx); err != nil {
 		return fmt.Errorf("install infra: %w", err)
 	}
 

--- a/api/controllers/install/infra.go
+++ b/api/controllers/install/infra.go
@@ -27,7 +27,7 @@ func (c *InstallController) SetupInfra(ctx context.Context) error {
 		}
 	}
 
-	if err := c.infraManager.Install(ctx); err != nil {
+	if err := c.infraManager.Install(ctx, c.rc); err != nil {
 		return fmt.Errorf("install infra: %w", err)
 	}
 

--- a/api/controllers/install/installation.go
+++ b/api/controllers/install/installation.go
@@ -24,7 +24,7 @@ func (c *InstallController) GetInstallationConfig(ctx context.Context) (*types.I
 		return nil, fmt.Errorf("set defaults: %w", err)
 	}
 
-	if err := c.installationManager.ValidateConfig(config); err != nil {
+	if err := c.installationManager.ValidateConfig(config, c.rc.ManagerPort()); err != nil {
 		return nil, fmt.Errorf("validate: %w", err)
 	}
 
@@ -32,7 +32,7 @@ func (c *InstallController) GetInstallationConfig(ctx context.Context) (*types.I
 }
 
 func (c *InstallController) ConfigureInstallation(ctx context.Context, config *types.InstallationConfig) error {
-	if err := c.installationManager.ValidateConfig(config); err != nil {
+	if err := c.installationManager.ValidateConfig(config, c.rc.ManagerPort()); err != nil {
 		return fmt.Errorf("validate: %w", err)
 	}
 
@@ -70,7 +70,7 @@ func (c *InstallController) ConfigureInstallation(ctx context.Context, config *t
 		return fmt.Errorf("set env vars: %w", err)
 	}
 
-	if err := c.installationManager.ConfigureHost(ctx); err != nil {
+	if err := c.installationManager.ConfigureHost(ctx, c.rc); err != nil {
 		return fmt.Errorf("configure: %w", err)
 	}
 

--- a/api/integration/hostpreflights_test.go
+++ b/api/integration/hostpreflights_test.go
@@ -176,13 +176,11 @@ func TestPostRunHostPreflights(t *testing.T) {
 
 		// Create a host preflights manager with the mock runner
 		pfManager := preflight.NewHostPreflightManager(
-			preflight.WithRuntimeConfig(rc),
 			preflight.WithPreflightRunner(runner),
 		)
 
 		// Create an installation manager
 		iManager := installation.NewInstallationManager(
-			installation.WithRuntimeConfig(rc),
 			installation.WithInstallationStore(installation.NewMemoryStore(inst)),
 		)
 

--- a/api/integration/install_test.go
+++ b/api/integration/install_test.go
@@ -933,7 +933,6 @@ func TestInstallWithAPIClient(t *testing.T) {
 
 	// Create a config manager
 	installationManager := installation.NewInstallationManager(
-		installation.WithRuntimeConfig(rc),
 		installation.WithHostUtils(mockHostUtils),
 	)
 

--- a/api/internal/managers/infra/install.go
+++ b/api/internal/managers/infra/install.go
@@ -198,7 +198,7 @@ func (m *infraManager) installK0s(ctx context.Context, rc runtimeconfig.RuntimeC
 	}
 
 	logFn("installing k0s")
-	if err := k0s.Install(rc, rc.NetworkInterface()); err != nil {
+	if err := k0s.Install(rc); err != nil {
 		return nil, fmt.Errorf("install cluster: %w", err)
 	}
 

--- a/api/internal/managers/infra/manager.go
+++ b/api/internal/managers/infra/manager.go
@@ -17,14 +17,13 @@ var _ InfraManager = &infraManager{}
 // InfraManager provides methods for managing infrastructure setup
 type InfraManager interface {
 	Get() (*types.Infra, error)
-	Install(ctx context.Context) error
+	Install(ctx context.Context, rc runtimeconfig.RuntimeConfig) error
 }
 
 // infraManager is an implementation of the InfraManager interface
 type infraManager struct {
 	infra         *types.Infra
 	infraStore    Store
-	rc            runtimeconfig.RuntimeConfig
 	password      string
 	tlsConfig     types.TLSConfig
 	licenseFile   string
@@ -37,12 +36,6 @@ type infraManager struct {
 }
 
 type InfraManagerOption func(*infraManager)
-
-func WithRuntimeConfig(rc runtimeconfig.RuntimeConfig) InfraManagerOption {
-	return func(c *infraManager) {
-		c.rc = rc
-	}
-}
 
 func WithLogger(logger logrus.FieldLogger) InfraManagerOption {
 	return func(c *infraManager) {
@@ -110,10 +103,6 @@ func NewInfraManager(opts ...InfraManagerOption) *infraManager {
 
 	for _, opt := range opts {
 		opt(manager)
-	}
-
-	if manager.rc == nil {
-		manager.rc = runtimeconfig.New(nil)
 	}
 
 	if manager.logger == nil {

--- a/api/internal/managers/infra/manager.go
+++ b/api/internal/managers/infra/manager.go
@@ -17,7 +17,7 @@ var _ InfraManager = &infraManager{}
 // InfraManager provides methods for managing infrastructure setup
 type InfraManager interface {
 	Get() (*types.Infra, error)
-	Install(ctx context.Context, config *types.InstallationConfig) error
+	Install(ctx context.Context) error
 }
 
 // infraManager is an implementation of the InfraManager interface

--- a/api/internal/managers/infra/manager_mock.go
+++ b/api/internal/managers/infra/manager_mock.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/replicatedhq/embedded-cluster/api/types"
+	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -14,8 +15,8 @@ type MockInfraManager struct {
 	mock.Mock
 }
 
-func (m *MockInfraManager) Install(ctx context.Context) error {
-	args := m.Called(ctx)
+func (m *MockInfraManager) Install(ctx context.Context, rc runtimeconfig.RuntimeConfig) error {
+	args := m.Called(ctx, rc)
 	return args.Error(0)
 }
 

--- a/api/internal/managers/infra/manager_mock.go
+++ b/api/internal/managers/infra/manager_mock.go
@@ -14,8 +14,8 @@ type MockInfraManager struct {
 	mock.Mock
 }
 
-func (m *MockInfraManager) Install(ctx context.Context, config *types.InstallationConfig) error {
-	args := m.Called(ctx, config)
+func (m *MockInfraManager) Install(ctx context.Context) error {
+	args := m.Called(ctx)
 	return args.Error(0)
 }
 

--- a/api/internal/managers/infra/util.go
+++ b/api/internal/managers/infra/util.go
@@ -9,6 +9,7 @@ import (
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
 	"github.com/replicatedhq/embedded-cluster/pkg/kubeutils"
+	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/replicatedhq/embedded-cluster/pkg/versions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -25,13 +26,13 @@ func (m *infraManager) waitForNode(ctx context.Context, kcli client.Client) erro
 	return nil
 }
 
-func (m *infraManager) getHelmClient() (helm.Client, error) {
+func (m *infraManager) getHelmClient(rc runtimeconfig.RuntimeConfig) (helm.Client, error) {
 	airgapChartsPath := ""
 	if m.airgapBundle != "" {
-		airgapChartsPath = m.rc.EmbeddedClusterChartsSubDir()
+		airgapChartsPath = rc.EmbeddedClusterChartsSubDir()
 	}
 	hcli, err := helm.NewClient(helm.HelmOptions{
-		KubeConfig: m.rc.PathToKubeConfig(),
+		KubeConfig: rc.PathToKubeConfig(),
 		K0sVersion: versions.K0sVersion,
 		AirgapPath: airgapChartsPath,
 		LogFn:      m.logFn("helm"),

--- a/api/internal/managers/installation/config_test.go
+++ b/api/internal/managers/installation/config_test.go
@@ -185,9 +185,9 @@ func TestValidateConfig(t *testing.T) {
 			}
 			rc.SetDataDir(t.TempDir())
 
-			manager := NewInstallationManager(WithRuntimeConfig(rc))
+			manager := NewInstallationManager()
 
-			err := manager.ValidateConfig(tt.config)
+			err := manager.ValidateConfig(tt.config, rc.ManagerPort())
 
 			if tt.expectedErr {
 				assert.Error(t, err)
@@ -443,7 +443,6 @@ func TestConfigureHost(t *testing.T) {
 
 			// Create manager with mocks
 			manager := NewInstallationManager(
-				WithRuntimeConfig(rc),
 				WithHostUtils(mockHostUtils),
 				WithInstallationStore(mockStore),
 				WithLicenseFile("license.yaml"),
@@ -451,7 +450,7 @@ func TestConfigureHost(t *testing.T) {
 			)
 
 			// Run the test
-			err := manager.ConfigureHost(context.Background())
+			err := manager.ConfigureHost(context.Background(), rc)
 
 			// Assertions
 			if tt.expectedErr {

--- a/api/internal/managers/installation/manager.go
+++ b/api/internal/managers/installation/manager.go
@@ -20,16 +20,15 @@ type InstallationManager interface {
 	SetConfig(config types.InstallationConfig) error
 	GetStatus() (*types.Status, error)
 	SetStatus(status types.Status) error
-	ValidateConfig(config *types.InstallationConfig) error
+	ValidateConfig(config *types.InstallationConfig, managerPort int) error
 	SetConfigDefaults(config *types.InstallationConfig) error
-	ConfigureHost(ctx context.Context) error
+	ConfigureHost(ctx context.Context, rc runtimeconfig.RuntimeConfig) error
 }
 
 // installationManager is an implementation of the InstallationManager interface
 type installationManager struct {
 	installation      *types.Installation
 	installationStore InstallationStore
-	rc                runtimeconfig.RuntimeConfig
 	licenseFile       string
 	airgapBundle      string
 	netUtils          utils.NetUtils
@@ -39,12 +38,6 @@ type installationManager struct {
 }
 
 type InstallationManagerOption func(*installationManager)
-
-func WithRuntimeConfig(rc runtimeconfig.RuntimeConfig) InstallationManagerOption {
-	return func(c *installationManager) {
-		c.rc = rc
-	}
-}
 
 func WithLogger(logger logrus.FieldLogger) InstallationManagerOption {
 	return func(c *installationManager) {
@@ -94,10 +87,6 @@ func NewInstallationManager(opts ...InstallationManagerOption) *installationMana
 
 	for _, opt := range opts {
 		opt(manager)
-	}
-
-	if manager.rc == nil {
-		manager.rc = runtimeconfig.New(nil)
 	}
 
 	if manager.logger == nil {

--- a/api/internal/managers/installation/manager_mock.go
+++ b/api/internal/managers/installation/manager_mock.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/replicatedhq/embedded-cluster/api/types"
+	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -45,8 +46,8 @@ func (m *MockInstallationManager) SetStatus(status types.Status) error {
 }
 
 // ValidateConfig mocks the ValidateConfig method
-func (m *MockInstallationManager) ValidateConfig(config *types.InstallationConfig) error {
-	args := m.Called(config)
+func (m *MockInstallationManager) ValidateConfig(config *types.InstallationConfig, managerPort int) error {
+	args := m.Called(config, managerPort)
 	return args.Error(0)
 }
 
@@ -57,7 +58,7 @@ func (m *MockInstallationManager) SetConfigDefaults(config *types.InstallationCo
 }
 
 // ConfigureHost mocks the ConfigureHost method
-func (m *MockInstallationManager) ConfigureHost(ctx context.Context) error {
-	args := m.Called(ctx)
+func (m *MockInstallationManager) ConfigureHost(ctx context.Context, rc runtimeconfig.RuntimeConfig) error {
+	args := m.Called(ctx, rc)
 	return args.Error(0)
 }

--- a/api/internal/managers/preflight/hostpreflight_test.go
+++ b/api/internal/managers/preflight/hostpreflight_test.go
@@ -215,14 +215,13 @@ func TestHostPreflightManager_PrepareHostPreflights(t *testing.T) {
 			manager := NewHostPreflightManager(
 				WithPreflightRunner(mockRunner),
 				WithHostPreflightStore(mockStore),
-				WithRuntimeConfig(rc),
 				WithLogger(logger.NewDiscardLogger()),
 				WithMetricsReporter(mockMetrics),
 				WithNetUtils(mockNetUtils),
 			)
 
 			// Execute
-			hpf, err := manager.PrepareHostPreflights(context.Background(), tt.opts)
+			hpf, err := manager.PrepareHostPreflights(context.Background(), rc, tt.opts)
 
 			// Assert
 			if tt.expectedError != "" {
@@ -457,13 +456,12 @@ func TestHostPreflightManager_RunHostPreflights(t *testing.T) {
 			manager := NewHostPreflightManager(
 				WithPreflightRunner(mockRunner),
 				WithHostPreflightStore(NewMemoryStore(tt.initialState)),
-				WithRuntimeConfig(rc),
 				WithLogger(logger.NewDiscardLogger()),
 				WithMetricsReporter(mockMetrics),
 			)
 
 			// Execute
-			err := manager.RunHostPreflights(context.Background(), tt.opts)
+			err := manager.RunHostPreflights(context.Background(), rc, tt.opts)
 			// If there's an error we don't need to wait for async execution
 			if tt.expectedError != "" {
 				require.Error(t, err)

--- a/api/internal/managers/preflight/manager_mock.go
+++ b/api/internal/managers/preflight/manager_mock.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/replicatedhq/embedded-cluster/api/types"
+	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"github.com/stretchr/testify/mock"
 )
@@ -16,8 +17,8 @@ type MockHostPreflightManager struct {
 }
 
 // PrepareHostPreflights mocks the PrepareHostPreflights method
-func (m *MockHostPreflightManager) PrepareHostPreflights(ctx context.Context, opts PrepareHostPreflightOptions) (*troubleshootv1beta2.HostPreflightSpec, error) {
-	args := m.Called(ctx, opts)
+func (m *MockHostPreflightManager) PrepareHostPreflights(ctx context.Context, rc runtimeconfig.RuntimeConfig, opts PrepareHostPreflightOptions) (*troubleshootv1beta2.HostPreflightSpec, error) {
+	args := m.Called(ctx, rc, opts)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
@@ -25,8 +26,8 @@ func (m *MockHostPreflightManager) PrepareHostPreflights(ctx context.Context, op
 }
 
 // RunHostPreflights mocks the RunHostPreflights method
-func (m *MockHostPreflightManager) RunHostPreflights(ctx context.Context, opts RunHostPreflightOptions) error {
-	args := m.Called(ctx, opts)
+func (m *MockHostPreflightManager) RunHostPreflights(ctx context.Context, rc runtimeconfig.RuntimeConfig, opts RunHostPreflightOptions) error {
+	args := m.Called(ctx, rc, opts)
 	return args.Error(0)
 }
 

--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -800,7 +800,7 @@ func installAndStartCluster(ctx context.Context, flags InstallCmdFlags, rc runti
 	}
 
 	logrus.Debugf("installing k0s")
-	if err := k0s.Install(rc, flags.networkInterface); err != nil {
+	if err := k0s.Install(rc); err != nil {
 		loading.ErrorClosef("Failed to install node")
 		return nil, fmt.Errorf("install cluster: %w", err)
 	}

--- a/pkg-new/k0s/k0s.go
+++ b/pkg-new/k0s/k0s.go
@@ -52,14 +52,14 @@ func (k *K0s) GetStatus(ctx context.Context) (*K0sStatus, error) {
 
 // Install runs the k0s install command and waits for it to finish. If no configuration
 // is found one is generated.
-func Install(rc runtimeconfig.RuntimeConfig, networkInterface string) error {
+func Install(rc runtimeconfig.RuntimeConfig) error {
 	ourbin := rc.PathToEmbeddedClusterBinary("k0s")
 	hstbin := runtimeconfig.K0sBinaryPath
 	if err := helpers.MoveFile(ourbin, hstbin); err != nil {
 		return fmt.Errorf("unable to move k0s binary: %w", err)
 	}
 
-	nodeIP, err := netutils.FirstValidAddress(networkInterface)
+	nodeIP, err := netutils.FirstValidAddress(rc.NetworkInterface())
 	if err != nil {
 		return fmt.Errorf("unable to find first valid address: %w", err)
 	}

--- a/pkg/dryrun/k0s.go
+++ b/pkg/dryrun/k0s.go
@@ -17,7 +17,7 @@ func (c *K0s) GetStatus(ctx context.Context) (*k0s.K0sStatus, error) {
 	return c.Status, nil
 }
 
-func (c *K0s) Install(rc runtimeconfig.RuntimeConfig, networkInterface string) error {
+func (c *K0s) Install(rc runtimeconfig.RuntimeConfig) error {
 	return nil // TODO: implement
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

We should no longer need to use the config. Everything is embedded in the runtime config. Pass the runtime config as an argument.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
