### PR TITLE
Adds a secret skip preflight environment variable

### DIFF
--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -369,6 +369,9 @@ func addManagerExperienceFlags(cmd *cobra.Command, flags *InstallCmdFlags) error
 func preRunInstall(cmd *cobra.Command, flags *InstallCmdFlags, rc runtimeconfig.RuntimeConfig) error {
 	if !slices.Contains([]string{"linux", "kubernetes"}, flags.target) {
 		return fmt.Errorf(`invalid target (must be one of: "linux", "kubernetes")`)
+
+	if !cmd.Flags().Changed("skip-host-preflights") && os.Getenv("SKIP_HOST_PREFLIGHTS") != "" {
+		flags.skipHostPreflights = true
 	}
 
 	if err := preRunInstallCommon(cmd, flags, rc); err != nil {

--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -434,12 +434,12 @@ func preRunInstallCommon(cmd *cobra.Command, flags *InstallCmdFlags, rc runtimec
 }
 
 func preRunInstallLinux(cmd *cobra.Command, flags *InstallCmdFlags, rc runtimeconfig.RuntimeConfig) error {
-	if os.Getuid() != 0 {
-		return fmt.Errorf("install command must be run as root")
-	}
-
 	if !cmd.Flags().Changed("skip-host-preflights") && (os.Getenv("SKIP_HOST_PREFLIGHTS") == "1" || os.Getenv("SKIP_HOST_PREFLIGHTS") == "true") {
 		flags.skipHostPreflights = true
+	}
+
+	if os.Getuid() != 0 {
+		return fmt.Errorf("install command must be run as root")
 	}
 
 	// set the umask to 022 so that we can create files/directories with 755 permissions

--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -369,6 +369,7 @@ func addManagerExperienceFlags(cmd *cobra.Command, flags *InstallCmdFlags) error
 func preRunInstall(cmd *cobra.Command, flags *InstallCmdFlags, rc runtimeconfig.RuntimeConfig) error {
 	if !slices.Contains([]string{"linux", "kubernetes"}, flags.target) {
 		return fmt.Errorf(`invalid target (must be one of: "linux", "kubernetes")`)
+	}
 
 	if !cmd.Flags().Changed("skip-host-preflights") && os.Getenv("SKIP_HOST_PREFLIGHTS") != "" {
 		flags.skipHostPreflights = true

--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -438,7 +438,7 @@ func preRunInstallLinux(cmd *cobra.Command, flags *InstallCmdFlags, rc runtimeco
 		return fmt.Errorf("install command must be run as root")
 	}
 
-	if !cmd.Flags().Changed("skip-host-preflights") && os.Getenv("SKIP_HOST_PREFLIGHTS") != "" {
+	if !cmd.Flags().Changed("skip-host-preflights") && (os.Getenv("SKIP_HOST_PREFLIGHTS") == "1" || os.Getenv("SKIP_HOST_PREFLIGHTS") == "true") {
 		flags.skipHostPreflights = true
 	}
 

--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -371,10 +371,6 @@ func preRunInstall(cmd *cobra.Command, flags *InstallCmdFlags, rc runtimeconfig.
 		return fmt.Errorf(`invalid target (must be one of: "linux", "kubernetes")`)
 	}
 
-	if !cmd.Flags().Changed("skip-host-preflights") && os.Getenv("SKIP_HOST_PREFLIGHTS") != "" {
-		flags.skipHostPreflights = true
-	}
-
 	if err := preRunInstallCommon(cmd, flags, rc); err != nil {
 		return err
 	}
@@ -440,6 +436,10 @@ func preRunInstallCommon(cmd *cobra.Command, flags *InstallCmdFlags, rc runtimec
 func preRunInstallLinux(cmd *cobra.Command, flags *InstallCmdFlags, rc runtimeconfig.RuntimeConfig) error {
 	if os.Getuid() != 0 {
 		return fmt.Errorf("install command must be run as root")
+	}
+
+	if !cmd.Flags().Changed("skip-host-preflights") && os.Getenv("SKIP_HOST_PREFLIGHTS") != "" {
+		flags.skipHostPreflights = true
 	}
 
 	// set the umask to 022 so that we can create files/directories with 755 permissions

--- a/cmd/installer/cli/install_test.go
+++ b/cmd/installer/cli/install_test.go
@@ -618,8 +618,14 @@ func Test_preRunInstall_SkipHostPreflightsEnvVar(t *testing.T) {
 		expectedSkipPreflights bool
 	}{
 		{
-			name:                   "env var set, no flag",
+			name:                   "env var set to 1, no flag",
 			envVarValue:            "1",
+			flagValue:              nil,
+			expectedSkipPreflights: true,
+		},
+		{
+			name:                   "env var set to true, no flag",
+			envVarValue:            "true",
 			flagValue:              nil,
 			expectedSkipPreflights: true,
 		},
@@ -680,7 +686,7 @@ func Test_preRunInstall_SkipHostPreflightsEnvVar(t *testing.T) {
 
 			// Call preRunInstall (this would normally require root, but we're just testing the flag logic)
 			// We expect this to fail due to non-root execution, but we can check the flag value before it fails
-			err := preRunInstall(cmd, flags, rc)
+			err := preRunInstallLinux(cmd, flags, rc)
 
 			// The function will fail due to non-root check, but we can verify the flag was set correctly
 			// by checking the flag value before the root check fails

--- a/cmd/installer/cli/install_test.go
+++ b/cmd/installer/cli/install_test.go
@@ -612,10 +612,10 @@ func Test_verifyProxyConfig(t *testing.T) {
 
 func Test_preRunInstall_SkipHostPreflightsEnvVar(t *testing.T) {
 	tests := []struct {
-		name                    string
-		envVarValue             string
-		flagValue               *bool // nil means not set, true/false means explicitly set
-		expectedSkipPreflights  bool
+		name                   string
+		envVarValue            string
+		flagValue              *bool // nil means not set, true/false means explicitly set
+		expectedSkipPreflights bool
 	}{
 		{
 			name:                   "env var set, no flag",
@@ -681,11 +681,11 @@ func Test_preRunInstall_SkipHostPreflightsEnvVar(t *testing.T) {
 			// Call preRunInstall (this would normally require root, but we're just testing the flag logic)
 			// We expect this to fail due to non-root execution, but we can check the flag value before it fails
 			err := preRunInstall(cmd, flags, rc)
-			
+
 			// The function will fail due to non-root check, but we can verify the flag was set correctly
 			// by checking the flag value before the root check fails
 			assert.Equal(t, tt.expectedSkipPreflights, flags.skipHostPreflights)
-			
+
 			// We expect an error due to non-root execution
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "install command must be run as root")

--- a/cmd/installer/cli/install_test.go
+++ b/cmd/installer/cli/install_test.go
@@ -14,7 +14,9 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/prompts"
 	"github.com/replicatedhq/embedded-cluster/pkg/prompts/plain"
 	"github.com/replicatedhq/embedded-cluster/pkg/release"
+	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -606,4 +608,92 @@ func Test_verifyProxyConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_preRunInstall_SkipHostPreflightsEnvVar(t *testing.T) {
+	tests := []struct {
+		name                    string
+		envVarValue             string
+		flagValue               *bool // nil means not set, true/false means explicitly set
+		expectedSkipPreflights  bool
+	}{
+		{
+			name:                   "env var set, no flag",
+			envVarValue:            "1",
+			flagValue:              nil,
+			expectedSkipPreflights: true,
+		},
+		{
+			name:                   "env var set, flag explicitly false (flag takes precedence)",
+			envVarValue:            "1",
+			flagValue:              boolPtr(false),
+			expectedSkipPreflights: false,
+		},
+		{
+			name:                   "env var set, flag explicitly true",
+			envVarValue:            "1",
+			flagValue:              boolPtr(true),
+			expectedSkipPreflights: true,
+		},
+		{
+			name:                   "env var not set, no flag",
+			envVarValue:            "",
+			flagValue:              nil,
+			expectedSkipPreflights: false,
+		},
+		{
+			name:                   "env var not set, flag explicitly false",
+			envVarValue:            "",
+			flagValue:              boolPtr(false),
+			expectedSkipPreflights: false,
+		},
+		{
+			name:                   "env var not set, flag explicitly true",
+			envVarValue:            "",
+			flagValue:              boolPtr(true),
+			expectedSkipPreflights: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up environment variable
+			if tt.envVarValue != "" {
+				t.Setenv("SKIP_HOST_PREFLIGHTS", tt.envVarValue)
+			}
+
+			// Create a mock cobra command to simulate flag behavior
+			cmd := &cobra.Command{}
+			flags := &InstallCmdFlags{}
+
+			// Add the flag to the command (similar to addInstallFlags)
+			cmd.Flags().BoolVar(&flags.skipHostPreflights, "skip-host-preflights", false, "Skip host preflight checks")
+
+			// Set the flag if explicitly provided in test
+			if tt.flagValue != nil {
+				err := cmd.Flags().Set("skip-host-preflights", fmt.Sprintf("%t", *tt.flagValue))
+				require.NoError(t, err)
+			}
+
+			// Create a minimal runtime config for the test
+			rc := runtimeconfig.New(nil)
+
+			// Call preRunInstall (this would normally require root, but we're just testing the flag logic)
+			// We expect this to fail due to non-root execution, but we can check the flag value before it fails
+			err := preRunInstall(cmd, flags, rc)
+			
+			// The function will fail due to non-root check, but we can verify the flag was set correctly
+			// by checking the flag value before the root check fails
+			assert.Equal(t, tt.expectedSkipPreflights, flags.skipHostPreflights)
+			
+			// We expect an error due to non-root execution
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "install command must be run as root")
+		})
+	}
+}
+
+// Helper function to create bool pointer
+func boolPtr(b bool) *bool {
+	return &b
 }


### PR DESCRIPTION
TL;DR
-----

Supports the `SKIP_HOST_PREFLIGHTS` environment variable to skip the preflight checks. This is not documented and not for general use.

Details
-------

Offers a "hidden" way to skip preflight checks by setting the environment variable `SKIP_HOST_PREFLIGHTS`. I'm adding the flag to support our Instruqt labs, since the Instruqt environment require a wildcard DNS entry that causes the host preflights to fail.

I decided on this approach to avoid teaching any bad habits by telling the user to use `--ignore-host-preflights` when teaching them about the Embedded Cluster. I wanted instead to avoid the checks on their behalf without them realized it. This variable is not deliberately not documented to avoid similar encouragement of bad habits.
