### PR TITLE
Document Architecture Decision: Kubernetes as a Subset of Linux

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -93,6 +93,12 @@ Provides a client library for interacting with the API. The client package imple
    - This design choice enables better testability and easier iteration in the development environment
    - API components should be independently configurable and testable
 
+2. **Kubernetes as a Subset of Linux**:
+   - The Kubernetes installation target should be a subset of the Linux installation target
+   - Linux installations include Kubernetes cluster setup (k0s, addons) plus application management
+   - Kubernetes installations focus on application management (deployment, upgrades, lifecycle) on an existing Kubernetes cluster
+   - Once Linux installation finishes setting up the Kubernetes cluster, subsequent operations should follow the same workflow as Kubernetes installations
+
 ## Integration
 
 The API package is designed to be used as part of the larger Embedded Cluster system. It provides both HTTP endpoints for external access and a client library for internal use.


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Documents Architecture Decision: Kubernetes as a Subset of Linux

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-125322](https://app.shortcut.com/replicated/story/125322)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE