### PR TITLE
chore: add statemachine event handlers

### DIFF
--- a/api/internal/statemachine/event_handler.go
+++ b/api/internal/statemachine/event_handler.go
@@ -7,7 +7,44 @@ import (
 	"time"
 )
 
-// eventHandler is a struct that holds the event handler function and its timeout.
+var (
+	_ EventHandler = &eventHandler{}
+)
+
+// EventHandler is an interface for handling state transition events in the state machine.
+type EventHandler interface {
+	// TriggerHandler triggers the event handler for a state transition.
+	TriggerHandler(ctx context.Context, fromState, toState State) error
+}
+
+// EventHandlerFunc is a function that handles state transition events. Used to report state changes.
+type EventHandlerFunc func(ctx context.Context, fromState, toState State)
+
+// EventHandlerOption is a configurable state machine option.
+type EventHandlerOption func(*eventHandler)
+
+// WithHandlerTimeout sets the timeout for the event handler to complete.
+func WithHandlerTimeout(timeout time.Duration) EventHandlerOption {
+	return func(eh *eventHandler) {
+		eh.timeout = timeout
+	}
+}
+
+// NewEventHandler creates a new event handler with the provided function and options.
+func NewEventHandler(handler EventHandlerFunc, options ...EventHandlerOption) EventHandler {
+	eh := &eventHandler{
+		handler: handler,
+		timeout: 5 * time.Second, // Default timeout
+	}
+
+	for _, option := range options {
+		option(eh)
+	}
+
+	return eh
+}
+
+// eventHandler is a struct that implements the EventHandler interface. It contains a handler function that is called when a state transition occurs, and it supports a timeout for the handler to complete.
 type eventHandler struct {
 	handler EventHandlerFunc
 	timeout time.Duration // Timeout for the handler to complete, default is 5 seconds
@@ -26,9 +63,9 @@ func (eh *eventHandler) TriggerHandler(ctx context.Context, fromState, toState S
 				err := fmt.Errorf("event handler panic from %s to %s: %v: %s\n", fromState, toState, r, debug.Stack())
 				done <- err
 			}
+			close(done)
 		}()
 		eh.handler(ctx, fromState, toState)
-		close(done)
 	}()
 
 	select {

--- a/api/internal/statemachine/event_handler.go
+++ b/api/internal/statemachine/event_handler.go
@@ -1,0 +1,41 @@
+package statemachine
+
+import (
+	"context"
+	"fmt"
+	"runtime/debug"
+	"time"
+)
+
+// eventHandler is a struct that holds the event handler function and its timeout.
+type eventHandler struct {
+	handler EventHandlerFunc
+	timeout time.Duration // Timeout for the handler to complete, default is 5 seconds
+}
+
+// TriggerHandler triggers the event handler for a state transition. The trigger is blocking and will wait for the handler to complete or timeout.
+func (eh *eventHandler) TriggerHandler(ctx context.Context, fromState, toState State) error {
+	ctx, cancel := context.WithTimeout(ctx, eh.timeout)
+	defer cancel()
+	done := make(chan error, 1)
+
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				// Capture panic but don't affect the transition
+				err := fmt.Errorf("event handler panic from %s to %s: %v: %s\n", fromState, toState, r, debug.Stack())
+				done <- err
+			}
+		}()
+		eh.handler(ctx, fromState, toState)
+		close(done)
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		err := fmt.Errorf("event handler for transition from %s to %s timed out after %s", fromState, toState, eh.timeout)
+		return err
+	}
+}

--- a/api/internal/statemachine/interface.go
+++ b/api/internal/statemachine/interface.go
@@ -1,16 +1,10 @@
 package statemachine
 
-import (
-	"context"
-	"time"
-)
-
 // State represents the possible states of the install process
 type State string
 
 var (
-	_ Interface    = &stateMachine{}
-	_ EventHandler = &eventHandler{}
+	_ Interface = &stateMachine{}
 )
 
 // Interface is the interface for the state machine
