### PR TITLE
bug: Use app slug in cli help menu

### DIFF
--- a/cmd/installer/main.go
+++ b/cmd/installer/main.go
@@ -3,12 +3,12 @@ package main
 import (
 	"context"
 	"os"
-	"path"
 	"syscall"
 
 	"github.com/mattn/go-isatty"
 	"github.com/replicatedhq/embedded-cluster/cmd/installer/cli"
 	"github.com/replicatedhq/embedded-cluster/pkg/prompts"
+	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 )
 
 func main() {
@@ -18,7 +18,7 @@ func main() {
 
 	prompts.SetTerminal(isatty.IsTerminal(os.Stdout.Fd()))
 
-	name := path.Base(os.Args[0])
+	name := runtimeconfig.BinaryName()
 
 	// set the umask to 022 so that we can create files/directories with 755 permissions
 	// this does not return an error - it returns the previous umask


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Fixes bug where app slug is not being used for the cli help menu

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/125645/use-app-slug-in-the-cli-help-menu-not-the-binary-name

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
