### PR TITLE
fix(ui): use installation target from initial state in authcontext

### DIFF
--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -36,8 +36,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   // Check token validity on mount and when token changes
   useEffect(() => {
     if (token) {
-      // Make a request to any authenticated endpoint to check token validity
-      fetch("/api/linux/install/installation/config", {
+      // Get the installation target from initial state
+      const initialState = window.__INITIAL_STATE__ || {};
+      const target = initialState.installTarget;
+      
+      // Make a request to the correct target-specific endpoint
+      fetch(`/api/${target}/install/installation/config`, {
         headers: {
           Authorization: `Bearer ${token}`,
         },

--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -40,7 +40,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       const initialState = window.__INITIAL_STATE__ || {};
       const target = initialState.installTarget;
       
-      // Make a request to the correct target-specific endpoint
+      // Make a request to any authenticated endpoint to check token validity
+      // Use the correct target-specific endpoint based on installation target
       fetch(`/api/${target}/install/installation/config`, {
         headers: {
           Authorization: `Bearer ${token}`,


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Fixes an incorrect request for the linux installation config in kubernetes target installations. 

There is `/console/available-network-interfaces` if we wanted to use that instead.

<img width="700" height="137" alt="Screenshot 2025-07-10 at 9 35 45 PM" src="https://github.com/user-attachments/assets/b9c58335-893e-4237-81ad-16e748af1f02" />
<img width="697" height="135" alt="Screenshot 2025-07-10 at 9 35 56 PM" src="https://github.com/user-attachments/assets/74c76ccc-b39e-4856-b53a-5a3a4ba14a24" />


#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