@@ -28,51 +22,13 @@ type Interface interface {
 	AcquireLock() (Lock, error)
 	// IsLockAcquired checks if a lock already exists on the state machine.
 	IsLockAcquired() bool
-	// Enable event handlers for state transitions
-	WithEventHandlers
-}
-
-// WithEventHandlers is an interface that allows registering and unregistering event handlers for state transitions.
-type WithEventHandlers interface {
-	// RegisterEventHandler registers a sync event handler for reporting events in the state machine.
+	// RegisterEventHandler registers a blocking event handler for reporting events in the state machine.
 	RegisterEventHandler(targetState State, handler EventHandlerFunc, options ...EventHandlerOption)
-	// UnregisterEventHandler unregisters a sync event handler for reporting events in the state machine.
+	// UnregisterEventHandler unregisters a blocking event handler for reporting events in the state machine.
 	UnregisterEventHandler(targetState State)
 }
 
 type Lock interface {
 	// Release releases the lock.
 	Release()
-}
-
-type EventHandler interface {
-	// TriggerHandler triggers the event handler for a state transition.
-	TriggerHandler(ctx context.Context, fromState, toState State) error
-}
-
-// EventHandlerFunc is a function that handles state transition events. Used to report state changes.
-type EventHandlerFunc func(ctx context.Context, fromState, toState State)
-
-// EventHandlerOption is a configurable state machine option.
-type EventHandlerOption func(*eventHandler)
-
-// WithHandlerTimeout sets the timeout for the event handler to complete.
-func WithHandlerTimeout(timeout time.Duration) EventHandlerOption {
-	return func(eh *eventHandler) {
-		eh.timeout = timeout
-	}
-}
-
-// NewEventHandler creates a new event handler with the provided function and options.
-func NewEventHandler(handler EventHandlerFunc, options ...EventHandlerOption) EventHandler {
-	eh := &eventHandler{
-		handler: handler,
-		timeout: 5 * time.Second, // Default timeout
-	}
-
-	for _, option := range options {
-		option(eh)
-	}
-
-	return eh
 }

--- a/api/internal/statemachine/interface.go
+++ b/api/internal/statemachine/interface.go
@@ -1,0 +1,78 @@
+package statemachine
+
+import (
+	"context"
+	"time"
+)
+
+// State represents the possible states of the install process
+type State string
+
+var (
+	_ Interface    = &stateMachine{}
+	_ EventHandler = &eventHandler{}
+)
+
+// Interface is the interface for the state machine
+type Interface interface {
+	// CurrentState returns the current state
+	CurrentState() State
+	// IsFinalState checks if the current state is a final state
+	IsFinalState() bool
+	// ValidateTransition checks if a transition from the current state to a new state is valid
+	ValidateTransition(lock Lock, newState State) error
+	// Transition attempts to transition to a new state and returns an error if the transition is
+	// invalid.
+	Transition(lock Lock, nextState State) error
+	// AcquireLock acquires a lock on the state machine.
+	AcquireLock() (Lock, error)
+	// IsLockAcquired checks if a lock already exists on the state machine.
+	IsLockAcquired() bool
+	// Enable event handlers for state transitions
+	WithEventHandlers
+}
+
+// WithEventHandlers is an interface that allows registering and unregistering event handlers for state transitions.
+type WithEventHandlers interface {
+	// RegisterEventHandler registers a sync event handler for reporting events in the state machine.
+	RegisterEventHandler(targetState State, handler EventHandlerFunc, options ...EventHandlerOption)
+	// UnregisterEventHandler unregisters a sync event handler for reporting events in the state machine.
+	UnregisterEventHandler(targetState State)
+}
+
+type Lock interface {
+	// Release releases the lock.
+	Release()
+}
+
+type EventHandler interface {
+	// TriggerHandler triggers the event handler for a state transition.
+	TriggerHandler(ctx context.Context, fromState, toState State) error
+}
+
+// EventHandlerFunc is a function that handles state transition events. Used to report state changes.
+type EventHandlerFunc func(ctx context.Context, fromState, toState State)
+
+// EventHandlerOption is a configurable state machine option.
+type EventHandlerOption func(*eventHandler)
+
+// WithHandlerTimeout sets the timeout for the event handler to complete.
+func WithHandlerTimeout(timeout time.Duration) EventHandlerOption {
+	return func(eh *eventHandler) {
+		eh.timeout = timeout
+	}
+}
+
+// NewEventHandler creates a new event handler with the provided function and options.
+func NewEventHandler(handler EventHandlerFunc, options ...EventHandlerOption) EventHandler {
+	eh := &eventHandler{
+		handler: handler,
+		timeout: 5 * time.Second, // Default timeout
+	}
+
+	for _, option := range options {
+		option(eh)
+	}
+
+	return eh
+}

