### PR TITLE
chore: validate state machine lock in tests

### DIFF
--- a/api/controllers/install/controller_test.go
+++ b/api/controllers/install/controller_test.go
@@ -246,6 +246,7 @@ func TestConfigureInstallation(t *testing.T) {
 			assert.Eventually(t, func() bool {
 				return sm.CurrentState() == tt.expectedState
 			}, time.Second, 100*time.Millisecond, "state should be %s but is %s", tt.expectedState, sm.CurrentState())
+			assert.False(t, sm.IsLockAcquired(), "state machine should not be locked after configuration")
 
 			mockManager.AssertExpectations(t)
 		})
@@ -413,6 +414,7 @@ func TestRunHostPreflights(t *testing.T) {
 			assert.Eventually(t, func() bool {
 				return sm.CurrentState() == tt.expectedState
 			}, time.Second, 100*time.Millisecond, "state should be %s but is %s", tt.expectedState, sm.CurrentState())
+			assert.False(t, sm.IsLockAcquired(), "state machine should not be locked after running preflights")
 
 			mockPreflightManager.AssertExpectations(t)
 		})
@@ -746,6 +748,7 @@ func TestSetupInfra(t *testing.T) {
 			assert.Eventually(t, func() bool {
 				return sm.CurrentState() == tt.expectedState
 			}, time.Second, 100*time.Millisecond, "state should be %s but is %s", tt.expectedState, sm.CurrentState())
+			assert.False(t, sm.IsLockAcquired(), "state machine should not be locked after running infra setup")
 
 			mockPreflightManager.AssertExpectations(t)
 			mockInstallationManager.AssertExpectations(t)

--- a/api/internal/statemachine/statemachine.go
+++ b/api/internal/statemachine/statemachine.go
@@ -26,6 +26,8 @@ type Interface interface {
 	Transition(lock Lock, nextState State) error
 	// AcquireLock acquires a lock on the state machine.
 	AcquireLock() (Lock, error)
+	// IsLockAcquired checks if a lock already exists on the state machine.
+	IsLockAcquired() bool
 }
 
 type Lock interface {
@@ -81,6 +83,13 @@ func (sm *stateMachine) AcquireLock() (Lock, error) {
 	}
 
 	return sm.lock, nil
+}
+
+func (sm *stateMachine) IsLockAcquired() bool {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	return sm.lock != nil
 }
 
 func (sm *stateMachine) ValidateTransition(lock Lock, nextState State) error {


### PR DESCRIPTION
#### What this PR does / why we need it:
Complement to #2356, adds tests to the failure scenarios fixed in it by checking if the state machine is locked or not after the controller methods are executed.

Unit tests will fail as expected until the changes in #2356 are introduced.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
Follow up to #2356 and #2334 

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
These are tests

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
