### PR TITLE
fix: parse flags before prompting, do not prompt in flag parsing code

### DIFF
--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -122,10 +122,10 @@ func InstallCmd(ctx context.Context, appSlug, appTitle string) *cobra.Command {
 			cancel() // Cancel context when command completes
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := verifyAndPrompt(ctx, appSlug, flags, prompts.New()); err != nil {
+			if err := preRunInstall(cmd, &flags, rc, ki); err != nil {
 				return err
 			}
-			if err := preRunInstall(cmd, &flags, rc, ki); err != nil {
+			if err := verifyAndPrompt(ctx, cmd, appSlug, &flags, prompts.New()); err != nil {
 				return err
 			}
 
@@ -434,13 +434,6 @@ func preRunInstallCommon(cmd *cobra.Command, flags *InstallCmdFlags, rc runtimec
 	proxy, err := proxyConfigFromCmd(cmd, flags.assumeYes)
 	if err != nil {
 		return err
-	}
-
-	// restore command doesn't have a password flag
-	if cmd.Flags().Lookup("admin-console-password") != nil {
-		if err := ensureAdminConsolePassword(flags); err != nil {
-			return err
-		}
 	}
 
 	rc.SetAdminConsolePort(flags.adminConsolePort)
@@ -813,7 +806,7 @@ func getAddonInstallOpts(flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig, 
 	return opts, nil
 }
 
-func verifyAndPrompt(ctx context.Context, appSlug string, flags InstallCmdFlags, prompt prompts.Prompt) error {
+func verifyAndPrompt(ctx context.Context, cmd *cobra.Command, appSlug string, flags *InstallCmdFlags, prompt prompts.Prompt) error {
 	logrus.Debugf("checking if k0s is already installed")
 	err := verifyNoInstallation(appSlug, "reinstall")
 	if err != nil {
@@ -850,6 +843,13 @@ func verifyAndPrompt(ctx context.Context, appSlug string, flags InstallCmdFlags,
 
 	if err := release.ValidateECConfig(); err != nil {
 		return err
+	}
+
+	// restore command doesn't have a password flag
+	if cmd.Flags().Lookup("admin-console-password") != nil {
+		if err := ensureAdminConsolePassword(flags); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/cmd/installer/cli/install_runpreflights.go
+++ b/cmd/installer/cli/install_runpreflights.go
@@ -45,7 +45,7 @@ func InstallRunPreflightsCmd(ctx context.Context, appSlug string) *cobra.Command
 
 			_ = rc.SetEnv()
 
-			if err := runInstallRunPreflights(cmd.Context(), appSlug, flags, rc); err != nil {
+			if err := runInstallRunPreflights(cmd.Context(), flags, rc); err != nil {
 				return err
 			}
 
@@ -62,7 +62,7 @@ func InstallRunPreflightsCmd(ctx context.Context, appSlug string) *cobra.Command
 	return cmd
 }
 
-func runInstallRunPreflights(ctx context.Context, appSlug string, flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig) error {
+func runInstallRunPreflights(ctx context.Context, flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig) error {
 	licenseBytes, err := os.ReadFile(flags.licenseFile)
 	if err != nil {
 		return fmt.Errorf("unable to read license file: %w", err)

--- a/cmd/installer/cli/install_runpreflights.go
+++ b/cmd/installer/cli/install_runpreflights.go
@@ -32,19 +32,19 @@ func InstallRunPreflightsCmd(ctx context.Context, appSlug string) *cobra.Command
 		Use:    "run-preflights",
 		Short:  "Run install host preflights",
 		Hidden: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PostRun: func(cmd *cobra.Command, args []string) {
+			rc.Cleanup()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := preRunInstall(cmd, &flags, rc, ki); err != nil {
+				return err
+			}
+			if err := verifyAndPrompt(ctx, cmd, appSlug, &flags, prompts.New()); err != nil {
 				return err
 			}
 
 			_ = rc.SetEnv()
 
-			return nil
-		},
-		PostRun: func(cmd *cobra.Command, args []string) {
-			rc.Cleanup()
-		},
-		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := runInstallRunPreflights(cmd.Context(), appSlug, flags, rc); err != nil {
 				return err
 			}
@@ -63,10 +63,6 @@ func InstallRunPreflightsCmd(ctx context.Context, appSlug string) *cobra.Command
 }
 
 func runInstallRunPreflights(ctx context.Context, appSlug string, flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig) error {
-	if err := verifyAndPrompt(ctx, appSlug, flags, prompts.New()); err != nil {
-		return err
-	}
-
 	licenseBytes, err := os.ReadFile(flags.licenseFile)
 	if err != nil {
 		return fmt.Errorf("unable to read license file: %w", err)

--- a/cmd/installer/cli/restore.go
+++ b/cmd/installer/cli/restore.go
@@ -98,19 +98,16 @@ func RestoreCmd(ctx context.Context, appSlug, appTitle string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "restore",
 		Short: fmt.Sprintf("Restore %s from a backup", appTitle),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PostRun: func(cmd *cobra.Command, args []string) {
+			rc.Cleanup()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := preRunInstall(cmd, &flags, rc, ki); err != nil {
 				return err
 			}
 
 			_ = rc.SetEnv()
 
-			return nil
-		},
-		PostRun: func(cmd *cobra.Command, args []string) {
-			rc.Cleanup()
-		},
-		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := runRestore(cmd.Context(), appSlug, appTitle, flags, rc, s3Store, skipStoreValidation); err != nil {
 				return err
 			}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/125973/the-installer-prompts-that-you-did-not-provide-an-airgap-bundle-when-you-did
https://app.shortcut.com/replicated/story/125975/prompt-to-update-to-current-app-release-does-not-not-work-when-a-proxy-is-provided-with-flags

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
