### PR TITLE
feat(kubernetes): support for kubeconfig flag and from env

### DIFF
--- a/cmd/installer/cli/cidr.go
+++ b/cmd/installer/cli/cidr.go
@@ -10,18 +10,14 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func addCIDRFlags(flagSet *pflag.FlagSet) error {
-	flagSet.String("pod-cidr", k0sv1beta1.DefaultNetwork().PodCIDR, "IP address range for Pods")
-	if err := flagSet.MarkHidden("pod-cidr"); err != nil {
-		return err
-	}
-	flagSet.String("service-cidr", k0sv1beta1.DefaultNetwork().ServiceCIDR, "IP address range for Services")
-	if err := flagSet.MarkHidden("service-cidr"); err != nil {
-		return err
-	}
+func mustAddCIDRFlags(flagSet *pflag.FlagSet) {
 	flagSet.String("cidr", ecv1beta1.DefaultNetworkCIDR, "CIDR block of available private IP addresses (/16 or larger)")
 
-	return nil
+	flagSet.String("pod-cidr", k0sv1beta1.DefaultNetwork().PodCIDR, "IP address range for Pods")
+	mustMarkFlagHidden(flagSet, "pod-cidr")
+
+	flagSet.String("service-cidr", k0sv1beta1.DefaultNetwork().ServiceCIDR, "IP address range for Services")
+	mustMarkFlagHidden(flagSet, "service-cidr")
 }
 
 func validateCIDRFlags(cmd *cobra.Command) error {

--- a/cmd/installer/cli/cidr_test.go
+++ b/cmd/installer/cli/cidr_test.go
@@ -83,7 +83,7 @@ func Test_getCIDRConfig(t *testing.T) {
 			req := require.New(t)
 
 			cmd := &cobra.Command{}
-			addCIDRFlags(cmd.Flags())
+			mustAddCIDRFlags(cmd.Flags())
 
 			test.setFlags(cmd.Flags())
 

--- a/cmd/installer/cli/flags.go
+++ b/cmd/installer/cli/flags.go
@@ -100,6 +100,20 @@ func mustSetFlagTarget(flags *pflag.FlagSet, name string, target string) {
 	}
 }
 
+func mustMarkFlagHidden(flags *pflag.FlagSet, name string) {
+	err := flags.MarkHidden(name)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func mustMarkFlagDeprecated(flags *pflag.FlagSet, name string, deprecationMessage string) {
+	err := flags.MarkDeprecated(name, deprecationMessage)
+	if err != nil {
+		panic(err)
+	}
+}
+
 func filterFlagSetByTarget(flags *pflag.FlagSet, target string) *pflag.FlagSet {
 	if flags == nil {
 		return nil

--- a/cmd/installer/cli/install_runpreflights.go
+++ b/cmd/installer/cli/install_runpreflights.go
@@ -50,9 +50,8 @@ func InstallRunPreflightsCmd(ctx context.Context, name string) *cobra.Command {
 		},
 	}
 
-	if err := addInstallFlags(cmd, &flags); err != nil {
-		panic(err)
-	}
+	mustAddInstallFlags(cmd, &flags)
+
 	if err := addInstallAdminConsoleFlags(cmd, &flags); err != nil {
 		panic(err)
 	}

--- a/cmd/installer/cli/proxy.go
+++ b/cmd/installer/cli/proxy.go
@@ -8,6 +8,7 @@ import (
 	newconfig "github.com/replicatedhq/embedded-cluster/pkg-new/config"
 	"github.com/replicatedhq/embedded-cluster/pkg/netutils"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // NetworkLookup defines the interface for network lookups
@@ -23,12 +24,10 @@ func (d *defaultNetworkLookup) FirstValidIPNet(networkInterface string) (*net.IP
 
 var defaultNetworkLookupImpl NetworkLookup = &defaultNetworkLookup{}
 
-func addProxyFlags(cmd *cobra.Command) error {
-	cmd.Flags().String("http-proxy", "", "HTTP proxy to use for the installation (overrides http_proxy/HTTP_PROXY environment variables)")
-	cmd.Flags().String("https-proxy", "", "HTTPS proxy to use for the installation (overrides https_proxy/HTTPS_PROXY environment variables)")
-	cmd.Flags().String("no-proxy", "", "Comma-separated list of hosts for which not to use a proxy (overrides no_proxy/NO_PROXY environment variables)")
-
-	return nil
+func mustAddProxyFlags(flagSet *pflag.FlagSet) {
+	flagSet.String("http-proxy", "", "HTTP proxy to use for the installation (overrides http_proxy/HTTP_PROXY environment variables)")
+	flagSet.String("https-proxy", "", "HTTPS proxy to use for the installation (overrides https_proxy/HTTPS_PROXY environment variables)")
+	flagSet.String("no-proxy", "", "Comma-separated list of hosts for which not to use a proxy (overrides no_proxy/NO_PROXY environment variables)")
 }
 
 func parseProxyFlags(cmd *cobra.Command) (*ecv1beta1.ProxySpec, error) {

--- a/cmd/installer/cli/proxy_test.go
+++ b/cmd/installer/cli/proxy_test.go
@@ -151,8 +151,8 @@ func Test_getProxySpecFromFlags(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmd := &cobra.Command{}
-			addCIDRFlags(cmd.Flags())
-			addProxyFlags(cmd)
+			mustAddCIDRFlags(cmd.Flags())
+			mustAddProxyFlags(cmd.Flags())
 			cmd.Flags().String("network-interface", "", "The network interface to use for the cluster")
 
 			flagSet := cmd.Flags()

--- a/cmd/installer/cli/restore.go
+++ b/cmd/installer/cli/restore.go
@@ -120,9 +120,7 @@ func RestoreCmd(ctx context.Context, name string) *cobra.Command {
 	addS3Flags(cmd, &s3Store)
 	cmd.Flags().BoolVar(&skipStoreValidation, "skip-store-validation", false, "Skip validation of the backup storage location")
 
-	if err := addInstallFlags(cmd, &flags); err != nil {
-		panic(err)
-	}
+	mustAddInstallFlags(cmd, &flags)
 
 	return cmd
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Adds `--kubeconfig` flag for `--target kubernetes`

Adds additional flags for configuring the kubernetes client borrowed from helm.

Uses helm EnvSettings to construct a kubernetes client from the flags or the environment.

![Screenshot 2025-06-25 at 1 32 55 PM](https://github.com/user-attachments/assets/02a04dcf-05d5-43d1-a082-ea153c6b1705)

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
