### PR TITLE
feat: Use the app name in the help menu output

### DIFF
--- a/api/internal/managers/infra/install.go
+++ b/api/internal/managers/infra/install.go
@@ -33,7 +33,7 @@ const K0sComponentName = "Runtime"
 func AlreadyInstalledError() error {
 	return fmt.Errorf(
 		"\nAn installation is detected on this machine.\nTo install, you must first remove the existing installation.\nYou can do this by running the following command:\n\n  sudo ./%s reset\n",
-		runtimeconfig.BinaryName(),
+		runtimeconfig.AppSlug(),
 	)
 }
 

--- a/api/pkg/logger/logger.go
+++ b/api/pkg/logger/logger.go
@@ -12,7 +12,7 @@ import (
 )
 
 func NewLogger() (*logrus.Logger, error) {
-	fname := fmt.Sprintf("%s-%s.api.log", runtimeconfig.BinaryName(), time.Now().Format("20060102150405.000"))
+	fname := fmt.Sprintf("%s-%s.api.log", runtimeconfig.AppSlug(), time.Now().Format("20060102150405.000"))
 	logpath := runtimeconfig.PathToLog(fname)
 	logfile, err := os.OpenFile(logpath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0400)
 	if err != nil {

--- a/cmd/installer/cli/adminconsole.go
+++ b/cmd/installer/cli/adminconsole.go
@@ -7,16 +7,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func AdminConsoleCmd(ctx context.Context, name string) *cobra.Command {
+func AdminConsoleCmd(ctx context.Context, releaseName string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "admin-console",
-		Short: fmt.Sprintf("Manage the %s Admin Console", name),
+		Short: fmt.Sprintf("Manage the %s Admin Console", releaseName),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return nil
 		},
 	}
 
-	cmd.AddCommand(AdminConsoleResetPasswordCmd(ctx, name))
+	cmd.AddCommand(AdminConsoleResetPasswordCmd(ctx, releaseName))
 
 	return cmd
 }

--- a/cmd/installer/cli/adminconsole.go
+++ b/cmd/installer/cli/adminconsole.go
@@ -7,16 +7,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func AdminConsoleCmd(ctx context.Context, releaseName string) *cobra.Command {
+func AdminConsoleCmd(ctx context.Context, appSlug string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "admin-console",
-		Short: fmt.Sprintf("Manage the %s Admin Console", releaseName),
+		Short: fmt.Sprintf("Manage the %s Admin Console", appSlug),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return nil
 		},
 	}
 
-	cmd.AddCommand(AdminConsoleResetPasswordCmd(ctx, releaseName))
+	cmd.AddCommand(AdminConsoleResetPasswordCmd(ctx, appSlug))
 
 	return cmd
 }

--- a/cmd/installer/cli/adminconsole.go
+++ b/cmd/installer/cli/adminconsole.go
@@ -7,16 +7,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func AdminConsoleCmd(ctx context.Context, appSlug string) *cobra.Command {
+func AdminConsoleCmd(ctx context.Context, appTitle string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "admin-console",
-		Short: fmt.Sprintf("Manage the %s Admin Console", appSlug),
+		Short: fmt.Sprintf("Manage the %s Admin Console", appTitle),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return nil
 		},
 	}
 
-	cmd.AddCommand(AdminConsoleResetPasswordCmd(ctx, appSlug))
+	cmd.AddCommand(AdminConsoleResetPasswordCmd(ctx, appTitle))
 
 	return cmd
 }

