### PR TITLE
feat: Add adm install command to k8s target UI

### DIFF
--- a/web/src/components/wizard/completion/KubernetesCompletionStep.tsx
+++ b/web/src/components/wizard/completion/KubernetesCompletionStep.tsx
@@ -1,13 +1,26 @@
-import React from "react";
+import React, {useState} from "react";
 import Card from "../../common/Card";
 import Button from "../../common/Button";
 import { useKubernetesConfig } from "../../../contexts/KubernetesConfigContext";
 import { useBranding } from "../../../contexts/BrandingContext";
-import { CheckCircle, ExternalLink } from "lucide-react";
+import { useSettings } from "../../../contexts/SettingsContext";
+import { CheckCircle, ClipboardCheck, Copy, Terminal } from "lucide-react";
 
 const KubernetesCompletionStep: React.FC = () => {
+  const [copied, setCopied] = useState(false);
   const { config } = useKubernetesConfig();
   const { title } = useBranding();
+  const { settings } = useSettings();
+  const themeColor = settings.themeColor;
+
+  const copyInstallCommand = () => {
+    if (config.installCommand) {
+      navigator.clipboard.writeText(config.installCommand).then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      });
+    }
+  };
 
   return (
     <div className="space-y-6">
@@ -15,19 +28,36 @@ const KubernetesCompletionStep: React.FC = () => {
         <div className="flex flex-col items-center text-center py-6">
           <div className="flex flex-col items-center justify-center mb-6">
             <div className="w-16 h-16 rounded-full flex items-center justify-center mb-4">
-              <CheckCircle className="w-10 h-10" style={{ color: "blue" }} />
+              <CheckCircle className="w-10 h-10" style={{ color: themeColor }} />
             </div>
-            <p className="text-gray-600 mt-2" data-testid="completion-message">
+            <p className="text-gray-600 mt-2 mb-6" data-testid="completion-message">
               Visit the Admin Console to configure and install {title}
             </p>
-            <Button
-              className="mt-4"
-              dataTestId="admin-console-button"
-              onClick={() => window.open(`http://${window.location.hostname}:${config.adminConsolePort}`, "_blank")}
-              icon={<ExternalLink className="ml-2 mr-1 h-5 w-5" />}
-            >
-              Visit Admin Console
-            </Button>
+            <div className="w-full max-w-2xl space-y-6">
+              <div className="bg-gray-50 rounded-lg border border-gray-200 p-4">
+                <div className="flex items-center justify-between mb-2">
+                  <h3 className="text-sm font-medium text-gray-700">Installation Command</h3>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="py-1 px-2 text-xs"
+                    icon={copied ? <ClipboardCheck className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
+                    onClick={copyInstallCommand}
+                  >
+                    {copied ? 'Copied!' : 'Copy Command'}
+                  </Button>
+                </div>
+                <div className="flex items-start space-x-2 p-2 bg-white rounded border border-gray-300">
+                  <Terminal className="w-4 h-4 text-gray-400 mt-0.5 flex-shrink-0" />
+                  <code className="font-mono text-sm text-left">
+                    {config.installCommand}
+                  </code>
+                </div>
+              </div>
+              <p className="text-sm text-gray-500">
+                Run this command to access the Admin Console
+              </p>
+            </div>
           </div>
         </div>
       </Card>

--- a/web/src/components/wizard/completion/LinuxCompletionStep.tsx
+++ b/web/src/components/wizard/completion/LinuxCompletionStep.tsx
@@ -3,11 +3,14 @@ import Card from "../../common/Card";
 import Button from "../../common/Button";
 import { useLinuxConfig } from "../../../contexts/LinuxConfigContext";
 import { useBranding } from "../../../contexts/BrandingContext";
+import { useSettings } from "../../../contexts/SettingsContext";
 import { CheckCircle, ExternalLink } from "lucide-react";
 
 const LinuxCompletionStep: React.FC = () => {
   const { config } = useLinuxConfig();
   const { title } = useBranding();
+  const { settings } = useSettings();
+  const themeColor = settings.themeColor;
 
   return (
     <div className="space-y-6">
@@ -15,7 +18,7 @@ const LinuxCompletionStep: React.FC = () => {
         <div className="flex flex-col items-center text-center py-6">
           <div className="flex flex-col items-center justify-center mb-6">
             <div className="w-16 h-16 rounded-full flex items-center justify-center mb-4">
-              <CheckCircle className="w-10 h-10" style={{ color: "blue" }} />
+              <CheckCircle className="w-10 h-10" style={{ color: themeColor }} />
             </div>
             <p className="text-gray-600 mt-2" data-testid="completion-message">
               Visit the Admin Console to configure and install {title}

--- a/web/src/components/wizard/tests/KubernetesCompletionStep.test.tsx
+++ b/web/src/components/wizard/tests/KubernetesCompletionStep.test.tsx
@@ -4,16 +4,8 @@ import { screen, fireEvent } from "@testing-library/react";
 import { renderWithProviders } from "../../../test/setup.tsx";
 import KubernetesCompletionStep from "../completion/KubernetesCompletionStep.tsx";
 
-// Mock window.open
-const mockOpen = vi.fn();
-Object.defineProperty(window, 'open', {
-  value: mockOpen,
-  writable: true,
-});
-
 describe("KubernetesCompletionStep", () => {
   beforeEach(() => {
-    mockOpen.mockClear();
     // Mock window.location.hostname
     Object.defineProperty(window, 'location', {
       value: { hostname: 'localhost' },
@@ -21,7 +13,7 @@ describe("KubernetesCompletionStep", () => {
     });
   });
 
-  it("renders completion message and button", () => {
+  it("renders completion message and copy command button", () => {
     renderWithProviders(<KubernetesCompletionStep />, {
       wrapperProps: {
         authenticated: true,
@@ -29,19 +21,26 @@ describe("KubernetesCompletionStep", () => {
     });
 
     expect(screen.getByTestId("completion-message")).toBeInTheDocument();
-    expect(screen.getByTestId("admin-console-button")).toBeInTheDocument();
+    expect(screen.getByText("Copy Command")).toBeInTheDocument();
   });
 
-  it("opens admin console when button is clicked", () => {
+  it("copies install command when button is clicked", async () => {
+    // Mock navigator.clipboard.writeText
+    const mockWriteText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: mockWriteText },
+      writable: true,
+    });
+
     renderWithProviders(<KubernetesCompletionStep />, {
       wrapperProps: {
         authenticated: true,
       },
     });
 
-    const button = screen.getByTestId("admin-console-button");
+    const button = screen.getByText("Copy Command");
     fireEvent.click(button);
 
-    expect(mockOpen).toHaveBeenCalledWith("http://localhost:8080", "_blank");
+    expect(mockWriteText).toHaveBeenCalled();
   });
-}); 
+});

--- a/web/src/contexts/KubernetesConfigContext.tsx
+++ b/web/src/contexts/KubernetesConfigContext.tsx
@@ -6,6 +6,7 @@ export interface KubernetesConfig {
   httpProxy?: string;
   httpsProxy?: string;
   noProxy?: string;
+  installCommand?: string;
 }
 
 interface KubernetesConfigContextType {
@@ -16,6 +17,7 @@ interface KubernetesConfigContextType {
 
 const defaultKubernetesConfig: KubernetesConfig = {
   useProxy: false,
+  installCommand: 'todo: install command here'
 };
 
 export const KubernetesConfigContext = createContext<KubernetesConfigContextType | undefined>(undefined);
@@ -44,4 +46,4 @@ export const useKubernetesConfig = (): KubernetesConfigContextType => {
     throw new Error('useKubernetesConfig must be used within a KubernetesConfigProvider');
   }
   return context;
-}; 
+};

--- a/web/src/contexts/KubernetesConfigContext.tsx
+++ b/web/src/contexts/KubernetesConfigContext.tsx
@@ -17,7 +17,7 @@ interface KubernetesConfigContextType {
 
 const defaultKubernetesConfig: KubernetesConfig = {
   useProxy: false,
-  installCommand: 'todo: install command here'
+  installCommand: 'kubectl -n kotsadm port-forward svc/kotsadm 8800:3000'
 };
 
 export const KubernetesConfigContext = createContext<KubernetesConfigContextType | undefined>(undefined);

--- a/web/src/test/setup.tsx
+++ b/web/src/test/setup.tsx
@@ -133,6 +133,7 @@ export const renderWithProviders = (
       config: {
         adminConsolePort: 8080,
         useProxy: false,
+        installCommand: 'kubectl -n kotsadm port-forward svc/kotsadm 8800:3000',
       },
       updateConfig: vi.fn(),
       resetConfig: vi.fn(),


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Adds the installation command (for Kubernetes target) in the UI Completion step, allowing users to access the KOTS admin console

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/126071/install-kots-into-a-cluster-with-a-provided-kubeconfig-make-visit-the-admin-console-link-work

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Tests were updated to account for the copy box of the installation command

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
None
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
None
