### PR TITLE
fix(e2e): Set sshArgs to mostly defaults

### DIFF
--- a/e2e/cluster/cmx/cluster.go
+++ b/e2e/cluster/cmx/cluster.go
@@ -504,9 +504,6 @@ func copyFileFromNode(node Node, src, dst string) error {
 func sshArgs() []string {
 	return []string{
 		"-o", "StrictHostKeyChecking=no",
-		"-o", "ServerAliveInterval=30",
-		"-o", "ServerAliveCountMax=10",
-		"-o", "ConnectTimeout=5",
 		"-o", "BatchMode=yes",
 	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
Using a bash script which creates VM's waits for a running status and then SSH's into them and runs uptime I was able to reproduce the banner exchange timeout issue that is faced when running e2e tests:

```
./scripts/vm-create-ssh.sh
=== Iteration 1 ===
Creating 3 VMs...
ID          NAME                           DISTRIBUTION    VERSION       STATUS        NETWORK      CREATED                           EXPIRES                           COST
c4c5a40d    eloquent_lumiere               ubuntu          24.04         running       8cb35c5f     2025-06-20 14:58 PDT              2025-06-20 15:59 PDT              $0.60
0a8cc730    eloquent_lumiere               ubuntu          24.04         running       8cb35c5f     2025-06-20 14:58 PDT              2025-06-20 15:59 PDT              $0.60
57815589    eloquent_lumiere               ubuntu          24.04         running       8cb35c5f     2025-06-20 14:58 PDT              2025-06-20 15:59 PDT              $0.60
Running uptime on each VM...
VM: 57815589
Warning: Permanently added '[135.181.6.187]:35525' (ED25519) to the list of known hosts.
 21:59:53 up 1 min,  1 user,  load average: 0.14, 0.05, 0.02
VM: 0a8cc730
Warning: Permanently added '[95.217.202.184]:36263' (ED25519) to the list of known hosts.
#!/bin/bash
 21:59:59 up 1 min,  1 user,  load average: 0.03, 0.01, 0.00
VM: c4c5a40d
Warning: Permanently added '[65.108.28.118]:42765' (ED25519) to the list of known hosts.
 22:00:03 up 1 min,  1 user,  load average: 0.12, 0.04, 0.01
removed vm 57815589
removed vm 0a8cc730
removed vm c4c5a40d
Iteration 1 completed successfully

=== Iteration 2 ===
Creating 3 VMs...
ID          NAME                           DISTRIBUTION    VERSION       STATUS        NETWORK      CREATED                           EXPIRES                           COST
e8517640    suspicious_kare                ubuntu          24.04         running       fcb76da0     2025-06-20 15:00 PDT              2025-06-20 16:01 PDT              $0.60
7ba2f671    suspicious_kare                ubuntu          24.04         running       fcb76da0     2025-06-20 15:00 PDT              2025-06-20 16:02 PDT              $0.60
b6dbac1e    suspicious_kare                ubuntu          24.04         running       fcb76da0     2025-06-20 15:00 PDT              2025-06-20 16:02 PDT              $0.60
Running uptime on each VM...
VM: b6dbac1e
Connection timed out during banner exchange
Connection to 65.108.28.141 port 34409 timed out
SSH error encountered at Fri Jun 20 15:02:40 PDT 2025! Stopping.
```

My script uses the same SSH options as specified in sshArgs, modifying them to use pretty much the defaults except for `-o StrictHostKeyChecking=no` improved the behavior dramatically and I was able to run 20 iterations without a single issue.  Before this change I ran the script and usually hit an issue on the 1st or 2nd attempt.

#### Which issue(s) this PR fixes:
Various SSH flake issues that are not all tracked by SC

#### Does this PR require a test?
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
NONE