### PR TITLE
chore(web): text on welcome string reflects install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -343,6 +343,7 @@ create-node%: DISTRO = debian-bookworm
 create-node%: NODE_PORT = 30000
 create-node%: MANAGER_NODE_PORT = 30080
 create-node%: K0S_DATA_DIR = /var/lib/embedded-cluster/k0s
+create-node%: ENABLE_V3 = 0
 create-node%:
 	@docker run -d \
 		--name node$* \
@@ -356,6 +357,7 @@ create-node%:
 		$(if $(filter node0,node$*),-p $(MANAGER_NODE_PORT):$(MANAGER_NODE_PORT)) \
 		$(if $(filter node0,node$*),-p 30003:30003) \
 		-e EC_PUBLIC_ADDRESS=localhost \
+		-e ENABLE_V3=$(ENABLE_V3) \
 		replicated/ec-distro:$(DISTRO)
 
 	@$(MAKE) ssh-node$*

--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -155,7 +155,7 @@ func InstallCmd(ctx context.Context, name string) *cobra.Command {
 
 func addInstallFlags(cmd *cobra.Command, flags *InstallCmdFlags) error {
 	cmd.Flags().StringVar(&flags.target, "target", "linux", "The target platform to install to. Valid options are 'linux' or 'kubernetes'.")
-	if os.Getenv("ENABLE_V3") == "1" {
+	if os.Getenv("ENABLE_V3") != "1" {
 		if err := cmd.Flags().MarkHidden("target"); err != nil {
 			return err
 		}

--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -154,6 +154,13 @@ func InstallCmd(ctx context.Context, name string) *cobra.Command {
 }
 
 func addInstallFlags(cmd *cobra.Command, flags *InstallCmdFlags) error {
+	cmd.Flags().StringVar(&flags.target, "target", "linux", "The target platform to install to. Valid options are 'linux' or 'kubernetes'.")
+	if os.Getenv("ENABLE_V3") == "1" {
+		if err := cmd.Flags().MarkHidden("target"); err != nil {
+			return err
+		}
+	}
+
 	cmd.Flags().StringVar(&flags.airgapBundle, "airgap-bundle", "", "Path to the air gap bundle. If set, the installation will complete without internet access.")
 	cmd.Flags().StringVar(&flags.dataDir, "data-dir", ecv1beta1.DefaultDataDir, "Path to the data directory")
 	cmd.Flags().IntVar(&flags.localArtifactMirrorPort, "local-artifact-mirror-port", ecv1beta1.DefaultLocalArtifactMirrorPort, "Port on which the Local Artifact Mirror will be served")
@@ -208,23 +215,19 @@ func addInstallAdminConsoleFlags(cmd *cobra.Command, flags *InstallCmdFlags) err
 func addManagerExperienceFlags(cmd *cobra.Command, flags *InstallCmdFlags) error {
 	// If the ENABLE_V3 environment variable is set, default to the new manager experience and do
 	// not hide the new flags.
-	enableV3 := os.Getenv("ENABLE_V3") != ""
+	enableV3 := os.Getenv("ENABLE_V3") == "1"
 
 	cmd.Flags().BoolVar(&flags.enableManagerExperience, "manager-experience", enableV3, "Run the browser-based installation experience.")
 	if err := cmd.Flags().MarkHidden("manager-experience"); err != nil {
 		return err
 	}
 
-	cmd.Flags().StringVar(&flags.target, "target", "linux", "The target platform to install to. Valid options are 'linux' or 'kubernetes'.")
 	cmd.Flags().IntVar(&flags.managerPort, "manager-port", ecv1beta1.DefaultManagerPort, "Port on which the Manager will be served")
 	cmd.Flags().StringVar(&flags.tlsCertFile, "tls-cert", "", "Path to the TLS certificate file")
 	cmd.Flags().StringVar(&flags.tlsKeyFile, "tls-key", "", "Path to the TLS key file")
 	cmd.Flags().StringVar(&flags.hostname, "hostname", "", "Hostname to use for TLS configuration")
 
-	if enableV3 {
-		if err := cmd.Flags().MarkHidden("target"); err != nil {
-			return err
-		}
+	if !enableV3 {
 		if err := cmd.Flags().MarkHidden("manager-port"); err != nil {
 			return err
 		}

--- a/web/src/components/wizard/setup/LinuxSetup.tsx
+++ b/web/src/components/wizard/setup/LinuxSetup.tsx
@@ -37,7 +37,7 @@ interface LinuxSetupProps {
     globalCidr?: string;
   };
   prototypeSettings: {
-    clusterMode: string;
+    installTarget: string;
     availableNetworkInterfaces?: Array<{
       name: string;
     }>;

--- a/web/src/components/wizard/tests/SetupStep.test.tsx
+++ b/web/src/components/wizard/tests/SetupStep.test.tsx
@@ -26,7 +26,6 @@ const server = setupServer(
 
 describe("SetupStep", () => {
   const mockOnNext = vi.fn();
-  const mockOnBack = vi.fn();
 
   beforeAll(() => {
     server.listen();
@@ -45,8 +44,8 @@ describe("SetupStep", () => {
     server.close();
   });
 
-  it("renders the linux setup form when it's embedded", async () => {
-    renderWithProviders(<SetupStep onNext={mockOnNext} onBack={mockOnBack} />, {
+  it("renders the linux setup form when the install target is linux", async () => {
+    renderWithProviders(<SetupStep onNext={mockOnNext} />, {
       wrapperProps: {
         authenticated: true,
         preloadedState: {
@@ -127,7 +126,7 @@ describe("SetupStep", () => {
       })
     );
 
-    renderWithProviders(<SetupStep onNext={mockOnNext} onBack={mockOnBack} />, {
+    renderWithProviders(<SetupStep onNext={mockOnNext} />, {
       wrapperProps: {
         authenticated: true,
         preloadedState: {
@@ -230,7 +229,7 @@ describe("SetupStep", () => {
       })
     );
 
-    renderWithProviders(<SetupStep onNext={mockOnNext} onBack={mockOnBack} />, {
+    renderWithProviders(<SetupStep onNext={mockOnNext} />, {
       wrapperProps: {
         authenticated: true,
         preloadedState: {

--- a/web/src/contexts/ConfigContext.tsx
+++ b/web/src/contexts/ConfigContext.tsx
@@ -18,7 +18,7 @@ interface PrototypeSettings {
   failPreflights: boolean;
   failInstallation: boolean;
   failHostPreflights: boolean;
-  clusterMode: 'existing' | 'embedded';
+  installTarget: 'linux' | 'kubernetes';
   themeColor: string;
   skipNodeValidation: boolean;
   useSelfSignedCert: boolean;
@@ -47,7 +47,7 @@ const defaultPrototypeSettings: PrototypeSettings = {
   failPreflights: false,
   failInstallation: false,
   failHostPreflights: false,
-  clusterMode: 'embedded',
+  installTarget: 'linux',
   themeColor: '#316DE6',
   skipNodeValidation: false,
   useSelfSignedCert: false,

--- a/web/src/contexts/WizardModeContext.tsx
+++ b/web/src/contexts/WizardModeContext.tsx
@@ -1,5 +1,4 @@
 import React, { createContext, useContext } from "react";
-import { useConfig } from "./ConfigContext";
 import { useBranding } from "./BrandingContext";
 
 export type WizardMode = "install" | "upgrade";
@@ -19,13 +18,13 @@ interface WizardText {
   nextButtonText: string;
 }
 
-const getTextVariations = (isEmbedded: boolean, title: string): Record<WizardMode, WizardText> => ({
+const getTextVariations = (isLinux: boolean, title: string): Record<WizardMode, WizardText> => ({
   install: {
     title: title || "",
     subtitle: "Installation Wizard",
     welcomeTitle: `Welcome to ${title}`,
     welcomeDescription: `This wizard will guide you through installing ${title} on your ${
-      isEmbedded ? "Linux machine" : "Kubernetes cluster"
+      isLinux ? "Linux machine" : "Kubernetes cluster"
     }.`,
     setupTitle: "Setup",
     setupDescription: "Configure the host settings for this installation.",
@@ -41,7 +40,7 @@ const getTextVariations = (isEmbedded: boolean, title: string): Record<WizardMod
     subtitle: "Upgrade Wizard",
     welcomeTitle: `Welcome to ${title}`,
     welcomeDescription: `This wizard will guide you through upgrading ${title} on your ${
-      isEmbedded ? "Linux machine" : "Kubernetes cluster"
+      isLinux ? "Linux machine" : "Kubernetes cluster"
     }.`,
     setupTitle: "Setup",
     setupDescription: "Set up the hosts to use for this upgrade.",
@@ -65,10 +64,12 @@ export const WizardModeProvider: React.FC<{
   children: React.ReactNode;
   mode: WizardMode;
 }> = ({ children, mode }) => {
-  const { prototypeSettings } = useConfig();
+  // __INITIAL_STATE__ is a global variable that can be set by the server-side rendering process
+  // as a way to pass initial data to the client.
+  const initialState = window.__INITIAL_STATE__ || {};
   const { title } = useBranding();
-  const isEmbedded = prototypeSettings.clusterMode === "embedded";
-  const text = getTextVariations(isEmbedded, title)[mode];
+  const isLinux = initialState.installTarget === "linux";
+  const text = getTextVariations(isLinux, title)[mode];
 
   return <WizardModeContext.Provider value={{ mode, text }}>{children}</WizardModeContext.Provider>;
 };

--- a/web/src/global.d.ts
+++ b/web/src/global.d.ts
@@ -10,5 +10,6 @@ declare global {
   interface InitialState {
     icon?: string;
     title?: string;
+    installTarget?: string;
   }
 }

--- a/web/src/test/setup.tsx
+++ b/web/src/test/setup.tsx
@@ -29,7 +29,7 @@ interface PrototypeSettings {
   failPreflights: boolean;
   failInstallation: boolean;
   failHostPreflights: boolean;
-  clusterMode: "existing" | "embedded";
+  installTarget: "linux" | "kubernetes";
   themeColor: string;
   skipNodeValidation: boolean;
   useSelfSignedCert: boolean;
@@ -91,7 +91,7 @@ const MockProvider = ({ children, queryClient, contexts }: MockProviderProps) =>
 
   return (
     <QueryClientProvider client={queryClient}>
-      <AuthContext.Provider value={contexts.authContext}>
+      <AuthContext.Provider value={{ ...contexts.authContext, isLoading: false }}>
         <ConfigContext.Provider value={contexts.configContext}>
           <BrandingContext.Provider value={contexts.brandingContext}>
             <WizardModeContext.Provider value={contexts.wizardModeContext}>{children}</WizardModeContext.Provider>
@@ -129,7 +129,7 @@ export const renderWithProviders = (
         failPreflights: false,
         failInstallation: false,
         failHostPreflights: false,
-        clusterMode: "embedded",
+        installTarget: "linux",
         themeColor: "#316DE6",
         skipNodeValidation: false,
         useSelfSignedCert: false,

--- a/web/src/test/testData.ts
+++ b/web/src/test/testData.ts
@@ -2,7 +2,7 @@ export const MOCK_INSTALL_CONFIG = {
   adminConsolePort: 8800,
   localArtifactMirrorPort: 8801,
   networkInterface: "eth0",
-  clusterMode: "embedded",
+  installTarget: "linux",
 };
 
 export const MOCK_NETWORK_INTERFACES = {
@@ -13,7 +13,7 @@ export const MOCK_NETWORK_INTERFACES = {
 };
 
 export const MOCK_PROTOTYPE_SETTINGS = {
-  clusterMode: "embedded",
+  installTarget: "linux",
   title: "Test Cluster",
   description: "Test cluster configuration",
 }; 

--- a/web/static.go
+++ b/web/static.go
@@ -28,8 +28,9 @@ func init() {
 }
 
 type InitialState struct {
-	Title string `json:"title"`
-	Icon  string `json:"icon"`
+	Title         string `json:"title"`
+	Icon          string `json:"icon"`
+	InstallTarget string `json:"installTarget"`
 }
 
 type Web struct {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Adds a flag target which as of now only controls the text on the welcome screen in the browser UI.

![Screenshot 2025-06-24 at 1 28 38 PM](https://github.com/user-attachments/assets/06683749-7623-4256-812c-6615be8eb026)

![Screenshot 2025-06-24 at 1 28 51 PM](https://github.com/user-attachments/assets/6546d3ee-77ae-45f4-b19f-f52108860636)

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
