### PR TITLE
feat: Refactor addons package to decouple from runtimeconfig

### DIFF
--- a/api/integration/install_test.go
+++ b/api/integration/install_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/replicatedhq/embedded-cluster/api/pkg/logger"
 	"github.com/replicatedhq/embedded-cluster/api/types"
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"github.com/replicatedhq/embedded-cluster/pkg-new/constants"
 	"github.com/replicatedhq/embedded-cluster/pkg-new/hostutils"
 	"github.com/replicatedhq/embedded-cluster/pkg-new/k0s"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
@@ -1334,11 +1335,11 @@ func TestPostSetupInfra(t *testing.T) {
 
 		// Verify kotsadm namespace and kotsadm-password secret were created
 		var gotKotsadmNamespace corev1.Namespace
-		err = fakeKcli.Get(t.Context(), client.ObjectKey{Name: runtimeconfig.KotsadmNamespace}, &gotKotsadmNamespace)
+		err = fakeKcli.Get(t.Context(), client.ObjectKey{Name: constants.KotsadmNamespace}, &gotKotsadmNamespace)
 		require.NoError(t, err)
 
 		var gotKotsadmPasswordSecret corev1.Secret
-		err = fakeKcli.Get(t.Context(), client.ObjectKey{Namespace: runtimeconfig.KotsadmNamespace, Name: "kotsadm-password"}, &gotKotsadmPasswordSecret)
+		err = fakeKcli.Get(t.Context(), client.ObjectKey{Namespace: constants.KotsadmNamespace, Name: "kotsadm-password"}, &gotKotsadmPasswordSecret)
 		require.NoError(t, err)
 		assert.NotEmpty(t, gotKotsadmPasswordSecret.Data["passwordBcrypt"])
 

--- a/api/internal/managers/infra/install.go
+++ b/api/internal/managers/infra/install.go
@@ -75,15 +75,7 @@ func (m *infraManager) Install(ctx context.Context, rc runtimeconfig.RuntimeConf
 func (m *infraManager) initComponentsList(license *kotsv1beta1.License, rc runtimeconfig.RuntimeConfig) error {
 	components := []types.InfraComponent{{Name: K0sComponentName}}
 
-	addOns := addons.GetAddOnsForInstall(addons.InstallOptions{
-		IsAirgap:                m.airgapBundle != "",
-		DisasterRecoveryEnabled: license.Spec.IsDisasterRecoverySupported,
-		ProxySpec:               rc.ProxySpec(),
-		HostCABundlePath:        rc.HostCABundlePath(),
-		OpenEBSDataDir:          rc.EmbeddedClusterOpenEBSLocalSubDir(),
-		K0sDataDir:              rc.EmbeddedClusterK0sSubDir(),
-		ServiceCIDR:             rc.ServiceCIDR(),
-	})
+	addOns := addons.GetAddOnsForInstall(m.getAddonInstallOpts(license, rc))
 	for _, addOn := range addOns {
 		components = append(components, types.InfraComponent{Name: addOn.Name()})
 	}
@@ -299,6 +291,7 @@ func (m *infraManager) getAddonInstallOpts(license *kotsv1beta1.License, rc runt
 
 	opts := addons.InstallOptions{
 		AdminConsolePwd:         m.password,
+		AdminConsolePort:        rc.AdminConsolePort(),
 		License:                 license,
 		IsAirgap:                m.airgapBundle != "",
 		TLSCertBytes:            m.tlsConfig.CertBytes,
@@ -310,9 +303,9 @@ func (m *infraManager) getAddonInstallOpts(license *kotsv1beta1.License, rc runt
 		EndUserConfigSpec:       m.getEndUserConfigSpec(),
 		ProxySpec:               rc.ProxySpec(),
 		HostCABundlePath:        rc.HostCABundlePath(),
-		OpenEBSDataDir:          rc.EmbeddedClusterOpenEBSLocalSubDir(),
 		DataDir:                 rc.EmbeddedClusterHomeDirectory(),
 		K0sDataDir:              rc.EmbeddedClusterK0sSubDir(),
+		OpenEBSDataDir:          rc.EmbeddedClusterOpenEBSLocalSubDir(),
 		ServiceCIDR:             rc.ServiceCIDR(),
 	}
 

--- a/api/internal/managers/infra/install.go
+++ b/api/internal/managers/infra/install.go
@@ -311,6 +311,7 @@ func (m *infraManager) getAddonInstallOpts(license *kotsv1beta1.License, rc runt
 		ProxySpec:               rc.ProxySpec(),
 		HostCABundlePath:        rc.HostCABundlePath(),
 		OpenEBSDataDir:          rc.EmbeddedClusterOpenEBSLocalSubDir(),
+		DataDir:                 rc.EmbeddedClusterHomeDirectory(),
 		K0sDataDir:              rc.EmbeddedClusterK0sSubDir(),
 		ServiceCIDR:             rc.ServiceCIDR(),
 	}

--- a/api/internal/managers/infra/install.go
+++ b/api/internal/managers/infra/install.go
@@ -80,8 +80,8 @@ func (m *infraManager) initComponentsList(license *kotsv1beta1.License, rc runti
 		DisasterRecoveryEnabled: license.Spec.IsDisasterRecoverySupported,
 		ProxySpec:               rc.ProxySpec(),
 		HostCABundlePath:        rc.HostCABundlePath(),
-		OpenEBSLocalSubDir:      rc.EmbeddedClusterOpenEBSLocalSubDir(),
-		K0sSubDir:               rc.EmbeddedClusterK0sSubDir(),
+		OpenEBSDataDir:          rc.EmbeddedClusterOpenEBSLocalSubDir(),
+		K0sDataDir:              rc.EmbeddedClusterK0sSubDir(),
 		ServiceCIDR:             rc.ServiceCIDR(),
 	})
 	for _, addOn := range addOns {
@@ -310,8 +310,8 @@ func (m *infraManager) getAddonInstallOpts(license *kotsv1beta1.License, rc runt
 		EndUserConfigSpec:       m.getEndUserConfigSpec(),
 		ProxySpec:               rc.ProxySpec(),
 		HostCABundlePath:        rc.HostCABundlePath(),
-		OpenEBSLocalSubDir:      rc.EmbeddedClusterOpenEBSLocalSubDir(),
-		K0sSubDir:               rc.EmbeddedClusterK0sSubDir(),
+		OpenEBSDataDir:          rc.EmbeddedClusterOpenEBSLocalSubDir(),
+		K0sDataDir:              rc.EmbeddedClusterK0sSubDir(),
 		ServiceCIDR:             rc.ServiceCIDR(),
 	}
 

--- a/cmd/installer/cli/adminconsole_resetpassword.go
+++ b/cmd/installer/cli/adminconsole_resetpassword.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/replicatedhq/embedded-cluster/cmd/installer/kotscli"
+	"github.com/replicatedhq/embedded-cluster/pkg/dryrun"
 	"github.com/replicatedhq/embedded-cluster/pkg/prompts"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	rcutil "github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig/util"
@@ -22,7 +23,8 @@ func AdminConsoleResetPasswordCmd(ctx context.Context, name string) *cobra.Comma
 		Args:  cobra.MaximumNArgs(1),
 		Short: fmt.Sprintf("Reset the %s Admin Console password. If no password is provided, you will be prompted to enter a new one.", name),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if os.Getuid() != 0 {
+			// Skip root check if dryrun mode is enabled
+			if !dryrun.Enabled() && os.Getuid() != 0 {
 				return fmt.Errorf("reset-password command must be run as root")
 			}
 

--- a/cmd/installer/cli/enable_ha.go
+++ b/cmd/installer/cli/enable_ha.go
@@ -111,9 +111,18 @@ func runEnableHA(ctx context.Context, rc runtimeconfig.RuntimeConfig) error {
 	defer loading.Close()
 
 	opts := addons.EnableHAOptions{
-		ServiceCIDR: rc.ServiceCIDR(),
-		ProxySpec:   rc.ProxySpec(),
+		AdminConsolePort:   rc.AdminConsolePort(),
+		IsAirgap:           in.Spec.AirGap,
+		IsMultiNodeEnabled: in.Spec.LicenseInfo != nil && in.Spec.LicenseInfo.IsMultiNodeEnabled,
+		EmbeddedConfigSpec: in.Spec.Config,
+		EndUserConfigSpec:  nil, // TODO: add support for end user config spec
+		ProxySpec:          rc.ProxySpec(),
+		HostCABundlePath:   rc.HostCABundlePath(),
+		DataDir:            rc.EmbeddedClusterHomeDirectory(),
+		K0sDataDir:         rc.EmbeddedClusterK0sSubDir(),
+		SeaweedFSDataDir:   rc.EmbeddedClusterSeaweedFSSubDir(),
+		ServiceCIDR:        rc.ServiceCIDR(),
 	}
 
-	return addOns.EnableHA(ctx, in.Spec, opts, loading)
+	return addOns.EnableHA(ctx, opts, loading)
 }

--- a/cmd/installer/cli/enable_ha.go
+++ b/cmd/installer/cli/enable_ha.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/replicatedhq/embedded-cluster/pkg-new/domains"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons"
+	"github.com/replicatedhq/embedded-cluster/pkg/dryrun"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
 	"github.com/replicatedhq/embedded-cluster/pkg/kubeutils"
 	"github.com/replicatedhq/embedded-cluster/pkg/release"
@@ -26,7 +27,8 @@ func EnableHACmd(ctx context.Context, name string) *cobra.Command {
 		Use:   "enable-ha",
 		Short: fmt.Sprintf("Enable high availability for the %s cluster", name),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if os.Getuid() != 0 {
+			// Skip root check if dryrun mode is enabled
+			if !dryrun.Enabled() && os.Getuid() != 0 {
 				return fmt.Errorf("enable-ha command must be run as root")
 			}
 
@@ -113,5 +115,5 @@ func runEnableHA(ctx context.Context, rc runtimeconfig.RuntimeConfig) error {
 		ProxySpec:   rc.ProxySpec(),
 	}
 
-	return addOns.EnableHA(ctx, in.Spec, loading, opts)
+	return addOns.EnableHA(ctx, in.Spec, opts, loading)
 }

--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -742,6 +742,7 @@ func getAddonInstallOpts(flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig, 
 
 	opts := &addons.InstallOptions{
 		AdminConsolePwd:         flags.adminConsolePassword,
+		AdminConsolePort:        rc.AdminConsolePort(),
 		License:                 flags.license,
 		IsAirgap:                flags.airgapBundle != "",
 		TLSCertBytes:            flags.tlsCertBytes,
@@ -753,8 +754,9 @@ func getAddonInstallOpts(flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig, 
 		EndUserConfigSpec:       euCfgSpec,
 		ProxySpec:               rc.ProxySpec(),
 		HostCABundlePath:        rc.HostCABundlePath(),
-		OpenEBSDataDir:          rc.EmbeddedClusterOpenEBSLocalSubDir(),
+		DataDir:                 rc.EmbeddedClusterHomeDirectory(),
 		K0sDataDir:              rc.EmbeddedClusterK0sSubDir(),
+		OpenEBSDataDir:          rc.EmbeddedClusterOpenEBSLocalSubDir(),
 		ServiceCIDR:             rc.ServiceCIDR(),
 		KotsInstaller: func() error {
 			opts := kotscli.InstallOptions{

--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -19,6 +19,8 @@ import (
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg-new/cloudutils"
 	newconfig "github.com/replicatedhq/embedded-cluster/pkg-new/config"
+	"github.com/replicatedhq/embedded-cluster/pkg-new/constants"
+	"github.com/replicatedhq/embedded-cluster/pkg-new/domains"
 	"github.com/replicatedhq/embedded-cluster/pkg-new/hostutils"
 	"github.com/replicatedhq/embedded-cluster/pkg-new/k0s"
 	ecmetadata "github.com/replicatedhq/embedded-cluster/pkg-new/metadata"
@@ -749,12 +751,17 @@ func getAddonInstallOpts(flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig, 
 		IsMultiNodeEnabled:      flags.license.Spec.IsEmbeddedClusterMultiNodeEnabled,
 		EmbeddedConfigSpec:      embCfgSpec,
 		EndUserConfigSpec:       euCfgSpec,
+		ProxySpec:               rc.ProxySpec(),
+		HostCABundlePath:        rc.HostCABundlePath(),
+		OpenEBSLocalSubDir:      rc.EmbeddedClusterOpenEBSLocalSubDir(),
+		K0sSubDir:               rc.EmbeddedClusterK0sSubDir(),
+		ServiceCIDR:             rc.ServiceCIDR(),
 		KotsInstaller: func() error {
 			opts := kotscli.InstallOptions{
 				RuntimeConfig:         rc,
 				AppSlug:               flags.license.Spec.AppSlug,
 				License:               flags.licenseBytes,
-				Namespace:             runtimeconfig.KotsadmNamespace,
+				Namespace:             constants.KotsadmNamespace,
 				AirgapBundle:          flags.airgapBundle,
 				ConfigValuesFile:      flags.configValues,
 				ReplicatedAppEndpoint: replicatedAppURL(),
@@ -1046,7 +1053,7 @@ func installAddons(ctx context.Context, kcli client.Client, mcli metadata.Interf
 		addons.WithKubernetesClient(kcli),
 		addons.WithMetadataClient(mcli),
 		addons.WithHelmClient(hcli),
-		addons.WithRuntimeConfig(rc),
+		addons.WithDomains(getDomains()),
 		addons.WithProgressChannel(progressChan),
 	)
 
@@ -1060,6 +1067,15 @@ func installAddons(ctx context.Context, kcli client.Client, mcli metadata.Interf
 	}
 
 	return nil
+}
+
+func getDomains() ecv1beta1.Domains {
+	var embCfgSpec *ecv1beta1.ConfigSpec
+	if embCfg := release.GetEmbeddedClusterConfig(); embCfg != nil {
+		embCfgSpec = &embCfg.Spec
+	}
+
+	return domains.GetDomains(embCfgSpec, release.GetChannelRelease())
 }
 
 func installExtensions(ctx context.Context, hcli helm.Client) error {
@@ -1213,20 +1229,12 @@ func validateAdminConsolePassword(password, passwordCheck string) bool {
 }
 
 func replicatedAppURL() string {
-	var embCfgSpec *ecv1beta1.ConfigSpec
-	if embCfg := release.GetEmbeddedClusterConfig(); embCfg != nil {
-		embCfgSpec = &embCfg.Spec
-	}
-	domains := runtimeconfig.GetDomains(embCfgSpec)
+	domains := getDomains()
 	return netutils.MaybeAddHTTPS(domains.ReplicatedAppDomain)
 }
 
 func proxyRegistryURL() string {
-	var embCfgSpec *ecv1beta1.ConfigSpec
-	if embCfg := release.GetEmbeddedClusterConfig(); embCfg != nil {
-		embCfgSpec = &embCfg.Spec
-	}
-	domains := runtimeconfig.GetDomains(embCfgSpec)
+	domains := getDomains()
 	return netutils.MaybeAddHTTPS(domains.ProxyRegistryDomain)
 }
 

--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -753,8 +753,8 @@ func getAddonInstallOpts(flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig, 
 		EndUserConfigSpec:       euCfgSpec,
 		ProxySpec:               rc.ProxySpec(),
 		HostCABundlePath:        rc.HostCABundlePath(),
-		OpenEBSLocalSubDir:      rc.EmbeddedClusterOpenEBSLocalSubDir(),
-		K0sSubDir:               rc.EmbeddedClusterK0sSubDir(),
+		OpenEBSDataDir:          rc.EmbeddedClusterOpenEBSLocalSubDir(),
+		K0sDataDir:              rc.EmbeddedClusterK0sSubDir(),
 		ServiceCIDR:             rc.ServiceCIDR(),
 		KotsInstaller: func() error {
 			opts := kotscli.InstallOptions{

--- a/cmd/installer/cli/join.go
+++ b/cmd/installer/cli/join.go
@@ -21,6 +21,7 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/addons"
 	"github.com/replicatedhq/embedded-cluster/pkg/airgap"
 	"github.com/replicatedhq/embedded-cluster/pkg/config"
+	"github.com/replicatedhq/embedded-cluster/pkg/dryrun"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
 	"github.com/replicatedhq/embedded-cluster/pkg/helpers"
 	"github.com/replicatedhq/embedded-cluster/pkg/kotsadm"
@@ -112,7 +113,8 @@ func JoinCmd(ctx context.Context, name string) *cobra.Command {
 }
 
 func preRunJoin(flags *JoinCmdFlags) error {
-	if os.Getuid() != 0 {
+	// Skip root check if dryrun mode is enabled
+	if !dryrun.Enabled() && os.Getuid() != 0 {
 		return fmt.Errorf("join command must be run as root")
 	}
 
@@ -659,5 +661,5 @@ func maybeEnableHA(ctx context.Context, kcli client.Client, mcli metadata.Interf
 		ProxySpec:   rc.ProxySpec(),
 	}
 
-	return addOns.EnableHA(ctx, jcmd.InstallationSpec, loading, opts)
+	return addOns.EnableHA(ctx, jcmd.InstallationSpec, opts, loading)
 }

--- a/cmd/installer/cli/join.go
+++ b/cmd/installer/cli/join.go
@@ -657,9 +657,18 @@ func maybeEnableHA(ctx context.Context, kcli client.Client, mcli metadata.Interf
 	defer loading.Close()
 
 	opts := addons.EnableHAOptions{
-		ServiceCIDR: rc.ServiceCIDR(),
-		ProxySpec:   rc.ProxySpec(),
+		AdminConsolePort:   rc.AdminConsolePort(),
+		IsAirgap:           jcmd.InstallationSpec.AirGap,
+		IsMultiNodeEnabled: jcmd.InstallationSpec.LicenseInfo != nil && jcmd.InstallationSpec.LicenseInfo.IsMultiNodeEnabled,
+		EmbeddedConfigSpec: jcmd.InstallationSpec.Config,
+		EndUserConfigSpec:  nil, // TODO: add support for end user config spec
+		ProxySpec:          rc.ProxySpec(),
+		HostCABundlePath:   rc.HostCABundlePath(),
+		DataDir:            rc.EmbeddedClusterHomeDirectory(),
+		K0sDataDir:         rc.EmbeddedClusterK0sSubDir(),
+		SeaweedFSDataDir:   rc.EmbeddedClusterSeaweedFSSubDir(),
+		ServiceCIDR:        rc.ServiceCIDR(),
 	}
 
-	return addOns.EnableHA(ctx, jcmd.InstallationSpec, opts, loading)
+	return addOns.EnableHA(ctx, opts, loading)
 }

--- a/cmd/installer/cli/join_printcommand.go
+++ b/cmd/installer/cli/join_printcommand.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/replicatedhq/embedded-cluster/cmd/installer/kotscli"
+	"github.com/replicatedhq/embedded-cluster/pkg/dryrun"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	rcutil "github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig/util"
 	"github.com/spf13/cobra"
@@ -18,7 +19,8 @@ func JoinPrintCommandCmd(ctx context.Context, name string) *cobra.Command {
 		Use:   "print-command",
 		Short: fmt.Sprintf("Print controller join command for %s", name),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if os.Getuid() != 0 {
+			// Skip root check if dryrun mode is enabled
+			if !dryrun.Enabled() && os.Getuid() != 0 {
 				return fmt.Errorf("print-command command must be run as root")
 			}
 

--- a/cmd/installer/cli/join_runpreflights.go
+++ b/cmd/installer/cli/join_runpreflights.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/replicatedhq/embedded-cluster/kinds/types/join"
 	newconfig "github.com/replicatedhq/embedded-cluster/pkg-new/config"
+	"github.com/replicatedhq/embedded-cluster/pkg-new/domains"
 	"github.com/replicatedhq/embedded-cluster/pkg-new/hostutils"
 	"github.com/replicatedhq/embedded-cluster/pkg-new/preflights"
 	"github.com/replicatedhq/embedded-cluster/pkg/kotsadm"
@@ -101,7 +102,7 @@ func runJoinPreflights(ctx context.Context, jcmd *join.JoinCommandResponse, flag
 		return fmt.Errorf("unable to find first valid address: %w", err)
 	}
 
-	domains := runtimeconfig.GetDomains(jcmd.InstallationSpec.Config)
+	domains := domains.GetDomains(jcmd.InstallationSpec.Config, release.GetChannelRelease())
 
 	hpf, err := preflights.Prepare(ctx, preflights.PrepareOptions{
 		HostPreflightSpec:       release.GetHostPreflights(),

--- a/cmd/installer/cli/materialize.go
+++ b/cmd/installer/cli/materialize.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/replicatedhq/embedded-cluster/cmd/installer/goods"
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"github.com/replicatedhq/embedded-cluster/pkg/dryrun"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/spf13/cobra"
 )
@@ -20,7 +21,8 @@ func MaterializeCmd(ctx context.Context, name string) *cobra.Command {
 		Short:  "Materialize embedded assets into the data directory",
 		Hidden: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if os.Getuid() != 0 {
+			// Skip root check if dryrun mode is enabled
+			if !dryrun.Enabled() && os.Getuid() != 0 {
 				return fmt.Errorf("materialize command must be run as root")
 			}
 

--- a/cmd/installer/cli/reset_firewalld.go
+++ b/cmd/installer/cli/reset_firewalld.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/replicatedhq/embedded-cluster/pkg-new/hostutils"
+	"github.com/replicatedhq/embedded-cluster/pkg/dryrun"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	rcutil "github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig/util"
 	"github.com/sirupsen/logrus"
@@ -20,7 +21,8 @@ func ResetFirewalldCmd(ctx context.Context, name string) *cobra.Command {
 		Short:  "Remove %s firewalld configuration from the current node",
 		Hidden: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if os.Getuid() != 0 {
+			// Skip root check if dryrun mode is enabled
+			if !dryrun.Enabled() && os.Getuid() != 0 {
 				return fmt.Errorf("reset firewalld command must be run as root")
 			}
 

--- a/cmd/installer/cli/restore.go
+++ b/cmd/installer/cli/restore.go
@@ -481,8 +481,8 @@ func installAddonsForRestore(ctx context.Context, kcli client.Client, mcli metad
 		EndUserConfigSpec:  nil, // TODO: support for end user config overrides
 		ProxySpec:          rc.ProxySpec(),
 		HostCABundlePath:   rc.HostCABundlePath(),
-		OpenEBSLocalSubDir: rc.EmbeddedClusterOpenEBSLocalSubDir(),
-		K0sSubDir:          rc.EmbeddedClusterK0sSubDir(),
+		OpenEBSDataDir:     rc.EmbeddedClusterOpenEBSLocalSubDir(),
+		K0sDataDir:         rc.EmbeddedClusterK0sSubDir(),
 	}); err != nil {
 		return fmt.Errorf("install addons: %w", err)
 	}

--- a/cmd/installer/cli/restore.go
+++ b/cmd/installer/cli/restore.go
@@ -481,6 +481,7 @@ func installAddonsForRestore(ctx context.Context, kcli client.Client, mcli metad
 		EndUserConfigSpec:  nil, // TODO: support for end user config overrides
 		ProxySpec:          rc.ProxySpec(),
 		HostCABundlePath:   rc.HostCABundlePath(),
+		DataDir:            rc.EmbeddedClusterHomeDirectory(),
 		OpenEBSDataDir:     rc.EmbeddedClusterOpenEBSLocalSubDir(),
 		K0sDataDir:         rc.EmbeddedClusterK0sSubDir(),
 	}); err != nil {
@@ -622,8 +623,10 @@ func runRestoreEnableAdminConsoleHA(ctx context.Context, flags InstallCmdFlags, 
 	)
 
 	opts := addons.EnableHAOptions{
-		ServiceCIDR: rc.ServiceCIDR(),
-		ProxySpec:   rc.ProxySpec(),
+		ServiceCIDR:      rc.ServiceCIDR(),
+		ProxySpec:        rc.ProxySpec(),
+		DataDir:          rc.EmbeddedClusterHomeDirectory(),
+		AdminConsolePort: rc.AdminConsolePort(),
 	}
 
 	err = addOns.EnableAdminConsoleHA(ctx, flags.isAirgap, in.Spec.Config, in.Spec.LicenseInfo, opts)

--- a/cmd/installer/cli/shell.go
+++ b/cmd/installer/cli/shell.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 
 	"github.com/creack/pty"
+	"github.com/replicatedhq/embedded-cluster/pkg/dryrun"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	rcutil "github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig/util"
 	"github.com/sirupsen/logrus"
@@ -34,7 +35,8 @@ func ShellCmd(ctx context.Context, name string) *cobra.Command {
 		Use:   "shell",
 		Short: fmt.Sprintf("Start a shell with access to the %s cluster", name),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if os.Getuid() != 0 {
+			// Skip root check if dryrun mode is enabled
+			if !dryrun.Enabled() && os.Getuid() != 0 {
 				return fmt.Errorf("shell command must be run as root")
 			}
 

--- a/cmd/installer/cli/update.go
+++ b/cmd/installer/cli/update.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/replicatedhq/embedded-cluster/cmd/installer/kotscli"
+	"github.com/replicatedhq/embedded-cluster/pkg-new/constants"
 	"github.com/replicatedhq/embedded-cluster/pkg/release"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	rcutil "github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig/util"
@@ -55,7 +56,7 @@ func UpdateCmd(ctx context.Context, name string) *cobra.Command {
 			if err := kotscli.AirgapUpdate(kotscli.AirgapUpdateOptions{
 				RuntimeConfig: rc,
 				AppSlug:       rel.AppSlug,
-				Namespace:     runtimeconfig.KotsadmNamespace,
+				Namespace:     constants.KotsadmNamespace,
 				AirgapBundle:  airgapBundle,
 			}); err != nil {
 				return err

--- a/cmd/installer/cli/update.go
+++ b/cmd/installer/cli/update.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/replicatedhq/embedded-cluster/cmd/installer/kotscli"
 	"github.com/replicatedhq/embedded-cluster/pkg-new/constants"
+	"github.com/replicatedhq/embedded-cluster/pkg/dryrun"
 	"github.com/replicatedhq/embedded-cluster/pkg/release"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	rcutil "github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig/util"
@@ -22,7 +23,8 @@ func UpdateCmd(ctx context.Context, name string) *cobra.Command {
 		Use:   "update",
 		Short: fmt.Sprintf("Update %s with a new air gap bundle", name),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if os.Getuid() != 0 {
+			// Skip root check if dryrun mode is enabled
+			if !dryrun.Enabled() && os.Getuid() != 0 {
 				return fmt.Errorf("update command must be run as root")
 			}
 

--- a/operator/pkg/upgrade/job.go
+++ b/operator/pkg/upgrade/job.go
@@ -294,8 +294,9 @@ func operatorImageName(ctx context.Context, cli client.Client, in *ecv1beta1.Ins
 	}
 	for _, image := range meta.Images {
 		if strings.Contains(image, "embedded-cluster-operator-image") {
-			// We use the domains from the installation spec and fall back to default here, as this is the
-			// operator binary so the channel release is not embedded.
+			// TODO: This will not work in a non-production environment.
+			// The domains in the release are used to supply alternative defaults for staging and the dev environment.
+			// The GetDomains function will always fall back to production defaults.
 			domains := domains.GetDomains(in.Spec.Config, nil)
 			image = strings.Replace(image, "proxy.replicated.com", domains.ProxyRegistryDomain, 1)
 			return image, nil

--- a/operator/pkg/upgrade/job.go
+++ b/operator/pkg/upgrade/job.go
@@ -14,6 +14,8 @@ import (
 	"github.com/replicatedhq/embedded-cluster/operator/pkg/autopilot"
 	"github.com/replicatedhq/embedded-cluster/operator/pkg/metadata"
 	"github.com/replicatedhq/embedded-cluster/operator/pkg/release"
+	"github.com/replicatedhq/embedded-cluster/pkg-new/constants"
+	"github.com/replicatedhq/embedded-cluster/pkg-new/domains"
 	"github.com/replicatedhq/embedded-cluster/pkg/kubeutils"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	batchv1 "k8s.io/api/batch/v1"
@@ -30,7 +32,7 @@ import (
 
 const (
 	upgradeJobName      = "embedded-cluster-upgrade-%s"
-	upgradeJobNamespace = runtimeconfig.KotsadmNamespace
+	upgradeJobNamespace = constants.KotsadmNamespace
 	upgradeJobConfigMap = "upgrade-job-configmap-%s"
 )
 
@@ -180,7 +182,7 @@ func CreateUpgradeJob(
 						},
 					},
 					RestartPolicy:      corev1.RestartPolicyNever,
-					ServiceAccountName: runtimeconfig.KotsadmServiceAccount,
+					ServiceAccountName: constants.KotsadmServiceAccount,
 					Volumes: []corev1.Volume{
 						{
 							Name: "config",
@@ -292,7 +294,9 @@ func operatorImageName(ctx context.Context, cli client.Client, in *ecv1beta1.Ins
 	}
 	for _, image := range meta.Images {
 		if strings.Contains(image, "embedded-cluster-operator-image") {
-			domains := runtimeconfig.GetDomains(in.Spec.Config)
+			// We use the domains from the installation spec and fall back to default here, as this is the
+			// operator binary so the channel release is not embedded.
+			domains := domains.GetDomains(in.Spec.Config, nil)
 			image = strings.Replace(image, "proxy.replicated.com", domains.ProxyRegistryDomain, 1)
 			return image, nil
 		}

--- a/operator/pkg/upgrade/upgrade.go
+++ b/operator/pkg/upgrade/upgrade.go
@@ -181,8 +181,9 @@ func updateClusterConfig(ctx context.Context, cli client.Client, in *ecv1beta1.I
 		return fmt.Errorf("get cluster config: %w", err)
 	}
 
-	// We use the domains from the installation spec and fall back to default here, as this is the
-	// operator binary so the channel release is not embedded.
+	// TODO: This will not work in a non-production environment.
+	// The domains in the release are used to supply alternative defaults for staging and the dev environment.
+	// The GetDomains function will always fall back to production defaults.
 	domains := domains.GetDomains(in.Spec.Config, nil)
 
 	didUpdate := false
@@ -270,8 +271,9 @@ func upgradeAddons(ctx context.Context, cli client.Client, hcli helm.Client, rc 
 		return fmt.Errorf("create metadata client: %w", err)
 	}
 
-	// We use the domains from the installation spec and fall back to default here, as this is the
-	// operator binary so the channel release is not embedded.
+	// TODO: This will not work in a non-production environment.
+	// The domains in the release are used to supply alternative defaults for staging and the dev environment.
+	// The GetDomains function will always fall back to production defaults.
 	domains := domains.GetDomains(in.Spec.Config, nil)
 
 	addOns := addons.New(

--- a/operator/pkg/upgrade/upgrade.go
+++ b/operator/pkg/upgrade/upgrade.go
@@ -283,8 +283,20 @@ func upgradeAddons(ctx context.Context, cli client.Client, hcli helm.Client, rc 
 	)
 
 	opts := addons.UpgradeOptions{
-		ServiceCIDR: rc.ServiceCIDR(),
-		ProxySpec:   rc.ProxySpec(),
+		AdminConsolePort:        rc.AdminConsolePort(),
+		IsAirgap:                in.Spec.AirGap,
+		IsHA:                    in.Spec.HighAvailability,
+		DisasterRecoveryEnabled: in.Spec.LicenseInfo != nil && in.Spec.LicenseInfo.IsDisasterRecoverySupported,
+		IsMultiNodeEnabled:      in.Spec.LicenseInfo != nil && in.Spec.LicenseInfo.IsMultiNodeEnabled,
+		EmbeddedConfigSpec:      in.Spec.Config,
+		EndUserConfigSpec:       nil, // TODO: add support for end user config spec
+		ProxySpec:               rc.ProxySpec(),
+		HostCABundlePath:        rc.HostCABundlePath(),
+		DataDir:                 rc.EmbeddedClusterHomeDirectory(),
+		K0sDataDir:              rc.EmbeddedClusterK0sSubDir(),
+		OpenEBSDataDir:          rc.EmbeddedClusterOpenEBSLocalSubDir(),
+		SeaweedFSDataDir:        rc.EmbeddedClusterSeaweedFSSubDir(),
+		ServiceCIDR:             rc.ServiceCIDR(),
 	}
 
 	if err := addOns.Upgrade(ctx, in, meta, opts); err != nil {

--- a/pkg-new/constants/constants.go
+++ b/pkg-new/constants/constants.go
@@ -1,0 +1,14 @@
+package constants
+
+const (
+	KotsadmNamespace         = "kotsadm"
+	KotsadmServiceAccount    = "kotsadm"
+	SeaweedFSNamespace       = "seaweedfs"
+	RegistryNamespace        = "registry"
+	VeleroNamespace          = "velero"
+	EmbeddedClusterNamespace = "embedded-cluster"
+)
+
+const (
+	EcRestoreStateCMName = "embedded-cluster-restore-state"
+)

--- a/pkg-new/k0s/k0s.go
+++ b/pkg-new/k0s/k0s.go
@@ -11,6 +11,7 @@ import (
 
 	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"github.com/replicatedhq/embedded-cluster/pkg-new/domains"
 	"github.com/replicatedhq/embedded-cluster/pkg/airgap"
 	"github.com/replicatedhq/embedded-cluster/pkg/config"
 	"github.com/replicatedhq/embedded-cluster/pkg/helpers"
@@ -100,7 +101,7 @@ func NewK0sConfig(networkInterface string, isAirgap bool, podCIDR string, servic
 		embCfgSpec = &embCfg.Spec
 	}
 
-	domains := runtimeconfig.GetDomains(embCfgSpec)
+	domains := domains.GetDomains(embCfgSpec, release.GetChannelRelease())
 	cfg := config.RenderK0sConfig(domains.ProxyRegistryDomain)
 
 	address, err := netutils.FirstValidAddress(networkInterface)

--- a/pkg-new/tlsutils/tls.go
+++ b/pkg-new/tlsutils/tls.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
+	"github.com/replicatedhq/embedded-cluster/pkg-new/constants"
 	certutil "k8s.io/client-go/util/cert"
 )
 
@@ -57,7 +57,7 @@ func GetTLSConfig(cert tls.Certificate) *tls.Config {
 }
 
 func generateCertHostnames(hostname string) (string, []string) {
-	namespace := runtimeconfig.KotsadmNamespace
+	namespace := constants.KotsadmNamespace
 
 	if hostname == "" {
 		hostname = fmt.Sprintf("kotsadm.%s.svc.cluster.local", namespace)

--- a/pkg/addons/adminconsole/adminconsole.go
+++ b/pkg/addons/adminconsole/adminconsole.go
@@ -22,16 +22,18 @@ type AdminConsole struct {
 	IsHA               bool
 	Proxy              *ecv1beta1.ProxySpec
 	ServiceCIDR        string
-	Password           string
-	TLSCertBytes       []byte
-	TLSKeyBytes        []byte
-	Hostname           string
-	KotsInstaller      KotsInstaller
 	IsMultiNodeEnabled bool
 	HostCABundlePath   string
 	DataDir            string
 	K0sDataDir         string
 	AdminConsolePort   int
+
+	// These options are only used during installation
+	Password      string
+	TLSCertBytes  []byte
+	TLSKeyBytes   []byte
+	Hostname      string
+	KotsInstaller KotsInstaller
 
 	// DryRun is a flag to enable dry-run mode for Admin Console.
 	// If true, Admin Console will only render the helm template and additional manifests, but not install

--- a/pkg/addons/adminconsole/adminconsole.go
+++ b/pkg/addons/adminconsole/adminconsole.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	_releaseName = "admin-console"
-	// TODO(screspo): get the namespace from somewhere else
+
 	_namespace = constants.KotsadmNamespace
 )
 

--- a/pkg/addons/adminconsole/adminconsole.go
+++ b/pkg/addons/adminconsole/adminconsole.go
@@ -5,13 +5,14 @@ import (
 	"strings"
 
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"github.com/replicatedhq/embedded-cluster/pkg-new/constants"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/types"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 )
 
 const (
 	_releaseName = "admin-console"
-	_namespace   = runtimeconfig.KotsadmNamespace
+	// TODO(screspo): get the namespace from somewhere else
+	_namespace = constants.KotsadmNamespace
 )
 
 var _ types.AddOn = (*AdminConsole)(nil)
@@ -27,6 +28,10 @@ type AdminConsole struct {
 	Hostname           string
 	KotsInstaller      KotsInstaller
 	IsMultiNodeEnabled bool
+	HostCABundlePath   string
+	DataDir            string
+	K0sDataDir         string
+	AdminConsolePort   int
 
 	// DryRun is a flag to enable dry-run mode for Admin Console.
 	// If true, Admin Console will only render the helm template and additional manifests, but not install

--- a/pkg/addons/adminconsole/install.go
+++ b/pkg/addons/adminconsole/install.go
@@ -13,7 +13,6 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/types"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
 	"github.com/replicatedhq/embedded-cluster/pkg/kubeutils"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"golang.org/x/crypto/bcrypt"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -38,16 +37,15 @@ func init() {
 func (a *AdminConsole) Install(
 	ctx context.Context, logf types.LogFunc,
 	kcli client.Client, mcli metadata.Interface, hcli helm.Client,
-	rc runtimeconfig.RuntimeConfig, domains ecv1beta1.Domains,
-	overrides []string,
+	domains ecv1beta1.Domains, overrides []string,
 ) error {
 	// some resources are not part of the helm chart and need to be created before the chart is installed
 	// TODO: move this to the helm chart
-	if err := a.createPreRequisites(ctx, logf, kcli, mcli, rc); err != nil {
+	if err := a.createPreRequisites(ctx, logf, kcli, mcli); err != nil {
 		return errors.Wrap(err, "create prerequisites")
 	}
 
-	values, err := a.GenerateHelmValues(ctx, kcli, rc, domains, overrides)
+	values, err := a.GenerateHelmValues(ctx, kcli, domains, overrides)
 	if err != nil {
 		return errors.Wrap(err, "generate helm values")
 	}
@@ -85,7 +83,7 @@ func (a *AdminConsole) Install(
 	return nil
 }
 
-func (a *AdminConsole) createPreRequisites(ctx context.Context, logf types.LogFunc, kcli client.Client, mcli metadata.Interface, rc runtimeconfig.RuntimeConfig) error {
+func (a *AdminConsole) createPreRequisites(ctx context.Context, logf types.LogFunc, kcli client.Client, mcli metadata.Interface) error {
 	if err := a.createNamespace(ctx, kcli); err != nil {
 		return errors.Wrap(err, "create namespace")
 	}
@@ -98,7 +96,7 @@ func (a *AdminConsole) createPreRequisites(ctx context.Context, logf types.LogFu
 		return errors.Wrap(err, "create kots TLS secret")
 	}
 
-	if err := a.ensureCAConfigmap(ctx, logf, kcli, mcli, rc); err != nil {
+	if err := a.ensureCAConfigmap(ctx, logf, kcli, mcli); err != nil {
 		return errors.Wrap(err, "ensure CA configmap")
 	}
 
@@ -265,17 +263,17 @@ func (a *AdminConsole) createTLSSecret(ctx context.Context, kcli client.Client) 
 	return nil
 }
 
-func (a *AdminConsole) ensureCAConfigmap(ctx context.Context, logf types.LogFunc, kcli client.Client, mcli metadata.Interface, rc runtimeconfig.RuntimeConfig) error {
-	if rc.HostCABundlePath() == "" {
+func (a *AdminConsole) ensureCAConfigmap(ctx context.Context, logf types.LogFunc, kcli client.Client, mcli metadata.Interface) error {
+	if a.HostCABundlePath == "" {
 		return nil
 	}
 
 	if a.DryRun {
-		checksum, err := calculateFileChecksum(rc.HostCABundlePath())
+		checksum, err := calculateFileChecksum(a.HostCABundlePath)
 		if err != nil {
 			return fmt.Errorf("calculate checksum: %w", err)
 		}
-		new, err := newCAConfigMap(rc.HostCABundlePath(), checksum)
+		new, err := newCAConfigMap(a.HostCABundlePath, checksum)
 		if err != nil {
 			return fmt.Errorf("create map: %w", err)
 		}
@@ -287,7 +285,7 @@ func (a *AdminConsole) ensureCAConfigmap(ctx context.Context, logf types.LogFunc
 		return nil
 	}
 
-	err := EnsureCAConfigmap(ctx, logf, kcli, mcli, rc.HostCABundlePath())
+	err := EnsureCAConfigmap(ctx, logf, kcli, mcli, a.HostCABundlePath)
 
 	if k8serrors.IsRequestEntityTooLargeError(err) || errors.Is(err, fs.ErrNotExist) {
 		// This can result in issues installing in environments with a MITM HTTP proxy.

--- a/pkg/addons/adminconsole/install_test.go
+++ b/pkg/addons/adminconsole/install_test.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -174,13 +173,12 @@ func TestAdminConsole_ensureCAConfigmap(t *testing.T) {
 
 			kcli, mcli := tt.initClients(t)
 
-			rc := runtimeconfig.New(nil)
-			rc.SetDataDir(t.TempDir())
-			rc.SetHostCABundlePath(tt.caPath)
-
 			// Run test
-			addon := &AdminConsole{}
-			err = addon.ensureCAConfigmap(t.Context(), t.Logf, kcli, mcli, rc)
+			addon := &AdminConsole{
+				DataDir:          t.TempDir(),
+				HostCABundlePath: tt.caPath,
+			}
+			err = addon.ensureCAConfigmap(t.Context(), t.Logf, kcli, mcli)
 
 			// Check results
 			if tt.expectedErr {

--- a/pkg/addons/adminconsole/upgrade.go
+++ b/pkg/addons/adminconsole/upgrade.go
@@ -7,7 +7,6 @@ import (
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/types"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/metadata"
@@ -17,7 +16,7 @@ import (
 func (a *AdminConsole) Upgrade(
 	ctx context.Context, logf types.LogFunc,
 	kcli client.Client, mcli metadata.Interface, hcli helm.Client,
-	rc runtimeconfig.RuntimeConfig, domains ecv1beta1.Domains, overrides []string,
+	domains ecv1beta1.Domains, overrides []string,
 ) error {
 	exists, err := hcli.ReleaseExists(ctx, a.Namespace(), a.ReleaseName())
 	if err != nil {
@@ -28,7 +27,7 @@ func (a *AdminConsole) Upgrade(
 		return errors.New("admin console release not found")
 	}
 
-	values, err := a.GenerateHelmValues(ctx, kcli, rc, domains, overrides)
+	values, err := a.GenerateHelmValues(ctx, kcli, domains, overrides)
 	if err != nil {
 		return errors.Wrap(err, "generate helm values")
 	}

--- a/pkg/addons/adminconsole/values.go
+++ b/pkg/addons/adminconsole/values.go
@@ -3,6 +3,7 @@ package adminconsole
 import (
 	"context"
 	_ "embed"
+	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -65,8 +66,17 @@ func (a *AdminConsole) GenerateHelmValues(ctx context.Context, kcli client.Clien
 	}
 
 	copiedValues["embeddedClusterID"] = metrics.ClusterID().String()
+	// TODO (@screspod): correct these
+	if a.DataDir == "" {
+		a.DataDir = ecv1beta1.DefaultDataDir
+	}
 	copiedValues["embeddedClusterDataDir"] = a.DataDir
+
+	if a.K0sDataDir == "" {
+		a.K0sDataDir = filepath.Join(a.DataDir, "k0s")
+	}
 	copiedValues["embeddedClusterK0sDir"] = a.K0sDataDir
+
 	copiedValues["isHA"] = a.IsHA
 	copiedValues["isMultiNodeEnabled"] = a.IsMultiNodeEnabled
 
@@ -142,7 +152,9 @@ func (a *AdminConsole) GenerateHelmValues(ctx context.Context, kcli client.Clien
 	copiedValues["extraVolumeMounts"] = extraVolumeMounts
 
 	// TODO (@screspod): check func (rc *runtimeConfig) AdminConsolePort()
-	a.AdminConsolePort = ecv1beta1.DefaultAdminConsolePort
+	if a.AdminConsolePort <= 0 {
+		a.AdminConsolePort = ecv1beta1.DefaultAdminConsolePort
+	}
 	err = helm.SetValue(copiedValues, "kurlProxy.nodePort", a.AdminConsolePort)
 	if err != nil {
 		return nil, errors.Wrap(err, "set kurlProxy.nodePort")

--- a/pkg/addons/adminconsole/values.go
+++ b/pkg/addons/adminconsole/values.go
@@ -141,6 +141,8 @@ func (a *AdminConsole) GenerateHelmValues(ctx context.Context, kcli client.Clien
 	copiedValues["extraVolumes"] = extraVolumes
 	copiedValues["extraVolumeMounts"] = extraVolumeMounts
 
+	// TODO (@screspod): check func (rc *runtimeConfig) AdminConsolePort()
+	a.AdminConsolePort = ecv1beta1.DefaultAdminConsolePort
 	err = helm.SetValue(copiedValues, "kurlProxy.nodePort", a.AdminConsolePort)
 	if err != nil {
 		return nil, errors.Wrap(err, "set kurlProxy.nodePort")

--- a/pkg/addons/adminconsole/values.go
+++ b/pkg/addons/adminconsole/values.go
@@ -141,10 +141,6 @@ func (a *AdminConsole) GenerateHelmValues(ctx context.Context, kcli client.Clien
 	copiedValues["extraVolumes"] = extraVolumes
 	copiedValues["extraVolumeMounts"] = extraVolumeMounts
 
-	// TODO (@screspod): check func (rc *runtimeConfig) AdminConsolePort()
-	if a.AdminConsolePort <= 0 {
-		a.AdminConsolePort = ecv1beta1.DefaultAdminConsolePort
-	}
 	err = helm.SetValue(copiedValues, "kurlProxy.nodePort", a.AdminConsolePort)
 	if err != nil {
 		return nil, errors.Wrap(err, "set kurlProxy.nodePort")

--- a/pkg/addons/adminconsole/values.go
+++ b/pkg/addons/adminconsole/values.go
@@ -3,7 +3,6 @@ package adminconsole
 import (
 	"context"
 	_ "embed"
-	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -66,17 +65,8 @@ func (a *AdminConsole) GenerateHelmValues(ctx context.Context, kcli client.Clien
 	}
 
 	copiedValues["embeddedClusterID"] = metrics.ClusterID().String()
-	// TODO (@screspod): correct these
-	if a.DataDir == "" {
-		a.DataDir = ecv1beta1.DefaultDataDir
-	}
 	copiedValues["embeddedClusterDataDir"] = a.DataDir
-
-	if a.K0sDataDir == "" {
-		a.K0sDataDir = filepath.Join(a.DataDir, "k0s")
-	}
 	copiedValues["embeddedClusterK0sDir"] = a.K0sDataDir
-
 	copiedValues["isHA"] = a.IsHA
 	copiedValues["isMultiNodeEnabled"] = a.IsMultiNodeEnabled
 

--- a/pkg/addons/adminconsole/values_test.go
+++ b/pkg/addons/adminconsole/values_test.go
@@ -5,20 +5,18 @@ import (
 	"testing"
 
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateHelmValues_HostCABundlePath(t *testing.T) {
 	t.Run("with host CA bundle path", func(t *testing.T) {
-		rc := runtimeconfig.New(nil)
-		rc.SetDataDir(t.TempDir())
-		rc.SetHostCABundlePath("/etc/ssl/certs/ca-certificates.crt")
+		adminConsole := &AdminConsole{
+			DataDir:          t.TempDir(),
+			HostCABundlePath: "/etc/ssl/certs/ca-certificates.crt",
+		}
 
-		adminConsole := &AdminConsole{}
-
-		values, err := adminConsole.GenerateHelmValues(context.Background(), nil, rc, ecv1beta1.Domains{}, nil)
+		values, err := adminConsole.GenerateHelmValues(context.Background(), nil, ecv1beta1.Domains{}, nil)
 		require.NoError(t, err, "GenerateHelmValues should not return an error")
 
 		// Verify structure types
@@ -61,13 +59,12 @@ func TestGenerateHelmValues_HostCABundlePath(t *testing.T) {
 	})
 
 	t.Run("without host CA bundle path", func(t *testing.T) {
-		rc := runtimeconfig.New(nil)
-		rc.SetDataDir(t.TempDir())
 		// HostCABundlePath intentionally not set
+		adminConsole := &AdminConsole{
+			DataDir: t.TempDir(),
+		}
 
-		adminConsole := &AdminConsole{}
-
-		values, err := adminConsole.GenerateHelmValues(context.Background(), nil, rc, ecv1beta1.Domains{}, nil)
+		values, err := adminConsole.GenerateHelmValues(context.Background(), nil, ecv1beta1.Domains{}, nil)
 		require.NoError(t, err, "GenerateHelmValues should not return an error")
 
 		// Verify structure types

--- a/pkg/addons/embeddedclusteroperator/embeddedclusteroperator.go
+++ b/pkg/addons/embeddedclusteroperator/embeddedclusteroperator.go
@@ -31,8 +31,8 @@ var _ types.AddOn = (*EmbeddedClusterOperator)(nil)
 type EmbeddedClusterOperator struct {
 	IsAirgap         bool
 	Proxy            *ecv1beta1.ProxySpec
-	DataDir          string
 	HostCABundlePath string
+	DataDir          string
 
 	ChartLocationOverride string
 	ChartVersionOverride  string

--- a/pkg/addons/embeddedclusteroperator/embeddedclusteroperator.go
+++ b/pkg/addons/embeddedclusteroperator/embeddedclusteroperator.go
@@ -29,8 +29,9 @@ func init() {
 var _ types.AddOn = (*EmbeddedClusterOperator)(nil)
 
 type EmbeddedClusterOperator struct {
-	IsAirgap bool
-	Proxy    *ecv1beta1.ProxySpec
+	IsAirgap         bool
+	Proxy            *ecv1beta1.ProxySpec
+	HostCABundlePath string
 
 	ChartLocationOverride string
 	ChartVersionOverride  string

--- a/pkg/addons/embeddedclusteroperator/embeddedclusteroperator.go
+++ b/pkg/addons/embeddedclusteroperator/embeddedclusteroperator.go
@@ -32,7 +32,6 @@ type EmbeddedClusterOperator struct {
 	IsAirgap         bool
 	Proxy            *ecv1beta1.ProxySpec
 	HostCABundlePath string
-	DataDir          string
 
 	ChartLocationOverride string
 	ChartVersionOverride  string

--- a/pkg/addons/embeddedclusteroperator/embeddedclusteroperator.go
+++ b/pkg/addons/embeddedclusteroperator/embeddedclusteroperator.go
@@ -31,6 +31,7 @@ var _ types.AddOn = (*EmbeddedClusterOperator)(nil)
 type EmbeddedClusterOperator struct {
 	IsAirgap         bool
 	Proxy            *ecv1beta1.ProxySpec
+	DataDir          string
 	HostCABundlePath string
 
 	ChartLocationOverride string

--- a/pkg/addons/embeddedclusteroperator/install.go
+++ b/pkg/addons/embeddedclusteroperator/install.go
@@ -7,7 +7,6 @@ import (
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/types"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"k8s.io/client-go/metadata"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -15,10 +14,9 @@ import (
 func (e *EmbeddedClusterOperator) Install(
 	ctx context.Context, logf types.LogFunc,
 	kcli client.Client, mcli metadata.Interface, hcli helm.Client,
-	rc runtimeconfig.RuntimeConfig, domains ecv1beta1.Domains,
-	overrides []string,
+	domains ecv1beta1.Domains, overrides []string,
 ) error {
-	values, err := e.GenerateHelmValues(ctx, kcli, rc, domains, overrides)
+	values, err := e.GenerateHelmValues(ctx, kcli, domains, overrides)
 	if err != nil {
 		return errors.Wrap(err, "generate helm values")
 	}

--- a/pkg/addons/embeddedclusteroperator/integration/hostcabundle_test.go
+++ b/pkg/addons/embeddedclusteroperator/integration/hostcabundle_test.go
@@ -9,7 +9,6 @@ import (
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/embeddedclusteroperator"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -22,18 +21,16 @@ func TestHostCABundle(t *testing.T) {
 	chartLocation, err := filepath.Abs("../../../../operator/charts/embedded-cluster-operator")
 	require.NoError(t, err, "Failed to get chart location")
 
-	rc := runtimeconfig.New(nil)
-	rc.SetHostCABundlePath("/etc/ssl/certs/ca-certificates.crt")
-
 	addon := &embeddedclusteroperator.EmbeddedClusterOperator{
 		DryRun:                true,
 		ChartLocationOverride: chartLocation,
+		HostCABundlePath:      "/etc/ssl/certs/ca-certificates.crt",
 	}
 
 	hcli, err := helm.NewClient(helm.HelmOptions{})
 	require.NoError(t, err, "NewClient should not return an error")
 
-	err = addon.Install(context.Background(), t.Logf, nil, nil, hcli, rc, ecv1beta1.Domains{}, nil)
+	err = addon.Install(context.Background(), t.Logf, nil, nil, hcli, ecv1beta1.Domains{}, nil)
 	require.NoError(t, err, "embeddedclusteroperator.Install should not return an error")
 
 	manifests := addon.DryRunManifests()

--- a/pkg/addons/embeddedclusteroperator/upgrade.go
+++ b/pkg/addons/embeddedclusteroperator/upgrade.go
@@ -7,7 +7,6 @@ import (
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/types"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/metadata"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -16,7 +15,7 @@ import (
 func (e *EmbeddedClusterOperator) Upgrade(
 	ctx context.Context, logf types.LogFunc,
 	kcli client.Client, mcli metadata.Interface, hcli helm.Client,
-	rc runtimeconfig.RuntimeConfig, domains ecv1beta1.Domains, overrides []string,
+	domains ecv1beta1.Domains, overrides []string,
 ) error {
 	exists, err := hcli.ReleaseExists(ctx, e.Namespace(), e.ReleaseName())
 	if err != nil {
@@ -24,13 +23,13 @@ func (e *EmbeddedClusterOperator) Upgrade(
 	}
 	if !exists {
 		logrus.Debugf("Release not found, installing release %s in namespace %s", e.ReleaseName(), e.Namespace())
-		if err := e.Install(ctx, logf, kcli, mcli, hcli, rc, domains, overrides); err != nil {
+		if err := e.Install(ctx, logf, kcli, mcli, hcli, domains, overrides); err != nil {
 			return errors.Wrap(err, "install")
 		}
 		return nil
 	}
 
-	values, err := e.GenerateHelmValues(ctx, kcli, rc, domains, overrides)
+	values, err := e.GenerateHelmValues(ctx, kcli, domains, overrides)
 	if err != nil {
 		return errors.Wrap(err, "generate helm values")
 	}

--- a/pkg/addons/embeddedclusteroperator/values.go
+++ b/pkg/addons/embeddedclusteroperator/values.go
@@ -10,7 +10,6 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
 	"github.com/replicatedhq/embedded-cluster/pkg/metrics"
 	"github.com/replicatedhq/embedded-cluster/pkg/release"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/replicatedhq/embedded-cluster/pkg/versions"
 	"gopkg.in/yaml.v3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -38,7 +37,7 @@ func init() {
 	helmValues["embeddedClusterK0sVersion"] = versions.K0sVersion
 }
 
-func (e *EmbeddedClusterOperator) GenerateHelmValues(ctx context.Context, kcli client.Client, rc runtimeconfig.RuntimeConfig, domains ecv1beta1.Domains, overrides []string) (map[string]interface{}, error) {
+func (e *EmbeddedClusterOperator) GenerateHelmValues(ctx context.Context, kcli client.Client, domains ecv1beta1.Domains, overrides []string) (map[string]interface{}, error) {
 	// create a copy of the helm values so we don't modify the original
 	marshalled, err := helm.MarshalValues(helmValues)
 	if err != nil {
@@ -92,11 +91,11 @@ func (e *EmbeddedClusterOperator) GenerateHelmValues(ctx context.Context, kcli c
 		}...)
 	}
 
-	if rc.HostCABundlePath() != "" {
+	if e.HostCABundlePath != "" {
 		extraVolumes = append(extraVolumes, map[string]any{
 			"name": "host-ca-bundle",
 			"hostPath": map[string]any{
-				"path": rc.HostCABundlePath(),
+				"path": e.HostCABundlePath,
 				"type": "FileOrCreate",
 			},
 		})

--- a/pkg/addons/embeddedclusteroperator/values_test.go
+++ b/pkg/addons/embeddedclusteroperator/values_test.go
@@ -5,19 +5,17 @@ import (
 	"testing"
 
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateHelmValues_HostCABundlePath(t *testing.T) {
-	rc := runtimeconfig.New(nil)
-	rc.SetDataDir(t.TempDir())
-	rc.SetHostCABundlePath("/etc/ssl/certs/ca-certificates.crt")
+	e := &EmbeddedClusterOperator{
+		DataDir:          t.TempDir(),
+		HostCABundlePath: "/etc/ssl/certs/ca-certificates.crt",
+	}
 
-	e := &EmbeddedClusterOperator{}
-
-	values, err := e.GenerateHelmValues(context.Background(), nil, rc, ecv1beta1.Domains{}, nil)
+	values, err := e.GenerateHelmValues(context.Background(), nil, ecv1beta1.Domains{}, nil)
 	require.NoError(t, err, "GenerateHelmValues should not return an error")
 
 	require.NotEmpty(t, values["extraVolumes"])

--- a/pkg/addons/embeddedclusteroperator/values_test.go
+++ b/pkg/addons/embeddedclusteroperator/values_test.go
@@ -11,7 +11,6 @@ import (
 
 func TestGenerateHelmValues_HostCABundlePath(t *testing.T) {
 	e := &EmbeddedClusterOperator{
-		DataDir:          t.TempDir(),
 		HostCABundlePath: "/etc/ssl/certs/ca-certificates.crt",
 	}
 

--- a/pkg/addons/highavailability.go
+++ b/pkg/addons/highavailability.go
@@ -53,7 +53,7 @@ func (a *AddOns) CanEnableHA(ctx context.Context) (bool, string, error) {
 }
 
 // EnableHA enables high availability.
-func (a *AddOns) EnableHA(ctx context.Context, inSpec ecv1beta1.InstallationSpec, spinner *spinner.MessageWriter, opts EnableHAOptions) error {
+func (a *AddOns) EnableHA(ctx context.Context, inSpec ecv1beta1.InstallationSpec, opts EnableHAOptions, spinner *spinner.MessageWriter) error {
 	if inSpec.AirGap {
 		logrus.Debugf("Enabling high availability")
 		spinner.Infof("Enabling high availability")

--- a/pkg/addons/highavailability_test.go
+++ b/pkg/addons/highavailability_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
-	"github.com/replicatedhq/embedded-cluster/pkg/constants"
+	"github.com/replicatedhq/embedded-cluster/pkg-new/constants"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v12 "k8s.io/api/core/v1"

--- a/pkg/addons/install.go
+++ b/pkg/addons/install.go
@@ -17,6 +17,7 @@ import (
 
 type InstallOptions struct {
 	AdminConsolePwd         string
+	AdminConsolePort        int
 	License                 *kotsv1beta1.License
 	IsAirgap                bool
 	TLSCertBytes            []byte
@@ -29,6 +30,7 @@ type InstallOptions struct {
 	KotsInstaller           adminconsole.KotsInstaller
 	ProxySpec               *ecv1beta1.ProxySpec
 	HostCABundlePath        string
+	DataDir                 string
 	OpenEBSDataDir          string
 	K0sDataDir              string
 	ServiceCIDR             string
@@ -58,6 +60,7 @@ type RestoreOptions struct {
 	EndUserConfigSpec  *ecv1beta1.ConfigSpec
 	ProxySpec          *ecv1beta1.ProxySpec
 	HostCABundlePath   string
+	DataDir            string
 	OpenEBSDataDir     string
 	K0sDataDir         string
 }
@@ -84,12 +87,14 @@ func (a *AddOns) Restore(ctx context.Context, opts RestoreOptions) error {
 func GetAddOnsForInstall(opts InstallOptions) []types.AddOn {
 	addOns := []types.AddOn{
 		&openebs.OpenEBS{
+			DataDir:        opts.DataDir,
 			OpenEBSDataDir: opts.OpenEBSDataDir,
 		},
 		&embeddedclusteroperator.EmbeddedClusterOperator{
 			IsAirgap:         opts.IsAirgap,
 			Proxy:            opts.ProxySpec,
 			HostCABundlePath: opts.HostCABundlePath,
+			DataDir:          opts.DataDir,
 		},
 	}
 
@@ -103,6 +108,7 @@ func GetAddOnsForInstall(opts InstallOptions) []types.AddOn {
 		addOns = append(addOns, &velero.Velero{
 			Proxy:            opts.ProxySpec,
 			HostCABundlePath: opts.HostCABundlePath,
+			DataDir:          opts.DataDir,
 			K0sDataDir:       opts.K0sDataDir,
 		})
 	}
@@ -117,6 +123,7 @@ func GetAddOnsForInstall(opts InstallOptions) []types.AddOn {
 		Hostname:           opts.Hostname,
 		KotsInstaller:      opts.KotsInstaller,
 		IsMultiNodeEnabled: opts.IsMultiNodeEnabled,
+		AdminConsolePort:   opts.AdminConsolePort,
 	}
 	addOns = append(addOns, adminConsoleAddOn)
 
@@ -126,11 +133,13 @@ func GetAddOnsForInstall(opts InstallOptions) []types.AddOn {
 func GetAddOnsForRestore(opts RestoreOptions) []types.AddOn {
 	addOns := []types.AddOn{
 		&openebs.OpenEBS{
+			DataDir:        opts.DataDir,
 			OpenEBSDataDir: opts.OpenEBSDataDir,
 		},
 		&velero.Velero{
 			Proxy:            opts.ProxySpec,
 			HostCABundlePath: opts.HostCABundlePath,
+			DataDir:          opts.DataDir,
 			K0sDataDir:       opts.K0sDataDir,
 		},
 	}

--- a/pkg/addons/install.go
+++ b/pkg/addons/install.go
@@ -93,7 +93,6 @@ func GetAddOnsForInstall(opts InstallOptions) []types.AddOn {
 			IsAirgap:         opts.IsAirgap,
 			Proxy:            opts.ProxySpec,
 			HostCABundlePath: opts.HostCABundlePath,
-			DataDir:          opts.DataDir,
 		},
 	}
 
@@ -108,7 +107,6 @@ func GetAddOnsForInstall(opts InstallOptions) []types.AddOn {
 		addOns = append(addOns, &velero.Velero{
 			Proxy:            opts.ProxySpec,
 			HostCABundlePath: opts.HostCABundlePath,
-			DataDir:          opts.DataDir,
 			K0sDataDir:       opts.K0sDataDir,
 		})
 	}
@@ -143,7 +141,6 @@ func GetAddOnsForRestore(opts RestoreOptions) []types.AddOn {
 		&velero.Velero{
 			Proxy:            opts.ProxySpec,
 			HostCABundlePath: opts.HostCABundlePath,
-			DataDir:          opts.DataDir,
 			K0sDataDir:       opts.K0sDataDir,
 		},
 	}

--- a/pkg/addons/install.go
+++ b/pkg/addons/install.go
@@ -29,8 +29,8 @@ type InstallOptions struct {
 	KotsInstaller           adminconsole.KotsInstaller
 	ProxySpec               *ecv1beta1.ProxySpec
 	HostCABundlePath        string
-	OpenEBSLocalSubDir      string
-	K0sSubDir               string
+	OpenEBSDataDir          string
+	K0sDataDir              string
 	ServiceCIDR             string
 }
 
@@ -58,8 +58,8 @@ type RestoreOptions struct {
 	EndUserConfigSpec  *ecv1beta1.ConfigSpec
 	ProxySpec          *ecv1beta1.ProxySpec
 	HostCABundlePath   string
-	OpenEBSLocalSubDir string
-	K0sSubDir          string
+	OpenEBSDataDir     string
+	K0sDataDir         string
 }
 
 func (a *AddOns) Restore(ctx context.Context, opts RestoreOptions) error {
@@ -84,7 +84,7 @@ func (a *AddOns) Restore(ctx context.Context, opts RestoreOptions) error {
 func GetAddOnsForInstall(opts InstallOptions) []types.AddOn {
 	addOns := []types.AddOn{
 		&openebs.OpenEBS{
-			OpenEBSDataDir: opts.OpenEBSLocalSubDir,
+			OpenEBSDataDir: opts.OpenEBSDataDir,
 		},
 		&embeddedclusteroperator.EmbeddedClusterOperator{
 			IsAirgap:         opts.IsAirgap,
@@ -103,7 +103,7 @@ func GetAddOnsForInstall(opts InstallOptions) []types.AddOn {
 		addOns = append(addOns, &velero.Velero{
 			Proxy:            opts.ProxySpec,
 			HostCABundlePath: opts.HostCABundlePath,
-			K0sDataDir:       opts.K0sSubDir,
+			K0sDataDir:       opts.K0sDataDir,
 		})
 	}
 
@@ -126,12 +126,12 @@ func GetAddOnsForInstall(opts InstallOptions) []types.AddOn {
 func GetAddOnsForRestore(opts RestoreOptions) []types.AddOn {
 	addOns := []types.AddOn{
 		&openebs.OpenEBS{
-			OpenEBSDataDir: opts.OpenEBSLocalSubDir,
+			OpenEBSDataDir: opts.OpenEBSDataDir,
 		},
 		&velero.Velero{
 			Proxy:            opts.ProxySpec,
 			HostCABundlePath: opts.HostCABundlePath,
-			K0sDataDir:       opts.K0sSubDir,
+			K0sDataDir:       opts.K0sDataDir,
 		},
 	}
 	return addOns

--- a/pkg/addons/install.go
+++ b/pkg/addons/install.go
@@ -31,8 +31,8 @@ type InstallOptions struct {
 	ProxySpec               *ecv1beta1.ProxySpec
 	HostCABundlePath        string
 	DataDir                 string
-	OpenEBSDataDir          string
 	K0sDataDir              string
+	OpenEBSDataDir          string
 	ServiceCIDR             string
 }
 
@@ -87,7 +87,6 @@ func (a *AddOns) Restore(ctx context.Context, opts RestoreOptions) error {
 func GetAddOnsForInstall(opts InstallOptions) []types.AddOn {
 	addOns := []types.AddOn{
 		&openebs.OpenEBS{
-			DataDir:        opts.DataDir,
 			OpenEBSDataDir: opts.OpenEBSDataDir,
 		},
 		&embeddedclusteroperator.EmbeddedClusterOperator{
@@ -101,6 +100,7 @@ func GetAddOnsForInstall(opts InstallOptions) []types.AddOn {
 	if opts.IsAirgap {
 		addOns = append(addOns, &registry.Registry{
 			ServiceCIDR: opts.ServiceCIDR,
+			IsHA:        false,
 		})
 	}
 
@@ -115,15 +115,20 @@ func GetAddOnsForInstall(opts InstallOptions) []types.AddOn {
 
 	adminConsoleAddOn := &adminconsole.AdminConsole{
 		IsAirgap:           opts.IsAirgap,
+		IsHA:               false,
 		Proxy:              opts.ProxySpec,
 		ServiceCIDR:        opts.ServiceCIDR,
-		Password:           opts.AdminConsolePwd,
-		TLSCertBytes:       opts.TLSCertBytes,
-		TLSKeyBytes:        opts.TLSKeyBytes,
-		Hostname:           opts.Hostname,
-		KotsInstaller:      opts.KotsInstaller,
 		IsMultiNodeEnabled: opts.IsMultiNodeEnabled,
+		HostCABundlePath:   opts.HostCABundlePath,
+		DataDir:            opts.DataDir,
+		K0sDataDir:         opts.K0sDataDir,
 		AdminConsolePort:   opts.AdminConsolePort,
+
+		Password:      opts.AdminConsolePwd,
+		TLSCertBytes:  opts.TLSCertBytes,
+		TLSKeyBytes:   opts.TLSKeyBytes,
+		Hostname:      opts.Hostname,
+		KotsInstaller: opts.KotsInstaller,
 	}
 	addOns = append(addOns, adminConsoleAddOn)
 
@@ -133,7 +138,6 @@ func GetAddOnsForInstall(opts InstallOptions) []types.AddOn {
 func GetAddOnsForRestore(opts RestoreOptions) []types.AddOn {
 	addOns := []types.AddOn{
 		&openebs.OpenEBS{
-			DataDir:        opts.DataDir,
 			OpenEBSDataDir: opts.OpenEBSDataDir,
 		},
 		&velero.Velero{

--- a/pkg/addons/install_test.go
+++ b/pkg/addons/install_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/registry"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/types"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/velero"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -18,7 +17,6 @@ import (
 func Test_getAddOnsForInstall(t *testing.T) {
 	tests := []struct {
 		name   string
-		rc     runtimeconfig.RuntimeConfig
 		opts   InstallOptions
 		before func()
 		verify func(t *testing.T, addons []types.AddOn)
@@ -26,7 +24,6 @@ func Test_getAddOnsForInstall(t *testing.T) {
 	}{
 		{
 			name: "online installation",
-			rc:   runtimeconfig.New(nil),
 			opts: InstallOptions{
 				IsAirgap:                false,
 				DisasterRecoveryEnabled: false,
@@ -59,15 +56,11 @@ func Test_getAddOnsForInstall(t *testing.T) {
 		},
 		{
 			name: "airgap installation",
-			rc: func() runtimeconfig.RuntimeConfig {
-				rc := runtimeconfig.New(nil)
-				rc.SetNetworkSpec(ecv1beta1.NetworkSpec{ServiceCIDR: "10.96.0.0/12"})
-				return rc
-			}(),
 			opts: InstallOptions{
 				IsAirgap:                true,
 				DisasterRecoveryEnabled: false,
 				AdminConsolePwd:         "password123",
+				ServiceCIDR:             "10.96.0.0/12",
 			},
 			verify: func(t *testing.T, addons []types.AddOn) {
 				assert.Len(t, addons, 4)
@@ -100,15 +93,11 @@ func Test_getAddOnsForInstall(t *testing.T) {
 		},
 		{
 			name: "disaster recovery enabled",
-			rc: func() runtimeconfig.RuntimeConfig {
-				rc := runtimeconfig.New(nil)
-				rc.SetNetworkSpec(ecv1beta1.NetworkSpec{ServiceCIDR: "10.96.0.0/12"})
-				return rc
-			}(),
 			opts: InstallOptions{
 				IsAirgap:                false,
 				DisasterRecoveryEnabled: true,
 				AdminConsolePwd:         "password123",
+				ServiceCIDR:             "10.96.0.0/12",
 			},
 			verify: func(t *testing.T, addons []types.AddOn) {
 				assert.Len(t, addons, 4)
@@ -141,20 +130,16 @@ func Test_getAddOnsForInstall(t *testing.T) {
 		},
 		{
 			name: "airgap with disaster recovery and proxy",
-			rc: func() runtimeconfig.RuntimeConfig {
-				rc := runtimeconfig.New(nil)
-				rc.SetNetworkSpec(ecv1beta1.NetworkSpec{ServiceCIDR: "10.96.0.0/12"})
-				rc.SetProxySpec(&ecv1beta1.ProxySpec{
-					HTTPProxy:  "http://proxy.example.com",
-					HTTPSProxy: "https://proxy.example.com",
-					NoProxy:    "localhost,127.0.0.1",
-				})
-				return rc
-			}(),
 			opts: InstallOptions{
 				IsAirgap:                true,
 				DisasterRecoveryEnabled: true,
 				AdminConsolePwd:         "password123",
+				ServiceCIDR:             "10.96.0.0/12",
+				ProxySpec: &ecv1beta1.ProxySpec{
+					HTTPProxy:  "http://proxy.example.com",
+					HTTPSProxy: "https://proxy.example.com",
+					NoProxy:    "localhost,127.0.0.1",
+				},
 			},
 			verify: func(t *testing.T, addons []types.AddOn) {
 				assert.Len(t, addons, 5)
@@ -200,12 +185,10 @@ func Test_getAddOnsForInstall(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rc := tt.rc
-			rc.SetDataDir(t.TempDir())
 			if tt.before != nil {
 				tt.before()
 			}
-			tt.verify(t, GetAddOnsForInstall(rc, tt.opts))
+			tt.verify(t, GetAddOnsForInstall(tt.opts))
 			if tt.after != nil {
 				tt.after()
 			}

--- a/pkg/addons/interface.go
+++ b/pkg/addons/interface.go
@@ -7,7 +7,6 @@ import (
 	ectypes "github.com/replicatedhq/embedded-cluster/kinds/types"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/types"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/replicatedhq/embedded-cluster/pkg/spinner"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
@@ -19,13 +18,13 @@ type AddOnsInterface interface {
 	// Install installs all addons
 	Install(ctx context.Context, opts InstallOptions) error
 	// Upgrade upgrades all addons
-	Upgrade(ctx context.Context, in *ecv1beta1.Installation, meta *ectypes.ReleaseMetadata) error
+	Upgrade(ctx context.Context, in *ecv1beta1.Installation, meta *ectypes.ReleaseMetadata, opts UpgradeOptions) error
 	// CanEnableHA checks if high availability can be enabled in the cluster
 	CanEnableHA(context.Context) (bool, string, error)
 	// EnableHA enables high availability for the cluster
-	EnableHA(ctx context.Context, inSpec ecv1beta1.InstallationSpec, spinner *spinner.MessageWriter) error
+	EnableHA(ctx context.Context, inSpec ecv1beta1.InstallationSpec, spinner *spinner.MessageWriter, opts EnableHAOptions) error
 	// EnableAdminConsoleHA enables high availability for the admin console
-	EnableAdminConsoleHA(ctx context.Context, isAirgap bool, cfgspec *ecv1beta1.ConfigSpec, licenseInfo *ecv1beta1.LicenseInfo) error
+	EnableAdminConsoleHA(ctx context.Context, isAirgap bool, cfgspec *ecv1beta1.ConfigSpec, licenseInfo *ecv1beta1.LicenseInfo, opts EnableHAOptions) error
 }
 
 var _ AddOnsInterface = (*AddOns)(nil)
@@ -36,7 +35,7 @@ type AddOns struct {
 	kcli     client.Client
 	mcli     metadata.Interface
 	kclient  kubernetes.Interface
-	rc       runtimeconfig.RuntimeConfig
+	domains  ecv1beta1.Domains
 	progress chan<- types.AddOnProgress
 }
 
@@ -72,9 +71,9 @@ func WithKubernetesClientSet(kclient kubernetes.Interface) AddOnsOption {
 	}
 }
 
-func WithRuntimeConfig(rc runtimeconfig.RuntimeConfig) AddOnsOption {
+func WithDomains(domains ecv1beta1.Domains) AddOnsOption {
 	return func(a *AddOns) {
-		a.rc = rc
+		a.domains = domains
 	}
 }
 
@@ -92,10 +91,6 @@ func New(opts ...AddOnsOption) *AddOns {
 
 	if a.logf == nil {
 		a.logf = logrus.Debugf
-	}
-
-	if a.rc == nil {
-		a.rc = runtimeconfig.New(nil)
 	}
 
 	return a

--- a/pkg/addons/interface.go
+++ b/pkg/addons/interface.go
@@ -22,9 +22,9 @@ type AddOnsInterface interface {
 	// CanEnableHA checks if high availability can be enabled in the cluster
 	CanEnableHA(context.Context) (bool, string, error)
 	// EnableHA enables high availability for the cluster
-	EnableHA(ctx context.Context, inSpec ecv1beta1.InstallationSpec, opts EnableHAOptions, spinner *spinner.MessageWriter) error
+	EnableHA(ctx context.Context, opts EnableHAOptions, spinner *spinner.MessageWriter) error
 	// EnableAdminConsoleHA enables high availability for the admin console
-	EnableAdminConsoleHA(ctx context.Context, isAirgap bool, cfgspec *ecv1beta1.ConfigSpec, licenseInfo *ecv1beta1.LicenseInfo, opts EnableHAOptions) error
+	EnableAdminConsoleHA(ctx context.Context, opts EnableHAOptions) error
 }
 
 var _ AddOnsInterface = (*AddOns)(nil)

--- a/pkg/addons/interface.go
+++ b/pkg/addons/interface.go
@@ -22,7 +22,7 @@ type AddOnsInterface interface {
 	// CanEnableHA checks if high availability can be enabled in the cluster
 	CanEnableHA(context.Context) (bool, string, error)
 	// EnableHA enables high availability for the cluster
-	EnableHA(ctx context.Context, inSpec ecv1beta1.InstallationSpec, spinner *spinner.MessageWriter, opts EnableHAOptions) error
+	EnableHA(ctx context.Context, inSpec ecv1beta1.InstallationSpec, opts EnableHAOptions, spinner *spinner.MessageWriter) error
 	// EnableAdminConsoleHA enables high availability for the admin console
 	EnableAdminConsoleHA(ctx context.Context, isAirgap bool, cfgspec *ecv1beta1.ConfigSpec, licenseInfo *ecv1beta1.LicenseInfo, opts EnableHAOptions) error
 }

--- a/pkg/addons/mock.go
+++ b/pkg/addons/mock.go
@@ -35,13 +35,13 @@ func (m *MockAddOns) CanEnableHA(ctx context.Context) (bool, string, error) {
 }
 
 // EnableHA mocks the EnableHA method
-func (m *MockAddOns) EnableHA(ctx context.Context, inSpec ecv1beta1.InstallationSpec, opts EnableHAOptions, spinner *spinner.MessageWriter) error {
-	args := m.Called(ctx, inSpec, opts, spinner)
+func (m *MockAddOns) EnableHA(ctx context.Context, opts EnableHAOptions, spinner *spinner.MessageWriter) error {
+	args := m.Called(ctx, opts, spinner)
 	return args.Error(0)
 }
 
 // EnableAdminConsoleHA mocks the EnableAdminConsoleHA method
-func (m *MockAddOns) EnableAdminConsoleHA(ctx context.Context, isAirgap bool, cfgspec *ecv1beta1.ConfigSpec, licenseInfo *ecv1beta1.LicenseInfo, opts EnableHAOptions) error {
-	args := m.Called(ctx, isAirgap, cfgspec, licenseInfo, opts)
+func (m *MockAddOns) EnableAdminConsoleHA(ctx context.Context, opts EnableHAOptions) error {
+	args := m.Called(ctx, opts)
 	return args.Error(0)
 }

--- a/pkg/addons/mock.go
+++ b/pkg/addons/mock.go
@@ -35,8 +35,8 @@ func (m *MockAddOns) CanEnableHA(ctx context.Context) (bool, string, error) {
 }
 
 // EnableHA mocks the EnableHA method
-func (m *MockAddOns) EnableHA(ctx context.Context, inSpec ecv1beta1.InstallationSpec, spinner *spinner.MessageWriter, opts EnableHAOptions) error {
-	args := m.Called(ctx, inSpec, spinner, opts)
+func (m *MockAddOns) EnableHA(ctx context.Context, inSpec ecv1beta1.InstallationSpec, opts EnableHAOptions, spinner *spinner.MessageWriter) error {
+	args := m.Called(ctx, inSpec, opts, spinner)
 	return args.Error(0)
 }
 

--- a/pkg/addons/mock.go
+++ b/pkg/addons/mock.go
@@ -23,8 +23,8 @@ func (m *MockAddOns) Install(ctx context.Context, opts InstallOptions) error {
 }
 
 // Upgrade mocks the Upgrade method
-func (m *MockAddOns) Upgrade(ctx context.Context, in *ecv1beta1.Installation, meta *ectypes.ReleaseMetadata) error {
-	args := m.Called(ctx, in, meta)
+func (m *MockAddOns) Upgrade(ctx context.Context, in *ecv1beta1.Installation, meta *ectypes.ReleaseMetadata, opts UpgradeOptions) error {
+	args := m.Called(ctx, in, meta, opts)
 	return args.Error(0)
 }
 
@@ -35,13 +35,13 @@ func (m *MockAddOns) CanEnableHA(ctx context.Context) (bool, string, error) {
 }
 
 // EnableHA mocks the EnableHA method
-func (m *MockAddOns) EnableHA(ctx context.Context, inSpec ecv1beta1.InstallationSpec, spinner *spinner.MessageWriter) error {
-	args := m.Called(ctx, inSpec, spinner)
+func (m *MockAddOns) EnableHA(ctx context.Context, inSpec ecv1beta1.InstallationSpec, spinner *spinner.MessageWriter, opts EnableHAOptions) error {
+	args := m.Called(ctx, inSpec, spinner, opts)
 	return args.Error(0)
 }
 
 // EnableAdminConsoleHA mocks the EnableAdminConsoleHA method
-func (m *MockAddOns) EnableAdminConsoleHA(ctx context.Context, isAirgap bool, cfgspec *ecv1beta1.ConfigSpec, licenseInfo *ecv1beta1.LicenseInfo) error {
-	args := m.Called(ctx, isAirgap, cfgspec, licenseInfo)
+func (m *MockAddOns) EnableAdminConsoleHA(ctx context.Context, isAirgap bool, cfgspec *ecv1beta1.ConfigSpec, licenseInfo *ecv1beta1.LicenseInfo, opts EnableHAOptions) error {
+	args := m.Called(ctx, isAirgap, cfgspec, licenseInfo, opts)
 	return args.Error(0)
 }

--- a/pkg/addons/openebs/install.go
+++ b/pkg/addons/openebs/install.go
@@ -7,7 +7,6 @@ import (
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/types"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"k8s.io/client-go/metadata"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -15,10 +14,9 @@ import (
 func (o *OpenEBS) Install(
 	ctx context.Context, logf types.LogFunc,
 	kcli client.Client, mcli metadata.Interface, hcli helm.Client,
-	rc runtimeconfig.RuntimeConfig, domains ecv1beta1.Domains,
-	overrides []string,
+	domains ecv1beta1.Domains, overrides []string,
 ) error {
-	values, err := o.GenerateHelmValues(ctx, kcli, rc, domains, overrides)
+	values, err := o.GenerateHelmValues(ctx, kcli, domains, overrides)
 	if err != nil {
 		return errors.Wrap(err, "generate helm values")
 	}

--- a/pkg/addons/openebs/openebs.go
+++ b/pkg/addons/openebs/openebs.go
@@ -15,6 +15,7 @@ const (
 var _ types.AddOn = (*OpenEBS)(nil)
 
 type OpenEBS struct {
+	OpenEBSDataDir string
 }
 
 func (o *OpenEBS) Name() string {

--- a/pkg/addons/openebs/openebs.go
+++ b/pkg/addons/openebs/openebs.go
@@ -15,7 +15,6 @@ const (
 var _ types.AddOn = (*OpenEBS)(nil)
 
 type OpenEBS struct {
-	DataDir        string
 	OpenEBSDataDir string
 }
 

--- a/pkg/addons/openebs/openebs.go
+++ b/pkg/addons/openebs/openebs.go
@@ -15,6 +15,7 @@ const (
 var _ types.AddOn = (*OpenEBS)(nil)
 
 type OpenEBS struct {
+	DataDir        string
 	OpenEBSDataDir string
 }
 

--- a/pkg/addons/openebs/upgrade.go
+++ b/pkg/addons/openebs/upgrade.go
@@ -7,7 +7,6 @@ import (
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/types"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/metadata"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -16,7 +15,7 @@ import (
 func (o *OpenEBS) Upgrade(
 	ctx context.Context, logf types.LogFunc,
 	kcli client.Client, mcli metadata.Interface, hcli helm.Client,
-	rc runtimeconfig.RuntimeConfig, domains ecv1beta1.Domains, overrides []string,
+	domains ecv1beta1.Domains, overrides []string,
 ) error {
 	exists, err := hcli.ReleaseExists(ctx, o.Namespace(), o.ReleaseName())
 	if err != nil {
@@ -24,13 +23,13 @@ func (o *OpenEBS) Upgrade(
 	}
 	if !exists {
 		logrus.Debugf("Release not found, installing release %s in namespace %s", o.ReleaseName(), o.Namespace())
-		if err := o.Install(ctx, logf, kcli, mcli, hcli, rc, domains, overrides); err != nil {
+		if err := o.Install(ctx, logf, kcli, mcli, hcli, domains, overrides); err != nil {
 			return errors.Wrap(err, "install")
 		}
 		return nil
 	}
 
-	values, err := o.GenerateHelmValues(ctx, kcli, rc, domains, overrides)
+	values, err := o.GenerateHelmValues(ctx, kcli, domains, overrides)
 	if err != nil {
 		return errors.Wrap(err, "generate helm values")
 	}

--- a/pkg/addons/openebs/values.go
+++ b/pkg/addons/openebs/values.go
@@ -9,7 +9,6 @@ import (
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
 	"github.com/replicatedhq/embedded-cluster/pkg/release"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"gopkg.in/yaml.v3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -33,7 +32,7 @@ func init() {
 	helmValues = hv
 }
 
-func (o *OpenEBS) GenerateHelmValues(ctx context.Context, kcli client.Client, rc runtimeconfig.RuntimeConfig, domains ecv1beta1.Domains, overrides []string) (map[string]interface{}, error) {
+func (o *OpenEBS) GenerateHelmValues(ctx context.Context, kcli client.Client, domains ecv1beta1.Domains, overrides []string) (map[string]interface{}, error) {
 	// create a copy of the helm values so we don't modify the original
 	marshalled, err := helm.MarshalValues(helmValues)
 	if err != nil {
@@ -50,7 +49,7 @@ func (o *OpenEBS) GenerateHelmValues(ctx context.Context, kcli client.Client, rc
 		return nil, errors.Wrap(err, "unmarshal helm values")
 	}
 
-	err = helm.SetValue(copiedValues, "localpv-provisioner.localpv.basePath", rc.EmbeddedClusterOpenEBSLocalSubDir())
+	err = helm.SetValue(copiedValues, "localpv-provisioner.localpv.basePath", o.OpenEBSDataDir)
 	if err != nil {
 		return nil, errors.Wrap(err, "set localpv-provisioner.localpv.basePath")
 	}

--- a/pkg/addons/registry/install.go
+++ b/pkg/addons/registry/install.go
@@ -10,7 +10,6 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/types"
 	"github.com/replicatedhq/embedded-cluster/pkg/certs"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"golang.org/x/crypto/bcrypt"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,7 +20,7 @@ import (
 func (r *Registry) Install(
 	ctx context.Context, logf types.LogFunc,
 	kcli client.Client, mcli metadata.Interface, hcli helm.Client,
-	rc runtimeconfig.RuntimeConfig, domains ecv1beta1.Domains,
+	domains ecv1beta1.Domains,
 	overrides []string,
 ) error {
 	registryIP, err := GetRegistryClusterIP(r.ServiceCIDR)
@@ -33,7 +32,7 @@ func (r *Registry) Install(
 		return errors.Wrap(err, "create prerequisites")
 	}
 
-	values, err := r.GenerateHelmValues(ctx, kcli, rc, domains, overrides)
+	values, err := r.GenerateHelmValues(ctx, kcli, domains, overrides)
 	if err != nil {
 		return errors.Wrap(err, "generate helm values")
 	}

--- a/pkg/addons/registry/migrate/pod.go
+++ b/pkg/addons/registry/migrate/pod.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"github.com/replicatedhq/embedded-cluster/pkg-new/constants"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/seaweedfs"
 	"github.com/replicatedhq/embedded-cluster/pkg/kubeutils"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -92,7 +92,8 @@ func ensureDataMigrationPod(ctx context.Context, cli client.Client, image string
 func maybeDeleteDataMigrationPod(ctx context.Context, cli client.Client) error {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: runtimeconfig.RegistryNamespace,
+			// TODO(screspo): get the namespace from somewhere else
+			Namespace: constants.RegistryNamespace,
 			Name:      dataMigrationPodName,
 		},
 	}
@@ -105,7 +106,7 @@ func maybeDeleteDataMigrationPod(ctx context.Context, cli client.Client) error {
 		return nil
 	}
 
-	err = kubeutils.WaitForPodDeleted(ctx, cli, runtimeconfig.RegistryNamespace, dataMigrationPodName, &kubeutils.WaitOptions{
+	err = kubeutils.WaitForPodDeleted(ctx, cli, constants.RegistryNamespace, dataMigrationPodName, &kubeutils.WaitOptions{
 		Backoff: &wait.Backoff{
 			Steps:    30,
 			Duration: 2 * time.Second,
@@ -132,7 +133,7 @@ func monitorPodStatus(ctx context.Context, cli client.Client, errCh chan<- error
 			Jitter:   0.1,
 		},
 	}
-	pod, err := kubeutils.WaitForPodComplete(ctx, cli, runtimeconfig.RegistryNamespace, dataMigrationPodName, opts)
+	pod, err := kubeutils.WaitForPodComplete(ctx, cli, constants.RegistryNamespace, dataMigrationPodName, opts)
 	if err != nil {
 		errCh <- err
 	}
@@ -178,7 +179,7 @@ func streamPodLogs(ctx context.Context, kclient kubernetes.Interface) (io.ReadCl
 		Follow:    true,
 		TailLines: ptr.To(int64(100)),
 	}
-	podLogs, err := kclient.CoreV1().Pods(runtimeconfig.RegistryNamespace).GetLogs(dataMigrationPodName, &logOpts).Stream(ctx)
+	podLogs, err := kclient.CoreV1().Pods(constants.RegistryNamespace).GetLogs(dataMigrationPodName, &logOpts).Stream(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("get logs: %w", err)
 	}
@@ -225,7 +226,7 @@ func newMigrationPod(image string) *corev1.Pod {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      dataMigrationPodName,
-			Namespace: runtimeconfig.RegistryNamespace,
+			Namespace: constants.RegistryNamespace,
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",
@@ -279,7 +280,7 @@ func ensureMigrationServiceAccount(ctx context.Context, cli client.Client) error
 	newRole := rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "registry-data-migration-role",
-			Namespace: runtimeconfig.RegistryNamespace,
+			Namespace: constants.RegistryNamespace,
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Role",
@@ -306,7 +307,7 @@ func ensureMigrationServiceAccount(ctx context.Context, cli client.Client) error
 	newServiceAccount := corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceAccountName,
-			Namespace: runtimeconfig.RegistryNamespace,
+			Namespace: constants.RegistryNamespace,
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ServiceAccount",
@@ -321,7 +322,7 @@ func ensureMigrationServiceAccount(ctx context.Context, cli client.Client) error
 	newRoleBinding := rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "registry-data-migration-rolebinding",
-			Namespace: runtimeconfig.RegistryNamespace,
+			Namespace: constants.RegistryNamespace,
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "RoleBinding",
@@ -336,7 +337,7 @@ func ensureMigrationServiceAccount(ctx context.Context, cli client.Client) error
 			{
 				Kind:      "ServiceAccount",
 				Name:      serviceAccountName,
-				Namespace: runtimeconfig.RegistryNamespace,
+				Namespace: constants.RegistryNamespace,
 			},
 		},
 	}
@@ -357,7 +358,7 @@ func ensureS3Secret(ctx context.Context, kcli client.Client) error {
 
 	var secret corev1.Secret
 	err = kcli.Get(ctx, client.ObjectKey{
-		Namespace: runtimeconfig.RegistryNamespace,
+		Namespace: constants.RegistryNamespace,
 		Name:      seaweedfsS3SecretName,
 	}, &secret)
 	if client.IgnoreNotFound(err) != nil {
@@ -377,7 +378,7 @@ func ensureS3Secret(ctx context.Context, kcli client.Client) error {
 
 	secret = corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: runtimeconfig.RegistryNamespace,
+			Namespace: constants.RegistryNamespace,
 			Name:      seaweedfsS3SecretName,
 			Labels:    seaweedfs.ApplyLabels(secret.ObjectMeta.Labels, "s3"),
 		},

--- a/pkg/addons/registry/migrate/pod.go
+++ b/pkg/addons/registry/migrate/pod.go
@@ -92,7 +92,6 @@ func ensureDataMigrationPod(ctx context.Context, cli client.Client, image string
 func maybeDeleteDataMigrationPod(ctx context.Context, cli client.Client) error {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			// TODO(screspo): get the namespace from somewhere else
 			Namespace: constants.RegistryNamespace,
 			Name:      dataMigrationPodName,
 		},

--- a/pkg/addons/registry/registry.go
+++ b/pkg/addons/registry/registry.go
@@ -23,7 +23,7 @@ type Registry struct {
 
 const (
 	_releaseName = "docker-registry"
-	// TODO(screspo): get the namespace from somewhere else
+
 	_namespace = constants.RegistryNamespace
 
 	_tlsSecretName    = "registry-tls"

--- a/pkg/addons/registry/registry.go
+++ b/pkg/addons/registry/registry.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/pkg/errors"
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"github.com/replicatedhq/embedded-cluster/pkg-new/constants"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/types"
 	"github.com/replicatedhq/embedded-cluster/pkg/helpers"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	appsv1 "k8s.io/api/apps/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -23,7 +23,8 @@ type Registry struct {
 
 const (
 	_releaseName = "docker-registry"
-	_namespace   = runtimeconfig.RegistryNamespace
+	// TODO(screspo): get the namespace from somewhere else
+	_namespace = constants.RegistryNamespace
 
 	_tlsSecretName    = "registry-tls"
 	_lowerBandIPIndex = 10

--- a/pkg/addons/registry/registry.go
+++ b/pkg/addons/registry/registry.go
@@ -23,8 +23,7 @@ type Registry struct {
 
 const (
 	_releaseName = "docker-registry"
-
-	_namespace = constants.RegistryNamespace
+	_namespace   = constants.RegistryNamespace
 
 	_tlsSecretName    = "registry-tls"
 	_lowerBandIPIndex = 10

--- a/pkg/addons/registry/upgrade.go
+++ b/pkg/addons/registry/upgrade.go
@@ -8,7 +8,6 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/seaweedfs"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/types"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -27,7 +26,7 @@ const (
 func (r *Registry) Upgrade(
 	ctx context.Context, logf types.LogFunc,
 	kcli client.Client, mcli metadata.Interface, hcli helm.Client,
-	rc runtimeconfig.RuntimeConfig, domains ecv1beta1.Domains, overrides []string,
+	domains ecv1beta1.Domains, overrides []string,
 ) error {
 	exists, err := hcli.ReleaseExists(ctx, r.Namespace(), r.ReleaseName())
 	if err != nil {
@@ -35,7 +34,7 @@ func (r *Registry) Upgrade(
 	}
 	if !exists {
 		logrus.Debugf("Release not found, installing release %s in namespace %s", r.ReleaseName(), r.Namespace())
-		if err := r.Install(ctx, logf, kcli, mcli, hcli, rc, domains, overrides); err != nil {
+		if err := r.Install(ctx, logf, kcli, mcli, hcli, domains, overrides); err != nil {
 			return errors.Wrap(err, "install")
 		}
 		return nil
@@ -45,7 +44,7 @@ func (r *Registry) Upgrade(
 		return errors.Wrap(err, "create prerequisites")
 	}
 
-	values, err := r.GenerateHelmValues(ctx, kcli, rc, domains, overrides)
+	values, err := r.GenerateHelmValues(ctx, kcli, domains, overrides)
 	if err != nil {
 		return errors.Wrap(err, "generate helm values")
 	}

--- a/pkg/addons/registry/values.go
+++ b/pkg/addons/registry/values.go
@@ -10,7 +10,6 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/seaweedfs"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
 	"github.com/replicatedhq/embedded-cluster/pkg/release"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -46,7 +45,7 @@ func init() {
 	helmValuesHA = hvHA
 }
 
-func (r *Registry) GenerateHelmValues(ctx context.Context, kcli client.Client, rc runtimeconfig.RuntimeConfig, domains ecv1beta1.Domains, overrides []string) (map[string]interface{}, error) {
+func (r *Registry) GenerateHelmValues(ctx context.Context, kcli client.Client, domains ecv1beta1.Domains, overrides []string) (map[string]interface{}, error) {
 	var values map[string]interface{}
 	if r.IsHA {
 		values = helmValuesHA

--- a/pkg/addons/seaweedfs/install.go
+++ b/pkg/addons/seaweedfs/install.go
@@ -10,7 +10,6 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/types"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
 	"github.com/replicatedhq/embedded-cluster/pkg/helpers"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,14 +21,13 @@ import (
 func (s *SeaweedFS) Install(
 	ctx context.Context, logf types.LogFunc,
 	kcli client.Client, mcli metadata.Interface, hcli helm.Client,
-	rc runtimeconfig.RuntimeConfig, domains ecv1beta1.Domains,
-	overrides []string,
+	domains ecv1beta1.Domains, overrides []string,
 ) error {
 	if err := s.ensurePreRequisites(ctx, kcli); err != nil {
 		return errors.Wrap(err, "create prerequisites")
 	}
 
-	values, err := s.GenerateHelmValues(ctx, kcli, rc, domains, overrides)
+	values, err := s.GenerateHelmValues(ctx, kcli, domains, overrides)
 	if err != nil {
 		return errors.Wrap(err, "generate helm values")
 	}

--- a/pkg/addons/seaweedfs/seaweedfs.go
+++ b/pkg/addons/seaweedfs/seaweedfs.go
@@ -29,8 +29,7 @@ var _ types.AddOn = (*SeaweedFS)(nil)
 
 type SeaweedFS struct {
 	ServiceCIDR      string
-	DataDir          string
-	SeaweedfsDataDir string
+	SeaweedFSDataDir string
 }
 
 func (s *SeaweedFS) Name() string {

--- a/pkg/addons/seaweedfs/seaweedfs.go
+++ b/pkg/addons/seaweedfs/seaweedfs.go
@@ -28,8 +28,8 @@ const (
 var _ types.AddOn = (*SeaweedFS)(nil)
 
 type SeaweedFS struct {
-	ServiceCIDR     string
-	SeaweedfsSubDir string
+	ServiceCIDR      string
+	SeaweedfsDataDir string
 }
 
 func (s *SeaweedFS) Name() string {

--- a/pkg/addons/seaweedfs/seaweedfs.go
+++ b/pkg/addons/seaweedfs/seaweedfs.go
@@ -29,6 +29,7 @@ var _ types.AddOn = (*SeaweedFS)(nil)
 
 type SeaweedFS struct {
 	ServiceCIDR      string
+	DataDir          string
 	SeaweedfsDataDir string
 }
 

--- a/pkg/addons/seaweedfs/seaweedfs.go
+++ b/pkg/addons/seaweedfs/seaweedfs.go
@@ -4,13 +4,13 @@ import (
 	"strings"
 
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"github.com/replicatedhq/embedded-cluster/pkg-new/constants"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/types"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 )
 
 const (
 	_releaseName = "seaweedfs"
-	_namespace   = runtimeconfig.SeaweedFSNamespace
+	_namespace   = constants.SeaweedFSNamespace
 
 	// _s3SVCName is the name of the Seaweedfs S3 service managed by the operator.
 	// HACK: This service has a hardcoded service IP shared by the cli and operator as it is used
@@ -28,7 +28,8 @@ const (
 var _ types.AddOn = (*SeaweedFS)(nil)
 
 type SeaweedFS struct {
-	ServiceCIDR string
+	ServiceCIDR     string
+	SeaweedfsSubDir string
 }
 
 func (s *SeaweedFS) Name() string {

--- a/pkg/addons/seaweedfs/upgrade.go
+++ b/pkg/addons/seaweedfs/upgrade.go
@@ -7,7 +7,6 @@ import (
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/types"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/metadata"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -16,7 +15,7 @@ import (
 func (s *SeaweedFS) Upgrade(
 	ctx context.Context, logf types.LogFunc,
 	kcli client.Client, mcli metadata.Interface, hcli helm.Client,
-	rc runtimeconfig.RuntimeConfig, domains ecv1beta1.Domains, overrides []string,
+	domains ecv1beta1.Domains, overrides []string,
 ) error {
 	exists, err := hcli.ReleaseExists(ctx, s.Namespace(), s.ReleaseName())
 	if err != nil {
@@ -24,14 +23,14 @@ func (s *SeaweedFS) Upgrade(
 	}
 	if !exists {
 		logrus.Debugf("Release not found, installing release %s in namespace %s", s.ReleaseName(), s.Namespace())
-		return s.Install(ctx, logf, kcli, mcli, hcli, rc, domains, overrides)
+		return s.Install(ctx, logf, kcli, mcli, hcli, domains, overrides)
 	}
 
 	if err := s.ensurePreRequisites(ctx, kcli); err != nil {
 		return errors.Wrap(err, "create prerequisites")
 	}
 
-	values, err := s.GenerateHelmValues(ctx, kcli, rc, domains, overrides)
+	values, err := s.GenerateHelmValues(ctx, kcli, domains, overrides)
 	if err != nil {
 		return errors.Wrap(err, "generate helm values")
 	}

--- a/pkg/addons/seaweedfs/values.go
+++ b/pkg/addons/seaweedfs/values.go
@@ -50,18 +50,13 @@ func (s *SeaweedFS) GenerateHelmValues(ctx context.Context, kcli client.Client, 
 		return nil, errors.Wrap(err, "unmarshal helm values")
 	}
 
-	// TODO (@screspod): is rc. check EmbeddedClusterSeaweedfsSubDir()
-	// dataPath := filepath.Join(rc.EmbeddedClusterSeaweedfsSubDir(), "ssd")
-	if s.SeaweedfsDataDir == "" {
-		s.SeaweedfsDataDir = filepath.Join(s.DataDir, "seaweedfs")
-	}
-	dataPath := filepath.Join(s.SeaweedfsDataDir, "ssd")
+	dataPath := filepath.Join(s.SeaweedFSDataDir, "ssd")
 	err = helm.SetValue(copiedValues, "master.data.hostPathPrefix", dataPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "set helm values global.data.hostPathPrefix")
 	}
 
-	logsPath := filepath.Join(s.SeaweedfsDataDir, "storage")
+	logsPath := filepath.Join(s.SeaweedFSDataDir, "storage")
 	err = helm.SetValue(copiedValues, "master.logs.hostPathPrefix", logsPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "set helm values global.logs.hostPathPrefix")

--- a/pkg/addons/seaweedfs/values.go
+++ b/pkg/addons/seaweedfs/values.go
@@ -52,7 +52,9 @@ func (s *SeaweedFS) GenerateHelmValues(ctx context.Context, kcli client.Client, 
 
 	// TODO (@screspod): is rc. check EmbeddedClusterSeaweedfsSubDir()
 	// dataPath := filepath.Join(rc.EmbeddedClusterSeaweedfsSubDir(), "ssd")
-	s.SeaweedfsDataDir = filepath.Join(ecv1beta1.DefaultDataDir, "seaweedfs")
+	if s.SeaweedfsDataDir == "" {
+		s.SeaweedfsDataDir = filepath.Join(s.DataDir, "seaweedfs")
+	}
 	dataPath := filepath.Join(s.SeaweedfsDataDir, "ssd")
 	err = helm.SetValue(copiedValues, "master.data.hostPathPrefix", dataPath)
 	if err != nil {

--- a/pkg/addons/seaweedfs/values.go
+++ b/pkg/addons/seaweedfs/values.go
@@ -50,13 +50,16 @@ func (s *SeaweedFS) GenerateHelmValues(ctx context.Context, kcli client.Client, 
 		return nil, errors.Wrap(err, "unmarshal helm values")
 	}
 
-	dataPath := filepath.Join(s.SeaweedfsSubDir, "ssd")
+	// TODO (@screspod): is rc. check EmbeddedClusterSeaweedfsSubDir()
+	// dataPath := filepath.Join(rc.EmbeddedClusterSeaweedfsSubDir(), "ssd")
+	s.SeaweedfsDataDir = filepath.Join(ecv1beta1.DefaultDataDir, "seaweedfs")
+	dataPath := filepath.Join(s.SeaweedfsDataDir, "ssd")
 	err = helm.SetValue(copiedValues, "master.data.hostPathPrefix", dataPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "set helm values global.data.hostPathPrefix")
 	}
 
-	logsPath := filepath.Join(s.SeaweedfsSubDir, "storage")
+	logsPath := filepath.Join(s.SeaweedfsDataDir, "storage")
 	err = helm.SetValue(copiedValues, "master.logs.hostPathPrefix", logsPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "set helm values global.logs.hostPathPrefix")

--- a/pkg/addons/seaweedfs/values.go
+++ b/pkg/addons/seaweedfs/values.go
@@ -10,7 +10,6 @@ import (
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
 	"github.com/replicatedhq/embedded-cluster/pkg/release"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"gopkg.in/yaml.v3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -34,7 +33,7 @@ func init() {
 	helmValues = hv
 }
 
-func (s *SeaweedFS) GenerateHelmValues(ctx context.Context, kcli client.Client, rc runtimeconfig.RuntimeConfig, domains ecv1beta1.Domains, overrides []string) (map[string]interface{}, error) {
+func (s *SeaweedFS) GenerateHelmValues(ctx context.Context, kcli client.Client, domains ecv1beta1.Domains, overrides []string) (map[string]interface{}, error) {
 	// create a copy of the helm values so we don't modify the original
 	marshalled, err := helm.MarshalValues(helmValues)
 	if err != nil {
@@ -51,13 +50,13 @@ func (s *SeaweedFS) GenerateHelmValues(ctx context.Context, kcli client.Client, 
 		return nil, errors.Wrap(err, "unmarshal helm values")
 	}
 
-	dataPath := filepath.Join(rc.EmbeddedClusterSeaweedfsSubDir(), "ssd")
+	dataPath := filepath.Join(s.SeaweedfsSubDir, "ssd")
 	err = helm.SetValue(copiedValues, "master.data.hostPathPrefix", dataPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "set helm values global.data.hostPathPrefix")
 	}
 
-	logsPath := filepath.Join(rc.EmbeddedClusterSeaweedfsSubDir(), "storage")
+	logsPath := filepath.Join(s.SeaweedfsSubDir, "storage")
 	err = helm.SetValue(copiedValues, "master.logs.hostPathPrefix", logsPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "set helm values global.logs.hostPathPrefix")

--- a/pkg/addons/types/types.go
+++ b/pkg/addons/types/types.go
@@ -6,7 +6,6 @@ import (
 	apitypes "github.com/replicatedhq/embedded-cluster/api/types"
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"k8s.io/client-go/metadata"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -18,9 +17,9 @@ type AddOn interface {
 	Version() string
 	ReleaseName() string
 	Namespace() string
-	GenerateHelmValues(ctx context.Context, kcli client.Client, rc runtimeconfig.RuntimeConfig, domains ecv1beta1.Domains, overrides []string) (map[string]interface{}, error)
-	Install(ctx context.Context, logf LogFunc, kcli client.Client, mcli metadata.Interface, hcli helm.Client, rc runtimeconfig.RuntimeConfig, domains ecv1beta1.Domains, overrides []string) error
-	Upgrade(ctx context.Context, logf LogFunc, kcli client.Client, mcli metadata.Interface, hcli helm.Client, rc runtimeconfig.RuntimeConfig, domains ecv1beta1.Domains, overrides []string) error
+	GenerateHelmValues(ctx context.Context, kcli client.Client, domains ecv1beta1.Domains, overrides []string) (map[string]interface{}, error)
+	Install(ctx context.Context, logf LogFunc, kcli client.Client, mcli metadata.Interface, hcli helm.Client, domains ecv1beta1.Domains, overrides []string) error
+	Upgrade(ctx context.Context, logf LogFunc, kcli client.Client, mcli metadata.Interface, hcli helm.Client, domains ecv1beta1.Domains, overrides []string) error
 }
 
 type AddOnProgress struct {

--- a/pkg/addons/upgrade.go
+++ b/pkg/addons/upgrade.go
@@ -23,6 +23,7 @@ import (
 type UpgradeOptions struct {
 	ServiceCIDR string
 	ProxySpec   *ecv1beta1.ProxySpec
+	DataDir     string
 }
 
 func (a *AddOns) Upgrade(ctx context.Context, in *ecv1beta1.Installation, meta *ectypes.ReleaseMetadata, opts UpgradeOptions) error {
@@ -42,7 +43,9 @@ func (a *AddOns) Upgrade(ctx context.Context, in *ecv1beta1.Installation, meta *
 
 func (a *AddOns) getAddOnsForUpgrade(in *ecv1beta1.Installation, meta *ectypes.ReleaseMetadata, opts UpgradeOptions) ([]types.AddOn, error) {
 	addOns := []types.AddOn{
-		&openebs.OpenEBS{},
+		&openebs.OpenEBS{
+			DataDir: opts.DataDir,
+		},
 	}
 
 	serviceCIDR := opts.ServiceCIDR

--- a/pkg/addons/upgrade.go
+++ b/pkg/addons/upgrade.go
@@ -75,7 +75,6 @@ func (a *AddOns) getAddOnsForUpgrade(meta *ectypes.ReleaseMetadata, opts Upgrade
 		IsAirgap:         opts.IsAirgap,
 		Proxy:            opts.ProxySpec,
 		HostCABundlePath: opts.HostCABundlePath,
-		DataDir:          opts.DataDir,
 
 		ChartLocationOverride: ecoChartLocation,
 		ChartVersionOverride:  ecoChartVersion,
@@ -102,7 +101,6 @@ func (a *AddOns) getAddOnsForUpgrade(meta *ectypes.ReleaseMetadata, opts Upgrade
 		addOns = append(addOns, &velero.Velero{
 			Proxy:            opts.ProxySpec,
 			HostCABundlePath: opts.HostCABundlePath,
-			DataDir:          opts.DataDir,
 			K0sDataDir:       opts.K0sDataDir,
 		})
 	}

--- a/pkg/addons/util.go
+++ b/pkg/addons/util.go
@@ -32,7 +32,7 @@ func (a *AddOns) operatorChart(meta *ectypes.ReleaseMetadata) (string, string, e
 	return "", "", errors.New("no embedded-cluster-operator chart found in release metadata")
 }
 
-func (a *AddOns) operatorImages(images []string, proxyRegistryDomain string) (string, string, string, error) {
+func (a *AddOns) operatorImages(images []string) (string, string, string, error) {
 	// determine the images to use for the operator chart
 	ecOperatorImage := ""
 	ecUtilsImage := ""
@@ -54,9 +54,9 @@ func (a *AddOns) operatorImages(images []string, proxyRegistryDomain string) (st
 	}
 
 	// the override images for operator during upgrades also need to be updated to use a whitelabeled proxy registry
-	if proxyRegistryDomain != "" {
-		ecOperatorImage = strings.Replace(ecOperatorImage, "proxy.replicated.com", proxyRegistryDomain, 1)
-		ecUtilsImage = strings.Replace(ecUtilsImage, "proxy.replicated.com", proxyRegistryDomain, 1)
+	if a.domains.ProxyRegistryDomain != "" {
+		ecOperatorImage = strings.Replace(ecOperatorImage, "proxy.replicated.com", a.domains.ProxyRegistryDomain, 1)
+		ecUtilsImage = strings.Replace(ecUtilsImage, "proxy.replicated.com", a.domains.ProxyRegistryDomain, 1)
 	}
 
 	repo := strings.Split(ecOperatorImage, ":")[0]

--- a/pkg/addons/util_test.go
+++ b/pkg/addons/util_test.go
@@ -3,6 +3,7 @@ package addons
 import (
 	"testing"
 
+	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/stretchr/testify/require"
 )
 
@@ -12,13 +13,14 @@ func Test_operatorImages(t *testing.T) {
 		images         []string
 		wantRepo       string
 		wantTag        string
-		proxyRegistry  string
+		domains        ecv1beta1.Domains
 		wantUtilsImage string
 		wantErr        string
 	}{
 		{
 			name:    "no images",
 			images:  []string{},
+			domains: ecv1beta1.Domains{},
 			wantErr: "no embedded-cluster-operator-image found in images",
 		},
 		{
@@ -26,6 +28,7 @@ func Test_operatorImages(t *testing.T) {
 			images: []string{
 				"docker.io/replicated/another-image:latest-arm64@sha256:a9ab9db181f9898283a87be0f79d85cb8f3d22a790b71f52c8a9d339e225dedd",
 			},
+			domains: ecv1beta1.Domains{},
 			wantErr: "no embedded-cluster-operator-image found in images",
 		},
 		{
@@ -34,6 +37,7 @@ func Test_operatorImages(t *testing.T) {
 				"docker.io/replicated/another-image:latest-arm64@sha256:a9ab9db181f9898283a87be0f79d85cb8f3d22a790b71f52c8a9d339e225dedd",
 				"docker.io/replicated/embedded-cluster-operator-image:latest-amd64@sha256:eeed01216b5d2192afbd90e2e1f70419a8758551d8708f9d4b4f50f41d106ce8",
 			},
+			domains: ecv1beta1.Domains{},
 			wantErr: "no ec-utils found in images",
 		},
 		{
@@ -42,6 +46,7 @@ func Test_operatorImages(t *testing.T) {
 				"docker.io/replicated/embedded-cluster-operator-image:latest-amd64",
 				"docker.io/replicated/ec-utils:latest-amd64",
 			},
+			domains:        ecv1beta1.Domains{},
 			wantRepo:       "docker.io/replicated/embedded-cluster-operator-image",
 			wantTag:        "latest-amd64",
 			wantUtilsImage: "docker.io/replicated/ec-utils:latest-amd64",
@@ -72,6 +77,7 @@ func Test_operatorImages(t *testing.T) {
 				"proxy.replicated.com/anonymous/replicated/embedded-cluster-local-artifact-mirror:v1.14.2-k8s-1.29@sha256:54463ce6b6fba13a25138890aa1ac28ae4f93f53cdb78a99d15abfdc1b5eddf5",
 				"proxy.replicated.com/anonymous/replicated/embedded-cluster-operator-image:v1.14.2-k8s-1.29-amd64@sha256:45a45e2ec6b73d2db029354cccfe7eb150dd7ef9dffe806db36de9b9ba0a66c6",
 			},
+			domains:        ecv1beta1.Domains{},
 			wantRepo:       "proxy.replicated.com/anonymous/replicated/embedded-cluster-operator-image",
 			wantTag:        "v1.14.2-k8s-1.29-amd64@sha256:45a45e2ec6b73d2db029354cccfe7eb150dd7ef9dffe806db36de9b9ba0a66c6",
 			wantUtilsImage: "proxy.replicated.com/anonymous/replicated/ec-utils:latest-amd64@sha256:2f3c5d81565eae3aea22f408af9a8ee91cd4ba010612c50c6be564869390639f",
@@ -82,7 +88,9 @@ func Test_operatorImages(t *testing.T) {
 				"proxy.replicated.com/replicated/embedded-cluster-operator-image:latest-amd64",
 				"proxy.replicated.com/replicated/ec-utils:latest-amd64",
 			},
-			proxyRegistry:  "myproxy.test",
+			domains: ecv1beta1.Domains{
+				ProxyRegistryDomain: "myproxy.test",
+			},
 			wantRepo:       "myproxy.test/replicated/embedded-cluster-operator-image",
 			wantTag:        "latest-amd64",
 			wantUtilsImage: "myproxy.test/replicated/ec-utils:latest-amd64",
@@ -113,7 +121,9 @@ func Test_operatorImages(t *testing.T) {
 				"proxy.replicated.com/anonymous/replicated/embedded-cluster-local-artifact-mirror:v1.14.2-k8s-1.29@sha256:54463ce6b6fba13a25138890aa1ac28ae4f93f53cdb78a99d15abfdc1b5eddf5",
 				"proxy.replicated.com/anonymous/replicated/embedded-cluster-operator-image:v1.14.2-k8s-1.29-amd64@sha256:45a45e2ec6b73d2db029354cccfe7eb150dd7ef9dffe806db36de9b9ba0a66c6",
 			},
-			proxyRegistry:  "myproxy.test",
+			domains: ecv1beta1.Domains{
+				ProxyRegistryDomain: "myproxy.test",
+			},
 			wantRepo:       "myproxy.test/anonymous/replicated/embedded-cluster-operator-image",
 			wantTag:        "v1.14.2-k8s-1.29-amd64@sha256:45a45e2ec6b73d2db029354cccfe7eb150dd7ef9dffe806db36de9b9ba0a66c6",
 			wantUtilsImage: "myproxy.test/anonymous/replicated/ec-utils:latest-amd64@sha256:2f3c5d81565eae3aea22f408af9a8ee91cd4ba010612c50c6be564869390639f",
@@ -122,7 +132,9 @@ func Test_operatorImages(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := require.New(t)
-			gotRepo, gotTag, gotUtilsImage, err := New().operatorImages(tt.images, tt.proxyRegistry)
+
+			addOns := New(WithDomains(tt.domains))
+			gotRepo, gotTag, gotUtilsImage, err := addOns.operatorImages(tt.images)
 			if tt.wantErr != "" {
 				req.Error(err)
 				req.EqualError(err, tt.wantErr)

--- a/pkg/addons/velero/install.go
+++ b/pkg/addons/velero/install.go
@@ -8,7 +8,6 @@ import (
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/types"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,14 +18,13 @@ import (
 func (v *Velero) Install(
 	ctx context.Context, logf types.LogFunc,
 	kcli client.Client, mcli metadata.Interface, hcli helm.Client,
-	rc runtimeconfig.RuntimeConfig, domains ecv1beta1.Domains,
-	overrides []string,
+	domains ecv1beta1.Domains, overrides []string,
 ) error {
 	if err := v.createPreRequisites(ctx, kcli); err != nil {
 		return errors.Wrap(err, "create prerequisites")
 	}
 
-	values, err := v.GenerateHelmValues(ctx, kcli, rc, domains, overrides)
+	values, err := v.GenerateHelmValues(ctx, kcli, domains, overrides)
 	if err != nil {
 		return errors.Wrap(err, "generate helm values")
 	}

--- a/pkg/addons/velero/integration/hostcabundle_test.go
+++ b/pkg/addons/velero/integration/hostcabundle_test.go
@@ -8,7 +8,6 @@ import (
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/velero"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -18,17 +17,15 @@ import (
 )
 
 func TestHostCABundle(t *testing.T) {
-	rc := runtimeconfig.New(nil)
-	rc.SetHostCABundlePath("/etc/ssl/certs/ca-certificates.crt")
-
 	addon := &velero.Velero{
-		DryRun: true,
+		DryRun:           true,
+		HostCABundlePath: "/etc/ssl/certs/ca-certificates.crt",
 	}
 
 	hcli, err := helm.NewClient(helm.HelmOptions{})
 	require.NoError(t, err, "NewClient should not return an error")
 
-	err = addon.Install(context.Background(), t.Logf, nil, nil, hcli, rc, ecv1beta1.Domains{}, nil)
+	err = addon.Install(context.Background(), t.Logf, nil, nil, hcli, ecv1beta1.Domains{}, nil)
 	require.NoError(t, err, "velero.Install should not return an error")
 
 	manifests := addon.DryRunManifests()

--- a/pkg/addons/velero/integration/k0ssubdir_test.go
+++ b/pkg/addons/velero/integration/k0ssubdir_test.go
@@ -9,7 +9,6 @@ import (
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/velero"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -20,19 +19,15 @@ import (
 func TestK0sDir(t *testing.T) {
 	k0sDir := filepath.Join(t.TempDir(), "other-k0s")
 
-	rcSpec := ecv1beta1.GetDefaultRuntimeConfig()
-	rcSpec.K0sDataDirOverride = k0sDir
-
-	rc := runtimeconfig.New(rcSpec)
-
 	addon := &velero.Velero{
-		DryRun: true,
+		DryRun:     true,
+		K0sDataDir: k0sDir,
 	}
 
 	hcli, err := helm.NewClient(helm.HelmOptions{})
 	require.NoError(t, err, "NewClient should not return an error")
 
-	err = addon.Install(context.Background(), t.Logf, nil, nil, hcli, rc, ecv1beta1.Domains{}, nil)
+	err = addon.Install(context.Background(), t.Logf, nil, nil, hcli, ecv1beta1.Domains{}, nil)
 	require.NoError(t, err, "velero.Install should not return an error")
 
 	manifests := addon.DryRunManifests()

--- a/pkg/addons/velero/upgrade.go
+++ b/pkg/addons/velero/upgrade.go
@@ -7,7 +7,6 @@ import (
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/types"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/metadata"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -16,7 +15,7 @@ import (
 func (v *Velero) Upgrade(
 	ctx context.Context, logf types.LogFunc,
 	kcli client.Client, mcli metadata.Interface, hcli helm.Client,
-	rc runtimeconfig.RuntimeConfig, domains ecv1beta1.Domains, overrides []string,
+	domains ecv1beta1.Domains, overrides []string,
 ) error {
 	exists, err := hcli.ReleaseExists(ctx, v.Namespace(), v.ReleaseName())
 	if err != nil {
@@ -24,13 +23,13 @@ func (v *Velero) Upgrade(
 	}
 	if !exists {
 		logrus.Debugf("Release not found, installing release %s in namespace %s", v.ReleaseName(), v.Namespace())
-		if err := v.Install(ctx, logf, kcli, mcli, hcli, rc, domains, overrides); err != nil {
+		if err := v.Install(ctx, logf, kcli, mcli, hcli, domains, overrides); err != nil {
 			return errors.Wrap(err, "install")
 		}
 		return nil
 	}
 
-	values, err := v.GenerateHelmValues(ctx, kcli, rc, domains, overrides)
+	values, err := v.GenerateHelmValues(ctx, kcli, domains, overrides)
 	if err != nil {
 		return errors.Wrap(err, "generate helm values")
 	}

--- a/pkg/addons/velero/values.go
+++ b/pkg/addons/velero/values.go
@@ -101,7 +101,9 @@ func (v *Velero) GenerateHelmValues(ctx context.Context, kcli client.Client, dom
 		"extraVolumes":      extraVolumes,
 		"extraVolumeMounts": extraVolumeMounts,
 	}
-
+	if v.K0sDataDir == "" {
+		v.K0sDataDir = filepath.Join(v.DataDir, "k0s")
+	}
 	podVolumePath := filepath.Join(v.K0sDataDir, "kubelet/pods")
 	err = helm.SetValue(copiedValues, "nodeAgent.podVolumePath", podVolumePath)
 	if err != nil {

--- a/pkg/addons/velero/values.go
+++ b/pkg/addons/velero/values.go
@@ -101,9 +101,7 @@ func (v *Velero) GenerateHelmValues(ctx context.Context, kcli client.Client, dom
 		"extraVolumes":      extraVolumes,
 		"extraVolumeMounts": extraVolumeMounts,
 	}
-	if v.K0sDataDir == "" {
-		v.K0sDataDir = filepath.Join(v.DataDir, "k0s")
-	}
+
 	podVolumePath := filepath.Join(v.K0sDataDir, "kubelet/pods")
 	err = helm.SetValue(copiedValues, "nodeAgent.podVolumePath", podVolumePath)
 	if err != nil {

--- a/pkg/addons/velero/values_test.go
+++ b/pkg/addons/velero/values_test.go
@@ -5,19 +5,16 @@ import (
 	"testing"
 
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateHelmValues_HostCABundlePath(t *testing.T) {
-	rc := runtimeconfig.New(nil)
-	rc.SetDataDir(t.TempDir())
-	rc.SetHostCABundlePath("/etc/ssl/certs/ca-certificates.crt")
+	v := &Velero{
+		HostCABundlePath: "/etc/ssl/certs/ca-certificates.crt",
+	}
 
-	v := &Velero{}
-
-	values, err := v.GenerateHelmValues(context.Background(), nil, rc, ecv1beta1.Domains{}, nil)
+	values, err := v.GenerateHelmValues(context.Background(), nil, ecv1beta1.Domains{}, nil)
 	require.NoError(t, err, "GenerateHelmValues should not return an error")
 
 	require.NotEmpty(t, values["extraVolumes"])

--- a/pkg/addons/velero/velero.go
+++ b/pkg/addons/velero/velero.go
@@ -4,16 +4,17 @@ import (
 	"strings"
 
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"github.com/replicatedhq/embedded-cluster/pkg-new/constants"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/types"
 	"github.com/replicatedhq/embedded-cluster/pkg/kubeutils"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"k8s.io/apimachinery/pkg/runtime"
 	jsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
 const (
 	_releaseName = "velero"
-	_namespace   = runtimeconfig.VeleroNamespace
+
+	_namespace = constants.VeleroNamespace
 
 	_credentialsSecretName = "cloud-credentials"
 )
@@ -32,7 +33,9 @@ func init() {
 var _ types.AddOn = (*Velero)(nil)
 
 type Velero struct {
-	Proxy *ecv1beta1.ProxySpec
+	Proxy            *ecv1beta1.ProxySpec
+	HostCABundlePath string
+	K0sDataDir       string
 
 	// DryRun is a flag to enable dry-run mode for Velero.
 	// If true, Velero will only render the helm template and additional manifests, but not install

--- a/pkg/addons/velero/velero.go
+++ b/pkg/addons/velero/velero.go
@@ -35,7 +35,6 @@ var _ types.AddOn = (*Velero)(nil)
 type Velero struct {
 	Proxy            *ecv1beta1.ProxySpec
 	HostCABundlePath string
-	DataDir          string
 	K0sDataDir       string
 
 	// DryRun is a flag to enable dry-run mode for Velero.

--- a/pkg/addons/velero/velero.go
+++ b/pkg/addons/velero/velero.go
@@ -35,6 +35,7 @@ var _ types.AddOn = (*Velero)(nil)
 type Velero struct {
 	Proxy            *ecv1beta1.ProxySpec
 	HostCABundlePath string
+	DataDir          string
 	K0sDataDir       string
 
 	// DryRun is a flag to enable dry-run mode for Velero.

--- a/pkg/constants/restore.go
+++ b/pkg/constants/restore.go
@@ -1,3 +1,0 @@
-package constants
-
-const EcRestoreStateCMName = "embedded-cluster-restore-state"

--- a/pkg/disasterrecovery/backup.go
+++ b/pkg/disasterrecovery/backup.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/replicatedhq/embedded-cluster/pkg-new/constants"
 	"github.com/replicatedhq/embedded-cluster/pkg/kubeutils"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -98,7 +98,7 @@ type ReplicatedBackup []velerov1.Backup
 
 // ListReplicatedBackups returns a sorted list of ReplicatedBackup backups by creation timestamp.
 func ListReplicatedBackups(ctx context.Context, cli client.Client) ([]ReplicatedBackup, error) {
-	backups, err := listBackups(ctx, cli, runtimeconfig.VeleroNamespace)
+	backups, err := listBackups(ctx, cli, constants.VeleroNamespace)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubeutils/installation.go
+++ b/pkg/kubeutils/installation.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"github.com/replicatedhq/embedded-cluster/pkg-new/constants"
 	"github.com/replicatedhq/embedded-cluster/pkg/crds"
 	"github.com/replicatedhq/embedded-cluster/pkg/metrics"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
@@ -133,7 +134,7 @@ func RecordInstallation(ctx context.Context, kcli client.Client, opts RecordInst
 	// ensure that the embedded-cluster namespace exists
 	ns := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: runtimeconfig.EmbeddedClusterNamespace,
+			Name: constants.EmbeddedClusterNamespace,
 		},
 	}
 	if err := kcli.Create(ctx, &ns); err != nil && !k8serrors.IsAlreadyExists(err) {

--- a/pkg/runtimeconfig/defaults.go
+++ b/pkg/runtimeconfig/defaults.go
@@ -5,8 +5,6 @@ import (
 	"path/filepath"
 
 	"github.com/gosimple/slug"
-	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
-	"github.com/replicatedhq/embedded-cluster/pkg-new/domains"
 	"github.com/replicatedhq/embedded-cluster/pkg/release"
 	"github.com/sirupsen/logrus"
 )
@@ -20,15 +18,6 @@ var DefaultNoProxy = []string{
 	// cloud metadata service
 	"169.254.169.254",
 }
-
-const (
-	KotsadmNamespace         = "kotsadm"
-	KotsadmServiceAccount    = "kotsadm"
-	SeaweedFSNamespace       = "seaweedfs"
-	RegistryNamespace        = "registry"
-	VeleroNamespace          = "velero"
-	EmbeddedClusterNamespace = "embedded-cluster"
-)
 
 const (
 	K0sBinaryPath           = "/usr/local/bin/k0s"
@@ -70,10 +59,4 @@ func EmbeddedClusterLogsSubDir() string {
 // if the file exists.
 func PathToLog(name string) string {
 	return filepath.Join(EmbeddedClusterLogsSubDir(), name)
-}
-
-// GetDomains returns the domains for the embedded cluster. The first priority is the domains configured within the provided config spec.
-// The second priority is the domains configured within the channel release. If neither is configured, the default domains are returned.
-func GetDomains(cfgspec *ecv1beta1.ConfigSpec) ecv1beta1.Domains {
-	return domains.GetDomains(cfgspec, release.GetChannelRelease())
 }

--- a/pkg/runtimeconfig/interface.go
+++ b/pkg/runtimeconfig/interface.go
@@ -18,7 +18,7 @@ type RuntimeConfig interface {
 	EmbeddedClusterChartsSubDirNoCreate() string
 	EmbeddedClusterImagesSubDir() string
 	EmbeddedClusterK0sSubDir() string
-	EmbeddedClusterSeaweedfsSubDir() string
+	EmbeddedClusterSeaweedFSSubDir() string
 	EmbeddedClusterOpenEBSLocalSubDir() string
 	PathToEmbeddedClusterBinary(name string) string
 	PathToKubeConfig() string

--- a/pkg/runtimeconfig/mock.go
+++ b/pkg/runtimeconfig/mock.go
@@ -73,8 +73,8 @@ func (m *MockRuntimeConfig) EmbeddedClusterK0sSubDir() string {
 	return args.String(0)
 }
 
-// EmbeddedClusterSeaweedfsSubDir mocks the EmbeddedClusterSeaweedfsSubDir method
-func (m *MockRuntimeConfig) EmbeddedClusterSeaweedfsSubDir() string {
+// EmbeddedClusterSeaweedFSSubDir mocks the EmbeddedClusterSeaweedFSSubDir method
+func (m *MockRuntimeConfig) EmbeddedClusterSeaweedFSSubDir() string {
 	args := m.Called()
 	return args.String(0)
 }

--- a/pkg/runtimeconfig/runtimeconfig.go
+++ b/pkg/runtimeconfig/runtimeconfig.go
@@ -150,8 +150,8 @@ func (rc *runtimeConfig) EmbeddedClusterK0sSubDir() string {
 	return filepath.Join(rc.EmbeddedClusterHomeDirectory(), "k0s")
 }
 
-// EmbeddedClusterSeaweedfsSubDir returns the path to the directory where seaweedfs data is stored.
-func (rc *runtimeConfig) EmbeddedClusterSeaweedfsSubDir() string {
+// EmbeddedClusterSeaweedFSSubDir returns the path to the directory where seaweedfs data is stored.
+func (rc *runtimeConfig) EmbeddedClusterSeaweedFSSubDir() string {
 	return filepath.Join(rc.EmbeddedClusterHomeDirectory(), "seaweedfs")
 }
 

--- a/pkg/runtimeconfig/runtimeconfig.go
+++ b/pkg/runtimeconfig/runtimeconfig.go
@@ -97,6 +97,7 @@ func (rc *runtimeConfig) Cleanup() {
 
 // EmbeddedClusterHomeDirectory returns the parent directory. Inside this parent directory we
 // store all the embedded-cluster related files.
+// TODO (@screspod): check seaweedfs comment
 func (rc *runtimeConfig) EmbeddedClusterHomeDirectory() string {
 	if rc.spec.DataDir != "" {
 		return rc.spec.DataDir

--- a/pkg/runtimeconfig/runtimeconfig.go
+++ b/pkg/runtimeconfig/runtimeconfig.go
@@ -97,7 +97,6 @@ func (rc *runtimeConfig) Cleanup() {
 
 // EmbeddedClusterHomeDirectory returns the parent directory. Inside this parent directory we
 // store all the embedded-cluster related files.
-// TODO (@screspod): check seaweedfs comment
 func (rc *runtimeConfig) EmbeddedClusterHomeDirectory() string {
 	if rc.spec.DataDir != "" {
 		return rc.spec.DataDir

--- a/pkg/support/materialize.go
+++ b/pkg/support/materialize.go
@@ -7,6 +7,7 @@ import (
 	"text/template"
 
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"github.com/replicatedhq/embedded-cluster/pkg-new/domains"
 	"github.com/replicatedhq/embedded-cluster/pkg/netutils"
 	"github.com/replicatedhq/embedded-cluster/pkg/release"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
@@ -29,7 +30,7 @@ func MaterializeSupportBundleSpec(rc runtimeconfig.RuntimeConfig, isAirgap bool)
 	if embCfg := release.GetEmbeddedClusterConfig(); embCfg != nil {
 		embCfgSpec = &embCfg.Spec
 	}
-	domains := runtimeconfig.GetDomains(embCfgSpec)
+	domains := domains.GetDomains(embCfgSpec, nil)
 
 	data := TemplateData{
 		DataDir:          rc.EmbeddedClusterHomeDirectory(),

--- a/tests/integration/kind/openebs/analytics_test.go
+++ b/tests/integration/kind/openebs/analytics_test.go
@@ -5,7 +5,6 @@ import (
 
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/openebs"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/replicatedhq/embedded-cluster/tests/integration/util"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -21,14 +20,12 @@ func TestOpenEBS_AnalyticsDisabled(t *testing.T) {
 	mcli := util.MetadataClient(t, kubeconfig)
 	hcli := util.HelmClient(t, kubeconfig)
 
-	rc := runtimeconfig.New(nil)
-
 	domains := ecv1beta1.Domains{
 		ProxyRegistryDomain: "proxy.replicated.com",
 	}
 
 	addon := &openebs.OpenEBS{}
-	if err := addon.Install(t.Context(), t.Logf, kcli, mcli, hcli, rc, domains, nil); err != nil {
+	if err := addon.Install(t.Context(), t.Logf, kcli, mcli, hcli, domains, nil); err != nil {
 		t.Fatalf("failed to install openebs: %v", err)
 	}
 

--- a/tests/integration/kind/openebs/customdatadir_test.go
+++ b/tests/integration/kind/openebs/customdatadir_test.go
@@ -8,7 +8,6 @@ import (
 
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/openebs"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/replicatedhq/embedded-cluster/tests/integration/util"
 	"github.com/replicatedhq/embedded-cluster/tests/integration/util/kind"
 	"github.com/stretchr/testify/assert"
@@ -28,9 +27,6 @@ func TestOpenEBS_CustomDataDir(t *testing.T) {
 	})
 	kubeconfig := util.SetupKindClusterFromConfig(t, kindConfig)
 
-	rc := runtimeconfig.New(nil)
-	rc.SetDataDir("/custom")
-
 	kcli := util.CtrlClient(t, kubeconfig)
 	mcli := util.MetadataClient(t, kubeconfig)
 	hcli := util.HelmClient(t, kubeconfig)
@@ -39,8 +35,10 @@ func TestOpenEBS_CustomDataDir(t *testing.T) {
 		ProxyRegistryDomain: "proxy.replicated.com",
 	}
 
-	addon := &openebs.OpenEBS{}
-	if err := addon.Install(t.Context(), t.Logf, kcli, mcli, hcli, rc, domains, nil); err != nil {
+	addon := &openebs.OpenEBS{
+		OpenEBSDataDir: "/custom/openebs-local",
+	}
+	if err := addon.Install(t.Context(), t.Logf, kcli, mcli, hcli, domains, nil); err != nil {
 		t.Fatalf("failed to install openebs: %v", err)
 	}
 
@@ -50,7 +48,7 @@ func TestOpenEBS_CustomDataDir(t *testing.T) {
 	createPodAndPVC(t, kubeconfig)
 
 	_, err := os.Stat(filepath.Join(dataDir, "openebs-local"))
-	require.NoError(t, err, "failed to find %s data dir")
+	require.NoError(t, err, "failed to find openebs data dir")
 	entries, err := os.ReadDir(dataDir)
 	require.NoError(t, err, "failed to read openebs data dir")
 	assert.Len(t, entries, 1, "expected pvc dir file in openebs data dir")

--- a/tests/integration/kind/velero/ca_test.go
+++ b/tests/integration/kind/velero/ca_test.go
@@ -5,7 +5,6 @@ import (
 
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/velero"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/replicatedhq/embedded-cluster/tests/integration/util"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -23,15 +22,15 @@ func TestVelero_HostCABundle(t *testing.T) {
 	mcli := util.MetadataClient(t, kubeconfig)
 	hcli := util.HelmClient(t, kubeconfig)
 
-	rc := runtimeconfig.New(nil)
-	rc.SetHostCABundlePath("/etc/ssl/certs/ca-certificates.crt")
-
 	domains := ecv1beta1.Domains{
 		ProxyRegistryDomain: "proxy.replicated.com",
 	}
 
-	addon := &velero.Velero{}
-	if err := addon.Install(t.Context(), t.Logf, kcli, mcli, hcli, rc, domains, nil); err != nil {
+	addon := &velero.Velero{
+		HostCABundlePath: "/etc/ssl/certs/ca-certificates.crt",
+	}
+
+	if err := addon.Install(t.Context(), t.Logf, kcli, mcli, hcli, domains, nil); err != nil {
 		t.Fatalf("failed to install velero: %v", err)
 	}
 

--- a/web/static.go
+++ b/web/static.go
@@ -143,6 +143,7 @@ func (web *Web) rootHandler(w http.ResponseWriter, r *http.Request) {
 		web.logger.WithError(err).
 			Info("failed to execute HTML template")
 		http.Error(w, "Template execution error", 500)
+		return
 	}
 
 	// Write the buffer contents to the response writer

--- a/web/static_test.go
+++ b/web/static_test.go
@@ -73,6 +73,9 @@ func TestNew(t *testing.T) {
 	// Create a test logger
 	logger, _ := logtest.NewNullLogger()
 
+	// Set the development environment variable to false
+	t.Setenv("EC_DEV_ENV", "false")
+
 	// Create a new Web instance
 	web, err := New(initialState, WithLogger(logger), WithAssetsFS(createMockFS()))
 	require.NoError(t, err, "Failed to create Web instance")
@@ -97,6 +100,9 @@ func TestNewWithDefaultFS(t *testing.T) {
 
 	// Create a test logger
 	logger, _ := logtest.NewNullLogger()
+
+	// Set the development environment variable to false
+	t.Setenv("EC_DEV_ENV", "false")
 
 	// Create a new Web instance
 	web, err := New(initialState, WithLogger(logger))
@@ -139,6 +145,9 @@ func TestNewWithIndexHTML(t *testing.T) {
 	// Create a test logger
 	logger, _ := logtest.NewNullLogger()
 
+	// Set the development environment variable to false
+	t.Setenv("EC_DEV_ENV", "false")
+
 	// Create a new Web instance, using the actual index.html template
 	web, err := New(initialState, WithLogger(logger), WithAssetsFS(mockFS))
 	require.NoError(t, err, "Failed to create Web instance")
@@ -171,6 +180,9 @@ func TestNewWithNonExistentTemplate(t *testing.T) {
 	// Create a test logger
 	logger, _ := logtest.NewNullLogger()
 
+	// Set the development environment variable to false
+	t.Setenv("EC_DEV_ENV", "false")
+
 	// Try to create a new Web instance without providing an HTML template
 	web, err := New(initialState, WithLogger(logger), WithAssetsFS(mockFS))
 
@@ -192,6 +204,9 @@ func TestRootHandler(t *testing.T) {
 
 	// Create a test logger
 	logger, _ := logtest.NewNullLogger()
+
+	// Set the development environment variable to false
+	t.Setenv("EC_DEV_ENV", "false")
 
 	// Create a new Web instance
 	web, err := New(initialState, WithLogger(logger), WithAssetsFS(createMockFS()))
@@ -227,6 +242,9 @@ func TestRootHandlerTemplateError(t *testing.T) {
 
 	// Create a test logger
 	logger, _ := logtest.NewNullLogger()
+
+	// Set the development environment variable to false
+	t.Setenv("EC_DEV_ENV", "false")
 
 	// Create a new Web instance
 	web, err := New(initialState, WithLogger(logger), WithAssetsFS(createMockFS()))
@@ -265,6 +283,9 @@ func TestRegisterRoutes(t *testing.T) {
 
 	// Create a test logger
 	logger, _ := logtest.NewNullLogger()
+
+	// Set the development environment variable to false
+	t.Setenv("EC_DEV_ENV", "false")
 
 	// Create a new Web instance
 	web, err := New(initialState, WithLogger(logger), WithAssetsFS(createMockFS()))


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Refactors the `addons` package to decouple it from runtime config.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/125324/refactor-addons-package-to-decouple-from-runtimeconfig

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
