### PR TITLE
feat: add preflight to check for XFS filesystem with ftype=0

### DIFF
--- a/pkg-new/preflights/host-preflight.yaml
+++ b/pkg-new/preflights/host-preflight.yaml
@@ -1215,7 +1215,7 @@ spec:
         outcomes:
           - fail:
               when: "true"
-              message: "The XFS filesystem on {{ .DataDir }} path is configured with ftype=0 which containers cannot run on. Please reconfigure the filesystem or use a different data directory."
+              message: "The XFS filesystem at {{ .DataDir }} is configured with ftype=0, which is not supported. Reformat the filesystem with ftype=1, or choose a different data directory on a supported filesystem."
           - pass:
               when: "false"
               message: "File system on {{ .DataDir }} path is fit for use with containers"

--- a/pkg-new/preflights/host-preflight.yaml
+++ b/pkg-new/preflights/host-preflight.yaml
@@ -172,6 +172,20 @@ spec:
             dir="{{ .DataDir }}"
             while [ "$dir" != "/" ]; do find "$dir" -maxdepth 0 ! -perm -111; dir=$(dirname "$dir"); done
             find "/" -maxdepth 0 ! -perm -111
+    - run:
+        collectorName: 'xfs_info-data-dir'
+        command: 'sh'
+        args:
+         - '-c'
+         - >
+          # Get filesystem type
+          fstype=$(findmnt -n -o FSTYPE --target "{{ .DataDir }}")
+          if [ "$fstype" = "xfs" ]; then
+            echo "Filesystem is XFS. Running xfs_info..."
+            xfs_info "{{ .DataDir }}"
+          else
+            echo "Filesystem is not XFS (detected: $fstype). Skipping xfs_info."
+          fi
   analyzers:
     - cpu:
         checkName: CPU
@@ -937,7 +951,7 @@ spec:
                 The node IP {{ .NodeIP }} cannot be within the Pod CIDR range {{ .PodCIDR.CIDR }}. Use --pod-cidr to specify a different Pod CIDR, or use --network-interface to specify a different network interface.
                 {{- end }}
           - pass:
-              when: "false" 
+              when: "false"
               message: The node IP {{ .NodeIP }} is not within the Pod CIDR range {{ .PodCIDR.CIDR }}.
     - subnetContainsIP:
         checkName: Node IP in Service CIDR Check
@@ -1194,3 +1208,14 @@ spec:
           - fail:
               message: >-
                 The following directories lack execute permissions: {{ `{{ .Dirs | trim | splitList "\n" | join ", " }}` }}.
+    - textAnalyze:
+        checkName: Check filesystem on data directory path
+        fileName: host-collectors/run-host/xfs_info-data-dir.txt
+        regex: 'ftype=0'
+        outcomes:
+          - fail:
+              when: "true"
+              message: "The XFS filesystem on {{ .DataDir }} path is configured with ftype=0 which containers cannot run on. Please reconfigure the filesystem or use a different data directory."
+          - pass:
+              when: "false"
+              message: "File system on {{ .DataDir }} path is fit for use with containers"

--- a/pkg-new/preflights/host-preflight.yaml
+++ b/pkg-new/preflights/host-preflight.yaml
@@ -1218,4 +1218,4 @@ spec:
               message: "The XFS filesystem at {{ .DataDir }} is configured with ftype=0, which is not supported. Reformat the filesystem with ftype=1, or choose a different data directory on a supported filesystem."
           - pass:
               when: "false"
-              message: "File system on {{ .DataDir }} path is fit for use with containers"
+              message: "The filesystem at {{ .DataDir }} is either not XFS or is XFS with ftype=1."


### PR DESCRIPTION
#### What this PR does / why we need it:
Some systems use an XFS filesystem that is configured with `ftype=0`, which is a requirement for `OverlayFS`. This causes problems for container runtimes like containerd, and can lead to failures during or after installation.

The failure and success (never shown) messages will be

```
FAIL: The XFS filesystem on /var/lib/embedded-cluster path is configured with ftype=0 which containers
      cannot run on. Please reconfigure the filesystem or use a different data directory.

PASS: File system on /var/lib/embedded-cluster path is fit for use with containers
```

#### Which issue(s) this PR fixes:
[sc-124752](https://app.shortcut.com/replicated/story/124752/add-preflight-check-for-xfs-with-ftype-0-to-prevent-container-runtime-issues)

#### Does this PR require a test?
NONE

#### Does this PR require a release note?
```release-note
Add preflight to check for XFS filesystem with ftype=0
```

#### Does this PR require documentation?
NONE