--- a/api/internal/statemachine/statemachine.go
+++ b/api/internal/statemachine/statemachine.go
@@ -5,47 +5,10 @@ import (
 	"fmt"
 	"slices"
 	"sync"
-	"time"
 
 	"github.com/replicatedhq/embedded-cluster/api/pkg/logger"
 	"github.com/sirupsen/logrus"
 )
-
-// State represents the possible states of the install process
-type State string
-
-var (
-	_ Interface = &stateMachine{}
-)
-
-// Interface is the interface for the state machine
-type Interface interface {
-	// CurrentState returns the current state
-	CurrentState() State
-	// IsFinalState checks if the current state is a final state
-	IsFinalState() bool
-	// ValidateTransition checks if a transition from the current state to a new state is valid
-	ValidateTransition(lock Lock, newState State) error
-	// Transition attempts to transition to a new state and returns an error if the transition is
-	// invalid.
-	Transition(lock Lock, nextState State) error
-	// AcquireLock acquires a lock on the state machine.
-	AcquireLock() (Lock, error)
-	// IsLockAcquired checks if a lock already exists on the state machine.
-	IsLockAcquired() bool
-	// RegisterEventHandler registers an async event handler for reporting events in the state machine.
-	RegisterEventHandler(targetState State, handler EventHandler)
-	// UnregisterEventHandler unregisters an async event handler for reporting events in the state machine.
-	UnregisterEventHandler(targetState State)
-}
-
-// EventHandler is a function that handles state transition events. Used to report state changes.
-type EventHandler func(ctx context.Context, fromState, toState State)
-
-type Lock interface {
-	// Release releases the lock.
-	Release()
-}
 
 // stateMachine manages the state transitions for the install process
 type stateMachine struct {
@@ -55,7 +18,6 @@ type stateMachine struct {
 	mu                    sync.RWMutex
 	eventHandlers         map[State][]EventHandler
 	logger                logrus.FieldLogger
-	handlerTimeout        time.Duration // Timeout for event handlers to complete, default is 5 seconds
 }
 
 // StateMachineOption is a configurable state machine option.
@@ -69,7 +31,6 @@ func New(currentState State, validStateTransitions map[State][]State, opts ...St
 		validStateTransitions: validStateTransitions,
 		logger:                logger.NewDiscardLogger(),
 		eventHandlers:         make(map[State][]EventHandler),
-		handlerTimeout:        5 * time.Second,
 	}
 
 	for _, opt := range opts {
@@ -82,12 +43,6 @@ func New(currentState State, validStateTransitions map[State][]State, opts ...St
 func WithLogger(logger logrus.FieldLogger) StateMachineOption {
 	return func(sm *stateMachine) {
 		sm.logger = logger
-	}
-}
-
-func WithHandlerTimeout(handlerTimeout time.Duration) StateMachineOption {
-	return func(sm *stateMachine) {
-		sm.handlerTimeout = handlerTimeout
 	}
 }
 
@@ -165,16 +120,16 @@ func (sm *stateMachine) Transition(lock Lock, nextState State) error {
 	fromState := sm.currentState
 	sm.currentState = nextState
 
-	// Trigger event handlers asynchronously after successful transition
+	// Trigger event handlers after successful transition
 	sm.triggerHandlers(fromState, nextState)
 
 	return nil
 }
 
-func (sm *stateMachine) RegisterEventHandler(targetState State, handler EventHandler) {
+func (sm *stateMachine) RegisterEventHandler(targetState State, handler EventHandlerFunc, options ...EventHandlerOption) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
-	sm.eventHandlers[targetState] = append(sm.eventHandlers[targetState], handler)
+	sm.eventHandlers[targetState] = append(sm.eventHandlers[targetState], NewEventHandler(handler, options...))
 }
 
 func (sm *stateMachine) UnregisterEventHandler(targetState State) {
@@ -183,32 +138,18 @@ func (sm *stateMachine) UnregisterEventHandler(targetState State) {
 	delete(sm.eventHandlers, targetState)
 }
 
-// triggerHandlers triggers event handlers asynchronously
+// triggerHandlers triggers event handlers
 func (sm *stateMachine) triggerHandlers(from, next State) {
 	handlers, exists := sm.eventHandlers[next]
 	if !exists || len(handlers) == 0 {
 		return
 	}
-	handlersCopy := make([]EventHandler, len(handlers))
-	// Make a copy of the handlers to avoid potential changes to the slice during execution
-	copy(handlersCopy, handlers)
-
-	go func(from, to State, handlerList []EventHandler) {
-		ctx, cancel := context.WithTimeout(context.Background(), sm.handlerTimeout)
-		defer cancel()
-
-		for _, handler := range handlerList {
-			func() {
-				defer func() {
-					if r := recover(); r != nil {
-						// Log panic but don't affect the transition
-						sm.logger.Errorf("event handler panic from %s to %s: %v\n", from, next, r)
-					}
-				}()
-				handler(ctx, from, to)
-			}()
+	for _, handler := range handlers {
+		err := handler.TriggerHandler(context.Background(), from, next)
+		if err != nil {
+			sm.logger.WithFields(logrus.Fields{"fromState": from, "toState": next}).Errorf("event handler error: %v", err)
 		}
-	}(from, next, handlersCopy)
+	}
 }
 
 func (sm *stateMachine) isValidTransition(currentState State, newState State) bool {

--- a/api/internal/statemachine/statemachine.go
+++ b/api/internal/statemachine/statemachine.go
@@ -1,9 +1,14 @@
 package statemachine
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"sync"
+	"time"
+
+	"github.com/replicatedhq/embedded-cluster/api/pkg/logger"
+	"github.com/sirupsen/logrus"
 )
 
 // State represents the possible states of the install process
@@ -28,7 +33,14 @@ type Interface interface {
 	AcquireLock() (Lock, error)
 	// IsLockAcquired checks if a lock already exists on the state machine.
 	IsLockAcquired() bool
+	// RegisterEventHandler registers an async event handler for reporting events in the state machine.
+	RegisterEventHandler(targetState State, handler EventHandler)
+	// UnregisterEventHandler unregisters an async event handler for reporting events in the state machine.
+	UnregisterEventHandler(targetState State)
 }
+
+// EventHandler is a function that handles state transition events. Used to report state changes.
+type EventHandler func(ctx context.Context, fromState, toState State)
 
 type Lock interface {
 	// Release releases the lock.
@@ -41,14 +53,41 @@ type stateMachine struct {
 	validStateTransitions map[State][]State
 	lock                  *lock
 	mu                    sync.RWMutex
+	eventHandlers         map[State][]EventHandler
+	logger                logrus.FieldLogger
+	handlerTimeout        time.Duration // Timeout for event handlers to complete, default is 5 seconds
 }
 
+// StateMachineOption is a configurable state machine option.
+type StateMachineOption func(*stateMachine)
+
 // New creates a new state machine starting in the given state with the given valid state
-// transitions.
-func New(currentState State, validStateTransitions map[State][]State) *stateMachine {
-	return &stateMachine{
+// transitions and options.
+func New(currentState State, validStateTransitions map[State][]State, opts ...StateMachineOption) *stateMachine {
+	sm := &stateMachine{
 		currentState:          currentState,
 		validStateTransitions: validStateTransitions,
+		logger:                logger.NewDiscardLogger(),
+		eventHandlers:         make(map[State][]EventHandler),
+		handlerTimeout:        5 * time.Second,
+	}
+
+	for _, opt := range opts {
+		opt(sm)
+	}
+
+	return sm
+}
+
+func WithLogger(logger logrus.FieldLogger) StateMachineOption {
+	return func(sm *stateMachine) {
+		sm.logger = logger
+	}
+}
+
+func WithHandlerTimeout(handlerTimeout time.Duration) StateMachineOption {
+	return func(sm *stateMachine) {
+		sm.handlerTimeout = handlerTimeout
 	}
 }
 
@@ -123,9 +162,53 @@ func (sm *stateMachine) Transition(lock Lock, nextState State) error {
 		return fmt.Errorf("invalid transition from %s to %s", sm.currentState, nextState)
 	}
 
+	fromState := sm.currentState
 	sm.currentState = nextState
 
+	// Trigger event handlers asynchronously after successful transition
+	sm.triggerHandlers(fromState, nextState)
+
 	return nil
+}
+
+func (sm *stateMachine) RegisterEventHandler(targetState State, handler EventHandler) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	sm.eventHandlers[targetState] = append(sm.eventHandlers[targetState], handler)
+}
+
+func (sm *stateMachine) UnregisterEventHandler(targetState State) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	delete(sm.eventHandlers, targetState)
+}
+
+// triggerHandlers triggers event handlers asynchronously
+func (sm *stateMachine) triggerHandlers(from, next State) {
+	handlers, exists := sm.eventHandlers[next]
+	if !exists || len(handlers) == 0 {
+		return
+	}
+	handlersCopy := make([]EventHandler, len(handlers))
+	// Make a copy of the handlers to avoid potential changes to the slice during execution
+	copy(handlersCopy, handlers)
+
+	go func(from, to State, handlerList []EventHandler) {
+		ctx, cancel := context.WithTimeout(context.Background(), sm.handlerTimeout)
+		defer cancel()
+
+		for _, handler := range handlerList {
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						// Log panic but don't affect the transition
+						sm.logger.Errorf("event handler panic from %s to %s: %v\n", from, next, r)
+					}
+				}()
+				handler(ctx, from, to)
+			}()
+		}
+	}(from, next, handlersCopy)
 }
 
 func (sm *stateMachine) isValidTransition(currentState State, newState State) bool {

--- a/api/internal/statemachine/statemachine_test.go
+++ b/api/internal/statemachine/statemachine_test.go
@@ -675,7 +675,7 @@ func TestEventHandlerPanicRecovery(t *testing.T) {
 }
 
 func TestEventHandlerContextTimeout(t *testing.T) {
-	sm := New(StateNew, validStateTransitions, WithHandlerTimeout(time.Millisecond))
+	sm := New(StateNew, validStateTransitions)
 
 	mockHandler := &MockEventHandler{}
 	mockHandler.On("Handle", mock.Anything, StateNew, StateInstallationConfigured).Return()
@@ -684,7 +684,7 @@ func TestEventHandlerContextTimeout(t *testing.T) {
 		mockHandler.Handle(ctx, from, to)
 	}
 
-	sm.RegisterEventHandler(StateInstallationConfigured, handler)
+	sm.RegisterEventHandler(StateInstallationConfigured, handler, WithHandlerTimeout(time.Millisecond))
 
 	// Perform transition
 	lock, err := sm.AcquireLock()

--- a/api/internal/statemachine/statemachine_test.go
+++ b/api/internal/statemachine/statemachine_test.go
@@ -1,11 +1,14 @@
 package statemachine
 
 import (
+	"context"
 	"slices"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 const (
@@ -515,4 +518,307 @@ func TestValidateTransitionEdgeCases(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid transition")
 
 	lock.Release()
+}
+
+func TestEventHandlerRegistrationAndTriggering(t *testing.T) {
+	sm := New(StateNew, validStateTransitions)
+
+	// Create a mock handler
+	mockHandler := &MockEventHandler{}
+	mockHandler.On("Handle", mock.Anything, StateNew, StateInstallationConfigured).Return()
+
+	// Register event handler
+	handler := func(ctx context.Context, from, to State) {
+		mockHandler.Handle(ctx, from, to)
+	}
+
+	sm.RegisterEventHandler(StateInstallationConfigured, handler)
+
+	// Perform transition
+	lock, err := sm.AcquireLock()
+	assert.NoError(t, err)
+
+	err = sm.Transition(lock, StateInstallationConfigured)
+	assert.NoError(t, err)
+
+	lock.Release()
+
+	// Use assert.Eventually to verify handler was called with correct parameters
+	assert.Eventually(t, func() bool {
+		return mockHandler.AssertCalled(t, "Handle", mock.Anything, StateNew, StateInstallationConfigured)
+	}, time.Second, time.Millisecond*50)
+
+	mockHandler.AssertExpectations(t)
+}
+
+func TestEventHandlerMultipleHandlers(t *testing.T) {
+	sm := New(StateNew, validStateTransitions)
+
+	// Create mock handlers
+	mockHandler1 := &MockEventHandler{}
+	mockHandler1.On("Handle", mock.Anything, StateNew, StateInstallationConfigured).Return()
+
+	mockHandler2 := &MockEventHandler{}
+	mockHandler2.On("Handle", mock.Anything, StateNew, StateInstallationConfigured).Return()
+
+	// Register multiple handlers for the same state
+	handler1 := func(ctx context.Context, from, to State) {
+		mockHandler1.Handle(ctx, from, to)
+	}
+
+	handler2 := func(ctx context.Context, from, to State) {
+		mockHandler2.Handle(ctx, from, to)
+	}
+
+	sm.RegisterEventHandler(StateInstallationConfigured, handler1)
+	sm.RegisterEventHandler(StateInstallationConfigured, handler2)
+
+	// Perform transition
+	lock, err := sm.AcquireLock()
+	assert.NoError(t, err)
+
+	err = sm.Transition(lock, StateInstallationConfigured)
+	assert.NoError(t, err)
+
+	lock.Release()
+
+	// Use assert.Eventually to verify handler was called with correct parameters
+	assert.Eventually(t, func() bool {
+		return mockHandler1.AssertCalled(t, "Handle", mock.Anything, StateNew, StateInstallationConfigured)
+	}, time.Second, time.Millisecond*50, "mockHandler1 was not called")
+
+	assert.Eventually(t, func() bool {
+		return mockHandler2.AssertCalled(t, "Handle", mock.Anything, StateNew, StateInstallationConfigured)
+	}, time.Second, time.Millisecond*50, "mockHandler2 was not called")
+
+	mockHandler1.AssertExpectations(t)
+	mockHandler2.AssertExpectations(t)
+}
+
+func TestEventHandlerUnregistration(t *testing.T) {
+	sm := New(StateNew, validStateTransitions)
+
+	mockHandler := &MockEventHandler{}
+
+	handler := func(ctx context.Context, from, to State) {
+		mockHandler.Handle(ctx, from, to)
+	}
+
+	sm.RegisterEventHandler(StateInstallationConfigured, handler)
+
+	// Unregister handlers
+	sm.UnregisterEventHandler(StateInstallationConfigured)
+
+	// Perform transition
+	lock, err := sm.AcquireLock()
+	assert.NoError(t, err)
+
+	err = sm.Transition(lock, StateInstallationConfigured)
+	assert.NoError(t, err)
+
+	lock.Release()
+
+	// Use assert.Eventually to wait for the state to change
+	assert.Eventually(t, func() bool {
+		return sm.currentState == StateInstallationConfigured
+	}, time.Second, time.Millisecond*50, "failed to transition to StateInstallationConfigured")
+	// Verify that the handler was not called
+	mockHandler.AssertNotCalled(t, "Handle", mock.Anything, StateNew, StateInstallationConfigured)
+	mockHandler.AssertExpectations(t)
+}
+
+func TestEventHandlerPanicRecovery(t *testing.T) {
+	sm := New(StateNew, validStateTransitions)
+
+	mockPanicHandler := &MockEventHandler{}
+	mockPanicHandler.On("Handle", mock.Anything, StateNew, StateInstallationConfigured).Return()
+
+	// Register panicking handler
+	panicHandler := func(ctx context.Context, from, to State) {
+		mockPanicHandler.Handle(ctx, from, to)
+		panic("test panic")
+	}
+
+	mockNormalHandler := &MockEventHandler{}
+	mockNormalHandler.On("Handle", mock.Anything, StateNew, StateInstallationConfigured).Return()
+
+	// Register normal handler
+	normalHandler := func(ctx context.Context, from, to State) {
+		mockNormalHandler.Handle(ctx, from, to)
+	}
+
+	sm.RegisterEventHandler(StateInstallationConfigured, panicHandler)
+	sm.RegisterEventHandler(StateInstallationConfigured, normalHandler)
+
+	// Perform transition
+	lock, err := sm.AcquireLock()
+	assert.NoError(t, err)
+
+	err = sm.Transition(lock, StateInstallationConfigured)
+	assert.NoError(t, err)
+
+	lock.Release()
+
+	// Use assert.Eventually to verify handler was called with correct parameters
+	assert.Eventually(t, func() bool {
+		return mockPanicHandler.AssertCalled(t, "Handle", mock.Anything, StateNew, StateInstallationConfigured)
+	}, time.Second, time.Millisecond*50, "mockPanicHandler was not called")
+
+	assert.Eventually(t, func() bool {
+		return mockNormalHandler.AssertCalled(t, "Handle", mock.Anything, StateNew, StateInstallationConfigured)
+	}, time.Second, time.Millisecond*50, "mockNormalHandler was not called")
+
+	mockPanicHandler.AssertExpectations(t)
+	mockNormalHandler.AssertExpectations(t)
+	// Verify state machine is still in correct state
+	assert.Equal(t, StateInstallationConfigured, sm.CurrentState())
+}
+
+func TestEventHandlerContextTimeout(t *testing.T) {
+	sm := New(StateNew, validStateTransitions, WithHandlerTimeout(time.Millisecond))
+
+	mockHandler := &MockEventHandler{}
+	mockHandler.On("Handle", mock.Anything, StateNew, StateInstallationConfigured).Return()
+
+	handler := func(ctx context.Context, from, to State) {
+		mockHandler.Handle(ctx, from, to)
+	}
+
+	sm.RegisterEventHandler(StateInstallationConfigured, handler)
+
+	// Perform transition
+	lock, err := sm.AcquireLock()
+	assert.NoError(t, err)
+
+	err = sm.Transition(lock, StateInstallationConfigured)
+	assert.NoError(t, err)
+
+	lock.Release()
+
+	// Verify handler was called and context was cancelled
+	assert.Eventually(t, func() bool {
+		return mockHandler.AssertCalled(t, "Handle", mock.Anything, StateNew, StateInstallationConfigured)
+	}, time.Second, time.Millisecond*50, "mockHandler was not called")
+
+	mockHandler.AssertExpectations(t)
+	// State machine correctly transitioned
+	assert.Equal(t, StateInstallationConfigured, sm.CurrentState())
+}
+
+func TestEventHandlerDifferentStates(t *testing.T) {
+	tests := []struct {
+		name              string
+		registerState     State
+		transitionToState State
+		shouldTrigger     bool
+	}{
+		{
+			name:              "handler for target state should trigger",
+			registerState:     StateInstallationConfigured,
+			transitionToState: StateInstallationConfigured,
+			shouldTrigger:     true,
+		},
+		{
+			name:              "handler for different state should not trigger",
+			registerState:     StatePreflightsRunning,
+			transitionToState: StateInstallationConfigured,
+			shouldTrigger:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sm := New(StateNew, validStateTransitions)
+
+			mockHandler := &MockEventHandler{}
+			if tt.shouldTrigger {
+				mockHandler.On("Handle", mock.Anything, StateNew, tt.transitionToState).Return()
+			}
+
+			handler := func(ctx context.Context, from, to State) {
+				mockHandler.Handle(ctx, from, to)
+			}
+
+			sm.RegisterEventHandler(tt.registerState, handler)
+
+			// Perform transition
+			lock, err := sm.AcquireLock()
+			assert.NoError(t, err)
+
+			err = sm.Transition(lock, tt.transitionToState)
+			assert.NoError(t, err)
+
+			lock.Release()
+
+			if tt.shouldTrigger {
+				assert.Eventually(t, func() bool {
+					return mockHandler.AssertCalled(t, "Handle", mock.Anything, StateNew, tt.transitionToState)
+				}, time.Second, time.Millisecond*50, "mockHandler was not called")
+				mockHandler.AssertExpectations(t)
+			} else {
+				// Use assert.Eventually to wait for the state to change, then verify no calls
+				assert.Eventually(t, func() bool {
+					return sm.CurrentState() == tt.transitionToState
+				}, time.Second, time.Millisecond*50, "failed to transition to target state")
+				mockHandler.AssertNotCalled(t, "Handle", mock.Anything, StateNew, tt.transitionToState)
+				mockHandler.AssertExpectations(t)
+			}
+		})
+	}
+}
+
+func TestEventHandlerConcurrentRegistration(t *testing.T) {
+	sm := New(StateNew, validStateTransitions)
+
+	numHandlers := 10
+	mockHandlers := make([]*MockEventHandler, numHandlers)
+	var wg sync.WaitGroup
+	wg.Add(numHandlers)
+
+	// Initialize mock handlers
+	for i := 0; i < numHandlers; i++ {
+		mockHandlers[i] = &MockEventHandler{}
+		mockHandlers[i].On("Handle", mock.Anything, StateNew, StateInstallationConfigured).Return()
+	}
+
+	// Register handlers concurrently
+	for i := 0; i < numHandlers; i++ {
+		i := i // capture loop variable
+		go func() {
+			defer wg.Done()
+			handler := func(ctx context.Context, from, to State) {
+				mockHandlers[i].Handle(ctx, from, to)
+			}
+			sm.RegisterEventHandler(StateInstallationConfigured, handler)
+		}()
+	}
+
+	wg.Wait()
+
+	// Perform transition
+	lock, err := sm.AcquireLock()
+	assert.NoError(t, err)
+
+	err = sm.Transition(lock, StateInstallationConfigured)
+	assert.NoError(t, err)
+
+	lock.Release()
+
+	// Verify all handlers were called using assert.Eventually
+	for i := 0; i < numHandlers; i++ {
+		i := i // capture loop variable
+		assert.Eventually(t, func() bool {
+			return mockHandlers[i].AssertCalled(t, "Handle", mock.Anything, StateNew, StateInstallationConfigured)
+		}, time.Second, time.Millisecond*50, "mockHandler %d was not called", i)
+		mockHandlers[i].AssertExpectations(t)
+	}
+}
+
+// MockEventHandler is a mock for event handler testing
+type MockEventHandler struct {
+	mock.Mock
+}
+
+func (m *MockEventHandler) Handle(ctx context.Context, from, to State) {
+	m.Called(ctx, from, to)
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR relates to https://github.com/replicatedhq/embedded-cluster/pull/2337. Where, in order to support our reporting strategy we introduce event handlers that are triggered when successful transitions happen on the state machine. This has the added benefits of:
- All the reporting logic can be aggregated under the same code area
- No potential for drift between reported state VS actual state
- Managers become entirely independent/unaware of the metrics reporting mechanism
- Potential to easily extend the events we report in future.
- Potential to extend with other reporting mechanisms in the future.

#### Which issue(s) this PR fixes:
https://app.shortcut.com/replicated/story/125431/spike-evaluate-setting-up-reporting-handlers-as-part-of-state-machine-transitions-in-new-manager-api

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Yes, added

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE