### PR TITLE
chore: Make `isRunning` atomic at the Manager level

### DIFF
--- a/api/internal/managers/installation/config.go
+++ b/api/internal/managers/installation/config.go
@@ -207,7 +207,7 @@ func (m *installationManager) ConfigureHost(ctx context.Context, rc runtimeconfi
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	running, err := m.isRunning()
+	running, err := m.IsInState(types.StateRunning)
 	if err != nil {
 		return fmt.Errorf("check if installation is running: %w", err)
 	}

--- a/api/internal/managers/installation/config_test.go
+++ b/api/internal/managers/installation/config_test.go
@@ -354,7 +354,7 @@ func TestConfigureHost(t *testing.T) {
 			}(),
 			setupMocks: func(hum *hostutils.MockHostUtils, im *installation.MockStore) {
 				mock.InOrder(
-					im.On("GetStatus").Return(types.Status{State: types.StatePending}, nil),
+					im.On("IsInState", types.StateRunning).Return(false),
 					im.On("SetStatus", mock.MatchedBy(func(status types.Status) bool { return status.State == types.StateRunning })).Return(nil),
 					hum.On("ConfigureHost", mock.Anything,
 						mock.MatchedBy(func(rc runtimeconfig.RuntimeConfig) bool {
@@ -380,7 +380,7 @@ func TestConfigureHost(t *testing.T) {
 				return rc
 			}(),
 			setupMocks: func(hum *hostutils.MockHostUtils, im *installation.MockStore) {
-				im.On("GetStatus").Return(types.Status{State: types.StateRunning}, nil)
+				im.On("IsInState", types.StateRunning).Return(true)
 			},
 			expectedErr: true,
 		},
@@ -394,7 +394,7 @@ func TestConfigureHost(t *testing.T) {
 			}(),
 			setupMocks: func(hum *hostutils.MockHostUtils, im *installation.MockStore) {
 				mock.InOrder(
-					im.On("GetStatus").Return(types.Status{State: types.StatePending}, nil),
+					im.On("IsInState", types.StateRunning).Return(false),
 					im.On("SetStatus", mock.MatchedBy(func(status types.Status) bool { return status.State == types.StateRunning })).Return(nil),
 					hum.On("ConfigureHost", mock.Anything,
 						mock.MatchedBy(func(rc runtimeconfig.RuntimeConfig) bool {
@@ -420,7 +420,7 @@ func TestConfigureHost(t *testing.T) {
 			}(),
 			setupMocks: func(hum *hostutils.MockHostUtils, im *installation.MockStore) {
 				mock.InOrder(
-					im.On("GetStatus").Return(types.Status{State: types.StatePending}, nil),
+					im.On("IsInState", types.StateRunning).Return(false),
 					im.On("SetStatus", mock.Anything).Return(errors.New("failed to set status")),
 				)
 			},

--- a/api/internal/managers/installation/manager.go
+++ b/api/internal/managers/installation/manager.go
@@ -21,6 +21,7 @@ type InstallationManager interface {
 	SetConfig(config types.InstallationConfig) error
 	GetStatus() (types.Status, error)
 	SetStatus(status types.Status) error
+	IsInState(state types.State) (bool, error)
 	ValidateConfig(config types.InstallationConfig, managerPort int) error
 	SetConfigDefaults(config *types.InstallationConfig) error
 	ConfigureHost(ctx context.Context, rc runtimeconfig.RuntimeConfig) error

--- a/api/internal/managers/installation/manager_mock.go
+++ b/api/internal/managers/installation/manager_mock.go
@@ -62,3 +62,9 @@ func (m *MockInstallationManager) ConfigureHost(ctx context.Context, rc runtimec
 	args := m.Called(ctx, rc)
 	return args.Error(0)
 }
+
+// IsInState mocks the IsInState method
+func (m *MockInstallationManager) IsInState(state types.State) (bool, error) {
+	args := m.Called(state)
+	return args.Bool(0), args.Error(1)
+}

--- a/api/internal/managers/installation/status.go
+++ b/api/internal/managers/installation/status.go
@@ -14,12 +14,12 @@ func (m *installationManager) SetStatus(status types.Status) error {
 	return m.installationStore.SetStatus(status)
 }
 
-func (m *installationManager) isRunning() (bool, error) {
+func (m *installationManager) IsInState(state types.State) (bool, error) {
 	status, err := m.GetStatus()
 	if err != nil {
 		return false, err
 	}
-	return status.State == types.StateRunning, nil
+	return status.State == state, nil
 }
 
 func (m *installationManager) setRunningStatus(description string) error {

--- a/api/internal/managers/installation/status.go
+++ b/api/internal/managers/installation/status.go
@@ -15,11 +15,7 @@ func (m *installationManager) SetStatus(status types.Status) error {
 }
 
 func (m *installationManager) IsInState(state types.State) (bool, error) {
-	status, err := m.GetStatus()
-	if err != nil {
-		return false, err
-	}
-	return status.State == state, nil
+	return m.installationStore.IsInState(state), nil
 }
 
 func (m *installationManager) setRunningStatus(description string) error {

--- a/api/internal/managers/preflight/hostpreflight.go
+++ b/api/internal/managers/preflight/hostpreflight.go
@@ -41,7 +41,7 @@ func (m *hostPreflightManager) RunHostPreflights(ctx context.Context, rc runtime
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if m.hostPreflightStore.IsRunning() {
+	if m.hostPreflightStore.IsInState(types.StateRunning) {
 		return types.NewConflictError(fmt.Errorf("host preflights are already running"))
 	}
 

--- a/api/internal/store/installation/store.go
+++ b/api/internal/store/installation/store.go
@@ -14,6 +14,7 @@ type Store interface {
 	SetConfig(cfg types.InstallationConfig) error
 	GetStatus() (types.Status, error)
 	SetStatus(status types.Status) error
+	IsInState(state types.State) bool
 }
 
 type memoryStore struct {
@@ -77,4 +78,11 @@ func (s *memoryStore) SetStatus(status types.Status) error {
 	s.installation.Status = status
 
 	return nil
+}
+
+func (s *memoryStore) IsInState(state types.State) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.installation.Status.State == state
 }

--- a/api/internal/store/installation/store_mock.go
+++ b/api/internal/store/installation/store_mock.go
@@ -41,3 +41,9 @@ func (m *MockStore) SetStatus(status types.Status) error {
 	args := m.Called(status)
 	return args.Error(0)
 }
+
+// IsInState mocks the IsInState method
+func (m *MockStore) IsInState(state types.State) bool {
+	args := m.Called(state)
+	return args.Bool(0)
+}

--- a/api/internal/store/preflight/store.go
+++ b/api/internal/store/preflight/store.go
@@ -16,7 +16,7 @@ type Store interface {
 	SetOutput(output *types.HostPreflightsOutput) error
 	GetStatus() (types.Status, error)
 	SetStatus(status types.Status) error
-	IsRunning() bool
+	IsInState(state types.State) bool
 }
 
 type memoryStore struct {
@@ -106,9 +106,9 @@ func (s *memoryStore) SetStatus(status types.Status) error {
 	return nil
 }
 
-func (s *memoryStore) IsRunning() bool {
+func (s *memoryStore) IsInState(state types.State) bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	return s.hostPreflight.Status.State == types.StateRunning
+	return s.hostPreflight.Status.State == state
 }

--- a/api/internal/store/preflight/store_mock.go
+++ b/api/internal/store/preflight/store_mock.go
@@ -57,8 +57,8 @@ func (m *MockStore) SetStatus(status types.Status) error {
 	return args.Error(0)
 }
 
-// IsRunning mocks the IsRunning method
-func (m *MockStore) IsRunning() bool {
-	args := m.Called()
+// IsInState mocks the IsInState method
+func (m *MockStore) IsInState(state types.State) bool {
+	args := m.Called(state)
 	return args.Bool(0)
 }

--- a/api/internal/store/preflight/store_test.go
+++ b/api/internal/store/preflight/store_test.go
@@ -160,7 +160,7 @@ func TestMemoryStore_SetStatus(t *testing.T) {
 	assert.Equal(t, expectedStatus, actualStatus)
 }
 
-func TestMemoryStore_IsRunning(t *testing.T) {
+func TestMemoryStore_IsInState(t *testing.T) {
 	tests := []struct {
 		name         string
 		status       types.Status
@@ -207,7 +207,7 @@ func TestMemoryStore_IsRunning(t *testing.T) {
 			}
 			store := NewMemoryStore(WithHostPreflight(hostPreflight))
 
-			result := store.IsRunning()
+			result := store.IsInState(types.StateRunning)
 
 			assert.Equal(t, tt.expectedBool, result)
 		})
@@ -226,11 +226,11 @@ func TestMemoryStore_ConcurrentAccess(t *testing.T) {
 
 	// Concurrent titles operations
 	wg.Add(numGoroutines * 2)
-	for i := 0; i < numGoroutines; i++ {
+	for i := range numGoroutines {
 		// Concurrent writes
 		go func(id int) {
 			defer wg.Done()
-			for j := 0; j < numOperations; j++ {
+			for range numOperations {
 				titles := []string{"Memory Check", "Disk Check", "Network Check"}
 				err := store.SetTitles(titles)
 				assert.NoError(t, err)
@@ -240,7 +240,7 @@ func TestMemoryStore_ConcurrentAccess(t *testing.T) {
 		// Concurrent reads
 		go func(id int) {
 			defer wg.Done()
-			for j := 0; j < numOperations; j++ {
+			for range numOperations {
 				_, err := store.GetTitles()
 				assert.NoError(t, err)
 			}
@@ -249,11 +249,11 @@ func TestMemoryStore_ConcurrentAccess(t *testing.T) {
 
 	// Concurrent output operations
 	wg.Add(numGoroutines * 2)
-	for i := 0; i < numGoroutines; i++ {
+	for i := range numGoroutines {
 		// Concurrent writes
 		go func(id int) {
 			defer wg.Done()
-			for j := 0; j < numOperations; j++ {
+			for range numOperations {
 				output := &types.HostPreflightsOutput{}
 				err := store.SetOutput(output)
 				assert.NoError(t, err)
@@ -263,7 +263,7 @@ func TestMemoryStore_ConcurrentAccess(t *testing.T) {
 		// Concurrent reads
 		go func(id int) {
 			defer wg.Done()
-			for j := 0; j < numOperations; j++ {
+			for range numOperations {
 				_, err := store.GetOutput()
 				assert.NoError(t, err)
 			}
@@ -272,11 +272,11 @@ func TestMemoryStore_ConcurrentAccess(t *testing.T) {
 
 	// Concurrent status operations
 	wg.Add(numGoroutines * 3)
-	for i := 0; i < numGoroutines; i++ {
+	for i := range numGoroutines {
 		// Concurrent writes
 		go func(id int) {
 			defer wg.Done()
-			for j := 0; j < numOperations; j++ {
+			for range numOperations {
 				status := types.Status{
 					State:       types.StateRunning,
 					Description: "Running",
@@ -290,17 +290,17 @@ func TestMemoryStore_ConcurrentAccess(t *testing.T) {
 		// Concurrent reads
 		go func(id int) {
 			defer wg.Done()
-			for j := 0; j < numOperations; j++ {
+			for range numOperations {
 				_, err := store.GetStatus()
 				assert.NoError(t, err)
 			}
 		}(i)
 
-		// Concurrent IsRunning calls
+		// Concurrent IsInState calls
 		go func(id int) {
 			defer wg.Done()
-			for j := 0; j < numOperations; j++ {
-				store.IsRunning()
+			for range numOperations {
+				store.IsInState(types.StateRunning)
 			}
 		}(i)
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
-->
Renames the isRunning function to isState, makes it atomic, and relocates it from the Store level to the Manager level.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/124680/make-isrunning-atomic-at-the-manager-level

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Existing tests were updated.

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE