### PR TITLE
feat(reporting): add metrics reporting to the new manager experience

### DIFF
--- a/api/controllers/linux/install/controller.go
+++ b/api/controllers/linux/install/controller.go
@@ -170,14 +170,17 @@ func WithStateMachine(stateMachine statemachine.Interface) InstallControllerOpti
 
 func NewInstallController(opts ...InstallControllerOption) (*InstallController, error) {
 	controller := &InstallController{
-		store:        store.NewMemoryStore(),
-		rc:           runtimeconfig.New(nil),
-		logger:       logger.NewDiscardLogger(),
-		stateMachine: NewStateMachine(),
+		store:  store.NewMemoryStore(),
+		rc:     runtimeconfig.New(nil),
+		logger: logger.NewDiscardLogger(),
 	}
 
 	for _, opt := range opts {
 		opt(controller)
+	}
+
+	if controller.stateMachine == nil {
+		controller.stateMachine = NewStateMachine(WithStateMachineLogger(controller.logger))
 	}
 
 	if controller.hostUtils == nil {

--- a/api/controllers/linux/install/controller.go
+++ b/api/controllers/linux/install/controller.go
@@ -168,6 +168,12 @@ func WithStateMachine(stateMachine statemachine.Interface) InstallControllerOpti
 	}
 }
 
+func WithStore(store store.Store) InstallControllerOption {
+	return func(c *InstallController) {
+		c.store = store
+	}
+}
+
 func NewInstallController(opts ...InstallControllerOption) (*InstallController, error) {
 	controller := &InstallController{
 		store:  store.NewMemoryStore(),
@@ -225,6 +231,8 @@ func NewInstallController(opts ...InstallControllerOption) (*InstallController, 
 			infra.WithEndUserConfig(controller.endUserConfig),
 		)
 	}
+
+	controller.registerReportingHandlers()
 
 	return controller, nil
 }

