### PR TITLE
feat: use ENABLE_V3 env var instead of flag

### DIFF
--- a/cmd/installer/cli/flags.go
+++ b/cmd/installer/cli/flags.go
@@ -65,7 +65,7 @@ func init() {
 	cobra.AddTemplateFuncs(template.FuncMap{
 		// usesTargetFlagMenu returns true if the target flag is present and the ENABLE_V3 environment variable is set.
 		"usesTargetFlagMenu": func(flagSet *pflag.FlagSet) bool {
-			if os.Getenv("ENABLE_V3") == "1" {
+			if isV3Enabled() {
 				return flagSet.Lookup("target") != nil
 			}
 			return false
@@ -85,6 +85,10 @@ func init() {
 	})
 }
 
+func isV3Enabled() bool {
+	return os.Getenv("ENABLE_V3") == "1"
+}
+
 func mustSetFlagTargetLinux(flags *pflag.FlagSet, name string) {
 	mustSetFlagTarget(flags, name, flagAnnotationTargetValueLinux)
 }
@@ -95,6 +99,13 @@ func mustSetFlagTargetKubernetes(flags *pflag.FlagSet, name string) {
 
 func mustSetFlagTarget(flags *pflag.FlagSet, name string, target string) {
 	err := flags.SetAnnotation(name, flagAnnotationTarget, []string{target})
+	if err != nil {
+		panic(err)
+	}
+}
+
+func mustMarkFlagRequired(flags *pflag.FlagSet, name string) {
+	err := cobra.MarkFlagRequired(flags, name)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -370,7 +370,11 @@ func addManagementConsoleFlags(cmd *cobra.Command, flags *InstallCmdFlags) error
 }
 
 func preRunInstall(cmd *cobra.Command, flags *InstallCmdFlags, rc runtimeconfig.RuntimeConfig, ki kubernetesinstallation.Installation) error {
-	if isV3Enabled() && !slices.Contains([]string{"linux", "kubernetes"}, flags.target) {
+	if !isV3Enabled() {
+		flags.target = "linux"
+	}
+
+	if !slices.Contains([]string{"linux", "kubernetes"}, flags.target) {
 		return fmt.Errorf(`invalid --target (must be one of: "linux", "kubernetes")`)
 	}
 

--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -370,7 +370,7 @@ func addManagementConsoleFlags(cmd *cobra.Command, flags *InstallCmdFlags) error
 }
 
 func preRunInstall(cmd *cobra.Command, flags *InstallCmdFlags, rc runtimeconfig.RuntimeConfig, ki kubernetesinstallation.Installation) error {
-	if !slices.Contains([]string{"linux", "kubernetes"}, flags.target) {
+	if isV3Enabled() && !slices.Contains([]string{"linux", "kubernetes"}, flags.target) {
 		return fmt.Errorf(`invalid --target (must be one of: "linux", "kubernetes")`)
 	}
 

--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -109,7 +109,7 @@ func InstallCmd(ctx context.Context, appSlug, appTitle string) *cobra.Command {
 	ki := kubernetesinstallation.New(nil)
 
 	short := fmt.Sprintf("Install %s", appTitle)
-	if os.Getenv("ENABLE_V3") == "1" {
+	if isV3Enabled() {
 		short = fmt.Sprintf("Install %s onto Linux or Kubernetes", appTitle)
 	}
 
@@ -169,7 +169,7 @@ func InstallCmd(ctx context.Context, appSlug, appTitle string) *cobra.Command {
 	if err := addInstallAdminConsoleFlags(cmd, &flags); err != nil {
 		panic(err)
 	}
-	if err := addManagerExperienceFlags(cmd, &flags); err != nil {
+	if err := addManagementConsoleFlags(cmd, &flags); err != nil {
 		panic(err)
 	}
 
@@ -197,7 +197,7 @@ const (
 )
 
 func installCmdExample(appSlug string) string {
-	if os.Getenv("ENABLE_V3") != "1" {
+	if !isV3Enabled() {
 		return ""
 	}
 
@@ -205,7 +205,7 @@ func installCmdExample(appSlug string) string {
 }
 
 func mustAddInstallFlags(cmd *cobra.Command, flags *InstallCmdFlags) {
-	enableV3 := os.Getenv("ENABLE_V3") == "1"
+	enableV3 := isV3Enabled()
 
 	normalizeFuncs := []func(f *pflag.FlagSet, name string) pflag.NormalizedName{}
 
@@ -215,7 +215,7 @@ func mustAddInstallFlags(cmd *cobra.Command, flags *InstallCmdFlags) {
 		normalizeFuncs = append(normalizeFuncs, fn)
 	}
 
-	linuxFlagSet := newLinuxInstallFlags(flags)
+	linuxFlagSet := newLinuxInstallFlags(flags, enableV3)
 	cmd.Flags().AddFlagSet(linuxFlagSet)
 	if fn := linuxFlagSet.GetNormalizeFunc(); fn != nil {
 		normalizeFuncs = append(normalizeFuncs, fn)
@@ -241,8 +241,10 @@ func mustAddInstallFlags(cmd *cobra.Command, flags *InstallCmdFlags) {
 func newCommonInstallFlags(flags *InstallCmdFlags, enableV3 bool) *pflag.FlagSet {
 	flagSet := pflag.NewFlagSet("common", pflag.ContinueOnError)
 
-	flagSet.StringVar(&flags.target, "target", "linux", "The target platform to install to. Valid options are 'linux' or 'kubernetes'.")
-	if !enableV3 {
+	flagSet.StringVar(&flags.target, "target", "", "The target platform to install to. Valid options are 'linux' or 'kubernetes'.")
+	if enableV3 {
+		mustMarkFlagRequired(flagSet, "target")
+	} else {
 		mustMarkFlagHidden(flagSet, "target")
 	}
 
@@ -259,12 +261,12 @@ func newCommonInstallFlags(flags *InstallCmdFlags, enableV3 bool) *pflag.FlagSet
 	return flagSet
 }
 
-func newLinuxInstallFlags(flags *InstallCmdFlags) *pflag.FlagSet {
+func newLinuxInstallFlags(flags *InstallCmdFlags, enableV3 bool) *pflag.FlagSet {
 	flagSet := pflag.NewFlagSet("linux", pflag.ContinueOnError)
 
 	// Use the app slug as default data directory only when ENABLE_V3 is set
 	defaultDataDir := ecv1beta1.DefaultDataDir
-	if os.Getenv("ENABLE_V3") == "1" {
+	if enableV3 {
 		defaultDataDir = filepath.Join("/var/lib", runtimeconfig.AppSlug())
 	}
 
@@ -335,30 +337,21 @@ func addInstallAdminConsoleFlags(cmd *cobra.Command, flags *InstallCmdFlags) err
 	cmd.Flags().StringVar(&flags.adminConsolePassword, "admin-console-password", "", "Password for the Admin Console")
 	cmd.Flags().IntVar(&flags.adminConsolePort, "admin-console-port", ecv1beta1.DefaultAdminConsolePort, "Port on which the Admin Console will be served")
 	cmd.Flags().StringVarP(&flags.licenseFile, "license", "l", "", "Path to the license file")
-	if err := cmd.MarkFlagRequired("license"); err != nil {
-		panic(err)
-	}
+	mustMarkFlagRequired(cmd.Flags(), "license")
 	cmd.Flags().StringVar(&flags.configValues, "config-values", "", "Path to the config values to use when installing")
 
 	return nil
 }
 
-func addManagerExperienceFlags(cmd *cobra.Command, flags *InstallCmdFlags) error {
-	// If the ENABLE_V3 environment variable is set, default to the new manager experience and do
-	// not hide the new flags.
-	enableV3 := os.Getenv("ENABLE_V3") == "1"
-
-	cmd.Flags().BoolVar(&flags.enableManagerExperience, "manager-experience", enableV3, "Run the browser-based installation experience.")
-	if err := cmd.Flags().MarkHidden("manager-experience"); err != nil {
-		return err
-	}
-
+func addManagementConsoleFlags(cmd *cobra.Command, flags *InstallCmdFlags) error {
 	cmd.Flags().IntVar(&flags.managerPort, "manager-port", ecv1beta1.DefaultManagerPort, "Port on which the Manager will be served")
 	cmd.Flags().StringVar(&flags.tlsCertFile, "tls-cert", "", "Path to the TLS certificate file")
 	cmd.Flags().StringVar(&flags.tlsKeyFile, "tls-key", "", "Path to the TLS key file")
 	cmd.Flags().StringVar(&flags.hostname, "hostname", "", "Hostname to use for TLS configuration")
 
-	if !enableV3 {
+	// If the ENABLE_V3 environment variable is set, default to the new manager experience and do
+	// not hide the new flags.
+	if !isV3Enabled() {
 		if err := cmd.Flags().MarkHidden("manager-port"); err != nil {
 			return err
 		}
@@ -378,7 +371,7 @@ func addManagerExperienceFlags(cmd *cobra.Command, flags *InstallCmdFlags) error
 
 func preRunInstall(cmd *cobra.Command, flags *InstallCmdFlags, rc runtimeconfig.RuntimeConfig, ki kubernetesinstallation.Installation) error {
 	if !slices.Contains([]string{"linux", "kubernetes"}, flags.target) {
-		return fmt.Errorf(`invalid target (must be one of: "linux", "kubernetes")`)
+		return fmt.Errorf(`invalid --target (must be one of: "linux", "kubernetes")`)
 	}
 
 	if err := preRunInstallCommon(cmd, flags, rc, ki); err != nil {
@@ -396,6 +389,8 @@ func preRunInstall(cmd *cobra.Command, flags *InstallCmdFlags, rc runtimeconfig.
 }
 
 func preRunInstallCommon(cmd *cobra.Command, flags *InstallCmdFlags, rc runtimeconfig.RuntimeConfig, ki kubernetesinstallation.Installation) error {
+	flags.enableManagerExperience = isV3Enabled()
+
 	// license file can be empty for restore
 	if flags.licenseFile != "" {
 		b, err := os.ReadFile(flags.licenseFile)

--- a/cmd/installer/cli/update.go
+++ b/cmd/installer/cli/update.go
@@ -63,7 +63,7 @@ func UpdateCmd(ctx context.Context, appSlug, appTitle string) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&airgapBundle, "airgap-bundle", "", "Path to the air gap bundle. If set, the installation will complete without internet access.")
-	cmd.MarkFlagRequired("airgap-bundle")
+	mustMarkFlagRequired(cmd.Flags(), "airgap-bundle")
 
 	return cmd
 }

--- a/e2e/scripts/install-and-configure-squid.sh
+++ b/e2e/scripts/install-and-configure-squid.sh
@@ -92,6 +92,7 @@ create_squid_ssl() {
 
 
 main() {
+        apt-get update -y
         apt install -y squid-openssl
         /usr/lib/squid/security_file_certgen -c -s /opt/ssl.db -M 4MB
         mkdir -p /etc/squid/ssl_cert


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

The `ENABLE_V3` environment variable is more flexible because we're able to change the format of the help menu and things like that. Whereas the `--manager-experience` flag can only change the behavior of the install. Now that we have the environment variable, the flag is duplicative, and we can just use the environment variable to control how the install functions. 

Make `--target` flag required with no default if `ENABLE_V3 == 1`

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
