### PR TITLE
chore(ci): fix unit test race condition

### DIFF
--- a/api/controllers/linux/install/controller_test.go
+++ b/api/controllers/linux/install/controller_test.go
@@ -398,6 +398,8 @@ func TestConfigureInstallation(t *testing.T) {
 			err = controller.ConfigureInstallation(t.Context(), tt.config)
 			if tt.expectedErr {
 				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
 			}
 
 			assert.Eventually(t, func() bool {
@@ -761,8 +763,6 @@ func TestRunHostPreflights(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-
-				assert.NotEqual(t, sm.CurrentState(), tt.currentState, "state should have changed and should not be %s", tt.currentState)
 			}
 
 			assert.Eventually(t, func() bool {
@@ -1152,8 +1152,6 @@ func TestSetupInfra(t *testing.T) {
 				}
 			} else {
 				require.NoError(t, err)
-
-				assert.NotEqual(t, sm.CurrentState(), tt.currentState, "state should have changed and should not be %s", tt.currentState)
 			}
 
 			assert.Eventually(t, func() bool {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

We cannot assert the intermediate state because it may finish before it context switches back to the current thread.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
