### PR TITLE
feat: use appslug for default data directory in install wizard

### DIFF
--- a/api/controllers/linux/install/installation.go
+++ b/api/controllers/linux/install/installation.go
@@ -21,6 +21,13 @@ func (c *InstallController) GetInstallationConfig(ctx context.Context) (types.In
 		return types.InstallationConfig{}, fmt.Errorf("set defaults: %w", err)
 	}
 
+	// Use the RuntimeConfig's data directory instead of the hardcoded default
+	// This ensures the UI shows the same data directory that was set by the CLI
+	rcDataDir := c.rc.EmbeddedClusterHomeDirectory()
+	if rcDataDir != ecv1beta1.DefaultDataDir {
+		config.DataDirectory = rcDataDir
+	}
+
 	if err := c.installationManager.ValidateConfig(config, c.rc.ManagerPort()); err != nil {
 		return types.InstallationConfig{}, fmt.Errorf("validate: %w", err)
 	}

--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"syscall"
@@ -480,6 +481,10 @@ func preRunInstallLinux(cmd *cobra.Command, flags *InstallCmdFlags, rc runtimeco
 	networkSpec.NetworkInterface = flags.networkInterface
 	if cidrCfg.GlobalCIDR != nil {
 		networkSpec.GlobalCIDR = *cidrCfg.GlobalCIDR
+	}
+
+	if flags.enableManagerExperience && !cmd.Flags().Changed("data-dir") {
+		flags.dataDir = filepath.Join("/var/lib", runtimeconfig.BinaryName())
 	}
 
 	// TODO: validate that a single port isn't used for multiple services


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Uses the app slug for the default data directory to provide users with a more white labeled experienced. If a user specifies the `--data-dir` CLI flag then that will be populated in the UI by default.

<img width="613" alt="Screenshot 2025-06-26 at 9 24 40 PM" src="https://github.com/user-attachments/assets/033c5b9d-55b1-4ef6-837c-f0d94c5888b9" />


#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

[SC-124300](https://app.shortcut.com/replicated/story/124300/use-the-app-slug-for-the-default-data-directory-name)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE