### PR TITLE
chore: update ci workflow to use different license ID env vars

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -680,7 +680,7 @@ jobs:
           export EC_VERSION="$(git describe --tags --abbrev=4 --match='[0-9]*.[0-9]*.[0-9]*')"
           export APP_VERSION="appver-${SHORT_SHA}"
 
-          echo "This PR has been released (on staging) and is available for download with a embedded-cluster-smoke-test-staging-app [license ID](https://vendor.staging.replicated.com/apps/embedded-cluster-smoke-test-staging-app/customers?sort=name-asc)." > download-link.txt
+          echo "This PR has been released (on staging) and is available for download with a embedded-cluster-smoke-test-staging-app [license ID](https://vendor.staging.replicated.com/apps/embedded-cluster-smoke-test-staging-app/customers?sort=name-asc). Online and airgap installers use different license IDs." > download-link.txt
           echo "" >> download-link.txt
           echo "Online Installer:" >> download-link.txt
           echo "\`\`\`" >> download-link.txt
@@ -688,7 +688,7 @@ jobs:
           echo "\`\`\`" >> download-link.txt
           echo "Airgap Installer (may take a few minutes before the airgap bundle is built):" >> download-link.txt
           echo "\`\`\`" >> download-link.txt
-          echo "curl \"https://staging.replicated.app/embedded/embedded-cluster-smoke-test-staging-app/ci-airgap/${APP_VERSION}?airgap=true\" -H \"Authorization: \$EC_SMOKE_TEST_LICENSE_ID\" -o embedded-cluster-smoke-test-staging-app-ci.tgz" >> download-link.txt
+          echo "curl \"https://staging.replicated.app/embedded/embedded-cluster-smoke-test-staging-app/ci-airgap/${APP_VERSION}?airgap=true\" -H \"Authorization: \$EC_SMOKE_TEST_AIRGAP_LICENSE_ID\" -o embedded-cluster-smoke-test-staging-app-ci-airgap.tgz" >> download-link.txt
           echo "\`\`\`" >> download-link.txt
           echo "Happy debugging!" >> download-link.txt
           cat download-link.txt


### PR DESCRIPTION
#### What this PR does / why we need it:
Indicate that airgap and online installers need to be downloaded using different license IDs from staging

I also allows users to have different environment variables in the shell environments

```
export EC_SMOKE_TEST_LICENSE_ID=<online>
export EC_SMOKE_TEST_AIRGAP_LICENSE_ID=<airgap>
```

#### Which issue(s) this PR fixes:

#### Does this PR require a test?
NONE

#### Does this PR require a release note?
NONE

#### Does this PR require documentation?
NONE