--- a/api/controllers/linux/install/controller.go
+++ b/api/controllers/linux/install/controller.go
@@ -207,7 +207,6 @@ func NewInstallController(opts ...InstallControllerOption) (*InstallController, 
 	if controller.hostPreflightManager == nil {
 		controller.hostPreflightManager = preflight.NewHostPreflightManager(
 			preflight.WithLogger(controller.logger),
-			preflight.WithMetricsReporter(controller.metricsReporter),
 			preflight.WithHostPreflightStore(controller.store.PreflightStore()),
 			preflight.WithNetUtils(controller.netUtils),
 		)

--- a/api/controllers/linux/install/controller_test.go
+++ b/api/controllers/linux/install/controller_test.go
@@ -398,10 +398,6 @@ func TestConfigureInstallation(t *testing.T) {
 			err = controller.ConfigureInstallation(t.Context(), tt.config)
 			if tt.expectedErr {
 				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-
-				assert.NotEqual(t, tt.currentState, sm.CurrentState(), "state should have changed and should not be %s", tt.currentState)
 			}
 
 			assert.Eventually(t, func() bool {

--- a/api/controllers/linux/install/hostpreflight.go
+++ b/api/controllers/linux/install/hostpreflight.go
@@ -6,6 +6,7 @@ import (
 	"runtime/debug"
 
 	"github.com/replicatedhq/embedded-cluster/api/internal/managers/preflight"
+	"github.com/replicatedhq/embedded-cluster/api/internal/statemachine"
 	"github.com/replicatedhq/embedded-cluster/api/internal/utils"
 	"github.com/replicatedhq/embedded-cluster/api/types"
 	"github.com/replicatedhq/embedded-cluster/pkg/netutils"
@@ -61,16 +62,21 @@ func (c *InstallController) RunHostPreflights(ctx context.Context, opts RunHostP
 			if r := recover(); r != nil {
 				finalErr = fmt.Errorf("panic running host preflights: %v: %s", r, string(debug.Stack()))
 			}
+			// Handle errors from preflight execution
 			if finalErr != nil {
 				c.logger.Error(finalErr)
 
-				if err := c.stateMachine.Transition(lock, StatePreflightsFailed); err != nil {
+				if err := c.stateMachine.Transition(lock, StatePreflightsExecutionFailed); err != nil {
 					c.logger.Errorf("failed to transition states: %w", err)
 				}
-			} else {
-				if err := c.stateMachine.Transition(lock, StatePreflightsSucceeded); err != nil {
-					c.logger.Errorf("failed to transition states: %w", err)
-				}
+				return
+			}
+
+			// Get the state from the preflights output
+			state := c.getStateFromPreflightsOutput(ctx)
+			// Transition to the appropriate state based on preflight results
+			if err := c.stateMachine.Transition(lock, state); err != nil {
+				c.logger.Errorf("failed to transition states: %w", err)
 			}
 		}()
 
@@ -85,6 +91,19 @@ func (c *InstallController) RunHostPreflights(ctx context.Context, opts RunHostP
 	}()
 
 	return nil
+}
+
+func (c *InstallController) getStateFromPreflightsOutput(ctx context.Context) statemachine.State {
+	output, err := c.GetHostPreflightOutput(ctx)
+	// If there was an error getting the state or if there's no output, we assume preflight execution failed
+	if err != nil || output == nil {
+		c.logger.WithError(err).Error("failed generate state based on prelights output, got error or niloutput")
+		return StatePreflightsExecutionFailed
+	}
+	if output.HasFail() {
+		return StatePreflightsFailed
+	}
+	return StatePreflightsSucceeded
 }
 
 func (c *InstallController) GetHostPreflightStatus(ctx context.Context) (types.Status, error) {

--- a/api/controllers/linux/install/hostpreflight.go
+++ b/api/controllers/linux/install/hostpreflight.go
@@ -95,15 +95,16 @@ func (c *InstallController) RunHostPreflights(ctx context.Context, opts RunHostP
 
 func (c *InstallController) getStateFromPreflightsOutput(ctx context.Context) statemachine.State {
 	output, err := c.GetHostPreflightOutput(ctx)
-	// If there was an error getting the state or if there's no output, we assume preflight execution failed
-	if err != nil || output == nil {
-		c.logger.WithError(err).Error("failed generate state based on prelights output, got error or niloutput")
+	// If there was an error getting the state we assume preflight execution failed
+	if err != nil {
+		c.logger.WithError(err).Error("error getting preflight output")
 		return StatePreflightsExecutionFailed
 	}
-	if output.HasFail() {
-		return StatePreflightsFailed
+	// If there is no output, we assume preflights succeeded
+	if output == nil || !output.HasFail() {
+		return StatePreflightsSucceeded
 	}
-	return StatePreflightsSucceeded
+	return StatePreflightsFailed
 }
 
 func (c *InstallController) GetHostPreflightStatus(ctx context.Context) (types.Status, error) {

--- a/api/controllers/linux/install/infra.go
+++ b/api/controllers/linux/install/infra.go
@@ -10,18 +10,10 @@ import (
 )
 
 var (
-	ErrPreflightChecksFailed      = errors.New("preflight checks failed")
-	ErrPreflightChecksNotComplete = errors.New("preflight checks not complete")
+	ErrPreflightChecksFailed = errors.New("preflight checks failed")
 )
 
 func (c *InstallController) SetupInfra(ctx context.Context, ignoreHostPreflights bool) (finalErr error) {
-	if c.stateMachine.CurrentState() == StatePreflightsFailed {
-		err := c.bypassPreflights(ctx, ignoreHostPreflights)
-		if err != nil {
-			return fmt.Errorf("bypass preflights: %w", err)
-		}
-	}
-
 	lock, err := c.stateMachine.AcquireLock()
 	if err != nil {
 		return types.NewConflictError(err)
@@ -35,6 +27,17 @@ func (c *InstallController) SetupInfra(ctx context.Context, ignoreHostPreflights
 			lock.Release()
 		}
 	}()
+
+	// Check if preflights have failed and if we should ignore them
+	if c.stateMachine.CurrentState() == StatePreflightsFailed {
+		if !ignoreHostPreflights || !c.allowIgnoreHostPreflights {
+			return types.NewBadRequestError(ErrPreflightChecksFailed)
+		}
+		err = c.stateMachine.Transition(lock, StatePreflightsFailedBypassed)
+		if err != nil {
+			return fmt.Errorf("failed to transition states: %w", err)
+		}
+	}
 
 	err = c.stateMachine.Transition(lock, StateInfrastructureInstalling)
 	if err != nil {
@@ -70,41 +73,6 @@ func (c *InstallController) SetupInfra(ctx context.Context, ignoreHostPreflights
 
 		return nil
 	}()
-
-	return nil
-}
-
-func (c *InstallController) bypassPreflights(ctx context.Context, ignoreHostPreflights bool) error {
-	if !ignoreHostPreflights || !c.allowIgnoreHostPreflights {
-		return types.NewBadRequestError(ErrPreflightChecksFailed)
-	}
-
-	lock, err := c.stateMachine.AcquireLock()
-	if err != nil {
-		return types.NewConflictError(err)
-	}
-	defer lock.Release()
-
-	if err := c.stateMachine.ValidateTransition(lock, StatePreflightsFailedBypassed); err != nil {
-		return types.NewConflictError(err)
-	}
-
-	// TODO (@ethan): we have already sent the preflight output when we sent the failed event.
-	// We should evaluate if we should send it again.
-	preflightOutput, err := c.GetHostPreflightOutput(ctx)
-	if err != nil {
-		return fmt.Errorf("get install host preflight output: %w", err)
-	}
-
-	// Report that preflights were bypassed
-	if preflightOutput != nil {
-		c.metricsReporter.ReportPreflightsBypassed(ctx, preflightOutput)
-	}
-
-	err = c.stateMachine.Transition(lock, StatePreflightsFailedBypassed)
-	if err != nil {
-		return types.NewConflictError(err)
-	}
 
 	return nil
 }

--- a/api/controllers/linux/install/infra.go
+++ b/api/controllers/linux/install/infra.go
@@ -54,7 +54,7 @@ func (c *InstallController) SetupInfra(ctx context.Context, ignoreHostPreflights
 			if finalErr != nil {
 				c.logger.Error(finalErr)
 
-				if err := c.stateMachine.Transition(lock, StateFailed); err != nil {
+				if err := c.stateMachine.Transition(lock, StateInfrastructureInstallFailed); err != nil {
 					c.logger.Errorf("failed to transition states: %w", err)
 				}
 			} else {

--- a/api/controllers/linux/install/installation.go
+++ b/api/controllers/linux/install/installation.go
@@ -81,11 +81,15 @@ func (c *InstallController) configureInstallation(ctx context.Context, config ty
 				c.logger.Errorf("failed to transition states: %w", err)
 			}
 
-			c.store.InstallationStore().SetStatus(types.Status{
+			failureStatus := types.Status{
 				State:       types.StateFailed,
 				Description: finalErr.Error(),
 				LastUpdated: time.Now(),
-			})
+			}
+
+			if err = c.store.InstallationStore().SetStatus(failureStatus); err != nil {
+				c.logger.Errorf("failed to update status: %w", err)
+			}
 		}
 	}()
 

--- a/api/controllers/linux/install/installation.go
+++ b/api/controllers/linux/install/installation.go
@@ -77,10 +77,6 @@ func (c *InstallController) configureInstallation(ctx context.Context, config ty
 
 	defer func() {
 		if finalErr != nil {
-			if err := c.stateMachine.Transition(lock, StateInstallationConfigurationFailed); err != nil {
-				c.logger.Errorf("failed to transition states: %w", err)
-			}
-
 			failureStatus := types.Status{
 				State:       types.StateFailed,
 				Description: finalErr.Error(),
@@ -89,6 +85,10 @@ func (c *InstallController) configureInstallation(ctx context.Context, config ty
 
 			if err = c.store.InstallationStore().SetStatus(failureStatus); err != nil {
 				c.logger.Errorf("failed to update status: %w", err)
+			}
+
+			if err := c.stateMachine.Transition(lock, StateInstallationConfigurationFailed); err != nil {
+				c.logger.Errorf("failed to transition states: %w", err)
 			}
 		}
 	}()

--- a/api/controllers/linux/install/reporting_handlers.go
+++ b/api/controllers/linux/install/reporting_handlers.go
@@ -1,0 +1,33 @@
+package install
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/replicatedhq/embedded-cluster/api/internal/statemachine"
+)
+
+func (c *InstallController) RegisterReportingHandlers() {
+	c.stateMachine.RegisterEventHandler(StateSucceeded, c.reportInstallSucceeded)
+	c.stateMachine.RegisterEventHandler(StateFailed, c.reportInstallFailed)
+	c.stateMachine.RegisterEventHandler(StatePreflightsFailed, c.reportPreflightsFailed)
+	c.stateMachine.RegisterEventHandler(StatePreflightsFailedBypassed, c.reportPreflightsBypassed)
+}
+
+func (c *InstallController) reportInstallSucceeded(ctx context.Context, _, _ statemachine.State) {
+	c.metricsReporter.ReportInstallationSucceeded(ctx)
+}
+
+func (c *InstallController) reportInstallFailed(ctx context.Context, from, _ statemachine.State) {
+	if from == StateInfrastructureInstalling {
+		c.metricsReporter.ReportInstallationFailed(ctx, fmt.Errorf(c.install.Steps.Infra.Status.Description))
+	}
+}
+
+func (c *InstallController) reportPreflightsFailed(ctx context.Context, _, _ statemachine.State) {
+	c.metricsReporter.ReportPreflightsFailed(ctx, c.install.Steps.HostPreflight.Output)
+}
+
+func (c *InstallController) reportPreflightsBypassed(ctx context.Context, _, _ statemachine.State) {
+	c.metricsReporter.ReportPreflightsFailed(ctx, c.install.Steps.HostPreflight.Output)
+}

--- a/api/controllers/linux/install/reporting_handlers.go
+++ b/api/controllers/linux/install/reporting_handlers.go
@@ -9,7 +9,7 @@ import (
 	"github.com/replicatedhq/embedded-cluster/api/types"
 )
 
-func (c *InstallController) RegisterReportingHandlers() {
+func (c *InstallController) registerReportingHandlers() {
 	c.stateMachine.RegisterEventHandler(StateSucceeded, c.reportInstallSucceeded)
 	c.stateMachine.RegisterEventHandler(StateInfrastructureInstallFailed, c.reportInstallFailed)
 	c.stateMachine.RegisterEventHandler(StateHostConfigurationFailed, c.reportInstallFailed)
@@ -54,6 +54,7 @@ func (c *InstallController) reportPreflightsFailed(ctx context.Context, _, _ sta
 	output, err := c.store.PreflightStore().GetOutput()
 	if err != nil {
 		c.logger.WithError(fmt.Errorf("failed to get output from preflight store: %w", err)).Error("failed to report preflights failed")
+		return
 	}
 	c.metricsReporter.ReportPreflightsFailed(ctx, output)
 }
@@ -62,6 +63,7 @@ func (c *InstallController) reportPreflightsBypassed(ctx context.Context, _, _ s
 	output, err := c.store.PreflightStore().GetOutput()
 	if err != nil {
 		c.logger.WithError(fmt.Errorf("failed to get output from preflight store: %w", err)).Error("failed to report preflights bypassed")
+		return
 	}
 	c.metricsReporter.ReportPreflightsBypassed(ctx, output)
 }

--- a/api/controllers/linux/install/statemachine.go
+++ b/api/controllers/linux/install/statemachine.go
@@ -8,8 +8,12 @@ import (
 const (
 	// StateNew is the initial state of the install process
 	StateNew statemachine.State = "New"
+	// StateInstallationConfigurationFailed is the state of the install process when the installation failed to be configured
+	StateInstallationConfigurationFailed statemachine.State = "InstallationConfigurationFailed"
 	// StateInstallationConfigured is the state of the install process when the installation is configured
 	StateInstallationConfigured statemachine.State = "InstallationConfigured"
+	// StateHostConfigurationFailed is the state of the install process when the installation failed to be configured
+	StateHostConfigurationFailed statemachine.State = "HostConfigurationFailed"
 	// StateHostConfigured is the state of the install process when the host is configured
 	StateHostConfigured statemachine.State = "HostConfigured"
 	// StatePreflightsRunning is the state of the install process when the preflights are running
@@ -22,23 +26,25 @@ const (
 	StatePreflightsFailedBypassed statemachine.State = "PreflightsFailedBypassed"
 	// StateInfrastructureInstalling is the state of the install process when the infrastructure is being installed
 	StateInfrastructureInstalling statemachine.State = "InfrastructureInstalling"
+	// StateInfrastructureInstallFailed is a final state of the install process when the infrastructure failed to isntall
+	StateInfrastructureInstallFailed statemachine.State = "InfrastructureInstallFailed"
 	// StateSucceeded is the final state of the install process when the install has succeeded
 	StateSucceeded statemachine.State = "Succeeded"
-	// StateFailed is the final state of the install process when the install has failed
-	StateFailed statemachine.State = "Failed"
 )
 
 var validStateTransitions = map[statemachine.State][]statemachine.State{
-	StateNew:                      {StateInstallationConfigured},
-	StateInstallationConfigured:   {StateHostConfigured, StateInstallationConfigured},
-	StateHostConfigured:           {StatePreflightsRunning, StateInstallationConfigured},
-	StatePreflightsRunning:        {StatePreflightsSucceeded, StatePreflightsFailed},
-	StatePreflightsSucceeded:      {StateInfrastructureInstalling, StatePreflightsRunning, StateInstallationConfigured},
-	StatePreflightsFailed:         {StatePreflightsFailedBypassed, StatePreflightsRunning, StateInstallationConfigured},
-	StatePreflightsFailedBypassed: {StateInfrastructureInstalling, StatePreflightsRunning, StateInstallationConfigured},
-	StateInfrastructureInstalling: {StateSucceeded, StateFailed},
-	StateSucceeded:                {},
-	StateFailed:                   {},
+	StateNew:                             {StateInstallationConfigured, StateInstallationConfigurationFailed},
+	StateInstallationConfigurationFailed: {StateInstallationConfigured, StateInstallationConfigurationFailed},
+	StateInstallationConfigured:          {StateHostConfigured, StateHostConfigurationFailed},
+	StateHostConfigurationFailed:         {StateInstallationConfigured, StateInstallationConfigurationFailed},
+	StateHostConfigured:                  {StatePreflightsRunning, StateInstallationConfigured, StateInstallationConfigurationFailed},
+	StatePreflightsRunning:               {StatePreflightsSucceeded, StatePreflightsFailed},
+	StatePreflightsSucceeded:             {StateInfrastructureInstalling, StatePreflightsRunning, StateInstallationConfigured, StateInstallationConfigurationFailed},
+	StatePreflightsFailed:                {StatePreflightsFailedBypassed, StatePreflightsRunning, StateInstallationConfigured, StateInstallationConfigurationFailed},
+	StatePreflightsFailedBypassed:        {StateInfrastructureInstalling, StatePreflightsRunning, StateInstallationConfigured, StateInstallationConfigurationFailed},
+	StateInfrastructureInstalling:        {StateSucceeded, StateInfrastructureInstallFailed},
+	StateInfrastructureInstallFailed:     {},
+	StateSucceeded:                       {},
 }
 
 type StateMachineOptions struct {

--- a/api/controllers/linux/install/statemachine.go
+++ b/api/controllers/linux/install/statemachine.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"github.com/replicatedhq/embedded-cluster/api/internal/statemachine"
+	"github.com/replicatedhq/embedded-cluster/api/pkg/logger"
 	"github.com/sirupsen/logrus"
 )
 
@@ -73,6 +74,7 @@ func WithStateMachineLogger(logger logrus.FieldLogger) StateMachineOption {
 func NewStateMachine(opts ...StateMachineOption) statemachine.Interface {
 	options := &StateMachineOptions{
 		CurrentState: StateNew,
+		Logger: logger.NewDiscardLogger(),
 	}
 	for _, opt := range opts {
 		opt(options)

--- a/api/controllers/linux/install/statemachine.go
+++ b/api/controllers/linux/install/statemachine.go
@@ -1,6 +1,9 @@
 package install
 
-import "github.com/replicatedhq/embedded-cluster/api/internal/statemachine"
+import (
+	"github.com/replicatedhq/embedded-cluster/api/internal/statemachine"
+	"github.com/sirupsen/logrus"
+)
 
 const (
 	// StateNew is the initial state of the install process
@@ -40,6 +43,7 @@ var validStateTransitions = map[statemachine.State][]statemachine.State{
 
 type StateMachineOptions struct {
 	CurrentState statemachine.State
+	Logger       logrus.FieldLogger
 }
 
 type StateMachineOption func(*StateMachineOptions)
@@ -47,6 +51,12 @@ type StateMachineOption func(*StateMachineOptions)
 func WithCurrentState(currentState statemachine.State) StateMachineOption {
 	return func(o *StateMachineOptions) {
 		o.CurrentState = currentState
+	}
+}
+
+func WithStateMachineLogger(logger logrus.FieldLogger) StateMachineOption {
+	return func(o *StateMachineOptions) {
+		o.Logger = logger
 	}
 }
 
@@ -58,5 +68,5 @@ func NewStateMachine(opts ...StateMachineOption) statemachine.Interface {
 	for _, opt := range opts {
 		opt(options)
 	}
-	return statemachine.New(options.CurrentState, validStateTransitions)
+	return statemachine.New(options.CurrentState, validStateTransitions, statemachine.WithLogger(options.Logger))
 }

--- a/api/controllers/linux/install/statemachine.go
+++ b/api/controllers/linux/install/statemachine.go
@@ -74,7 +74,7 @@ func WithStateMachineLogger(logger logrus.FieldLogger) StateMachineOption {
 func NewStateMachine(opts ...StateMachineOption) statemachine.Interface {
 	options := &StateMachineOptions{
 		CurrentState: StateNew,
-		Logger: logger.NewDiscardLogger(),
+		Logger:       logger.NewDiscardLogger(),
 	}
 	for _, opt := range opts {
 		opt(options)

--- a/api/controllers/linux/install/statemachine.go
+++ b/api/controllers/linux/install/statemachine.go
@@ -18,11 +18,13 @@ const (
 	StateHostConfigured statemachine.State = "HostConfigured"
 	// StatePreflightsRunning is the state of the install process when the preflights are running
 	StatePreflightsRunning statemachine.State = "PreflightsRunning"
+	// StatePreflightsExecutionFailed is the state of the install process when the preflights failed to execute due to an underlying system error
+	StatePreflightsExecutionFailed statemachine.State = "PreflightsExecutionFailed"
 	// StatePreflightsSucceeded is the state of the install process when the preflights have succeeded
 	StatePreflightsSucceeded statemachine.State = "PreflightsSucceeded"
-	// StatePreflightsFailed is the state of the install process when the preflights have failed
+	// StatePreflightsFailed is the state of the install process when the preflights execution succeeded but the preflights detected issues on the host
 	StatePreflightsFailed statemachine.State = "PreflightsFailed"
-	// StatePreflightsFailedBypassed is the state of the install process when the preflights have failed bypassed
+	// StatePreflightsFailedBypassed is the state of the install process when, despite preflights failing, the user has chosen to bypass the preflights and continue with the installation
 	StatePreflightsFailedBypassed statemachine.State = "PreflightsFailedBypassed"
 	// StateInfrastructureInstalling is the state of the install process when the infrastructure is being installed
 	StateInfrastructureInstalling statemachine.State = "InfrastructureInstalling"
@@ -38,7 +40,8 @@ var validStateTransitions = map[statemachine.State][]statemachine.State{
 	StateInstallationConfigured:          {StateHostConfigured, StateHostConfigurationFailed},
 	StateHostConfigurationFailed:         {StateInstallationConfigured, StateInstallationConfigurationFailed},
 	StateHostConfigured:                  {StatePreflightsRunning, StateInstallationConfigured, StateInstallationConfigurationFailed},
-	StatePreflightsRunning:               {StatePreflightsSucceeded, StatePreflightsFailed},
+	StatePreflightsRunning:               {StatePreflightsSucceeded, StatePreflightsFailed, StatePreflightsExecutionFailed},
+	StatePreflightsExecutionFailed:       {StatePreflightsRunning, StateInstallationConfigured, StateInstallationConfigurationFailed},
 	StatePreflightsSucceeded:             {StateInfrastructureInstalling, StatePreflightsRunning, StateInstallationConfigured, StateInstallationConfigurationFailed},
 	StatePreflightsFailed:                {StatePreflightsFailedBypassed, StatePreflightsRunning, StateInstallationConfigured, StateInstallationConfigurationFailed},
 	StatePreflightsFailedBypassed:        {StateInfrastructureInstalling, StatePreflightsRunning, StateInstallationConfigured, StateInstallationConfigurationFailed},

--- a/api/controllers/linux/install/statemachine_test.go
+++ b/api/controllers/linux/install/statemachine_test.go
@@ -56,11 +56,21 @@ func TestStateMachineTransitions(t *testing.T) {
 			},
 		},
 		{
-			name:       `State "PreflightsRunning" can transition to "PreflightsSucceeded" or "PreflightsFailed"`,
+			name:       `State "PreflightsRunning" can transition to "PreflightsSucceeded", "PreflightsFailed", or "PreflightsExecutionFailed"`,
 			startState: StatePreflightsRunning,
 			validTransitions: []statemachine.State{
 				StatePreflightsSucceeded,
 				StatePreflightsFailed,
+				StatePreflightsExecutionFailed,
+			},
+		},
+		{
+			name:       `State "PreflightsExecutionFailed" can transition to "PreflightsRunning", "InstallationConfigured", or "InstallationConfigurationFailed"`,
+			startState: StatePreflightsExecutionFailed,
+			validTransitions: []statemachine.State{
+				StatePreflightsRunning,
+				StateInstallationConfigured,
+				StateInstallationConfigurationFailed,
 			},
 		},
 		{

--- a/api/controllers/linux/install/statemachine_test.go
+++ b/api/controllers/linux/install/statemachine_test.go
@@ -15,26 +15,44 @@ func TestStateMachineTransitions(t *testing.T) {
 		validTransitions []statemachine.State
 	}{
 		{
-			name:       `State "New" can transition to "InstallationConfigured"`,
+			name:       `State "New" can transition to "InstallationConfigured" or "InstallationConfigurationFailed"`,
 			startState: StateNew,
 			validTransitions: []statemachine.State{
 				StateInstallationConfigured,
+				StateInstallationConfigurationFailed,
 			},
 		},
 		{
-			name:       `State "InstallationConfigured" can transition to "HostConfigured" or "InstallationConfigured"`,
+			name:       `State "InstallationConfigurationFailed" can transition to "InstallationConfigured" or "InstallationConfigurationFailed"`,
+			startState: StateInstallationConfigurationFailed,
+			validTransitions: []statemachine.State{
+				StateInstallationConfigured,
+				StateInstallationConfigurationFailed,
+			},
+		},
+		{
+			name:       `State "InstallationConfigured" can transition to "HostConfigured" or "HostConfigurationFailed"`,
 			startState: StateInstallationConfigured,
 			validTransitions: []statemachine.State{
 				StateHostConfigured,
-				StateInstallationConfigured,
+				StateHostConfigurationFailed,
 			},
 		},
 		{
-			name:       `State "HostConfigured" can transition to "PreflightsRunning" or "InstallationConfigured"`,
+			name:       `State "HostConfigurationFailed" can transition to "InstallationConfigured" or "InstallationConfigurationFailed"`,
+			startState: StateHostConfigurationFailed,
+			validTransitions: []statemachine.State{
+				StateInstallationConfigured,
+				StateInstallationConfigurationFailed,
+			},
+		},
+		{
+			name:       `State "HostConfigured" can transition to "PreflightsRunning" or "InstallationConfigured" or "InstallationConfigurationFailed"`,
 			startState: StateHostConfigured,
 			validTransitions: []statemachine.State{
 				StatePreflightsRunning,
 				StateInstallationConfigured,
+				StateInstallationConfigurationFailed,
 			},
 		},
 		{
@@ -46,48 +64,51 @@ func TestStateMachineTransitions(t *testing.T) {
 			},
 		},
 		{
-			name:       `State "PreflightsSucceeded" can transition to "InfrastructureInstalling", "PreflightsRunning" or "InstallationConfigured"`,
+			name:       `State "PreflightsSucceeded" can transition to "InfrastructureInstalling", "PreflightsRunning", "InstallationConfigured", or "InstallationConfigurationFailed"`,
 			startState: StatePreflightsSucceeded,
 			validTransitions: []statemachine.State{
 				StateInfrastructureInstalling,
 				StatePreflightsRunning,
 				StateInstallationConfigured,
+				StateInstallationConfigurationFailed,
 			},
 		},
 		{
-			name:       `State "PreflightsFailed" can transition to "PreflightsFailedBypassed" , "PreflightsRunning" or "InstallationConfigured"`,
+			name:       `State "PreflightsFailed" can transition to "PreflightsFailedBypassed", "PreflightsRunning", "InstallationConfigured", or "InstallationConfigurationFailed"`,
 			startState: StatePreflightsFailed,
 			validTransitions: []statemachine.State{
 				StatePreflightsFailedBypassed,
 				StatePreflightsRunning,
 				StateInstallationConfigured,
+				StateInstallationConfigurationFailed,
 			},
 		},
 		{
-			name:       `State "PreflightsFailedBypassed" can transition to "InfrastructureInstalling", "PreflightsRunning" or "InstallationConfigured"`,
+			name:       `State "PreflightsFailedBypassed" can transition to "InfrastructureInstalling", "PreflightsRunning", "InstallationConfigured", or "InstallationConfigurationFailed"`,
 			startState: StatePreflightsFailedBypassed,
 			validTransitions: []statemachine.State{
 				StateInfrastructureInstalling,
 				StatePreflightsRunning,
 				StateInstallationConfigured,
+				StateInstallationConfigurationFailed,
 			},
 		},
 		{
-			name:       `State "InfrastructureInstalling" can transition to "Succeeded" or "Failed"`,
+			name:       `State "InfrastructureInstalling" can transition to "Succeeded" or "InfrastructureInstallFailed"`,
 			startState: StateInfrastructureInstalling,
 			validTransitions: []statemachine.State{
 				StateSucceeded,
-				StateFailed,
+				StateInfrastructureInstallFailed,
 			},
+		},
+		{
+			name:             `State "InfrastructureInstallFailed" can not transition to any other state`,
+			startState:       StateInfrastructureInstallFailed,
+			validTransitions: []statemachine.State{},
 		},
 		{
 			name:             `State "Succeeded" can not transition to any other state`,
 			startState:       StateSucceeded,
-			validTransitions: []statemachine.State{},
-		},
-		{
-			name:             `State "Failed" can not transition to any other state`,
-			startState:       StateFailed,
 			validTransitions: []statemachine.State{},
 		},
 	}
@@ -120,7 +141,7 @@ func TestStateMachineTransitions(t *testing.T) {
 func TestIsFinalState(t *testing.T) {
 	finalStates := []statemachine.State{
 		StateSucceeded,
-		StateFailed,
+		StateInfrastructureInstallFailed,
 	}
 
 	for state := range validStateTransitions {

--- a/api/integration/install_test.go
+++ b/api/integration/install_test.go
@@ -18,7 +18,6 @@ import (
 	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/api"
 	apiclient "github.com/replicatedhq/embedded-cluster/api/client"
-	"github.com/replicatedhq/embedded-cluster/api/controllers/linux/install"
 	linuxinstall "github.com/replicatedhq/embedded-cluster/api/controllers/linux/install"
 	"github.com/replicatedhq/embedded-cluster/api/internal/managers/infra"
 	"github.com/replicatedhq/embedded-cluster/api/internal/managers/installation"
@@ -278,7 +277,7 @@ func TestConfigureInstallation(t *testing.T) {
 			// Create an install controller with the config manager
 			installController, err := linuxinstall.NewInstallController(
 				linuxinstall.WithRuntimeConfig(rc),
-				linuxinstall.WithStateMachine(linuxinstall.NewStateMachine(linuxinstall.WithCurrentState(linuxinstall.StateHostConfigured))),
+				linuxinstall.WithStateMachine(linuxinstall.NewStateMachine(linuxinstall.WithCurrentState(linuxinstall.StateNew))),
 				linuxinstall.WithHostUtils(tc.mockHostUtils),
 				linuxinstall.WithNetUtils(tc.mockNetUtils),
 			)
@@ -1409,10 +1408,10 @@ func TestPostSetupInfra(t *testing.T) {
 		)
 
 		// Create an install controller with CLI flag allowing bypass
-		installController, err := install.NewInstallController(
-			install.WithStateMachine(install.NewStateMachine(install.WithCurrentState(install.StatePreflightsFailed))),
-			install.WithHostPreflightManager(pfManager),
-			install.WithAllowIgnoreHostPreflights(true), // CLI flag allows bypass
+		installController, err := linuxinstall.NewInstallController(
+			linuxinstall.WithStateMachine(linuxinstall.NewStateMachine(linuxinstall.WithCurrentState(linuxinstall.StatePreflightsFailed))),
+			linuxinstall.WithHostPreflightManager(pfManager),
+			linuxinstall.WithAllowIgnoreHostPreflights(true), // CLI flag allows bypass
 		)
 		require.NoError(t, err)
 
@@ -1466,10 +1465,10 @@ func TestPostSetupInfra(t *testing.T) {
 		)
 
 		// Create an install controller with CLI flag NOT allowing bypass
-		installController, err := install.NewInstallController(
-			install.WithStateMachine(install.NewStateMachine(install.WithCurrentState(install.StatePreflightsFailed))),
-			install.WithHostPreflightManager(pfManager),
-			install.WithAllowIgnoreHostPreflights(false), // CLI flag does NOT allow bypass
+		installController, err := linuxinstall.NewInstallController(
+			linuxinstall.WithStateMachine(linuxinstall.NewStateMachine(linuxinstall.WithCurrentState(linuxinstall.StatePreflightsFailed))),
+			linuxinstall.WithHostPreflightManager(pfManager),
+			linuxinstall.WithAllowIgnoreHostPreflights(false), // CLI flag does NOT allow bypass
 		)
 		require.NoError(t, err)
 
@@ -1530,10 +1529,10 @@ func TestPostSetupInfra(t *testing.T) {
 		)
 
 		// Create an install controller with CLI flag allowing bypass
-		installController, err := install.NewInstallController(
-			install.WithStateMachine(install.NewStateMachine(install.WithCurrentState(install.StatePreflightsFailed))),
-			install.WithHostPreflightManager(pfManager),
-			install.WithAllowIgnoreHostPreflights(true), // CLI flag allows bypass
+		installController, err := linuxinstall.NewInstallController(
+			linuxinstall.WithStateMachine(linuxinstall.NewStateMachine(linuxinstall.WithCurrentState(linuxinstall.StatePreflightsFailed))),
+			linuxinstall.WithHostPreflightManager(pfManager),
+			linuxinstall.WithAllowIgnoreHostPreflights(true), // CLI flag allows bypass
 		)
 		require.NoError(t, err)
 

--- a/api/internal/managers/preflight/hostpreflight.go
+++ b/api/internal/managers/preflight/hostpreflight.go
@@ -105,13 +105,8 @@ func (m *hostPreflightManager) RunHostPreflights(ctx context.Context, rc runtime
 		m.logger.WithField("error", err).Warn("copy preflight bundle to embedded-cluster support dir")
 	}
 
-	if output.HasFail() || output.HasWarn() {
-		if m.metricsReporter != nil {
-			m.metricsReporter.ReportPreflightsFailed(ctx, output)
-		}
-	}
-
 	// Set final status based on results
+	// TODO @jgantunes: we're currently not handling warnings in the output.
 	if output.HasFail() {
 		if err := m.setCompletedStatus(types.StateFailed, "Host preflights failed", output); err != nil {
 			return fmt.Errorf("set failed status: %w", err)

--- a/api/internal/managers/preflight/manager.go
+++ b/api/internal/managers/preflight/manager.go
@@ -8,7 +8,6 @@ import (
 	"github.com/replicatedhq/embedded-cluster/api/pkg/logger"
 	"github.com/replicatedhq/embedded-cluster/api/types"
 	"github.com/replicatedhq/embedded-cluster/pkg-new/preflights"
-	"github.com/replicatedhq/embedded-cluster/pkg/metrics"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"github.com/sirupsen/logrus"
@@ -28,7 +27,6 @@ type hostPreflightManager struct {
 	runner             preflights.PreflightsRunnerInterface
 	netUtils           utils.NetUtils
 	logger             logrus.FieldLogger
-	metricsReporter    metrics.ReporterInterface
 }
 
 type HostPreflightManagerOption func(*hostPreflightManager)
@@ -36,12 +34,6 @@ type HostPreflightManagerOption func(*hostPreflightManager)
 func WithLogger(logger logrus.FieldLogger) HostPreflightManagerOption {
 	return func(m *hostPreflightManager) {
 		m.logger = logger
-	}
-}
-
-func WithMetricsReporter(metricsReporter metrics.ReporterInterface) HostPreflightManagerOption {
-	return func(m *hostPreflightManager) {
-		m.metricsReporter = metricsReporter
 	}
 }
 

--- a/api/internal/store/store_mock.go
+++ b/api/internal/store/store_mock.go
@@ -1,0 +1,31 @@
+package store
+
+import (
+	"github.com/replicatedhq/embedded-cluster/api/internal/store/infra"
+	"github.com/replicatedhq/embedded-cluster/api/internal/store/installation"
+	"github.com/replicatedhq/embedded-cluster/api/internal/store/preflight"
+)
+
+var _ Store = (*MockStore)(nil)
+
+// MockStore is a mock implementation of the Store interface
+type MockStore struct {
+	PreflightMockStore    preflight.MockStore
+	InfraMockStore        infra.MockStore
+	InstallationMockStore installation.MockStore
+}
+
+// PreflightStore returns the mock preflight store
+func (m *MockStore) PreflightStore() preflight.Store {
+	return &m.PreflightMockStore
+}
+
+// InstallationStore returns the mock installation store
+func (m *MockStore) InstallationStore() installation.Store {
+	return &m.InstallationMockStore
+}
+
+// InfraStore returns the mock infra store
+func (m *MockStore) InfraStore() infra.Store {
+	return &m.InfraMockStore
+}

--- a/pkg/metrics/reporter_mock.go
+++ b/pkg/metrics/reporter_mock.go
@@ -15,47 +15,49 @@ type MockReporter struct {
 	mock.Mock
 }
 
+// TODO: all the methods in this file aren't passing over the context.Context to avoid potential data races when using this struct in state machine event handler tests. See: https://github.com/stretchr/testify/issues/1597
+
 // ReportInstallationStarted mocks the ReportInstallationStarted method
 func (m *MockReporter) ReportInstallationStarted(ctx context.Context, licenseID string, appSlug string) {
-	m.Called(ctx, licenseID, appSlug)
+	m.Called(mock.Anything, licenseID, appSlug)
 }
 
 // ReportInstallationSucceeded mocks the ReportInstallationSucceeded method
 func (m *MockReporter) ReportInstallationSucceeded(ctx context.Context) {
-	m.Called(ctx)
+	m.Called(mock.Anything)
 }
 
 // ReportInstallationFailed mocks the ReportInstallationFailed method
 func (m *MockReporter) ReportInstallationFailed(ctx context.Context, err error) {
-	m.Called(ctx, err)
+	m.Called(mock.Anything, err)
 }
 
 // ReportJoinStarted mocks the ReportJoinStarted method
 func (m *MockReporter) ReportJoinStarted(ctx context.Context) {
-	m.Called(ctx)
+	m.Called(mock.Anything)
 }
 
 // ReportJoinSucceeded mocks the ReportJoinSucceeded method
 func (m *MockReporter) ReportJoinSucceeded(ctx context.Context) {
-	m.Called(ctx)
+	m.Called(mock.Anything)
 }
 
 // ReportJoinFailed mocks the ReportJoinFailed method
 func (m *MockReporter) ReportJoinFailed(ctx context.Context, err error) {
-	m.Called(ctx, err)
+	m.Called(mock.Anything, err)
 }
 
 // ReportPreflightsFailed mocks the ReportPreflightsFailed method
 func (m *MockReporter) ReportPreflightsFailed(ctx context.Context, output *apitypes.HostPreflightsOutput) {
-	m.Called(ctx, output)
+	m.Called(mock.Anything, output)
 }
 
 // ReportPreflightsBypassed mocks the ReportPreflightsBypassed method
 func (m *MockReporter) ReportPreflightsBypassed(ctx context.Context, output *apitypes.HostPreflightsOutput) {
-	m.Called(ctx, output)
+	m.Called(mock.Anything, output)
 }
 
 // ReportSignalAborted mocks the ReportSignalAborted method
 func (m *MockReporter) ReportSignalAborted(ctx context.Context, signal os.Signal) {
-	m.Called(ctx, signal)
+	m.Called(mock.Anything, signal)
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
This ended up tackling a bit more than intended as we started digging through the state transitions and we spotted that:
- The lack of some states complicated our overall flow and reporting
- Some transitions were not happening or just wrong (e.g. we were conflating the PreflightsFailed state).

The bulk of this PR is around adding new states and fixing the ones that we have as well the transition mechanisms. This mermaid diagram illustrates the final graph:
```mermaid
graph TD

    %% Initial & config states
    StateNew -->|Success| StateInstallationConfigured
    StateNew -->|Fail| StateInstallationConfigurationFailed

    StateInstallationConfigurationFailed -->|Retry| StateInstallationConfigured
    StateInstallationConfigurationFailed -->|Retry| StateInstallationConfigurationFailed

    StateInstallationConfigured -->|Success| StateHostConfigured
    StateInstallationConfigured -->|Fail| StateHostConfigurationFailed

    StateHostConfigurationFailed -->|Retry| StateInstallationConfigured
    StateHostConfigurationFailed -->|Retry| StateInstallationConfigurationFailed

    StateHostConfigured -->|Success| StatePreflightsRunning
    StateHostConfigured -->|Retry| StateInstallationConfigured
    StateHostConfigured -->|Retry| StateInstallationConfigurationFailed

    %% Preflights
    StatePreflightsRunning -->|Success| StatePreflightsSucceeded
    StatePreflightsRunning -->|SuccessWithFailures| StatePreflightsFailed
    StatePreflightsRunning -->|FailureToExecute| StatePreflightsExecutionFailed

    StatePreflightsExecutionFailed -->|Retry| StatePreflightsRunning
    StatePreflightsExecutionFailed -->|RetryConfig| StateInstallationConfigured
    StatePreflightsExecutionFailed -->|RetryConfig| StateInstallationConfigurationFailed

    StatePreflightsSucceeded -->|Success| StateInfrastructureInstalling
    StatePreflightsSucceeded -->|Retry| StatePreflightsRunning
    StatePreflightsSucceeded -->|RetryConfig| StateInstallationConfigured
    StatePreflightsSucceeded -->|RetryConfig| StateInstallationConfigurationFailed

    StatePreflightsFailed -->|Success| StatePreflightsFailedBypassed
    StatePreflightsFailed -->|Retry| StatePreflightsRunning
    StatePreflightsFailed -->|RetryConfig| StateInstallationConfigured
    StatePreflightsFailed -->|RetryConfig| StateInstallationConfigurationFailed

    StatePreflightsFailedBypassed -->|Success| StateInfrastructureInstalling
    StatePreflightsFailedBypassed -->|Retry| StatePreflightsRunning
    StatePreflightsFailedBypassed -->|RetryConfig| StateInstallationConfigured
    StatePreflightsFailedBypassed -->|RetryConfig| StateInstallationConfigurationFailed

    %% Infrastructure
    StateInfrastructureInstalling -->|Success| StateSucceeded
    StateInfrastructureInstalling -->|Fail| StateInfrastructureInstallFailed

    %% Terminal states
    StateSucceeded
    StateInfrastructureInstallFailed
```

We then proceed to add the reporting mechanism by leveraging the even handlers.

I'm working on doing some manual testing and will share a loom with it once done.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/124647/implement-reporting-in-the-new-manager-api

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Yes, added a series of new tests.

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
