### PR TITLE
feat(api): handle config item "when" attribute

### DIFF
--- a/api/controllers/kubernetes/install/app.go
+++ b/api/controllers/kubernetes/install/app.go
@@ -15,10 +15,14 @@ func (c *InstallController) GetAppConfig(ctx context.Context) (kotsv1beta1.Confi
 		return kotsv1beta1.Config{}, errors.New("app config not found")
 	}
 
-	return *c.releaseData.AppConfig, nil
+	return c.appConfigManager.GetConfig(*c.releaseData.AppConfig)
 }
 
 func (c *InstallController) SetAppConfigValues(ctx context.Context, values map[string]string) (finalErr error) {
+	if c.releaseData == nil || c.releaseData.AppConfig == nil {
+		return errors.New("app config not found")
+	}
+
 	lock, err := c.stateMachine.AcquireLock()
 	if err != nil {
 		return types.NewConflictError(err)
@@ -47,7 +51,7 @@ func (c *InstallController) SetAppConfigValues(ctx context.Context, values map[s
 		}
 	}()
 
-	err = c.appConfigManager.SetConfigValues(ctx, values)
+	err = c.appConfigManager.SetConfigValues(*c.releaseData.AppConfig, values)
 	if err != nil {
 		return fmt.Errorf("set app config values: %w", err)
 	}

--- a/api/controllers/kubernetes/install/controller_mock.go
+++ b/api/controllers/kubernetes/install/controller_mock.go
@@ -57,9 +57,6 @@ func (m *MockController) GetInfra(ctx context.Context) (types.Infra, error) {
 // GetAppConfig mocks the GetAppConfig method
 func (m *MockController) GetAppConfig(ctx context.Context) (kotsv1beta1.Config, error) {
 	args := m.Called(ctx)
-	if args.Get(0) == nil {
-		return kotsv1beta1.Config{}, args.Error(1)
-	}
 	return args.Get(0).(kotsv1beta1.Config), args.Error(1)
 }
 

--- a/api/controllers/linux/install/app.go
+++ b/api/controllers/linux/install/app.go
@@ -15,10 +15,14 @@ func (c *InstallController) GetAppConfig(ctx context.Context) (kotsv1beta1.Confi
 		return kotsv1beta1.Config{}, errors.New("app config not found")
 	}
 
-	return *c.releaseData.AppConfig, nil
+	return c.appConfigManager.GetConfig(*c.releaseData.AppConfig)
 }
 
 func (c *InstallController) SetAppConfigValues(ctx context.Context, values map[string]string) (finalErr error) {
+	if c.releaseData == nil || c.releaseData.AppConfig == nil {
+		return errors.New("app config not found")
+	}
+
 	lock, err := c.stateMachine.AcquireLock()
 	if err != nil {
 		return types.NewConflictError(err)
@@ -47,7 +51,7 @@ func (c *InstallController) SetAppConfigValues(ctx context.Context, values map[s
 		}
 	}()
 
-	err = c.appConfigManager.SetConfigValues(ctx, values)
+	err = c.appConfigManager.SetConfigValues(*c.releaseData.AppConfig, values)
 	if err != nil {
 		return fmt.Errorf("set app config values: %w", err)
 	}

--- a/api/controllers/linux/install/controller_mock.go
+++ b/api/controllers/linux/install/controller_mock.go
@@ -90,9 +90,6 @@ func (m *MockController) GetInfra(ctx context.Context) (types.Infra, error) {
 // GetAppConfig mocks the GetAppConfig method
 func (m *MockController) GetAppConfig(ctx context.Context) (kotsv1beta1.Config, error) {
 	args := m.Called(ctx)
-	if args.Get(0) == nil {
-		return kotsv1beta1.Config{}, args.Error(1)
-	}
 	return args.Get(0).(kotsv1beta1.Config), args.Error(1)
 }
 

--- a/api/internal/managers/app/config/config.go
+++ b/api/internal/managers/app/config/config.go
@@ -1,13 +1,82 @@
 package config
 
 import (
-	"context"
+	"fmt"
+
+	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
+	"github.com/replicatedhq/kotskinds/multitype"
+	"github.com/tiendc/go-deepcopy"
 )
+
+func (m *appConfigManager) GetConfig(config kotsv1beta1.Config) (kotsv1beta1.Config, error) {
+	return filterAppConfig(config)
+}
 
 func (m *appConfigManager) GetConfigValues() (map[string]string, error) {
 	return m.appConfigStore.GetConfigValues()
 }
 
-func (m *appConfigManager) SetConfigValues(ctx context.Context, values map[string]string) error {
-	return m.appConfigStore.SetConfigValues(values)
+func (m *appConfigManager) SetConfigValues(config kotsv1beta1.Config, configValues map[string]string) error {
+	filteredValues := make(map[string]string)
+
+	// only include values for enabled groups and items, otherwise keep the original value
+	for _, g := range config.Spec.Groups {
+		for _, i := range g.Items {
+			if !isItemEnabled(g.When) || !isItemEnabled(i.When) {
+				filteredValues[i.Name] = i.Value.String()
+			} else {
+				value, ok := configValues[i.Name]
+				if ok {
+					filteredValues[i.Name] = value
+				}
+			}
+			for _, c := range i.Items {
+				if !isItemEnabled(g.When) || !isItemEnabled(i.When) {
+					filteredValues[c.Name] = c.Value.String()
+				} else {
+					value, ok := configValues[c.Name]
+					if ok {
+						filteredValues[c.Name] = value
+					}
+				}
+			}
+		}
+	}
+
+	return m.appConfigStore.SetConfigValues(filteredValues)
+}
+
+// filterAppConfig filters out disabled groups and items based on their 'when' condition
+func filterAppConfig(config kotsv1beta1.Config) (kotsv1beta1.Config, error) {
+	// deepcopy the config to avoid mutating the original config
+	var updatedConfig kotsv1beta1.Config
+	if err := deepcopy.Copy(&updatedConfig, &config); err != nil {
+		return kotsv1beta1.Config{}, fmt.Errorf("deepcopy: %w", err)
+	}
+
+	filteredGroups := make([]kotsv1beta1.ConfigGroup, 0)
+
+	for _, group := range config.Spec.Groups {
+		if !isItemEnabled(group.When) {
+			continue
+		}
+		filteredItems := make([]kotsv1beta1.ConfigItem, 0)
+		for _, item := range group.Items {
+			if !isItemEnabled(item.When) {
+				continue
+			}
+			filteredItems = append(filteredItems, item)
+		}
+		if len(filteredItems) > 0 {
+			group.Items = filteredItems
+			filteredGroups = append(filteredGroups, group)
+		}
+	}
+	updatedConfig.Spec.Groups = filteredGroups
+	return updatedConfig, nil
+}
+
+// isItemEnabled checks if an item is enabled based on its 'when' condition
+func isItemEnabled(when multitype.QuotedBool) bool {
+	return when != "false"
 }

--- a/api/internal/managers/app/config/config.go
+++ b/api/internal/managers/app/config/config.go
@@ -19,21 +19,15 @@ func (m *appConfigManager) GetConfigValues() (map[string]string, error) {
 func (m *appConfigManager) SetConfigValues(config kotsv1beta1.Config, configValues map[string]string) error {
 	filteredValues := make(map[string]string)
 
-	// only include values for enabled groups and items, otherwise keep the original value
+	// only include values for enabled groups and items
 	for _, g := range config.Spec.Groups {
 		for _, i := range g.Items {
-			if !isItemEnabled(g.When) || !isItemEnabled(i.When) {
-				filteredValues[i.Name] = i.Value.String()
-			} else {
+			if isItemEnabled(g.When) && isItemEnabled(i.When) {
 				value, ok := configValues[i.Name]
 				if ok {
 					filteredValues[i.Name] = value
 				}
-			}
-			for _, c := range i.Items {
-				if !isItemEnabled(g.When) || !isItemEnabled(i.When) {
-					filteredValues[c.Name] = c.Value.String()
-				} else {
+				for _, c := range i.Items {
 					value, ok := configValues[c.Name]
 					if ok {
 						filteredValues[c.Name] = value

--- a/api/internal/managers/app/config/config_test.go
+++ b/api/internal/managers/app/config/config_test.go
@@ -1,0 +1,764 @@
+package config
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/replicatedhq/embedded-cluster/api/internal/store/app/config"
+	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
+	"github.com/replicatedhq/kotskinds/multitype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tiendc/go-deepcopy"
+)
+
+func TestAppConfigManager_GetConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   kotsv1beta1.Config
+		expected kotsv1beta1.Config
+	}{
+		{
+			name: "conditional filtering with when conditions",
+			config: kotsv1beta1.Config{
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{
+						{
+							Name:  "visible_config_group",
+							Title: "Visible Config Group",
+							When:  "true",
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name:  "visible_config_group_visible_item_1",
+									Title: "Visible Item 1",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "visible_config_group_visible_item_1_value"},
+									When:  "true",
+								},
+								{
+									Name:  "visible_config_group_invisible_item_1",
+									Title: "Invisible Item 1",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "visible_config_group_invisible_item_1_value"},
+									When:  "false",
+								},
+							},
+						},
+						{
+							Name:  "invisible_config_group",
+							Title: "Invisible Config Group",
+							When:  "false",
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name:  "invisible_config_group_visible_item_1",
+									Title: "Visible Item 2",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "invisible_config_group_visible_item_1_value"},
+									When:  "true",
+								},
+								{
+									Name:  "invisible_config_group_invisible_item_2",
+									Title: "Invisible Item 2",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "invisible_config_group_invisible_item_2_value"},
+									When:  "false",
+								},
+							},
+						},
+						{
+							Name:  "no_visible_items_group",
+							Title: "No Visible Items Group",
+							When:  "true",
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name:  "no_visible_items_group_item_1",
+									Title: "No Visible Items Group Item 1",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "no_visible_items_group_item_1_value"},
+									When:  "false",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: kotsv1beta1.Config{
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{
+						{
+							Name:  "visible_config_group",
+							Title: "Visible Config Group",
+							When:  "true",
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name:  "visible_config_group_visible_item_1",
+									Title: "Visible Item 1",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "visible_config_group_visible_item_1_value"},
+									When:  "true",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "conditional filtering with empty when conditions",
+			config: kotsv1beta1.Config{
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{
+						{
+							Name:  "group_with_empty_when",
+							Title: "Group with Empty When",
+							When:  "",
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name:  "item_with_empty_when",
+									Title: "Item with Empty When",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "item_with_empty_when_value"},
+									When:  "",
+								},
+								{
+									Name:  "item_with_false_when",
+									Title: "Item with False When",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "item_with_false_when_value"},
+									When:  "false",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: kotsv1beta1.Config{
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{
+						{
+							Name:  "group_with_empty_when",
+							Title: "Group with Empty When",
+							When:  "",
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name:  "item_with_empty_when",
+									Title: "Item with Empty When",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "item_with_empty_when_value"},
+									When:  "",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "empty config with no groups",
+			config: kotsv1beta1.Config{
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{},
+				},
+			},
+			expected: kotsv1beta1.Config{
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{},
+				},
+			},
+		},
+		{
+			name: "config with empty groups",
+			config: kotsv1beta1.Config{
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{
+						{
+							Name:  "empty_group",
+							Title: "Empty Group",
+							When:  "true",
+							Items: []kotsv1beta1.ConfigItem{},
+						},
+					},
+				},
+			},
+			expected: kotsv1beta1.Config{
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{},
+				},
+			},
+		},
+		{
+			name: "config with all disabled groups",
+			config: kotsv1beta1.Config{
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{
+						{
+							Name:  "disabled_group_1",
+							Title: "Disabled Group 1",
+							When:  "false",
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name:  "item_in_disabled_group",
+									Title: "Item in Disabled Group",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "item_in_disabled_group_value"},
+									When:  "true",
+								},
+							},
+						},
+						{
+							Name:  "disabled_group_2",
+							Title: "Disabled Group 2",
+							When:  "false",
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name:  "another_item_in_disabled_group",
+									Title: "Another Item in Disabled Group",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "another_item_in_disabled_group_value"},
+									When:  "true",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: kotsv1beta1.Config{
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{},
+				},
+			},
+		},
+		{
+			name: "config with mixed enabled and disabled items in enabled group",
+			config: kotsv1beta1.Config{
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{
+						{
+							Name:  "mixed_group",
+							Title: "Mixed Group",
+							When:  "true",
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name:  "enabled_item_1",
+									Title: "Enabled Item 1",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "enabled_item_1_value"},
+									When:  "true",
+								},
+								{
+									Name:  "disabled_item_1",
+									Title: "Disabled Item 1",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "disabled_item_1_value"},
+									When:  "false",
+								},
+								{
+									Name:  "enabled_item_2",
+									Title: "Enabled Item 2",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "enabled_item_2_value"},
+									When:  "true",
+								},
+								{
+									Name:  "disabled_item_2",
+									Title: "Disabled Item 2",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "disabled_item_2_value"},
+									When:  "false",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: kotsv1beta1.Config{
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{
+						{
+							Name:  "mixed_group",
+							Title: "Mixed Group",
+							When:  "true",
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name:  "enabled_item_1",
+									Title: "Enabled Item 1",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "enabled_item_1_value"},
+									When:  "true",
+								},
+								{
+									Name:  "enabled_item_2",
+									Title: "Enabled Item 2",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "enabled_item_2_value"},
+									When:  "true",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a deep copy of the original config before testing
+			var originalConfig kotsv1beta1.Config
+			err := deepcopy.Copy(&originalConfig, &tt.config)
+			require.NoError(t, err)
+
+			// Create a new app config manager
+			manager := NewAppConfigManager()
+
+			// Apply values to config
+			result, err := manager.GetConfig(tt.config)
+
+			// Verify no error occurred
+			require.NoError(t, err)
+
+			// Verify the result matches expected
+			assert.Equal(t, tt.expected, result)
+
+			// Verify the original config was not modified (deep copy worked)
+			assert.Equal(t, originalConfig, tt.config, "original config should not be modified")
+		})
+	}
+}
+
+func TestAppConfigManager_SetConfigValues(t *testing.T) {
+	tests := []struct {
+		name         string
+		config       kotsv1beta1.Config
+		configValues map[string]string
+		setupMock    func(*config.MockStore)
+		wantErr      bool
+	}{
+		{
+			name: "enabled group and items with new values",
+			config: kotsv1beta1.Config{
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{
+						{
+							Name:  "enabled-group",
+							Title: "Enabled Group",
+							When:  "true",
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name:  "enabled-item-1",
+									Title: "Enabled Item 1",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "original-value-1"},
+									When:  "true",
+								},
+								{
+									Name:  "enabled-item-2",
+									Title: "Enabled Item 2",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "original-value-2"},
+									When:  "true",
+									Items: []kotsv1beta1.ConfigChildItem{
+										{
+											Name:  "enabled-child-item",
+											Title: "Enabled Child Item",
+											Value: multitype.BoolOrString{StrVal: "original-child-value"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			configValues: map[string]string{
+				"enabled-item-1":     "new-value-1",
+				"enabled-item-2":     "new-value-2",
+				"enabled-child-item": "new-child-value",
+			},
+			setupMock: func(mockStore *config.MockStore) {
+				expectedValues := map[string]string{
+					"enabled-item-1":     "new-value-1",
+					"enabled-item-2":     "new-value-2",
+					"enabled-child-item": "new-child-value",
+				}
+				mockStore.On("SetConfigValues", expectedValues).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "disabled group keeps original values",
+			config: kotsv1beta1.Config{
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{
+						{
+							Name:  "disabled-group",
+							Title: "Disabled Group",
+							When:  "false",
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name:  "item-in-disabled-group",
+									Title: "Item in Disabled Group",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "original-value"},
+									When:  "true",
+								},
+								{
+									Name:  "child-in-disabled-group",
+									Title: "Child in Disabled Group",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "original-child-value"},
+									When:  "true",
+									Items: []kotsv1beta1.ConfigChildItem{
+										{
+											Name:  "grandchild-in-disabled-group",
+											Title: "Grandchild in Disabled Group",
+											Value: multitype.BoolOrString{StrVal: "original-grandchild-value"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			configValues: map[string]string{
+				"item-in-disabled-group":       "new-value",
+				"child-in-disabled-group":      "new-child-value",
+				"grandchild-in-disabled-group": "new-grandchild-value",
+			},
+			setupMock: func(mockStore *config.MockStore) {
+				expectedValues := map[string]string{
+					"item-in-disabled-group":       "original-value",
+					"child-in-disabled-group":      "original-child-value",
+					"grandchild-in-disabled-group": "original-grandchild-value",
+				}
+				mockStore.On("SetConfigValues", expectedValues).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "disabled item keeps original value",
+			config: kotsv1beta1.Config{
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{
+						{
+							Name:  "enabled-group",
+							Title: "Enabled Group",
+							When:  "true",
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name:  "enabled-item",
+									Title: "Enabled Item",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "enabled-original-value"},
+									When:  "true",
+								},
+								{
+									Name:  "disabled-item",
+									Title: "Disabled Item",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "disabled-original-value"},
+									When:  "false",
+									Items: []kotsv1beta1.ConfigChildItem{
+										{
+											Name:  "child-of-disabled-item",
+											Title: "Child of Disabled Item",
+											Value: multitype.BoolOrString{StrVal: "child-of-disabled-original-value"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			configValues: map[string]string{
+				"enabled-item":           "new-enabled-value",
+				"disabled-item":          "new-disabled-value",
+				"child-of-disabled-item": "new-child-value",
+			},
+			setupMock: func(mockStore *config.MockStore) {
+				expectedValues := map[string]string{
+					"enabled-item":           "new-enabled-value",
+					"disabled-item":          "disabled-original-value",
+					"child-of-disabled-item": "child-of-disabled-original-value",
+				}
+				mockStore.On("SetConfigValues", expectedValues).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "mixed enabled and disabled items",
+			config: kotsv1beta1.Config{
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{
+						{
+							Name:  "mixed-group",
+							Title: "Mixed Group",
+							When:  "true",
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name:  "enabled-item",
+									Title: "Enabled Item",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "enabled-original"},
+									When:  "true",
+								},
+								{
+									Name:  "disabled-item",
+									Title: "Disabled Item",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "disabled-original"},
+									When:  "false",
+								},
+								{
+									Name:  "enabled-item-with-children",
+									Title: "Enabled Item with Children",
+									Type:  "group",
+									Value: multitype.BoolOrString{StrVal: "parent-original"},
+									When:  "true",
+									Items: []kotsv1beta1.ConfigChildItem{
+										{
+											Name:  "enabled-child",
+											Title: "Enabled Child",
+											Value: multitype.BoolOrString{StrVal: "enabled-child-original"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			configValues: map[string]string{
+				"enabled-item":               "new-enabled-value",
+				"disabled-item":              "new-disabled-value",
+				"enabled-item-with-children": "new-parent-value",
+				"enabled-child":              "new-enabled-child-value",
+				"disabled-child":             "new-disabled-child-value",
+			},
+			setupMock: func(mockStore *config.MockStore) {
+				expectedValues := map[string]string{
+					"enabled-item":               "new-enabled-value",
+					"disabled-item":              "disabled-original",
+					"enabled-item-with-children": "new-parent-value",
+					"enabled-child":              "new-enabled-child-value",
+				}
+				mockStore.On("SetConfigValues", expectedValues).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty config values",
+			config: kotsv1beta1.Config{
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{
+						{
+							Name:  "enabled-group",
+							Title: "Enabled Group",
+							When:  "true",
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name:  "enabled-item",
+									Title: "Enabled Item",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "original-value"},
+									When:  "true",
+								},
+							},
+						},
+					},
+				},
+			},
+			configValues: map[string]string{},
+			setupMock: func(mockStore *config.MockStore) {
+				expectedValues := map[string]string{}
+				mockStore.On("SetConfigValues", expectedValues).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "store error",
+			config: kotsv1beta1.Config{
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{
+						{
+							Name:  "enabled-group",
+							Title: "Enabled Group",
+							When:  "true",
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name:  "enabled-item",
+									Title: "Enabled Item",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "original-value"},
+									When:  "true",
+								},
+							},
+						},
+					},
+				},
+			},
+			configValues: map[string]string{
+				"enabled-item": "new-value",
+			},
+			setupMock: func(mockStore *config.MockStore) {
+				expectedValues := map[string]string{
+					"enabled-item": "new-value",
+				}
+				mockStore.On("SetConfigValues", expectedValues).Return(errors.New("store error"))
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty when conditions treated as enabled",
+			config: kotsv1beta1.Config{
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{
+						{
+							Name:  "group-with-empty-when",
+							Title: "Group with Empty When",
+							When:  "",
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name:  "item-with-empty-when",
+									Title: "Item with Empty When",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "original-value"},
+									When:  "",
+								},
+							},
+						},
+					},
+				},
+			},
+			configValues: map[string]string{
+				"item-with-empty-when": "new-value",
+			},
+			setupMock: func(mockStore *config.MockStore) {
+				expectedValues := map[string]string{
+					"item-with-empty-when": "new-value",
+				}
+				mockStore.On("SetConfigValues", expectedValues).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "all groups disabled",
+			config: kotsv1beta1.Config{
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{
+						{
+							Name:  "disabled-group-1",
+							Title: "Disabled Group 1",
+							When:  "false",
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name:  "item-1",
+									Title: "Item 1",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "original-1"},
+									When:  "true",
+								},
+							},
+						},
+						{
+							Name:  "disabled-group-2",
+							Title: "Disabled Group 2",
+							When:  "false",
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name:  "item-2",
+									Title: "Item 2",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "original-2"},
+									When:  "true",
+								},
+							},
+						},
+					},
+				},
+			},
+			configValues: map[string]string{
+				"item-1": "new-value-1",
+				"item-2": "new-value-2",
+			},
+			setupMock: func(mockStore *config.MockStore) {
+				expectedValues := map[string]string{
+					"item-1": "original-1",
+					"item-2": "original-2",
+				}
+				mockStore.On("SetConfigValues", expectedValues).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "enabled item without config value",
+			config: kotsv1beta1.Config{
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{
+						{
+							Name:  "enabled-group",
+							Title: "Enabled Group",
+							When:  "true",
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name:  "enabled-item-1",
+									Title: "Enabled Item 1",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "original-value-1"},
+									When:  "true",
+								},
+								{
+									Name:  "enabled-item-2",
+									Title: "Enabled Item 2",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "original-value-2"},
+									When:  "true",
+								},
+							},
+						},
+					},
+				},
+			},
+			configValues: map[string]string{
+				"enabled-item-1": "new-value-1",
+				// enabled-item-2 intentionally omitted
+			},
+			setupMock: func(mockStore *config.MockStore) {
+				expectedValues := map[string]string{
+					"enabled-item-1": "new-value-1",
+					// enabled-item-2 should not be included since no value provided
+				}
+				mockStore.On("SetConfigValues", expectedValues).Return(nil)
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create mock store
+			mockStore := &config.MockStore{}
+			tt.setupMock(mockStore)
+
+			// Create manager with mock store
+			manager := &appConfigManager{
+				appConfigStore: mockStore,
+			}
+
+			// Call SetConfigValues
+			err := manager.SetConfigValues(tt.config, tt.configValues)
+
+			// Verify expectations
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			// Verify mock expectations
+			mockStore.AssertExpectations(t)
+		})
+	}
+}

--- a/api/internal/managers/app/config/config_test.go
+++ b/api/internal/managers/app/config/config_test.go
@@ -427,11 +427,7 @@ func TestAppConfigManager_SetConfigValues(t *testing.T) {
 				"grandchild-in-disabled-group": "new-grandchild-value",
 			},
 			setupMock: func(mockStore *config.MockStore) {
-				expectedValues := map[string]string{
-					"item-in-disabled-group":       "original-value",
-					"child-in-disabled-group":      "original-child-value",
-					"grandchild-in-disabled-group": "original-grandchild-value",
-				}
+				expectedValues := map[string]string{}
 				mockStore.On("SetConfigValues", expectedValues).Return(nil)
 			},
 			wantErr: false,
@@ -479,9 +475,7 @@ func TestAppConfigManager_SetConfigValues(t *testing.T) {
 			},
 			setupMock: func(mockStore *config.MockStore) {
 				expectedValues := map[string]string{
-					"enabled-item":           "new-enabled-value",
-					"disabled-item":          "disabled-original-value",
-					"child-of-disabled-item": "child-of-disabled-original-value",
+					"enabled-item": "new-enabled-value",
 				}
 				mockStore.On("SetConfigValues", expectedValues).Return(nil)
 			},
@@ -540,7 +534,6 @@ func TestAppConfigManager_SetConfigValues(t *testing.T) {
 			setupMock: func(mockStore *config.MockStore) {
 				expectedValues := map[string]string{
 					"enabled-item":               "new-enabled-value",
-					"disabled-item":              "disabled-original",
 					"enabled-item-with-children": "new-parent-value",
 					"enabled-child":              "new-enabled-child-value",
 				}
@@ -684,10 +677,7 @@ func TestAppConfigManager_SetConfigValues(t *testing.T) {
 				"item-2": "new-value-2",
 			},
 			setupMock: func(mockStore *config.MockStore) {
-				expectedValues := map[string]string{
-					"item-1": "original-1",
-					"item-2": "original-2",
-				}
+				expectedValues := map[string]string{}
 				mockStore.On("SetConfigValues", expectedValues).Return(nil)
 			},
 			wantErr: false,

--- a/api/internal/managers/app/config/manager.go
+++ b/api/internal/managers/app/config/manager.go
@@ -1,10 +1,9 @@
 package config
 
 import (
-	"context"
-
 	configstore "github.com/replicatedhq/embedded-cluster/api/internal/store/app/config"
 	"github.com/replicatedhq/embedded-cluster/api/pkg/logger"
+	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	"github.com/sirupsen/logrus"
 )
 
@@ -12,8 +11,12 @@ var _ AppConfigManager = &appConfigManager{}
 
 // AppConfigManager provides methods for managing appConfigstructure setup
 type AppConfigManager interface {
+	// GetConfig returns the config with disabled groups and items filtered out
+	GetConfig(config kotsv1beta1.Config) (kotsv1beta1.Config, error)
+	// GetConfigValues returns the current config values
 	GetConfigValues() (map[string]string, error)
-	SetConfigValues(ctx context.Context, values map[string]string) error
+	// SetConfigValues sets the config values
+	SetConfigValues(config kotsv1beta1.Config, values map[string]string) error
 }
 
 // appConfigManager is an implementation of the AppConfigManager interface

--- a/api/internal/managers/app/config/manager_mock.go
+++ b/api/internal/managers/app/config/manager_mock.go
@@ -15,9 +15,6 @@ type MockAppConfigManager struct {
 // GetConfig mocks the GetConfig method
 func (m *MockAppConfigManager) GetConfig(config kotsv1beta1.Config) (kotsv1beta1.Config, error) {
 	args := m.Called(config)
-	if args.Get(0) == nil {
-		return kotsv1beta1.Config{}, args.Error(1)
-	}
 	return args.Get(0).(kotsv1beta1.Config), args.Error(1)
 }
 

--- a/api/internal/managers/app/config/manager_mock.go
+++ b/api/internal/managers/app/config/manager_mock.go
@@ -1,8 +1,7 @@
 package config
 
 import (
-	"context"
-
+	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -11,6 +10,15 @@ var _ AppConfigManager = (*MockAppConfigManager)(nil)
 // MockAppConfigManager is a mock implementation of the AppConfigManager interface
 type MockAppConfigManager struct {
 	mock.Mock
+}
+
+// GetConfig mocks the GetConfig method
+func (m *MockAppConfigManager) GetConfig(config kotsv1beta1.Config) (kotsv1beta1.Config, error) {
+	args := m.Called(config)
+	if args.Get(0) == nil {
+		return kotsv1beta1.Config{}, args.Error(1)
+	}
+	return args.Get(0).(kotsv1beta1.Config), args.Error(1)
 }
 
 // GetConfigValues mocks the GetConfigValues method
@@ -23,7 +31,7 @@ func (m *MockAppConfigManager) GetConfigValues() (map[string]string, error) {
 }
 
 // SetConfigValues mocks the SetConfigValues method
-func (m *MockAppConfigManager) SetConfigValues(ctx context.Context, values map[string]string) error {
-	args := m.Called(ctx, values)
+func (m *MockAppConfigManager) SetConfigValues(config kotsv1beta1.Config, configValues map[string]string) error {
+	args := m.Called(config, configValues)
 	return args.Error(0)
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Only returns items with when != "false" to the ui.

Filters values for items with when == "false"

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