--- a/cmd/installer/cli/adminconsole_resetpassword.go
+++ b/cmd/installer/cli/adminconsole_resetpassword.go
@@ -15,13 +15,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func AdminConsoleResetPasswordCmd(ctx context.Context, releaseName string) *cobra.Command {
+func AdminConsoleResetPasswordCmd(ctx context.Context, appSlug string) *cobra.Command {
 	var rc runtimeconfig.RuntimeConfig
 
 	cmd := &cobra.Command{
 		Use:   "reset-password [password]",
 		Args:  cobra.MaximumNArgs(1),
-		Short: fmt.Sprintf("Reset the %s Admin Console password. If no password is provided, you will be prompted to enter a new one.", releaseName),
+		Short: fmt.Sprintf("Reset the %s Admin Console password. If no password is provided, you will be prompted to enter a new one.", appSlug),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Skip root check if dryrun mode is enabled
 			if !dryrun.Enabled() && os.Getuid() != 0 {

--- a/cmd/installer/cli/adminconsole_resetpassword.go
+++ b/cmd/installer/cli/adminconsole_resetpassword.go
@@ -15,13 +15,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func AdminConsoleResetPasswordCmd(ctx context.Context, name string) *cobra.Command {
+func AdminConsoleResetPasswordCmd(ctx context.Context, releaseName string) *cobra.Command {
 	var rc runtimeconfig.RuntimeConfig
 
 	cmd := &cobra.Command{
 		Use:   "reset-password [password]",
 		Args:  cobra.MaximumNArgs(1),
-		Short: fmt.Sprintf("Reset the %s Admin Console password. If no password is provided, you will be prompted to enter a new one.", name),
+		Short: fmt.Sprintf("Reset the %s Admin Console password. If no password is provided, you will be prompted to enter a new one.", releaseName),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Skip root check if dryrun mode is enabled
 			if !dryrun.Enabled() && os.Getuid() != 0 {

--- a/cmd/installer/cli/adminconsole_resetpassword.go
+++ b/cmd/installer/cli/adminconsole_resetpassword.go
@@ -15,13 +15,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func AdminConsoleResetPasswordCmd(ctx context.Context, appSlug string) *cobra.Command {
+func AdminConsoleResetPasswordCmd(ctx context.Context, appTitle string) *cobra.Command {
 	var rc runtimeconfig.RuntimeConfig
 
 	cmd := &cobra.Command{
 		Use:   "reset-password [password]",
 		Args:  cobra.MaximumNArgs(1),
-		Short: fmt.Sprintf("Reset the %s Admin Console password. If no password is provided, you will be prompted to enter a new one.", appSlug),
+		Short: fmt.Sprintf("Reset the %s Admin Console password. If no password is provided, you will be prompted to enter a new one.", appTitle),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Skip root check if dryrun mode is enabled
 			if !dryrun.Enabled() && os.Getuid() != 0 {

--- a/cmd/installer/cli/enable_ha.go
+++ b/cmd/installer/cli/enable_ha.go
@@ -20,12 +20,12 @@ import (
 )
 
 // EnableHACmd is the command for enabling HA mode.
-func EnableHACmd(ctx context.Context, appSlug string) *cobra.Command {
+func EnableHACmd(ctx context.Context, appTitle string) *cobra.Command {
 	var rc runtimeconfig.RuntimeConfig
 
 	cmd := &cobra.Command{
 		Use:   "enable-ha",
-		Short: fmt.Sprintf("Enable high availability for the %s cluster", appSlug),
+		Short: fmt.Sprintf("Enable high availability for the %s cluster", appTitle),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Skip root check if dryrun mode is enabled
 			if !dryrun.Enabled() && os.Getuid() != 0 {

--- a/cmd/installer/cli/enable_ha.go
+++ b/cmd/installer/cli/enable_ha.go
@@ -20,12 +20,12 @@ import (
 )
 
 // EnableHACmd is the command for enabling HA mode.
-func EnableHACmd(ctx context.Context, releaseName string) *cobra.Command {
+func EnableHACmd(ctx context.Context, appSlug string) *cobra.Command {
 	var rc runtimeconfig.RuntimeConfig
 
 	cmd := &cobra.Command{
 		Use:   "enable-ha",
-		Short: fmt.Sprintf("Enable high availability for the %s cluster", releaseName),
+		Short: fmt.Sprintf("Enable high availability for the %s cluster", appSlug),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Skip root check if dryrun mode is enabled
 			if !dryrun.Enabled() && os.Getuid() != 0 {

--- a/cmd/installer/cli/enable_ha.go
+++ b/cmd/installer/cli/enable_ha.go
@@ -20,12 +20,12 @@ import (
 )
 
 // EnableHACmd is the command for enabling HA mode.
-func EnableHACmd(ctx context.Context, name string) *cobra.Command {
+func EnableHACmd(ctx context.Context, releaseName string) *cobra.Command {
 	var rc runtimeconfig.RuntimeConfig
 
 	cmd := &cobra.Command{
 		Use:   "enable-ha",
-		Short: fmt.Sprintf("Enable high availability for the %s cluster", name),
+		Short: fmt.Sprintf("Enable high availability for the %s cluster", releaseName),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Skip root check if dryrun mode is enabled
 			if !dryrun.Enabled() && os.Getuid() != 0 {

--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -137,7 +137,7 @@ func InstallCmd(ctx context.Context, name string) *cobra.Command {
 			installReporter.ReportInstallationStarted(ctx)
 
 			if flags.enableManagerExperience {
-				return runManagerExperienceInstall(ctx, flags, rc, ki, installReporter)
+				return runManagerExperienceInstall(ctx, flags, rc, ki, installReporter, name)
 			}
 
 			_ = rc.SetEnv()
@@ -570,7 +570,7 @@ func cidrConfigFromCmd(cmd *cobra.Command) (*newconfig.CIDRConfig, error) {
 	return cidrCfg, nil
 }
 
-func runManagerExperienceInstall(ctx context.Context, flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig, ki kubernetesinstallation.Installation, installReporter *InstallReporter) (finalErr error) {
+func runManagerExperienceInstall(ctx context.Context, flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig, ki kubernetesinstallation.Installation, installReporter *InstallReporter, name string) (finalErr error) {
 	// this is necessary because the api listens on all interfaces,
 	// and we only know the interface to use when the user selects it in the ui
 	ipAddresses, err := netutils.ListAllValidIPAddresses()
@@ -663,7 +663,7 @@ func runManagerExperienceInstall(ctx context.Context, flags InstallCmdFlags, rc 
 	}
 
 	logrus.Infof("\nVisit the %s manager to continue: %s\n",
-		runtimeconfig.BinaryName(),
+		name,
 		getManagerURL(flags.hostname, flags.managerPort))
 	<-ctx.Done()
 

--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -100,7 +100,7 @@ type installConfig struct {
 var webAssetsFS fs.FS = nil
 
 // InstallCmd returns a cobra command for installing the embedded cluster.
-func InstallCmd(ctx context.Context, appSlug string) *cobra.Command {
+func InstallCmd(ctx context.Context, appSlug, appTitle string) *cobra.Command {
 	var flags InstallCmdFlags
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -108,9 +108,9 @@ func InstallCmd(ctx context.Context, appSlug string) *cobra.Command {
 	rc := runtimeconfig.New(nil)
 	ki := kubernetesinstallation.New(nil)
 
-	short := fmt.Sprintf("Install %s", appSlug)
+	short := fmt.Sprintf("Install %s", appTitle)
 	if os.Getenv("ENABLE_V3") == "1" {
-		short = fmt.Sprintf("Install %s onto Linux or Kubernetes", appSlug)
+		short = fmt.Sprintf("Install %s onto Linux or Kubernetes", appTitle)
 	}
 
 	cmd := &cobra.Command{
@@ -137,7 +137,7 @@ func InstallCmd(ctx context.Context, appSlug string) *cobra.Command {
 			installReporter.ReportInstallationStarted(ctx)
 
 			if flags.enableManagerExperience {
-				return runManagerExperienceInstall(ctx, flags, rc, ki, installReporter, appSlug)
+				return runManagerExperienceInstall(ctx, flags, rc, ki, installReporter, appTitle)
 			}
 
 			_ = rc.SetEnv()
@@ -570,7 +570,7 @@ func cidrConfigFromCmd(cmd *cobra.Command) (*newconfig.CIDRConfig, error) {
 	return cidrCfg, nil
 }
 
-func runManagerExperienceInstall(ctx context.Context, flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig, ki kubernetesinstallation.Installation, installReporter *InstallReporter, appSlug string) (finalErr error) {
+func runManagerExperienceInstall(ctx context.Context, flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig, ki kubernetesinstallation.Installation, installReporter *InstallReporter, appTitle string) (finalErr error) {
 	// this is necessary because the api listens on all interfaces,
 	// and we only know the interface to use when the user selects it in the ui
 	ipAddresses, err := netutils.ListAllValidIPAddresses()
@@ -663,7 +663,7 @@ func runManagerExperienceInstall(ctx context.Context, flags InstallCmdFlags, rc 
 	}
 
 	logrus.Infof("\nVisit the %s manager to continue: %s\n",
-		appSlug,
+		appTitle,
 		getManagerURL(flags.hostname, flags.managerPort))
 	<-ctx.Done()
 

--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -100,7 +100,7 @@ type installConfig struct {
 var webAssetsFS fs.FS = nil
 
 // InstallCmd returns a cobra command for installing the embedded cluster.
-func InstallCmd(ctx context.Context, name string) *cobra.Command {
+func InstallCmd(ctx context.Context, releaseName string) *cobra.Command {
 	var flags InstallCmdFlags
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -108,21 +108,21 @@ func InstallCmd(ctx context.Context, name string) *cobra.Command {
 	rc := runtimeconfig.New(nil)
 	ki := kubernetesinstallation.New(nil)
 
-	short := fmt.Sprintf("Install %s", name)
+	short := fmt.Sprintf("Install %s", releaseName)
 	if os.Getenv("ENABLE_V3") == "1" {
-		short = fmt.Sprintf("Install %s onto Linux or Kubernetes", name)
+		short = fmt.Sprintf("Install %s onto Linux or Kubernetes", releaseName)
 	}
 
 	cmd := &cobra.Command{
 		Use:     "install",
 		Short:   short,
-		Example: installCmdExample(name),
+		Example: installCmdExample(releaseName),
 		PostRun: func(cmd *cobra.Command, args []string) {
 			rc.Cleanup()
 			cancel() // Cancel context when command completes
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := verifyAndPrompt(ctx, name, flags, prompts.New()); err != nil {
+			if err := verifyAndPrompt(ctx, releaseName, flags, prompts.New()); err != nil {
 				return err
 			}
 			if err := preRunInstall(cmd, &flags, rc, ki); err != nil {
@@ -137,7 +137,7 @@ func InstallCmd(ctx context.Context, name string) *cobra.Command {
 			installReporter.ReportInstallationStarted(ctx)
 
 			if flags.enableManagerExperience {
-				return runManagerExperienceInstall(ctx, flags, rc, ki, installReporter, name)
+				return runManagerExperienceInstall(ctx, flags, rc, ki, installReporter, releaseName)
 			}
 
 			_ = rc.SetEnv()
@@ -173,7 +173,7 @@ func InstallCmd(ctx context.Context, name string) *cobra.Command {
 		panic(err)
 	}
 
-	cmd.AddCommand(InstallRunPreflightsCmd(ctx, name))
+	cmd.AddCommand(InstallRunPreflightsCmd(ctx, releaseName))
 
 	return cmd
 }
@@ -196,12 +196,12 @@ const (
 `
 )
 
-func installCmdExample(name string) string {
+func installCmdExample(releaseName string) string {
 	if os.Getenv("ENABLE_V3") != "1" {
 		return ""
 	}
 
-	return fmt.Sprintf(installCmdExampleText, name, name)
+	return fmt.Sprintf(installCmdExampleText, releaseName, releaseName)
 }
 
 func mustAddInstallFlags(cmd *cobra.Command, flags *InstallCmdFlags) {
@@ -570,7 +570,7 @@ func cidrConfigFromCmd(cmd *cobra.Command) (*newconfig.CIDRConfig, error) {
 	return cidrCfg, nil
 }
 
-func runManagerExperienceInstall(ctx context.Context, flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig, ki kubernetesinstallation.Installation, installReporter *InstallReporter, name string) (finalErr error) {
+func runManagerExperienceInstall(ctx context.Context, flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig, ki kubernetesinstallation.Installation, installReporter *InstallReporter, releaseName string) (finalErr error) {
 	// this is necessary because the api listens on all interfaces,
 	// and we only know the interface to use when the user selects it in the ui
 	ipAddresses, err := netutils.ListAllValidIPAddresses()
@@ -663,7 +663,7 @@ func runManagerExperienceInstall(ctx context.Context, flags InstallCmdFlags, rc 
 	}
 
 	logrus.Infof("\nVisit the %s manager to continue: %s\n",
-		name,
+		releaseName,
 		getManagerURL(flags.hostname, flags.managerPort))
 	<-ctx.Done()
 
@@ -813,9 +813,9 @@ func getAddonInstallOpts(flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig, 
 	return opts, nil
 }
 
-func verifyAndPrompt(ctx context.Context, name string, flags InstallCmdFlags, prompt prompts.Prompt) error {
+func verifyAndPrompt(ctx context.Context, releaseName string, flags InstallCmdFlags, prompt prompts.Prompt) error {
 	logrus.Debugf("checking if k0s is already installed")
-	err := verifyNoInstallation(name, "reinstall")
+	err := verifyNoInstallation(releaseName, "reinstall")
 	if err != nil {
 		return err
 	}
@@ -987,7 +987,7 @@ func verifyChannelRelease(cmdName string, isAirgap bool, assumeYes bool) error {
 	return nil
 }
 
-func verifyNoInstallation(name string, cmdName string) error {
+func verifyNoInstallation(releaseName string, cmdName string) error {
 	installed, err := k0s.IsInstalled()
 	if err != nil {
 		return err
@@ -996,7 +996,7 @@ func verifyNoInstallation(name string, cmdName string) error {
 		logrus.Errorf("\nAn installation is detected on this machine.")
 		logrus.Infof("To %s, you must first remove the existing installation.", cmdName)
 		logrus.Infof("You can do this by running the following command:")
-		logrus.Infof("\n  sudo ./%s reset\n", name)
+		logrus.Infof("\n  sudo ./%s reset\n", releaseName)
 		return NewErrorNothingElseToAdd(errors.New("previous installation detected"))
 	}
 	return nil

--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -265,7 +265,7 @@ func newLinuxInstallFlags(flags *InstallCmdFlags) *pflag.FlagSet {
 	// Use the app slug as default data directory only when ENABLE_V3 is set
 	defaultDataDir := ecv1beta1.DefaultDataDir
 	if os.Getenv("ENABLE_V3") == "1" {
-		defaultDataDir = filepath.Join("/var/lib", runtimeconfig.BinaryName())
+		defaultDataDir = filepath.Join("/var/lib", runtimeconfig.AppSlug())
 	}
 
 	flagSet.StringVar(&flags.dataDir, "data-dir", defaultDataDir, "Path to the data directory")

--- a/cmd/installer/cli/install_runpreflights.go
+++ b/cmd/installer/cli/install_runpreflights.go
@@ -22,7 +22,7 @@ import (
 // they contain failures. We use this to differentiate the way we provide user feedback.
 var ErrPreflightsHaveFail = metrics.NewErrorNoFail(fmt.Errorf("host preflight failures detected"))
 
-func InstallRunPreflightsCmd(ctx context.Context, releaseName string) *cobra.Command {
+func InstallRunPreflightsCmd(ctx context.Context, appSlug string) *cobra.Command {
 	var flags InstallCmdFlags
 
 	rc := runtimeconfig.New(nil)
@@ -45,7 +45,7 @@ func InstallRunPreflightsCmd(ctx context.Context, releaseName string) *cobra.Com
 			rc.Cleanup()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := runInstallRunPreflights(cmd.Context(), releaseName, flags, rc); err != nil {
+			if err := runInstallRunPreflights(cmd.Context(), appSlug, flags, rc); err != nil {
 				return err
 			}
 
@@ -62,8 +62,8 @@ func InstallRunPreflightsCmd(ctx context.Context, releaseName string) *cobra.Com
 	return cmd
 }
 
-func runInstallRunPreflights(ctx context.Context, releaseName string, flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig) error {
-	if err := verifyAndPrompt(ctx, releaseName, flags, prompts.New()); err != nil {
+func runInstallRunPreflights(ctx context.Context, appSlug string, flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig) error {
+	if err := verifyAndPrompt(ctx, appSlug, flags, prompts.New()); err != nil {
 		return err
 	}
 

--- a/cmd/installer/cli/install_runpreflights.go
+++ b/cmd/installer/cli/install_runpreflights.go
@@ -22,7 +22,7 @@ import (
 // they contain failures. We use this to differentiate the way we provide user feedback.
 var ErrPreflightsHaveFail = metrics.NewErrorNoFail(fmt.Errorf("host preflight failures detected"))
 
-func InstallRunPreflightsCmd(ctx context.Context, name string) *cobra.Command {
+func InstallRunPreflightsCmd(ctx context.Context, releaseName string) *cobra.Command {
 	var flags InstallCmdFlags
 
 	rc := runtimeconfig.New(nil)
@@ -45,7 +45,7 @@ func InstallRunPreflightsCmd(ctx context.Context, name string) *cobra.Command {
 			rc.Cleanup()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := runInstallRunPreflights(cmd.Context(), name, flags, rc); err != nil {
+			if err := runInstallRunPreflights(cmd.Context(), releaseName, flags, rc); err != nil {
 				return err
 			}
 
@@ -62,8 +62,8 @@ func InstallRunPreflightsCmd(ctx context.Context, name string) *cobra.Command {
 	return cmd
 }
 
-func runInstallRunPreflights(ctx context.Context, name string, flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig) error {
-	if err := verifyAndPrompt(ctx, name, flags, prompts.New()); err != nil {
+func runInstallRunPreflights(ctx context.Context, releaseName string, flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig) error {
+	if err := verifyAndPrompt(ctx, releaseName, flags, prompts.New()); err != nil {
 		return err
 	}
 

--- a/cmd/installer/cli/join.go
+++ b/cmd/installer/cli/join.go
@@ -50,7 +50,7 @@ type JoinCmdFlags struct {
 }
 
 // JoinCmd returns a cobra command for joining a node to the cluster.
-func JoinCmd(ctx context.Context, releaseName string) *cobra.Command {
+func JoinCmd(ctx context.Context, appSlug string) *cobra.Command {
 	var flags JoinCmdFlags
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -58,7 +58,7 @@ func JoinCmd(ctx context.Context, releaseName string) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "join <url> <token>",
-		Short: fmt.Sprintf("Join a node to the %s cluster", releaseName),
+		Short: fmt.Sprintf("Join a node to the %s cluster", appSlug),
 		Args:  cobra.ExactArgs(2),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := preRunJoin(&flags); err != nil {
@@ -87,7 +87,7 @@ func JoinCmd(ctx context.Context, releaseName string) *cobra.Command {
 				joinReporter.ReportSignalAborted(ctx, sig)
 			})
 
-			if err := runJoin(cmd.Context(), releaseName, flags, rc, jcmd, args[0], joinReporter); err != nil {
+			if err := runJoin(cmd.Context(), appSlug, flags, rc, jcmd, args[0], joinReporter); err != nil {
 				// Check if this is an interrupt error from the terminal
 				if errors.Is(err, terminal.InterruptErr) {
 					joinReporter.ReportSignalAborted(ctx, syscall.SIGINT)
@@ -106,8 +106,8 @@ func JoinCmd(ctx context.Context, releaseName string) *cobra.Command {
 		panic(err)
 	}
 
-	cmd.AddCommand(JoinRunPreflightsCmd(ctx, releaseName))
-	cmd.AddCommand(JoinPrintCommandCmd(ctx, releaseName))
+	cmd.AddCommand(JoinRunPreflightsCmd(ctx, appSlug))
+	cmd.AddCommand(JoinPrintCommandCmd(ctx, appSlug))
 
 	return cmd
 }
@@ -153,18 +153,18 @@ func addJoinFlags(cmd *cobra.Command, flags *JoinCmdFlags) error {
 	return nil
 }
 
-func runJoin(ctx context.Context, releaseName string, flags JoinCmdFlags, rc runtimeconfig.RuntimeConfig, jcmd *join.JoinCommandResponse, kotsAPIAddress string, joinReporter *JoinReporter) error {
+func runJoin(ctx context.Context, appSlug string, flags JoinCmdFlags, rc runtimeconfig.RuntimeConfig, jcmd *join.JoinCommandResponse, kotsAPIAddress string, joinReporter *JoinReporter) error {
 	// both controller and worker nodes will have 'worker' in the join command
 	isWorker := !strings.Contains(jcmd.K0sJoinCommand, "controller")
 	if !isWorker {
 		logrus.Warn("\nDo not join another node until this node has joined successfully.")
 	}
 
-	if err := runJoinVerifyAndPrompt(releaseName, flags, rc, jcmd); err != nil {
+	if err := runJoinVerifyAndPrompt(appSlug, flags, rc, jcmd); err != nil {
 		return err
 	}
 
-	cidrCfg, err := initializeJoin(ctx, releaseName, rc, jcmd, kotsAPIAddress)
+	cidrCfg, err := initializeJoin(ctx, appSlug, rc, jcmd, kotsAPIAddress)
 	if err != nil {
 		return fmt.Errorf("unable to initialize join: %w", err)
 	}
@@ -180,7 +180,7 @@ func runJoin(ctx context.Context, releaseName string, flags JoinCmdFlags, rc run
 	logrus.Debugf("installing and joining cluster")
 	loading := spinner.Start()
 	loading.Infof("Installing node")
-	if err := installAndJoinCluster(ctx, rc, jcmd, releaseName, flags, isWorker); err != nil {
+	if err := installAndJoinCluster(ctx, rc, jcmd, appSlug, flags, isWorker); err != nil {
 		loading.ErrorClosef("Failed to install node")
 		return err
 	}
@@ -226,9 +226,9 @@ func runJoin(ctx context.Context, releaseName string, flags JoinCmdFlags, rc run
 	return nil
 }
 
-func runJoinVerifyAndPrompt(releaseName string, flags JoinCmdFlags, rc runtimeconfig.RuntimeConfig, jcmd *join.JoinCommandResponse) error {
+func runJoinVerifyAndPrompt(appSlug string, flags JoinCmdFlags, rc runtimeconfig.RuntimeConfig, jcmd *join.JoinCommandResponse) error {
 	logrus.Debugf("checking if k0s is already installed")
-	err := verifyNoInstallation(releaseName, "join a node")
+	err := verifyNoInstallation(appSlug, "join a node")
 	if err != nil {
 		return err
 	}
@@ -284,7 +284,7 @@ func runJoinVerifyAndPrompt(releaseName string, flags JoinCmdFlags, rc runtimeco
 	return nil
 }
 
-func initializeJoin(ctx context.Context, releaseName string, rc runtimeconfig.RuntimeConfig, jcmd *join.JoinCommandResponse, kotsAPIAddress string) (cidrCfg *newconfig.CIDRConfig, err error) {
+func initializeJoin(ctx context.Context, appSlug string, rc runtimeconfig.RuntimeConfig, jcmd *join.JoinCommandResponse, kotsAPIAddress string) (cidrCfg *newconfig.CIDRConfig, err error) {
 	logrus.Info("")
 	spinner := spinner.Start()
 	spinner.Infof("Initializing")
@@ -306,7 +306,7 @@ func initializeJoin(ctx context.Context, releaseName string, rc runtimeconfig.Ru
 		logrus.Debugf("unable to chmod embedded-cluster home dir: %s", err)
 	}
 
-	logrus.Debugf("materializing %s binaries", releaseName)
+	logrus.Debugf("materializing %s binaries", appSlug)
 	if err := materializeFilesForJoin(ctx, rc, jcmd, kotsAPIAddress); err != nil {
 		return nil, fmt.Errorf("failed to materialize files: %w", err)
 	}
@@ -382,13 +382,13 @@ func getJoinCIDRConfig(rc runtimeconfig.RuntimeConfig) (*newconfig.CIDRConfig, e
 	}, nil
 }
 
-func installAndJoinCluster(ctx context.Context, rc runtimeconfig.RuntimeConfig, jcmd *join.JoinCommandResponse, releaseName string, flags JoinCmdFlags, isWorker bool) error {
+func installAndJoinCluster(ctx context.Context, rc runtimeconfig.RuntimeConfig, jcmd *join.JoinCommandResponse, appSlug string, flags JoinCmdFlags, isWorker bool) error {
 	logrus.Debugf("saving token to disk")
 	if err := saveTokenToDisk(jcmd.K0sToken); err != nil {
 		return fmt.Errorf("unable to save token to disk: %w", err)
 	}
 
-	logrus.Debugf("installing %s binaries", releaseName)
+	logrus.Debugf("installing %s binaries", appSlug)
 	if err := installK0sBinary(rc); err != nil {
 		return fmt.Errorf("unable to install k0s binary: %w", err)
 	}
@@ -424,7 +424,7 @@ func installAndJoinCluster(ctx context.Context, rc runtimeconfig.RuntimeConfig, 
 		return fmt.Errorf("unable to join node to cluster: %w", err)
 	}
 
-	if err := startAndWaitForK0s(releaseName); err != nil {
+	if err := startAndWaitForK0s(appSlug); err != nil {
 		return err
 	}
 
@@ -495,8 +495,8 @@ func applyNetworkConfiguration(rc runtimeconfig.RuntimeConfig, jcmd *join.JoinCo
 }
 
 // startAndWaitForK0s starts the k0s service and waits for the node to be ready.
-func startAndWaitForK0s(releaseName string) error {
-	logrus.Debugf("starting %s service", releaseName)
+func startAndWaitForK0s(appSlug string) error {
+	logrus.Debugf("starting %s service", appSlug)
 	if _, err := helpers.RunCommand(runtimeconfig.K0sBinaryPath, "start"); err != nil {
 		return fmt.Errorf("unable to start service: %w", err)
 	}

--- a/cmd/installer/cli/join.go
+++ b/cmd/installer/cli/join.go
@@ -50,7 +50,7 @@ type JoinCmdFlags struct {
 }
 
 // JoinCmd returns a cobra command for joining a node to the cluster.
-func JoinCmd(ctx context.Context, appSlug string) *cobra.Command {
+func JoinCmd(ctx context.Context, appSlug, appTitle string) *cobra.Command {
 	var flags JoinCmdFlags
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -58,7 +58,7 @@ func JoinCmd(ctx context.Context, appSlug string) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "join <url> <token>",
-		Short: fmt.Sprintf("Join a node to the %s cluster", appSlug),
+		Short: fmt.Sprintf("Join a node to the %s cluster", appTitle),
 		Args:  cobra.ExactArgs(2),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := preRunJoin(&flags); err != nil {
@@ -106,8 +106,8 @@ func JoinCmd(ctx context.Context, appSlug string) *cobra.Command {
 		panic(err)
 	}
 
-	cmd.AddCommand(JoinRunPreflightsCmd(ctx, appSlug))
-	cmd.AddCommand(JoinPrintCommandCmd(ctx, appSlug))
+	cmd.AddCommand(JoinRunPreflightsCmd(ctx, appSlug, appTitle))
+	cmd.AddCommand(JoinPrintCommandCmd(ctx, appTitle))
 
 	return cmd
 }

--- a/cmd/installer/cli/join_printcommand.go
+++ b/cmd/installer/cli/join_printcommand.go
@@ -12,12 +12,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func JoinPrintCommandCmd(ctx context.Context, name string) *cobra.Command {
+func JoinPrintCommandCmd(ctx context.Context, appTitle string) *cobra.Command {
 	var rc runtimeconfig.RuntimeConfig
 
 	cmd := &cobra.Command{
 		Use:   "print-command",
-		Short: fmt.Sprintf("Print controller join command for %s", name),
+		Short: fmt.Sprintf("Print controller join command for %s", appTitle),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Skip root check if dryrun mode is enabled
 			if !dryrun.Enabled() && os.Getuid() != 0 {

--- a/cmd/installer/cli/join_runpreflights.go
+++ b/cmd/installer/cli/join_runpreflights.go
@@ -19,13 +19,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func JoinRunPreflightsCmd(ctx context.Context, name string) *cobra.Command {
+func JoinRunPreflightsCmd(ctx context.Context, appSlug, appTitle string) *cobra.Command {
 	var flags JoinCmdFlags
 	rc := runtimeconfig.New(nil)
 
 	cmd := &cobra.Command{
 		Use:   "run-preflights",
-		Short: fmt.Sprintf("Run join host preflights for %s", name),
+		Short: fmt.Sprintf("Run join host preflights for %s", appTitle),
 		Args:  cobra.ExactArgs(2),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := preRunJoin(&flags); err != nil {
@@ -43,7 +43,7 @@ func JoinRunPreflightsCmd(ctx context.Context, name string) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("unable to get join token: %w", err)
 			}
-			if err := runJoinRunPreflights(cmd.Context(), name, flags, rc, jcmd, args[0]); err != nil {
+			if err := runJoinRunPreflights(cmd.Context(), appSlug, flags, rc, jcmd, args[0]); err != nil {
 				return err
 			}
 
@@ -58,12 +58,12 @@ func JoinRunPreflightsCmd(ctx context.Context, name string) *cobra.Command {
 	return cmd
 }
 
-func runJoinRunPreflights(ctx context.Context, name string, flags JoinCmdFlags, rc runtimeconfig.RuntimeConfig, jcmd *join.JoinCommandResponse, kotsAPIAddress string) error {
-	if err := runJoinVerifyAndPrompt(name, flags, rc, jcmd); err != nil {
+func runJoinRunPreflights(ctx context.Context, appSlug string, flags JoinCmdFlags, rc runtimeconfig.RuntimeConfig, jcmd *join.JoinCommandResponse, kotsAPIAddress string) error {
+	if err := runJoinVerifyAndPrompt(appSlug, flags, rc, jcmd); err != nil {
 		return err
 	}
 
-	logrus.Debugf("materializing %s binaries", name)
+	logrus.Debugf("materializing %s binaries", appSlug)
 	if err := materializeFilesForJoin(ctx, rc, jcmd, kotsAPIAddress); err != nil {
 		return fmt.Errorf("failed to materialize files: %w", err)
 	}

--- a/cmd/installer/cli/logging.go
+++ b/cmd/installer/cli/logging.go
@@ -108,7 +108,7 @@ func SetupLogging() {
 		return
 	}
 	logrus.SetLevel(logrus.DebugLevel)
-	fname := fmt.Sprintf("%s-%s.log", runtimeconfig.BinaryName(), time.Now().Format("20060102150405.000"))
+	fname := fmt.Sprintf("%s-%s.log", runtimeconfig.AppSlug(), time.Now().Format("20060102150405.000"))
 	logpath := runtimeconfig.PathToLog(fname)
 	logfile, err := os.OpenFile(logpath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0400)
 	if err != nil {

--- a/cmd/installer/cli/materialize.go
+++ b/cmd/installer/cli/materialize.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func MaterializeCmd(ctx context.Context, name string) *cobra.Command {
+func MaterializeCmd(ctx context.Context) *cobra.Command {
 	var dataDir string
 	rc := runtimeconfig.New(nil)
 

--- a/cmd/installer/cli/node.go
+++ b/cmd/installer/cli/node.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NodeCmd(ctx context.Context, appSlug string) *cobra.Command {
+func NodeCmd(ctx context.Context, appSlug, appTitle string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "node",
 		Short: "Manage cluster nodes",
@@ -17,11 +17,11 @@ func NodeCmd(ctx context.Context, appSlug string) *cobra.Command {
 	}
 
 	// here for legacy reasons
-	joinCmd := JoinCmd(ctx, appSlug)
+	joinCmd := JoinCmd(ctx, appSlug, appTitle)
 	joinCmd.Hidden = true
 	cmd.AddCommand(joinCmd)
 
-	resetCmd := ResetCmd(ctx, appSlug)
+	resetCmd := ResetCmd(ctx, appTitle)
 	resetCmd.Hidden = true
 	cmd.AddCommand(resetCmd)
 

--- a/cmd/installer/cli/node.go
+++ b/cmd/installer/cli/node.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NodeCmd(ctx context.Context, releaseName string) *cobra.Command {
+func NodeCmd(ctx context.Context, appSlug string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "node",
 		Short: "Manage cluster nodes",
@@ -17,11 +17,11 @@ func NodeCmd(ctx context.Context, releaseName string) *cobra.Command {
 	}
 
 	// here for legacy reasons
-	joinCmd := JoinCmd(ctx, releaseName)
+	joinCmd := JoinCmd(ctx, appSlug)
 	joinCmd.Hidden = true
 	cmd.AddCommand(joinCmd)
 
-	resetCmd := ResetCmd(ctx, releaseName)
+	resetCmd := ResetCmd(ctx, appSlug)
 	resetCmd.Hidden = true
 	cmd.AddCommand(resetCmd)
 

--- a/cmd/installer/cli/node.go
+++ b/cmd/installer/cli/node.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NodeCmd(ctx context.Context, name string) *cobra.Command {
+func NodeCmd(ctx context.Context, releaseName string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "node",
 		Short: "Manage cluster nodes",
@@ -17,11 +17,11 @@ func NodeCmd(ctx context.Context, name string) *cobra.Command {
 	}
 
 	// here for legacy reasons
-	joinCmd := JoinCmd(ctx, name)
+	joinCmd := JoinCmd(ctx, releaseName)
 	joinCmd.Hidden = true
 	cmd.AddCommand(joinCmd)
 
-	resetCmd := ResetCmd(ctx, name)
+	resetCmd := ResetCmd(ctx, releaseName)
 	resetCmd.Hidden = true
 	cmd.AddCommand(resetCmd)
 

--- a/cmd/installer/cli/reset.go
+++ b/cmd/installer/cli/reset.go
@@ -43,7 +43,7 @@ type hostInfo struct {
 	RoleName         string
 }
 
-func ResetCmd(ctx context.Context, appSlug string) *cobra.Command {
+func ResetCmd(ctx context.Context, appTitle string) *cobra.Command {
 	var (
 		force     bool
 		assumeYes bool
@@ -53,7 +53,7 @@ func ResetCmd(ctx context.Context, appSlug string) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "reset",
-		Short: fmt.Sprintf("Remove %s from the current node", appSlug),
+		Short: fmt.Sprintf("Remove %s from the current node", appTitle),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if os.Getuid() != 0 {
 				return fmt.Errorf("reset command must be run as root")
@@ -221,7 +221,7 @@ func ResetCmd(ctx context.Context, appSlug string) *cobra.Command {
 	cmd.Flags().BoolVarP(&assumeYes, "yes", "y", false, "Assume yes to all prompts.")
 	cmd.Flags().SetNormalizeFunc(normalizeNoPromptToYes)
 
-	cmd.AddCommand(ResetFirewalldCmd(ctx))
+	cmd.AddCommand(ResetFirewalldCmd(ctx, appTitle))
 
 	return cmd
 }

--- a/cmd/installer/cli/reset.go
+++ b/cmd/installer/cli/reset.go
@@ -43,7 +43,7 @@ type hostInfo struct {
 	RoleName         string
 }
 
-func ResetCmd(ctx context.Context, name string) *cobra.Command {
+func ResetCmd(ctx context.Context, releaseName string) *cobra.Command {
 	var (
 		force     bool
 		assumeYes bool
@@ -53,7 +53,7 @@ func ResetCmd(ctx context.Context, name string) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "reset",
-		Short: fmt.Sprintf("Remove %s from the current node", name),
+		Short: fmt.Sprintf("Remove %s from the current node", releaseName),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if os.Getuid() != 0 {
 				return fmt.Errorf("reset command must be run as root")
@@ -97,7 +97,7 @@ func ResetCmd(ctx context.Context, name string) *cobra.Command {
 					return err
 				}
 				if !safeToRemove {
-					return fmt.Errorf("%s\nRun reset command with --force to ignore this.", reason)
+					return fmt.Errorf("%s\nRun reset command with --force to ignore this", reason)
 				}
 			}
 
@@ -221,7 +221,7 @@ func ResetCmd(ctx context.Context, name string) *cobra.Command {
 	cmd.Flags().BoolVarP(&assumeYes, "yes", "y", false, "Assume yes to all prompts.")
 	cmd.Flags().SetNormalizeFunc(normalizeNoPromptToYes)
 
-	cmd.AddCommand(ResetFirewalldCmd(ctx, name))
+	cmd.AddCommand(ResetFirewalldCmd(ctx))
 
 	return cmd
 }

--- a/cmd/installer/cli/reset.go
+++ b/cmd/installer/cli/reset.go
@@ -43,7 +43,7 @@ type hostInfo struct {
 	RoleName         string
 }
 
-func ResetCmd(ctx context.Context, releaseName string) *cobra.Command {
+func ResetCmd(ctx context.Context, appSlug string) *cobra.Command {
 	var (
 		force     bool
 		assumeYes bool
@@ -53,7 +53,7 @@ func ResetCmd(ctx context.Context, releaseName string) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "reset",
-		Short: fmt.Sprintf("Remove %s from the current node", releaseName),
+		Short: fmt.Sprintf("Remove %s from the current node", appSlug),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if os.Getuid() != 0 {
 				return fmt.Errorf("reset command must be run as root")

--- a/cmd/installer/cli/reset_firewalld.go
+++ b/cmd/installer/cli/reset_firewalld.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func ResetFirewalldCmd(ctx context.Context, name string) *cobra.Command {
+func ResetFirewalldCmd(ctx context.Context) *cobra.Command {
 	var rc runtimeconfig.RuntimeConfig
 
 	cmd := &cobra.Command{

--- a/cmd/installer/cli/reset_firewalld.go
+++ b/cmd/installer/cli/reset_firewalld.go
@@ -13,12 +13,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func ResetFirewalldCmd(ctx context.Context) *cobra.Command {
+func ResetFirewalldCmd(ctx context.Context, appTitle string) *cobra.Command {
 	var rc runtimeconfig.RuntimeConfig
 
 	cmd := &cobra.Command{
 		Use:    "firewalld",
-		Short:  "Remove %s firewalld configuration from the current node",
+		Short:  fmt.Sprintf("Remove %s firewalld configuration from the current node", appTitle),
 		Hidden: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Skip root check if dryrun mode is enabled

--- a/cmd/installer/cli/restore.go
+++ b/cmd/installer/cli/restore.go
@@ -86,7 +86,7 @@ const (
 	resourceModifiersCMName = "restore-resource-modifiers"
 )
 
-func RestoreCmd(ctx context.Context, name string) *cobra.Command {
+func RestoreCmd(ctx context.Context, releaseName string) *cobra.Command {
 	var flags InstallCmdFlags
 
 	var s3Store s3BackupStore
@@ -97,7 +97,7 @@ func RestoreCmd(ctx context.Context, name string) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "restore",
-		Short: fmt.Sprintf("Restore %s from a backup", name),
+		Short: fmt.Sprintf("Restore %s from a backup", releaseName),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := preRunInstall(cmd, &flags, rc, ki); err != nil {
 				return err
@@ -111,7 +111,7 @@ func RestoreCmd(ctx context.Context, name string) *cobra.Command {
 			rc.Cleanup()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := runRestore(cmd.Context(), name, flags, rc, s3Store, skipStoreValidation); err != nil {
+			if err := runRestore(cmd.Context(), releaseName, flags, rc, s3Store, skipStoreValidation); err != nil {
 				return err
 			}
 
@@ -127,7 +127,7 @@ func RestoreCmd(ctx context.Context, name string) *cobra.Command {
 	return cmd
 }
 
-func runRestore(ctx context.Context, name string, flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig, s3Store s3BackupStore, skipStoreValidation bool) error {
+func runRestore(ctx context.Context, releaseName string, flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig, s3Store s3BackupStore, skipStoreValidation bool) error {
 	err := verifyChannelRelease("restore", flags.isAirgap, flags.assumeYes)
 	if err != nil {
 		return err
@@ -193,7 +193,7 @@ func runRestore(ctx context.Context, name string, flags InstallCmdFlags, rc runt
 
 	switch state {
 	case ecRestoreStateNew:
-		err = runRestoreStepNew(ctx, name, flags, rc, &s3Store, skipStoreValidation)
+		err = runRestoreStepNew(ctx, releaseName, flags, rc, &s3Store, skipStoreValidation)
 		if err != nil {
 			return err
 		}
@@ -348,15 +348,15 @@ func runRestore(ctx context.Context, name string, flags InstallCmdFlags, rc runt
 	return nil
 }
 
-func runRestoreStepNew(ctx context.Context, name string, flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig, s3Store *s3BackupStore, skipStoreValidation bool) error {
+func runRestoreStepNew(ctx context.Context, releaseName string, flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig, s3Store *s3BackupStore, skipStoreValidation bool) error {
 	logrus.Debugf("checking if k0s is already installed")
-	err := verifyNoInstallation(name, "restore")
+	err := verifyNoInstallation(releaseName, "restore")
 	if err != nil {
 		return err
 	}
 
 	if !s3BackupStoreHasData(s3Store) {
-		logrus.Infof("You'll be guided through the process of restoring %s from a backup.\n", name)
+		logrus.Infof("You'll be guided through the process of restoring %s from a backup.\n", releaseName)
 		logrus.Info("Enter information to configure access to your backup storage location.\n")
 
 		if err := promptForS3BackupStore(s3Store); err != nil {

--- a/cmd/installer/cli/restore.go
+++ b/cmd/installer/cli/restore.go
@@ -86,7 +86,7 @@ const (
 	resourceModifiersCMName = "restore-resource-modifiers"
 )
 
-func RestoreCmd(ctx context.Context, appSlug string) *cobra.Command {
+func RestoreCmd(ctx context.Context, appSlug, appTitle string) *cobra.Command {
 	var flags InstallCmdFlags
 
 	var s3Store s3BackupStore
@@ -97,7 +97,7 @@ func RestoreCmd(ctx context.Context, appSlug string) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "restore",
-		Short: fmt.Sprintf("Restore %s from a backup", appSlug),
+		Short: fmt.Sprintf("Restore %s from a backup", appTitle),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := preRunInstall(cmd, &flags, rc, ki); err != nil {
 				return err
@@ -111,7 +111,7 @@ func RestoreCmd(ctx context.Context, appSlug string) *cobra.Command {
 			rc.Cleanup()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := runRestore(cmd.Context(), appSlug, flags, rc, s3Store, skipStoreValidation); err != nil {
+			if err := runRestore(cmd.Context(), appSlug, appTitle, flags, rc, s3Store, skipStoreValidation); err != nil {
 				return err
 			}
 
@@ -127,7 +127,7 @@ func RestoreCmd(ctx context.Context, appSlug string) *cobra.Command {
 	return cmd
 }
 
-func runRestore(ctx context.Context, appSlug string, flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig, s3Store s3BackupStore, skipStoreValidation bool) error {
+func runRestore(ctx context.Context, appSlug, appTitle string, flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig, s3Store s3BackupStore, skipStoreValidation bool) error {
 	err := verifyChannelRelease("restore", flags.isAirgap, flags.assumeYes)
 	if err != nil {
 		return err
@@ -193,7 +193,7 @@ func runRestore(ctx context.Context, appSlug string, flags InstallCmdFlags, rc r
 
 	switch state {
 	case ecRestoreStateNew:
-		err = runRestoreStepNew(ctx, appSlug, flags, rc, &s3Store, skipStoreValidation)
+		err = runRestoreStepNew(ctx, appSlug, appTitle, flags, rc, &s3Store, skipStoreValidation)
 		if err != nil {
 			return err
 		}
@@ -348,7 +348,7 @@ func runRestore(ctx context.Context, appSlug string, flags InstallCmdFlags, rc r
 	return nil
 }
 
-func runRestoreStepNew(ctx context.Context, appSlug string, flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig, s3Store *s3BackupStore, skipStoreValidation bool) error {
+func runRestoreStepNew(ctx context.Context, appSlug, appTitle string, flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig, s3Store *s3BackupStore, skipStoreValidation bool) error {
 	logrus.Debugf("checking if k0s is already installed")
 	err := verifyNoInstallation(appSlug, "restore")
 	if err != nil {
@@ -356,7 +356,7 @@ func runRestoreStepNew(ctx context.Context, appSlug string, flags InstallCmdFlag
 	}
 
 	if !s3BackupStoreHasData(s3Store) {
-		logrus.Infof("You'll be guided through the process of restoring %s from a backup.\n", appSlug)
+		logrus.Infof("You'll be guided through the process of restoring %s from a backup.\n", appTitle)
 		logrus.Info("Enter information to configure access to your backup storage location.\n")
 
 		if err := promptForS3BackupStore(s3Store); err != nil {

--- a/cmd/installer/cli/root.go
+++ b/cmd/installer/cli/root.go
@@ -104,17 +104,17 @@ func RootCmd(ctx context.Context, appSlug string) *cobra.Command {
 		appTitle = appSlug
 	}
 
-	cmd.AddCommand(InstallCmd(ctx, appSlug))
-	cmd.AddCommand(JoinCmd(ctx, appSlug))
-	cmd.AddCommand(ShellCmd(ctx, appSlug))
-	cmd.AddCommand(NodeCmd(ctx, appSlug))
-	cmd.AddCommand(EnableHACmd(ctx, appSlug))
-	cmd.AddCommand(VersionCmd(ctx, appSlug))
-	cmd.AddCommand(ResetCmd(ctx, appSlug))
+	cmd.AddCommand(InstallCmd(ctx, appSlug, appTitle))
+	cmd.AddCommand(JoinCmd(ctx, appSlug, appTitle))
+	cmd.AddCommand(ShellCmd(ctx, appTitle))
+	cmd.AddCommand(NodeCmd(ctx, appSlug, appTitle))
+	cmd.AddCommand(EnableHACmd(ctx, appTitle))
+	cmd.AddCommand(VersionCmd(ctx, appTitle))
+	cmd.AddCommand(ResetCmd(ctx, appTitle))
 	cmd.AddCommand(MaterializeCmd(ctx))
-	cmd.AddCommand(UpdateCmd(ctx, appSlug))
-	cmd.AddCommand(RestoreCmd(ctx, appSlug))
-	cmd.AddCommand(AdminConsoleCmd(ctx, appSlug))
+	cmd.AddCommand(UpdateCmd(ctx, appSlug, appTitle))
+	cmd.AddCommand(RestoreCmd(ctx, appSlug, appTitle))
+	cmd.AddCommand(AdminConsoleCmd(ctx, appTitle))
 	cmd.AddCommand(SupportBundleCmd(ctx))
 
 	return cmd

--- a/cmd/installer/cli/root.go
+++ b/cmd/installer/cli/root.go
@@ -31,8 +31,8 @@ func NewErrorNothingElseToAdd(err error) ErrorNothingElseToAdd {
 	}
 }
 
-func InitAndExecute(ctx context.Context, name string) {
-	cmd := RootCmd(ctx, name)
+func InitAndExecute(ctx context.Context, appSlug string) {
+	cmd := RootCmd(ctx, appSlug)
 	err := cmd.Execute()
 	if err != nil {
 		if !errors.As(err, &ErrorNothingElseToAdd{}) {
@@ -49,10 +49,10 @@ func InitAndExecute(ctx context.Context, name string) {
 	}
 }
 
-func RootCmd(ctx context.Context, name string) *cobra.Command {
+func RootCmd(ctx context.Context, appSlug string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:           name,
-		Short:         name,
+		Use:           appSlug,
+		Short:         appSlug,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
@@ -99,22 +99,22 @@ func RootCmd(ctx context.Context, name string) *cobra.Command {
 
 	// Use release title if set, otherwise fall back to name parameter (name is the app slug for embedded releases,
 	// or executable basename for standalone builds)
-	releaseName := release.GetReleaseTitle()
-	if releaseName == "" {
-		releaseName = name
+	appTitle := release.GetReleaseTitle()
+	if appTitle == "" {
+		appTitle = appSlug
 	}
 
-	cmd.AddCommand(InstallCmd(ctx, releaseName))
-	cmd.AddCommand(JoinCmd(ctx, releaseName))
-	cmd.AddCommand(ShellCmd(ctx, releaseName))
-	cmd.AddCommand(NodeCmd(ctx, releaseName))
-	cmd.AddCommand(EnableHACmd(ctx, releaseName))
-	cmd.AddCommand(VersionCmd(ctx, releaseName))
-	cmd.AddCommand(ResetCmd(ctx, releaseName))
+	cmd.AddCommand(InstallCmd(ctx, appSlug))
+	cmd.AddCommand(JoinCmd(ctx, appSlug))
+	cmd.AddCommand(ShellCmd(ctx, appSlug))
+	cmd.AddCommand(NodeCmd(ctx, appSlug))
+	cmd.AddCommand(EnableHACmd(ctx, appSlug))
+	cmd.AddCommand(VersionCmd(ctx, appSlug))
+	cmd.AddCommand(ResetCmd(ctx, appSlug))
 	cmd.AddCommand(MaterializeCmd(ctx))
-	cmd.AddCommand(UpdateCmd(ctx, releaseName))
-	cmd.AddCommand(RestoreCmd(ctx, releaseName))
-	cmd.AddCommand(AdminConsoleCmd(ctx, releaseName))
+	cmd.AddCommand(UpdateCmd(ctx, appSlug))
+	cmd.AddCommand(RestoreCmd(ctx, appSlug))
+	cmd.AddCommand(AdminConsoleCmd(ctx, appSlug))
 	cmd.AddCommand(SupportBundleCmd(ctx))
 
 	return cmd

--- a/cmd/installer/cli/root.go
+++ b/cmd/installer/cli/root.go
@@ -97,9 +97,7 @@ func RootCmd(ctx context.Context, appSlug string) *cobra.Command {
 		},
 	}
 
-	// Use release title if set, otherwise fall back to name parameter (name is the app slug for embedded releases,
-	// or executable basename for standalone builds)
-	appTitle := release.GetReleaseTitle()
+	appTitle := release.GetAppTitle()
 	if appTitle == "" {
 		appTitle = appSlug
 	}

--- a/cmd/installer/cli/root.go
+++ b/cmd/installer/cli/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/dryrun"
 	"github.com/replicatedhq/embedded-cluster/pkg/metrics"
 	"github.com/replicatedhq/embedded-cluster/pkg/release"
+	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -31,8 +32,8 @@ func NewErrorNothingElseToAdd(err error) ErrorNothingElseToAdd {
 	}
 }
 
-func InitAndExecute(ctx context.Context, appSlug string) {
-	cmd := RootCmd(ctx, appSlug)
+func InitAndExecute(ctx context.Context) {
+	cmd := RootCmd(ctx)
 	err := cmd.Execute()
 	if err != nil {
 		if !errors.As(err, &ErrorNothingElseToAdd{}) {
@@ -49,7 +50,9 @@ func InitAndExecute(ctx context.Context, appSlug string) {
 	}
 }
 
-func RootCmd(ctx context.Context, appSlug string) *cobra.Command {
+func RootCmd(ctx context.Context) *cobra.Command {
+	appSlug := runtimeconfig.AppSlug()
+
 	cmd := &cobra.Command{
 		Use:           appSlug,
 		Short:         appSlug,

--- a/cmd/installer/cli/root.go
+++ b/cmd/installer/cli/root.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/replicatedhq/embedded-cluster/pkg/dryrun"
 	"github.com/replicatedhq/embedded-cluster/pkg/metrics"
+	"github.com/replicatedhq/embedded-cluster/pkg/release"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -96,18 +97,25 @@ func RootCmd(ctx context.Context, name string) *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(InstallCmd(ctx, name))
-	cmd.AddCommand(JoinCmd(ctx, name))
-	cmd.AddCommand(ShellCmd(ctx, name))
-	cmd.AddCommand(NodeCmd(ctx, name))
-	cmd.AddCommand(EnableHACmd(ctx, name))
-	cmd.AddCommand(VersionCmd(ctx, name))
-	cmd.AddCommand(ResetCmd(ctx, name))
-	cmd.AddCommand(MaterializeCmd(ctx, name))
-	cmd.AddCommand(UpdateCmd(ctx, name))
-	cmd.AddCommand(RestoreCmd(ctx, name))
-	cmd.AddCommand(AdminConsoleCmd(ctx, name))
-	cmd.AddCommand(SupportBundleCmd(ctx, name))
+	// Use release title if set, otherwise fall back to name parameter (name is the app slug for embedded releases,
+	// or executable basename for standalone builds)
+	releaseName := release.GetReleaseTitle()
+	if releaseName == "" {
+		releaseName = name
+	}
+
+	cmd.AddCommand(InstallCmd(ctx, releaseName))
+	cmd.AddCommand(JoinCmd(ctx, releaseName))
+	cmd.AddCommand(ShellCmd(ctx, releaseName))
+	cmd.AddCommand(NodeCmd(ctx, releaseName))
+	cmd.AddCommand(EnableHACmd(ctx, releaseName))
+	cmd.AddCommand(VersionCmd(ctx, releaseName))
+	cmd.AddCommand(ResetCmd(ctx, releaseName))
+	cmd.AddCommand(MaterializeCmd(ctx, releaseName))
+	cmd.AddCommand(UpdateCmd(ctx, releaseName))
+	cmd.AddCommand(RestoreCmd(ctx, releaseName))
+	cmd.AddCommand(AdminConsoleCmd(ctx, releaseName))
+	cmd.AddCommand(SupportBundleCmd(ctx, releaseName))
 
 	return cmd
 }

--- a/cmd/installer/cli/root.go
+++ b/cmd/installer/cli/root.go
@@ -111,11 +111,11 @@ func RootCmd(ctx context.Context, name string) *cobra.Command {
 	cmd.AddCommand(EnableHACmd(ctx, releaseName))
 	cmd.AddCommand(VersionCmd(ctx, releaseName))
 	cmd.AddCommand(ResetCmd(ctx, releaseName))
-	cmd.AddCommand(MaterializeCmd(ctx, releaseName))
+	cmd.AddCommand(MaterializeCmd(ctx))
 	cmd.AddCommand(UpdateCmd(ctx, releaseName))
 	cmd.AddCommand(RestoreCmd(ctx, releaseName))
 	cmd.AddCommand(AdminConsoleCmd(ctx, releaseName))
-	cmd.AddCommand(SupportBundleCmd(ctx, releaseName))
+	cmd.AddCommand(SupportBundleCmd(ctx))
 
 	return cmd
 }

--- a/cmd/installer/cli/shell.go
+++ b/cmd/installer/cli/shell.go
@@ -28,12 +28,12 @@ const welcome = `
  ~~~~~~~~~~~
 `
 
-func ShellCmd(ctx context.Context, name string) *cobra.Command {
+func ShellCmd(ctx context.Context, releaseName string) *cobra.Command {
 	var rc runtimeconfig.RuntimeConfig
 
 	cmd := &cobra.Command{
 		Use:   "shell",
-		Short: fmt.Sprintf("Start a shell with access to the %s cluster", name),
+		Short: fmt.Sprintf("Start a shell with access to the %s cluster", releaseName),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Skip root check if dryrun mode is enabled
 			if !dryrun.Enabled() && os.Getuid() != 0 {

--- a/cmd/installer/cli/shell.go
+++ b/cmd/installer/cli/shell.go
@@ -28,12 +28,12 @@ const welcome = `
  ~~~~~~~~~~~
 `
 
-func ShellCmd(ctx context.Context, releaseName string) *cobra.Command {
+func ShellCmd(ctx context.Context, appSlug string) *cobra.Command {
 	var rc runtimeconfig.RuntimeConfig
 
 	cmd := &cobra.Command{
 		Use:   "shell",
-		Short: fmt.Sprintf("Start a shell with access to the %s cluster", releaseName),
+		Short: fmt.Sprintf("Start a shell with access to the %s cluster", appSlug),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Skip root check if dryrun mode is enabled
 			if !dryrun.Enabled() && os.Getuid() != 0 {

--- a/cmd/installer/cli/shell.go
+++ b/cmd/installer/cli/shell.go
@@ -28,12 +28,12 @@ const welcome = `
  ~~~~~~~~~~~
 `
 
-func ShellCmd(ctx context.Context, appSlug string) *cobra.Command {
+func ShellCmd(ctx context.Context, appTitle string) *cobra.Command {
 	var rc runtimeconfig.RuntimeConfig
 
 	cmd := &cobra.Command{
 		Use:   "shell",
-		Short: fmt.Sprintf("Start a shell with access to the %s cluster", appSlug),
+		Short: fmt.Sprintf("Start a shell with access to the %s cluster", appTitle),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Skip root check if dryrun mode is enabled
 			if !dryrun.Enabled() && os.Getuid() != 0 {

--- a/cmd/installer/cli/shell.go
+++ b/cmd/installer/cli/shell.go
@@ -55,7 +55,7 @@ func ShellCmd(ctx context.Context, appTitle string) *cobra.Command {
 				shpath = "/bin/bash"
 			}
 
-			fmt.Printf(welcome, runtimeconfig.BinaryName())
+			fmt.Printf(welcome, runtimeconfig.AppSlug())
 			shell := exec.Command(shpath)
 			shell.Env = os.Environ()
 

--- a/cmd/installer/cli/supportbundle.go
+++ b/cmd/installer/cli/supportbundle.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func SupportBundleCmd(ctx context.Context, name string) *cobra.Command {
+func SupportBundleCmd(ctx context.Context) *cobra.Command {
 	var rc runtimeconfig.RuntimeConfig
 
 	cmd := &cobra.Command{

--- a/cmd/installer/cli/update.go
+++ b/cmd/installer/cli/update.go
@@ -8,20 +8,19 @@ import (
 	"github.com/replicatedhq/embedded-cluster/cmd/installer/kotscli"
 	"github.com/replicatedhq/embedded-cluster/pkg-new/constants"
 	"github.com/replicatedhq/embedded-cluster/pkg/dryrun"
-	"github.com/replicatedhq/embedded-cluster/pkg/release"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	rcutil "github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig/util"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
-func UpdateCmd(ctx context.Context, appSlug string) *cobra.Command {
+func UpdateCmd(ctx context.Context, appSlug, appTitle string) *cobra.Command {
 	var airgapBundle string
 	var rc runtimeconfig.RuntimeConfig
 
 	cmd := &cobra.Command{
 		Use:   "update",
-		Short: fmt.Sprintf("Update %s with a new air gap bundle", appSlug),
+		Short: fmt.Sprintf("Update %s with a new air gap bundle", appTitle),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Skip root check if dryrun mode is enabled
 			if !dryrun.Enabled() && os.Getuid() != 0 {
@@ -50,14 +49,9 @@ func UpdateCmd(ctx context.Context, appSlug string) *cobra.Command {
 				}
 			}
 
-			rel := release.GetChannelRelease()
-			if rel == nil {
-				return fmt.Errorf("no channel release found")
-			}
-
 			if err := kotscli.AirgapUpdate(kotscli.AirgapUpdateOptions{
 				RuntimeConfig: rc,
-				AppSlug:       rel.AppSlug,
+				AppSlug:       appSlug,
 				Namespace:     constants.KotsadmNamespace,
 				AirgapBundle:  airgapBundle,
 			}); err != nil {

--- a/cmd/installer/cli/update.go
+++ b/cmd/installer/cli/update.go
@@ -8,6 +8,7 @@ import (
 	"github.com/replicatedhq/embedded-cluster/cmd/installer/kotscli"
 	"github.com/replicatedhq/embedded-cluster/pkg-new/constants"
 	"github.com/replicatedhq/embedded-cluster/pkg/dryrun"
+	"github.com/replicatedhq/embedded-cluster/pkg/release"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	rcutil "github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig/util"
 	"github.com/sirupsen/logrus"
@@ -49,9 +50,14 @@ func UpdateCmd(ctx context.Context, appSlug, appTitle string) *cobra.Command {
 				}
 			}
 
+			rel := release.GetChannelRelease()
+			if rel == nil {
+				return fmt.Errorf("no channel release found")
+			}
+
 			if err := kotscli.AirgapUpdate(kotscli.AirgapUpdateOptions{
 				RuntimeConfig: rc,
-				AppSlug:       appSlug,
+				AppSlug:       rel.AppSlug,
 				Namespace:     constants.KotsadmNamespace,
 				AirgapBundle:  airgapBundle,
 			}); err != nil {

--- a/cmd/installer/cli/update.go
+++ b/cmd/installer/cli/update.go
@@ -15,13 +15,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func UpdateCmd(ctx context.Context, releaseName string) *cobra.Command {
+func UpdateCmd(ctx context.Context, appSlug string) *cobra.Command {
 	var airgapBundle string
 	var rc runtimeconfig.RuntimeConfig
 
 	cmd := &cobra.Command{
 		Use:   "update",
-		Short: fmt.Sprintf("Update %s with a new air gap bundle", releaseName),
+		Short: fmt.Sprintf("Update %s with a new air gap bundle", appSlug),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Skip root check if dryrun mode is enabled
 			if !dryrun.Enabled() && os.Getuid() != 0 {

--- a/cmd/installer/cli/update.go
+++ b/cmd/installer/cli/update.go
@@ -8,7 +8,6 @@ import (
 	"github.com/replicatedhq/embedded-cluster/cmd/installer/kotscli"
 	"github.com/replicatedhq/embedded-cluster/pkg-new/constants"
 	"github.com/replicatedhq/embedded-cluster/pkg/dryrun"
-	"github.com/replicatedhq/embedded-cluster/pkg/release"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	rcutil "github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig/util"
 	"github.com/sirupsen/logrus"
@@ -50,14 +49,9 @@ func UpdateCmd(ctx context.Context, appSlug, appTitle string) *cobra.Command {
 				}
 			}
 
-			rel := release.GetChannelRelease()
-			if rel == nil {
-				return fmt.Errorf("no channel release found")
-			}
-
 			if err := kotscli.AirgapUpdate(kotscli.AirgapUpdateOptions{
 				RuntimeConfig: rc,
-				AppSlug:       rel.AppSlug,
+				AppSlug:       appSlug,
 				Namespace:     constants.KotsadmNamespace,
 				AirgapBundle:  airgapBundle,
 			}); err != nil {

--- a/cmd/installer/cli/update.go
+++ b/cmd/installer/cli/update.go
@@ -15,13 +15,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func UpdateCmd(ctx context.Context, name string) *cobra.Command {
+func UpdateCmd(ctx context.Context, releaseName string) *cobra.Command {
 	var airgapBundle string
 	var rc runtimeconfig.RuntimeConfig
 
 	cmd := &cobra.Command{
 		Use:   "update",
-		Short: fmt.Sprintf("Update %s with a new air gap bundle", name),
+		Short: fmt.Sprintf("Update %s with a new air gap bundle", releaseName),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Skip root check if dryrun mode is enabled
 			if !dryrun.Enabled() && os.Getuid() != 0 {

--- a/cmd/installer/cli/version.go
+++ b/cmd/installer/cli/version.go
@@ -24,7 +24,7 @@ func VersionCmd(ctx context.Context, appTitle string) *cobra.Command {
 			writer.AppendHeader(table.Row{"component", "version"})
 			channelRelease := release.GetChannelRelease()
 			if channelRelease != nil {
-				writer.AppendRow(table.Row{runtimeconfig.BinaryName(), channelRelease.VersionLabel})
+				writer.AppendRow(table.Row{runtimeconfig.AppSlug(), channelRelease.VersionLabel})
 			}
 			writer.AppendRow(table.Row{"Installer", versions.Version})
 			writer.AppendRow(table.Row{"Kubernetes", versions.K0sVersion})

--- a/cmd/installer/cli/version.go
+++ b/cmd/installer/cli/version.go
@@ -15,10 +15,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func VersionCmd(ctx context.Context, appSlug string) *cobra.Command {
+func VersionCmd(ctx context.Context, appTitle string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
-		Short: fmt.Sprintf("Show the %s component versions", appSlug),
+		Short: fmt.Sprintf("Show the %s component versions", appTitle),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			writer := table.NewWriter()
 			writer.AppendHeader(table.Row{"component", "version"})

--- a/cmd/installer/cli/version.go
+++ b/cmd/installer/cli/version.go
@@ -15,10 +15,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func VersionCmd(ctx context.Context, releaseName string) *cobra.Command {
+func VersionCmd(ctx context.Context, appSlug string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
-		Short: fmt.Sprintf("Show the %s component versions", releaseName),
+		Short: fmt.Sprintf("Show the %s component versions", appSlug),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			writer := table.NewWriter()
 			writer.AppendHeader(table.Row{"component", "version"})

--- a/cmd/installer/cli/version.go
+++ b/cmd/installer/cli/version.go
@@ -15,10 +15,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func VersionCmd(ctx context.Context, name string) *cobra.Command {
+func VersionCmd(ctx context.Context, releaseName string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
-		Short: fmt.Sprintf("Show the %s component versions", name),
+		Short: fmt.Sprintf("Show the %s component versions", releaseName),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			writer := table.NewWriter()
 			writer.AppendHeader(table.Row{"component", "version"})
@@ -56,9 +56,9 @@ func VersionCmd(ctx context.Context, name string) *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(VersionMetadataCmd(ctx, name))
-	cmd.AddCommand(VersionEmbeddedDataCmd(ctx, name))
-	cmd.AddCommand(VersionListImagesCmd(ctx, name))
+	cmd.AddCommand(VersionMetadataCmd(ctx))
+	cmd.AddCommand(VersionEmbeddedDataCmd(ctx))
+	cmd.AddCommand(VersionListImagesCmd(ctx))
 
 	return cmd
 }

--- a/cmd/installer/cli/version_embeddeddata.go
+++ b/cmd/installer/cli/version_embeddeddata.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func VersionEmbeddedDataCmd(ctx context.Context, name string) *cobra.Command {
+func VersionEmbeddedDataCmd(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "embedded-data",
 		Short: "Read the application data embedded in the cluster",

--- a/cmd/installer/cli/version_listimages.go
+++ b/cmd/installer/cli/version_listimages.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func VersionListImagesCmd(ctx context.Context, name string) *cobra.Command {
+func VersionListImagesCmd(ctx context.Context) *cobra.Command {
 	var (
 		omitReleaseMetadata bool
 	)

--- a/cmd/installer/cli/version_metadata.go
+++ b/cmd/installer/cli/version_metadata.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func VersionMetadataCmd(ctx context.Context, name string) *cobra.Command {
+func VersionMetadataCmd(ctx context.Context) *cobra.Command {
 	var (
 		omitReleaseMetadata bool
 	)

--- a/cmd/installer/goods/materializer.go
+++ b/cmd/installer/goods/materializer.go
@@ -207,7 +207,7 @@ func (m *Materializer) Ourselves() error {
 		return fmt.Errorf("unable to get our own executable path: %w", err)
 	}
 
-	dstpath := m.rc.PathToEmbeddedClusterBinary(runtimeconfig.BinaryName())
+	dstpath := m.rc.PathToEmbeddedClusterBinary(runtimeconfig.AppSlug())
 	if srcpath == dstpath {
 		return nil
 	}

--- a/cmd/installer/main.go
+++ b/cmd/installer/main.go
@@ -18,12 +18,12 @@ func main() {
 
 	prompts.SetTerminal(isatty.IsTerminal(os.Stdout.Fd()))
 
-	name := runtimeconfig.BinaryName()
+	appSlug := runtimeconfig.BinaryName()
 
 	// set the umask to 022 so that we can create files/directories with 755 permissions
 	// this does not return an error - it returns the previous umask
 	// we do this before calling cli.InitAndExecute so that it is set before the process forks
 	_ = syscall.Umask(0o022)
 
-	cli.InitAndExecute(ctx, name)
+	cli.InitAndExecute(ctx, appSlug)
 }

--- a/cmd/installer/main.go
+++ b/cmd/installer/main.go
@@ -18,7 +18,7 @@ func main() {
 
 	prompts.SetTerminal(isatty.IsTerminal(os.Stdout.Fd()))
 
-	appSlug := runtimeconfig.BinaryName()
+	appSlug := runtimeconfig.AppSlug()
 
 	// set the umask to 022 so that we can create files/directories with 755 permissions
 	// this does not return an error - it returns the previous umask

--- a/cmd/installer/main.go
+++ b/cmd/installer/main.go
@@ -8,7 +8,6 @@ import (
 	"github.com/mattn/go-isatty"
 	"github.com/replicatedhq/embedded-cluster/cmd/installer/cli"
 	"github.com/replicatedhq/embedded-cluster/pkg/prompts"
-	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 )
 
 func main() {
@@ -18,12 +17,10 @@ func main() {
 
 	prompts.SetTerminal(isatty.IsTerminal(os.Stdout.Fd()))
 
-	appSlug := runtimeconfig.AppSlug()
-
 	// set the umask to 022 so that we can create files/directories with 755 permissions
 	// this does not return an error - it returns the previous umask
 	// we do this before calling cli.InitAndExecute so that it is set before the process forks
 	_ = syscall.Umask(0o022)
 
-	cli.InitAndExecute(ctx, appSlug)
+	cli.InitAndExecute(ctx)
 }

--- a/pkg-new/hostutils/system.go
+++ b/pkg-new/hostutils/system.go
@@ -237,7 +237,7 @@ func (h *HostUtils) CreateSystemdUnitFiles(ctx context.Context, logger logrus.Fi
 }
 
 func systemdUnitFileName() string {
-	return fmt.Sprintf("/etc/systemd/system/%s.service", runtimeconfig.BinaryName())
+	return fmt.Sprintf("/etc/systemd/system/%s.service", runtimeconfig.AppSlug())
 }
 
 // ensureProxyConfig creates a new http-proxy.conf configuration file. The file is saved in the

--- a/pkg-new/k0s/k0s.go
+++ b/pkg-new/k0s/k0s.go
@@ -264,7 +264,7 @@ func (k *K0s) WaitForK0s() error {
 		break
 	}
 	if !success {
-		return fmt.Errorf("timeout waiting for %s", runtimeconfig.BinaryName())
+		return fmt.Errorf("timeout waiting for %s", runtimeconfig.AppSlug())
 	}
 
 	for i := 1; ; i++ {

--- a/pkg-new/metadata/metadata.go
+++ b/pkg-new/metadata/metadata.go
@@ -86,7 +86,7 @@ func GatherVersionMetadata(channelRelease *release.ChannelRelease) (*types.Relea
 	versionsMap["Troubleshoot"] = versions.TroubleshootVersion
 
 	if channelRelease != nil {
-		versionsMap[runtimeconfig.BinaryName()] = channelRelease.VersionLabel
+		versionsMap[runtimeconfig.AppSlug()] = channelRelease.VersionLabel
 	}
 
 	sha, err := goods.K0sBinarySHA256()

--- a/pkg/kubeutils/installation.go
+++ b/pkg/kubeutils/installation.go
@@ -166,7 +166,7 @@ func RecordInstallation(ctx context.Context, kcli client.Client, opts RecordInst
 			Config:                    opts.ConfigSpec,
 			RuntimeConfig:             opts.RuntimeConfig,
 			EndUserK0sConfigOverrides: euOverrides,
-			BinaryName:                runtimeconfig.BinaryName(),
+			BinaryName:                runtimeconfig.AppSlug(),
 			LicenseInfo: &ecv1beta1.LicenseInfo{
 				IsDisasterRecoverySupported: opts.License.Spec.IsDisasterRecoverySupported,
 				IsMultiNodeEnabled:          opts.License.Spec.IsEmbeddedClusterMultiNodeEnabled,

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -39,6 +39,15 @@ func GetReleaseData() *ReleaseData {
 	return _releaseData
 }
 
+// GetReleaseTitle returns the title from the kots application embedded as part of the
+// release. If no application is found, returns an empty string.
+func GetReleaseTitle() string {
+	if _releaseData.Application == nil {
+		return ""
+	}
+	return _releaseData.Application.Spec.Title
+}
+
 // GetHostPreflights returns a list of HostPreflight specs that are found in the
 // binary. These are part of the embedded Kots Application Release.
 func GetHostPreflights() *troubleshootv1beta2.HostPreflightSpec {

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -39,9 +39,9 @@ func GetReleaseData() *ReleaseData {
 	return _releaseData
 }
 
-// GetReleaseTitle returns the title from the kots application embedded as part of the
+// GetAppTitle returns the title from the kots application embedded as part of the
 // release. If no application is found, returns an empty string.
-func GetReleaseTitle() string {
+func GetAppTitle() string {
 	if _releaseData.Application == nil {
 		return ""
 	}

--- a/pkg/release/release_test.go
+++ b/pkg/release/release_test.go
@@ -55,7 +55,7 @@ func TestGetHostPreflights(t *testing.T) {
 	assert.NotNil(t, preflights)
 }
 
-func TestGetReleaseTitle(t *testing.T) {
+func TestGetAppTitle(t *testing.T) {
 	release, err := newReleaseDataFrom(testReleaseData)
 	assert.NoError(t, err)
 	title := release.Application.Spec.Title

--- a/pkg/release/release_test.go
+++ b/pkg/release/release_test.go
@@ -11,6 +11,58 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// Global test data to avoid regenerating for each test
+var testReleaseData []byte
+
+func init() {
+	data, err := generateReleaseTGZ()
+	if err != nil {
+		panic("Failed to generate test release data: " + err.Error())
+	}
+	testReleaseData = data
+}
+
+func Test_newReleaseDataFrom(t *testing.T) {
+	release, err := newReleaseDataFrom([]byte{})
+	assert.NoError(t, err)
+	assert.NotNil(t, release)
+	cfg := release.EmbeddedClusterConfig
+	assert.NoError(t, err)
+	assert.Nil(t, cfg)
+}
+
+func TestGetApplication(t *testing.T) {
+	release, err := newReleaseDataFrom(testReleaseData)
+	assert.NoError(t, err)
+	app := release.Application
+	assert.NoError(t, err)
+	assert.NotNil(t, app)
+}
+
+func TestGetEmbeddedClusterConfig(t *testing.T) {
+	release, err := newReleaseDataFrom(testReleaseData)
+	assert.NoError(t, err)
+	cfg := release.EmbeddedClusterConfig
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
+}
+
+func TestGetHostPreflights(t *testing.T) {
+	release, err := newReleaseDataFrom(testReleaseData)
+	assert.NoError(t, err)
+	preflights := release.HostPreflights
+	assert.NoError(t, err)
+	assert.NotNil(t, preflights)
+}
+
+func TestGetReleaseTitle(t *testing.T) {
+	release, err := newReleaseDataFrom(testReleaseData)
+	assert.NoError(t, err)
+	title := release.Application.Spec.Title
+	assert.NoError(t, err)
+	assert.Equal(t, "Embedded Cluster Smoke Test App", title)
+}
+
 func generateReleaseTGZ() ([]byte, error) {
 	content, err := os.ReadFile("testdata/release.yaml")
 	if err != nil {
@@ -49,43 +101,4 @@ func generateReleaseTGZ() ([]byte, error) {
 	}
 
 	return buf.Bytes(), nil
-}
-
-func Test_newReleaseDataFrom(t *testing.T) {
-	release, err := newReleaseDataFrom([]byte{})
-	assert.NoError(t, err)
-	assert.NotNil(t, release)
-	cfg := release.EmbeddedClusterConfig
-	assert.NoError(t, err)
-	assert.Nil(t, cfg)
-}
-
-func TestGetApplication(t *testing.T) {
-	data, err := generateReleaseTGZ()
-	assert.NoError(t, err)
-	release, err := newReleaseDataFrom(data)
-	assert.NoError(t, err)
-	app := release.Application
-	assert.NoError(t, err)
-	assert.NotNil(t, app)
-}
-
-func TestGetEmbeddedClusterConfig(t *testing.T) {
-	data, err := generateReleaseTGZ()
-	assert.NoError(t, err)
-	release, err := newReleaseDataFrom(data)
-	assert.NoError(t, err)
-	cfg := release.EmbeddedClusterConfig
-	assert.NoError(t, err)
-	assert.NotNil(t, cfg)
-}
-
-func TestGetHostPreflights(t *testing.T) {
-	data, err := generateReleaseTGZ()
-	assert.NoError(t, err)
-	release, err := newReleaseDataFrom(data)
-	assert.NoError(t, err)
-	preflights := release.HostPreflights
-	assert.NoError(t, err)
-	assert.NotNil(t, preflights)
 }

--- a/pkg/runtimeconfig/defaults.go
+++ b/pkg/runtimeconfig/defaults.go
@@ -27,11 +27,11 @@ const (
 	ECConfigPath            = "/etc/embedded-cluster/ec.yaml"
 )
 
-// BinaryName returns the intended binary name. This is the app slug when a release is embedded,
+// AppSlug returns the intended binary name. This is the app slug when a release is embedded,
 // otherwise it is the basename of the executable. This is useful for places where we need to
 // present the name of the binary to the user. We make sure the name does not contain invalid
 // characters for a filename.
-func BinaryName() string {
+func AppSlug() string {
 	var name string
 	if release := release.GetChannelRelease(); release != nil {
 		name = release.AppSlug

--- a/pkg/runtimeconfig/util/util.go
+++ b/pkg/runtimeconfig/util/util.go
@@ -44,7 +44,7 @@ func GetRuntimeConfigFromCluster(ctx context.Context) (runtimeconfig.RuntimeConf
 	status, err := k0s.GetStatus(ctx)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return nil, fmt.Errorf("%s does not seem to be installed on this node", runtimeconfig.BinaryName())
+			return nil, fmt.Errorf("%s does not seem to be installed on this node", runtimeconfig.AppSlug())
 		}
 		return nil, fmt.Errorf("get k0s status: %w", err)
 	}

--- a/tests/dryrun/util.go
+++ b/tests/dryrun/util.go
@@ -132,7 +132,7 @@ func runInstallerCmd(args ...string) error {
 	fullArgs := append([]string{"dryrun"}, args...)
 	os.Args = fullArgs // for reporting
 
-	installerCmd := cli.RootCmd(context.Background(), "dryrun")
+	installerCmd := cli.RootCmd(context.Background())
 	installerCmd.SetArgs(args)
 	return installerCmd.Execute()
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
This PR changes the help menu output to use the app name (title field in the embedded Kots application release).

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/125748/use-the-app-name-not-slug-in-the-help-menu-output

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Test was added

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
