### PR TITLE
feat(api): support Go templating with sprig in config resource

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -99,6 +99,13 @@ Provides a client library for interacting with the API. The client package imple
    - Kubernetes installations focus on application management (deployment, upgrades, lifecycle) on an existing Kubernetes cluster
    - Once Linux installation finishes setting up the Kubernetes cluster, subsequent operations should follow the same workflow as Kubernetes installations
 
+3. **Consistent Processing of App Config**:
+   - All access to the application config must go through the AppConfigManager interface
+   - Direct access to `releaseData.AppConfig` should be avoided when possible
+   - This ensures consistent template processing across all config usage and prevents bypassing of template evaluation
+   - The manager stores the raw config internally and provides processed config through its interface methods
+   - Controllers check `appConfigManager == nil` to determine config availability rather than checking the raw config
+
 ## Integration
 
 The API package is designed to be used as part of the larger Embedded Cluster system. It provides both HTTP endpoints for external access and a client library for internal use.

--- a/api/controllers/kubernetes/install/app.go
+++ b/api/controllers/kubernetes/install/app.go
@@ -11,15 +11,15 @@ import (
 )
 
 func (c *InstallController) GetAppConfig(ctx context.Context) (kotsv1beta1.Config, error) {
-	if c.releaseData == nil || c.releaseData.AppConfig == nil {
+	if c.appConfigManager == nil {
 		return kotsv1beta1.Config{}, errors.New("app config not found")
 	}
 
-	return c.appConfigManager.GetConfig(*c.releaseData.AppConfig)
+	return c.appConfigManager.GetConfig()
 }
 
 func (c *InstallController) PatchAppConfigValues(ctx context.Context, values map[string]string) (finalErr error) {
-	if c.releaseData == nil || c.releaseData.AppConfig == nil {
+	if c.appConfigManager == nil {
 		return errors.New("app config not found")
 	}
 
@@ -51,12 +51,12 @@ func (c *InstallController) PatchAppConfigValues(ctx context.Context, values map
 		}
 	}()
 
-	err = c.appConfigManager.ValidateConfigValues(*c.releaseData.AppConfig, values)
+	err = c.appConfigManager.ValidateConfigValues(values)
 	if err != nil {
 		return fmt.Errorf("validate app config values: %w", err)
 	}
 
-	err = c.appConfigManager.PatchConfigValues(*c.releaseData.AppConfig, values)
+	err = c.appConfigManager.PatchConfigValues(values)
 	if err != nil {
 		return fmt.Errorf("patch app config values: %w", err)
 	}
@@ -70,11 +70,8 @@ func (c *InstallController) PatchAppConfigValues(ctx context.Context, values map
 }
 
 func (c *InstallController) GetAppConfigValues(ctx context.Context, maskPasswords bool) (map[string]string, error) {
-	// Get the app config to determine which fields are password type
-	appConfig, err := c.GetAppConfig(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("get app config: %w", err)
+	if c.appConfigManager == nil {
+		return nil, errors.New("app config not found")
 	}
-
-	return c.appConfigManager.GetConfigValues(appConfig, maskPasswords)
+	return c.appConfigManager.GetConfigValues(maskPasswords)
 }

--- a/api/controllers/kubernetes/install/controller.go
+++ b/api/controllers/kubernetes/install/controller.go
@@ -223,11 +223,11 @@ func NewInstallController(opts ...InstallControllerOption) (*InstallController, 
 		if controller.releaseData == nil || controller.releaseData.AppConfig == nil {
 			return nil, errors.New("app config not found")
 		}
-		err := controller.appConfigManager.ValidateConfigValues(*controller.releaseData.AppConfig, controller.configValues)
+		err := controller.appConfigManager.ValidateConfigValues(controller.configValues)
 		if err != nil {
 			return nil, fmt.Errorf("validate app config values: %w", err)
 		}
-		err = controller.appConfigManager.PatchConfigValues(*controller.releaseData.AppConfig, controller.configValues)
+		err = controller.appConfigManager.PatchConfigValues(controller.configValues)
 		if err != nil {
 			return nil, fmt.Errorf("set app config values: %w", err)
 		}

--- a/api/controllers/kubernetes/install/controller.go
+++ b/api/controllers/kubernetes/install/controller.go
@@ -2,7 +2,6 @@ package install
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 
@@ -195,41 +194,25 @@ func NewInstallController(opts ...InstallControllerOption) (*InstallController, 
 		controller.infraManager = infraManager
 	}
 
-	if controller.appConfigManager == nil {
-		if controller.releaseData != nil && controller.releaseData.AppConfig != nil {
+	if controller.releaseData != nil && controller.releaseData.AppConfig != nil {
+		// Initialize the app config manager if an app config is provided
+		if controller.appConfigManager == nil {
 			controller.appConfigManager = appconfig.NewAppConfigManager(
 				*controller.releaseData.AppConfig,
 				appconfig.WithLogger(controller.logger),
 				appconfig.WithAppConfigStore(controller.store.AppConfigStore()),
 			)
 		}
-	}
 
-	if controller.configValues != nil {
-		if controller.releaseData == nil || controller.releaseData.AppConfig == nil {
-			return nil, errors.New("app config not found")
-		}
-		err := controller.appConfigManager.ValidateConfigValues(controller.configValues)
-		if err != nil {
-			return nil, fmt.Errorf("validate app config values: %w", err)
-		}
-		err = controller.appConfigManager.PatchConfigValues(controller.configValues)
-		if err != nil {
-			return nil, fmt.Errorf("set app config values: %w", err)
-		}
-	}
-
-	if controller.configValues != nil {
-		if controller.releaseData == nil || controller.releaseData.AppConfig == nil {
-			return nil, errors.New("app config not found")
-		}
-		err := controller.appConfigManager.ValidateConfigValues(controller.configValues)
-		if err != nil {
-			return nil, fmt.Errorf("validate app config values: %w", err)
-		}
-		err = controller.appConfigManager.PatchConfigValues(controller.configValues)
-		if err != nil {
-			return nil, fmt.Errorf("set app config values: %w", err)
+		if controller.configValues != nil {
+			err := controller.appConfigManager.ValidateConfigValues(controller.configValues)
+			if err != nil {
+				return nil, fmt.Errorf("validate app config values: %w", err)
+			}
+			err = controller.appConfigManager.PatchConfigValues(controller.configValues)
+			if err != nil {
+				return nil, fmt.Errorf("patch app config values: %w", err)
+			}
 		}
 	}
 

--- a/api/controllers/kubernetes/install/controller.go
+++ b/api/controllers/kubernetes/install/controller.go
@@ -196,10 +196,27 @@ func NewInstallController(opts ...InstallControllerOption) (*InstallController, 
 	}
 
 	if controller.appConfigManager == nil {
-		controller.appConfigManager = appconfig.NewAppConfigManager(
-			appconfig.WithLogger(controller.logger),
-			appconfig.WithAppConfigStore(controller.store.AppConfigStore()),
-		)
+		if controller.releaseData != nil && controller.releaseData.AppConfig != nil {
+			controller.appConfigManager = appconfig.NewAppConfigManager(
+				*controller.releaseData.AppConfig,
+				appconfig.WithLogger(controller.logger),
+				appconfig.WithAppConfigStore(controller.store.AppConfigStore()),
+			)
+		}
+	}
+
+	if controller.configValues != nil {
+		if controller.releaseData == nil || controller.releaseData.AppConfig == nil {
+			return nil, errors.New("app config not found")
+		}
+		err := controller.appConfigManager.ValidateConfigValues(controller.configValues)
+		if err != nil {
+			return nil, fmt.Errorf("validate app config values: %w", err)
+		}
+		err = controller.appConfigManager.PatchConfigValues(controller.configValues)
+		if err != nil {
+			return nil, fmt.Errorf("set app config values: %w", err)
+		}
 	}
 
 	if controller.configValues != nil {

--- a/api/controllers/kubernetes/install/infra.go
+++ b/api/controllers/kubernetes/install/infra.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (c *InstallController) SetupInfra(ctx context.Context) (finalErr error) {
-	if c.releaseData == nil || c.releaseData.AppConfig == nil {
+	if c.appConfigManager == nil {
 		return errors.New("app config not found")
 	}
 
@@ -28,7 +28,7 @@ func (c *InstallController) SetupInfra(ctx context.Context) (finalErr error) {
 		}
 	}()
 
-	configValues, err := c.appConfigManager.GetKotsadmConfigValues(*c.releaseData.AppConfig)
+	configValues, err := c.appConfigManager.GetKotsadmConfigValues()
 	if err != nil {
 		return fmt.Errorf("failed to get kotsadm config values: %w", err)
 	}

--- a/api/controllers/linux/install/app.go
+++ b/api/controllers/linux/install/app.go
@@ -11,15 +11,15 @@ import (
 )
 
 func (c *InstallController) GetAppConfig(ctx context.Context) (kotsv1beta1.Config, error) {
-	if c.releaseData == nil || c.releaseData.AppConfig == nil {
+	if c.appConfigManager == nil {
 		return kotsv1beta1.Config{}, errors.New("app config not found")
 	}
 
-	return c.appConfigManager.GetConfig(*c.releaseData.AppConfig)
+	return c.appConfigManager.GetConfig()
 }
 
 func (c *InstallController) PatchAppConfigValues(ctx context.Context, values map[string]string) (finalErr error) {
-	if c.releaseData == nil || c.releaseData.AppConfig == nil {
+	if c.appConfigManager == nil {
 		return errors.New("app config not found")
 	}
 
@@ -51,12 +51,12 @@ func (c *InstallController) PatchAppConfigValues(ctx context.Context, values map
 		}
 	}()
 
-	err = c.appConfigManager.ValidateConfigValues(*c.releaseData.AppConfig, values)
+	err = c.appConfigManager.ValidateConfigValues(values)
 	if err != nil {
 		return fmt.Errorf("validate app config values: %w", err)
 	}
 
-	err = c.appConfigManager.PatchConfigValues(*c.releaseData.AppConfig, values)
+	err = c.appConfigManager.PatchConfigValues(values)
 	if err != nil {
 		return fmt.Errorf("patch app config values: %w", err)
 	}
@@ -70,11 +70,8 @@ func (c *InstallController) PatchAppConfigValues(ctx context.Context, values map
 }
 
 func (c *InstallController) GetAppConfigValues(ctx context.Context, maskPasswords bool) (map[string]string, error) {
-	// Get the app config to determine which fields are password type
-	appConfig, err := c.GetAppConfig(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("get app config: %w", err)
+	if c.appConfigManager == nil {
+		return nil, errors.New("app config not found")
 	}
-
-	return c.appConfigManager.GetConfigValues(appConfig, maskPasswords)
+	return c.appConfigManager.GetConfigValues(maskPasswords)
 }

--- a/api/controllers/linux/install/controller.go
+++ b/api/controllers/linux/install/controller.go
@@ -236,10 +236,13 @@ func NewInstallController(opts ...InstallControllerOption) (*InstallController, 
 	}
 
 	if controller.appConfigManager == nil {
-		controller.appConfigManager = appconfig.NewAppConfigManager(
-			appconfig.WithLogger(controller.logger),
-			appconfig.WithAppConfigStore(controller.store.AppConfigStore()),
-		)
+		if controller.releaseData != nil && controller.releaseData.AppConfig != nil {
+			controller.appConfigManager = appconfig.NewAppConfigManager(
+				*controller.releaseData.AppConfig,
+				appconfig.WithLogger(controller.logger),
+				appconfig.WithAppConfigStore(controller.store.AppConfigStore()),
+			)
+		}
 	}
 
 	if controller.infraManager == nil {
@@ -260,11 +263,11 @@ func NewInstallController(opts ...InstallControllerOption) (*InstallController, 
 		if controller.releaseData == nil || controller.releaseData.AppConfig == nil {
 			return nil, errors.New("app config not found")
 		}
-		err := controller.appConfigManager.ValidateConfigValues(*controller.releaseData.AppConfig, controller.configValues)
+		err := controller.appConfigManager.ValidateConfigValues(controller.configValues)
 		if err != nil {
 			return nil, fmt.Errorf("validate app config values: %w", err)
 		}
-		err = controller.appConfigManager.PatchConfigValues(*controller.releaseData.AppConfig, controller.configValues)
+		err = controller.appConfigManager.PatchConfigValues(controller.configValues)
 		if err != nil {
 			return nil, fmt.Errorf("set app config values: %w", err)
 		}

--- a/api/controllers/linux/install/infra.go
+++ b/api/controllers/linux/install/infra.go
@@ -14,7 +14,7 @@ var (
 )
 
 func (c *InstallController) SetupInfra(ctx context.Context, ignoreHostPreflights bool) (finalErr error) {
-	if c.releaseData == nil || c.releaseData.AppConfig == nil {
+	if c.appConfigManager == nil {
 		return errors.New("app config not found")
 	}
 
@@ -43,7 +43,7 @@ func (c *InstallController) SetupInfra(ctx context.Context, ignoreHostPreflights
 		}
 	}
 
-	configValues, err := c.appConfigManager.GetKotsadmConfigValues(*c.releaseData.AppConfig)
+	configValues, err := c.appConfigManager.GetKotsadmConfigValues()
 	if err != nil {
 		return fmt.Errorf("failed to get kotsadm config values: %w", err)
 	}

--- a/api/integration/kubernetes/install/app_test.go
+++ b/api/integration/kubernetes/install/app_test.go
@@ -44,6 +44,27 @@ func TestKubernetesGetAppConfig(t *testing.T) {
 		},
 	}
 
+	// Create an app config with templates
+	appConfigWithTemplates := kotsv1beta1.Config{
+		Spec: kotsv1beta1.ConfigSpec{
+			Groups: []kotsv1beta1.ConfigGroup{
+				{
+					Name:  "templated-group",
+					Title: "{{ print \"HTTP Configuration\" }}",
+					Items: []kotsv1beta1.ConfigItem{
+						{
+							Name:    "templated-item",
+							Type:    "text",
+							Title:   "{{ upper \"http port\" }}",
+							Default: multitype.BoolOrString{StrVal: "{{ print \"8080\" }}"},
+							Value:   multitype.BoolOrString{StrVal: "{{ print \"8080\" }}"},
+						},
+					},
+				},
+			},
+		},
+	}
+
 	// Create config values that should be applied to the config
 	configValues := map[string]string{
 		"test-item": "applied-value",
@@ -115,6 +136,55 @@ func TestKubernetesGetAppConfig(t *testing.T) {
 		err = json.NewDecoder(rec.Body).Decode(&apiError)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusUnauthorized, apiError.StatusCode)
+	})
+
+	// Test template processing
+	t.Run("Template processing", func(t *testing.T) {
+		// Create an install controller with the templated config
+		installController, err := kubernetesinstall.NewInstallController(
+			kubernetesinstall.WithReleaseData(&release.ReleaseData{
+				AppConfig: &appConfigWithTemplates,
+			}),
+		)
+		require.NoError(t, err)
+
+		// Create the API with the install controller
+		apiInstance, err := api.New(
+			types.APIConfig{
+				Password: "password",
+			},
+			api.WithKubernetesInstallController(installController),
+			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
+			api.WithLogger(logger.NewDiscardLogger()),
+		)
+		require.NoError(t, err)
+
+		// Create a router and register the API routes
+		router := mux.NewRouter()
+		apiInstance.RegisterRoutes(router)
+
+		// Create a request
+		req := httptest.NewRequest(http.MethodGet, "/kubernetes/install/app/config", nil)
+		req.Header.Set("Authorization", "Bearer "+"TOKEN")
+		rec := httptest.NewRecorder()
+
+		// Serve the request
+		router.ServeHTTP(rec, req)
+
+		// Check the response
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+		// Parse the response body
+		var response types.AppConfig
+		err = json.NewDecoder(rec.Body).Decode(&response)
+		require.NoError(t, err)
+
+		// Verify the templates were processed
+		assert.Equal(t, "HTTP Configuration", response.Groups[0].Title, "group title should be processed from template")
+		assert.Equal(t, "HTTP PORT", response.Groups[0].Items[0].Title, "item title should be processed from template")
+		assert.Equal(t, "8080", response.Groups[0].Items[0].Value.String(), "item value should be processed from template")
+		assert.Equal(t, "8080", response.Groups[0].Items[0].Default.String(), "item default should be processed from template")
 	})
 }
 

--- a/api/integration/linux/install/app_test.go
+++ b/api/integration/linux/install/app_test.go
@@ -44,6 +44,27 @@ func TestLinuxGetAppConfig(t *testing.T) {
 		},
 	}
 
+	// Create an app config with templates
+	appConfigWithTemplates := kotsv1beta1.Config{
+		Spec: kotsv1beta1.ConfigSpec{
+			Groups: []kotsv1beta1.ConfigGroup{
+				{
+					Name:  "templated-group",
+					Title: "{{ print \"HTTP Configuration\" }}",
+					Items: []kotsv1beta1.ConfigItem{
+						{
+							Name:    "templated-item",
+							Type:    "text",
+							Title:   "{{ upper \"http port\" }}",
+							Default: multitype.BoolOrString{StrVal: "{{ print \"8080\" }}"},
+							Value:   multitype.BoolOrString{StrVal: "{{ print \"8080\" }}"},
+						},
+					},
+				},
+			},
+		},
+	}
+
 	// Create config values that should be applied to the config
 	configValues := map[string]string{
 		"test-item": "applied-value",
@@ -115,6 +136,55 @@ func TestLinuxGetAppConfig(t *testing.T) {
 		err = json.NewDecoder(rec.Body).Decode(&apiError)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusUnauthorized, apiError.StatusCode)
+	})
+
+	// Test template processing
+	t.Run("Template processing", func(t *testing.T) {
+		// Create an install controller with the templated config
+		installController, err := linuxinstall.NewInstallController(
+			linuxinstall.WithReleaseData(&release.ReleaseData{
+				AppConfig: &appConfigWithTemplates,
+			}),
+		)
+		require.NoError(t, err)
+
+		// Create the API with the install controller
+		apiInstance, err := api.New(
+			types.APIConfig{
+				Password: "password",
+			},
+			api.WithLinuxInstallController(installController),
+			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
+			api.WithLogger(logger.NewDiscardLogger()),
+		)
+		require.NoError(t, err)
+
+		// Create a router and register the API routes
+		router := mux.NewRouter()
+		apiInstance.RegisterRoutes(router)
+
+		// Create a request
+		req := httptest.NewRequest(http.MethodGet, "/linux/install/app/config", nil)
+		req.Header.Set("Authorization", "Bearer "+"TOKEN")
+		rec := httptest.NewRecorder()
+
+		// Serve the request
+		router.ServeHTTP(rec, req)
+
+		// Check the response
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+		// Parse the response body
+		var response types.AppConfig
+		err = json.NewDecoder(rec.Body).Decode(&response)
+		require.NoError(t, err)
+
+		// Verify the templates were processed
+		assert.Equal(t, "HTTP Configuration", response.Groups[0].Title, "group title should be processed from template")
+		assert.Equal(t, "HTTP PORT", response.Groups[0].Items[0].Title, "item title should be processed from template")
+		assert.Equal(t, "8080", response.Groups[0].Items[0].Value.String(), "item value should be processed from template")
+		assert.Equal(t, "8080", response.Groups[0].Items[0].Default.String(), "item default should be processed from template")
 	})
 }
 

--- a/api/internal/managers/app/config/config.go
+++ b/api/internal/managers/app/config/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/replicatedhq/kotskinds/multitype"
 	"github.com/tiendc/go-deepcopy"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -22,16 +23,34 @@ var (
 	ErrConfigItemRequired = errors.New("item is required")
 )
 
-func (m *appConfigManager) GetConfig(config kotsv1beta1.Config) (kotsv1beta1.Config, error) {
-	return filterAppConfig(config)
+func (m *appConfigManager) GetConfig() (kotsv1beta1.Config, error) {
+	// Convert config to YAML string
+	configYAML, err := yaml.Marshal(m.rawConfig)
+	if err != nil {
+		return kotsv1beta1.Config{}, fmt.Errorf("marshal config to yaml: %w", err)
+	}
+
+	// Process templates in the entire config string
+	processedYAML, err := m.processTemplate(string(configYAML))
+	if err != nil {
+		return kotsv1beta1.Config{}, fmt.Errorf("process config template: %w", err)
+	}
+
+	// Parse back to Config struct
+	var processedConfig kotsv1beta1.Config
+	if err := yaml.Unmarshal([]byte(processedYAML), &processedConfig); err != nil {
+		return kotsv1beta1.Config{}, fmt.Errorf("unmarshal processed config: %w", err)
+	}
+
+	return filterAppConfig(processedConfig)
 }
 
-func (m *appConfigManager) ValidateConfigValues(config kotsv1beta1.Config, configValues map[string]string) error {
+func (m *appConfigManager) ValidateConfigValues(configValues map[string]string) error {
 	var ve *types.APIError
 
-	filteredConfig, err := filterAppConfig(config)
+	filteredConfig, err := m.GetConfig()
 	if err != nil {
-		return fmt.Errorf("filter app config: %w", err)
+		return fmt.Errorf("get config: %w", err)
 	}
 
 	// check required items
@@ -48,7 +67,7 @@ func (m *appConfigManager) ValidateConfigValues(config kotsv1beta1.Config, confi
 }
 
 // PatchConfigValues performs a partial update by merging new values with existing ones
-func (m *appConfigManager) PatchConfigValues(config kotsv1beta1.Config, newValues map[string]string) error {
+func (m *appConfigManager) PatchConfigValues(newValues map[string]string) error {
 	// Get existing values
 	existingValues, err := m.appConfigStore.GetConfigValues()
 	if err != nil {
@@ -60,9 +79,15 @@ func (m *appConfigManager) PatchConfigValues(config kotsv1beta1.Config, newValue
 	maps.Copy(mergedValues, existingValues)
 	maps.Copy(mergedValues, newValues)
 
+	// Get processed config to determine enabled groups and items
+	processedConfig, err := m.GetConfig()
+	if err != nil {
+		return fmt.Errorf("get config: %w", err)
+	}
+
 	// only keep values for enabled groups and items
 	filteredValues := make(map[string]string)
-	for _, g := range config.Spec.Groups {
+	for _, g := range processedConfig.Spec.Groups {
 		for _, i := range g.Items {
 			if isItemEnabled(g.When) && isItemEnabled(i.When) {
 				value, ok := mergedValues[i.Name]
@@ -83,7 +108,7 @@ func (m *appConfigManager) PatchConfigValues(config kotsv1beta1.Config, newValue
 }
 
 // GetConfigValues returns config values with optional password field masking
-func (m *appConfigManager) GetConfigValues(config kotsv1beta1.Config, maskPasswords bool) (map[string]string, error) {
+func (m *appConfigManager) GetConfigValues(maskPasswords bool) (map[string]string, error) {
 	configValues, err := m.appConfigStore.GetConfigValues()
 	if err != nil {
 		return nil, err
@@ -94,12 +119,18 @@ func (m *appConfigManager) GetConfigValues(config kotsv1beta1.Config, maskPasswo
 		return configValues, nil
 	}
 
+	// Get processed config to determine password fields
+	processedConfig, err := m.GetConfig()
+	if err != nil {
+		return nil, fmt.Errorf("get config: %w", err)
+	}
+
 	// Create a copy of the config values to mask password fields
 	maskedValues := make(map[string]string)
 	maps.Copy(maskedValues, configValues)
 
 	// Mask password fields
-	for _, group := range config.Spec.Groups {
+	for _, group := range processedConfig.Spec.Groups {
 		for _, item := range group.Items {
 			if item.Type == "password" {
 				// Mask item
@@ -119,13 +150,13 @@ func (m *appConfigManager) GetConfigValues(config kotsv1beta1.Config, maskPasswo
 	return maskedValues, nil
 }
 
-func (m *appConfigManager) GetKotsadmConfigValues(config kotsv1beta1.Config) (kotsv1beta1.ConfigValues, error) {
-	filteredConfig, err := m.GetConfig(config)
+func (m *appConfigManager) GetKotsadmConfigValues() (kotsv1beta1.ConfigValues, error) {
+	processedConfig, err := m.GetConfig()
 	if err != nil {
 		return kotsv1beta1.ConfigValues{}, fmt.Errorf("get config: %w", err)
 	}
 
-	storedValues, err := m.GetConfigValues(filteredConfig, false)
+	storedValues, err := m.appConfigStore.GetConfigValues()
 	if err != nil {
 		return kotsv1beta1.ConfigValues{}, fmt.Errorf("get config values: %w", err)
 	}
@@ -143,8 +174,8 @@ func (m *appConfigManager) GetKotsadmConfigValues(config kotsv1beta1.Config) (ko
 		},
 	}
 
-	// add values from the filtered config
-	for _, group := range filteredConfig.Spec.Groups {
+	// add values from the processed config
+	for _, group := range processedConfig.Spec.Groups {
 		for _, item := range group.Items {
 			kotsadmConfigValues.Spec.Values[item.Name] = getConfigValueFromItem(item, storedValues)
 

--- a/api/internal/managers/app/config/config_test.go
+++ b/api/internal/managers/app/config/config_test.go
@@ -22,6 +22,113 @@ func TestAppConfigManager_GetConfig(t *testing.T) {
 		expected kotsv1beta1.Config
 	}{
 		{
+			name: "config with template processing",
+			config: kotsv1beta1.Config{
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{
+						{
+							Name:  "templated_group",
+							Title: "{{ print \"HTTP Configuration\" }}",
+							When:  "true",
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name:  "templated_item",
+									Title: "{{ upper \"http enabled\" }}",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "{{ print \"8080\" }}"},
+									When:  "true",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: kotsv1beta1.Config{
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{
+						{
+							Name:  "templated_group",
+							Title: "HTTP Configuration",
+							When:  "true",
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name:  "templated_item",
+									Title: "HTTP ENABLED",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "8080"},
+									When:  "true",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "config with template processing and filtering",
+			config: kotsv1beta1.Config{
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{
+						{
+							Name:  "templated_enabled_group",
+							Title: "{{ print \"Enabled Group\" }}",
+							When:  "true",
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name:  "templated_enabled_item",
+									Title: "{{ printf \"Port: %d\" 8080 }}",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "{{ print \"true\" }}"},
+									When:  "true",
+								},
+								{
+									Name:  "templated_disabled_item",
+									Title: "{{ print \"Disabled Item\" }}",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "{{ print \"false\" }}"},
+									When:  "false",
+								},
+							},
+						},
+						{
+							Name:  "templated_disabled_group",
+							Title: "{{ print \"Disabled Group\" }}",
+							When:  "false",
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name:  "item_in_disabled_group",
+									Title: "{{ print \"Item in Disabled Group\" }}",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "{{ print \"disabled\" }}"},
+									When:  "true",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: kotsv1beta1.Config{
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{
+						{
+							Name:  "templated_enabled_group",
+							Title: "Enabled Group",
+							When:  "true",
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name:  "templated_enabled_item",
+									Title: "Port: 8080",
+									Type:  "text",
+									Value: multitype.BoolOrString{StrVal: "true"},
+									When:  "true",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "conditional filtering with when conditions",
 			config: kotsv1beta1.Config{
 				Spec: kotsv1beta1.ConfigSpec{
@@ -312,10 +419,10 @@ func TestAppConfigManager_GetConfig(t *testing.T) {
 			require.NoError(t, err)
 
 			// Create a new app config manager
-			manager := NewAppConfigManager()
+			manager := NewAppConfigManager(tt.config)
 
 			// Apply values to config
-			result, err := manager.GetConfig(tt.config)
+			result, err := manager.GetConfig()
 
 			// Verify no error occurred
 			require.NoError(t, err)
@@ -1175,6 +1282,47 @@ func TestAppConfigManager_PatchConfigValues(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "config with template processing and filtering",
+			config: kotsv1beta1.Config{
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{
+						{
+							Name:  "templated-group",
+							Title: "{{ upper \"http configuration\" }}",
+							When:  "true",
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name:  "templated-enabled-item",
+									Title: "{{ printf \"Port: %d\" 8080 }}",
+									Type:  "text",
+									When:  "true",
+								},
+								{
+									Name:  "templated-disabled-item",
+									Title: "{{ lower \"DISABLED ITEM\" }}",
+									Type:  "text",
+									When:  "false",
+								},
+							},
+						},
+					},
+				},
+			},
+			newValues: map[string]string{
+				"templated-enabled-item":  "enabled-value",
+				"templated-disabled-item": "disabled-value",
+			},
+			setupMock: func(mockStore *config.MockStore) {
+				mockStore.On("GetConfigValues").Return(map[string]string{}, nil)
+				expectedValues := map[string]string{
+					"templated-enabled-item": "enabled-value",
+					// templated-disabled-item should be filtered out due to when: "false"
+				}
+				mockStore.On("SetConfigValues", expectedValues).Return(nil)
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1184,12 +1332,10 @@ func TestAppConfigManager_PatchConfigValues(t *testing.T) {
 			tt.setupMock(mockStore)
 
 			// Create manager with mock store
-			manager := &appConfigManager{
-				appConfigStore: mockStore,
-			}
+			manager := NewAppConfigManager(tt.config, WithAppConfigStore(mockStore))
 
 			// Call PatchConfigValues
-			err := manager.PatchConfigValues(tt.config, tt.newValues)
+			err := manager.PatchConfigValues(tt.newValues)
 
 			// Verify expectations
 			if tt.wantErr {
@@ -1490,6 +1636,52 @@ func TestAppConfigManager_GetConfigValues(t *testing.T) {
 			expectedValues: nil,
 			wantErr:        true,
 		},
+		{
+			name: "config with template processing and password masking",
+			appConfig: kotsv1beta1.Config{
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{
+						{
+							Name:  "templated-group",
+							Title: "{{ title \"user configuration\" }}",
+							When:  "true",
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name:  "templated-text",
+									Title: "{{ upper \"text field\" }}",
+									Type:  "text",
+									When:  "true",
+								},
+								{
+									Name:  "templated-password",
+									Title: "{{ printf \"Password for %s\" \"admin\" }}",
+									Type:  "password",
+									When:  "true",
+								},
+								{
+									Name:  "disabled-templated-item",
+									Title: "{{ lower \"DISABLED ITEM\" }}",
+									Type:  "text",
+									When:  "false",
+								},
+							},
+						},
+					},
+				},
+			},
+			maskPasswords: true,
+			storeValues: map[string]string{
+				"templated-text":          "text-value",
+				"templated-password":      "secret-password",
+				"disabled-templated-item": "disabled-value",
+			},
+			expectedValues: map[string]string{
+				"templated-text":          "text-value",
+				"templated-password":      PasswordMask,
+				"disabled-templated-item": "disabled-value", // store value is returned even if item is disabled
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1499,12 +1691,10 @@ func TestAppConfigManager_GetConfigValues(t *testing.T) {
 			mockStore.On("GetConfigValues").Return(tt.storeValues, tt.storeError)
 
 			// Create manager with mock store
-			manager := &appConfigManager{
-				appConfigStore: mockStore,
-			}
+			manager := NewAppConfigManager(tt.appConfig, WithAppConfigStore(mockStore))
 
 			// Call GetConfigValues
-			result, err := manager.GetConfigValues(tt.appConfig, tt.maskPasswords)
+			result, err := manager.GetConfigValues(tt.maskPasswords)
 
 			// Verify expectations
 			if tt.wantErr {
@@ -2245,6 +2435,77 @@ func TestAppConfigManager_GetKotsadmConfigValues(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "config with template processing",
+			config: kotsv1beta1.Config{
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{
+						{
+							Name:  "templated-group",
+							Title: "{{ title \"server configuration\" }}",
+							When:  "true",
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name:    "templated-item",
+									Title:   "{{ upper \"http port\" }}",
+									Type:    "text",
+									Value:   multitype.BoolOrString{StrVal: "{{ toString 8080 }}"},
+									Default: multitype.BoolOrString{StrVal: "{{ toString 8080 }}"},
+									When:    "true",
+								},
+								{
+									Name:    "sprig-functions-item",
+									Title:   "{{ printf \"Port: %d\" 9090 }}",
+									Type:    "text",
+									Value:   multitype.BoolOrString{StrVal: "{{ add 9000 90 }}"},
+									Default: multitype.BoolOrString{StrVal: "{{ add 9000 90 }}"},
+									When:    "true",
+								},
+								{
+									Name:    "disabled-templated-item",
+									Title:   "{{ lower \"DISABLED ITEM\" }}",
+									Type:    "text",
+									Value:   multitype.BoolOrString{StrVal: "{{ trim \"  disabled  \" }}"},
+									Default: multitype.BoolOrString{StrVal: "{{ trim \"  disabled  \" }}"},
+									When:    "false",
+								},
+							},
+						},
+					},
+				},
+			},
+			setupMock: func(mockStore *config.MockStore) {
+				storeValues := map[string]string{
+					"templated-item":          "store-overridden-value",
+					"sprig-functions-item":    "store-sprig-value",
+					"disabled-templated-item": "disabled-store-value",
+				}
+				mockStore.On("GetConfigValues").Return(storeValues, nil)
+			},
+			expected: kotsv1beta1.ConfigValues{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kots.io/v1beta1",
+					Kind:       "ConfigValues",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "kots-app-config",
+				},
+				Spec: kotsv1beta1.ConfigValuesSpec{
+					Values: map[string]kotsv1beta1.ConfigValue{
+						"templated-item": {
+							Value:   "store-overridden-value",
+							Default: "8080",
+						},
+						"sprig-functions-item": {
+							Value:   "store-sprig-value",
+							Default: "9090",
+						},
+						// disabled-templated-item should not be present due to when: "false"
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -2254,12 +2515,10 @@ func TestAppConfigManager_GetKotsadmConfigValues(t *testing.T) {
 			tt.setupMock(mockStore)
 
 			// Create manager with mock store
-			manager := &appConfigManager{
-				appConfigStore: mockStore,
-			}
+			manager := NewAppConfigManager(tt.config, WithAppConfigStore(mockStore))
 
 			// Call GetKotsadmConfigValues
-			result, err := manager.GetKotsadmConfigValues(tt.config)
+			result, err := manager.GetKotsadmConfigValues()
 
 			// Verify expectations
 			if tt.wantErr {
@@ -2539,10 +2798,10 @@ func TestValidateConfigValues(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a real appConfigManager instance for testing
-			manager := &appConfigManager{}
+			manager := NewAppConfigManager(tt.config)
 
 			// Run the validation
-			err := manager.ValidateConfigValues(tt.config, tt.configValues)
+			err := manager.ValidateConfigValues(tt.configValues)
 
 			// Check if error is expected
 			if tt.wantErr {

--- a/api/internal/managers/app/config/manager_mock.go
+++ b/api/internal/managers/app/config/manager_mock.go
@@ -13,14 +13,14 @@ type MockAppConfigManager struct {
 }
 
 // GetConfig mocks the GetConfig method
-func (m *MockAppConfigManager) GetConfig(config kotsv1beta1.Config) (kotsv1beta1.Config, error) {
-	args := m.Called(config)
+func (m *MockAppConfigManager) GetConfig() (kotsv1beta1.Config, error) {
+	args := m.Called()
 	return args.Get(0).(kotsv1beta1.Config), args.Error(1)
 }
 
 // GetConfigValues mocks the GetConfigValues method
-func (m *MockAppConfigManager) GetConfigValues(config kotsv1beta1.Config, maskPasswords bool) (map[string]string, error) {
-	args := m.Called(config, maskPasswords)
+func (m *MockAppConfigManager) GetConfigValues(maskPasswords bool) (map[string]string, error) {
+	args := m.Called(maskPasswords)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
@@ -28,19 +28,19 @@ func (m *MockAppConfigManager) GetConfigValues(config kotsv1beta1.Config, maskPa
 }
 
 // ValidateConfigValues mocks the ValidateConfigValues method
-func (m *MockAppConfigManager) ValidateConfigValues(config kotsv1beta1.Config, configValues map[string]string) error {
-	args := m.Called(config, configValues)
+func (m *MockAppConfigManager) ValidateConfigValues(configValues map[string]string) error {
+	args := m.Called(configValues)
 	return args.Error(0)
 }
 
 // PatchConfigValues mocks the PatchConfigValues method
-func (m *MockAppConfigManager) PatchConfigValues(config kotsv1beta1.Config, values map[string]string) error {
-	args := m.Called(config, values)
+func (m *MockAppConfigManager) PatchConfigValues(values map[string]string) error {
+	args := m.Called(values)
 	return args.Error(0)
 }
 
 // GetKotsadmConfigValues mocks the GetKotsadmConfigValues method
-func (m *MockAppConfigManager) GetKotsadmConfigValues(config kotsv1beta1.Config) (kotsv1beta1.ConfigValues, error) {
-	args := m.Called(config)
+func (m *MockAppConfigManager) GetKotsadmConfigValues() (kotsv1beta1.ConfigValues, error) {
+	args := m.Called()
 	return args.Get(0).(kotsv1beta1.ConfigValues), args.Error(1)
 }

--- a/api/internal/managers/app/config/template.go
+++ b/api/internal/managers/app/config/template.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+)
+
+func (m *appConfigManager) processTemplate(configYAML string) (string, error) {
+	if configYAML == "" {
+		return configYAML, nil
+	}
+
+	tmpl, err := m.templateEngine.Parse(configYAML)
+	if err != nil {
+		return "", fmt.Errorf("template parse error: %w", err)
+	}
+
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, nil) // No custom context - vanilla Go templates only
+	if err != nil {
+		return "", fmt.Errorf("template execution error: %w", err)
+	}
+
+	return buf.String(), nil
+}

--- a/api/internal/managers/app/config/template_test.go
+++ b/api/internal/managers/app/config/template_test.go
@@ -1,0 +1,139 @@
+package config
+
+import (
+	"testing"
+
+	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessTemplate(t *testing.T) {
+	// Create a manager using NewAppConfigManager
+	manager := NewAppConfigManager(kotsv1beta1.Config{})
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+		hasError bool
+	}{
+		{
+			name:     "empty input",
+			input:    "",
+			expected: "",
+			hasError: false,
+		},
+		{
+			name:     "no template",
+			input:    "title: HTTP Configuration",
+			expected: "title: HTTP Configuration",
+			hasError: false,
+		},
+		{
+			name:     "simple print template",
+			input:    "title: {{ print \"HTTP Configuration\" }}",
+			expected: "title: HTTP Configuration",
+			hasError: false,
+		},
+		{
+			name:     "printf template",
+			input:    "help: {{ printf \"Port number (default: %d)\" 8080 }}",
+			expected: "help: Port number (default: 8080)",
+			hasError: false,
+		},
+		{
+			name:     "sprig upper function",
+			input:    "title: {{ upper \"http enabled\" }}",
+			expected: "title: HTTP ENABLED",
+			hasError: false,
+		},
+		{
+			name:     "sprig lower function",
+			input:    "title: {{ lower \"HTTP ENABLED\" }}",
+			expected: "title: http enabled",
+			hasError: false,
+		},
+		{
+			name:     "sprig default function",
+			input:    "value: {{ default \"8080\" \"\" }}",
+			expected: "value: 8080",
+			hasError: false,
+		},
+		{
+			name:     "multiple templates",
+			input:    "title: {{ print \"HTTP\" }}\nhelp: {{ printf \"Port %d\" 8080 }}",
+			expected: "title: HTTP\nhelp: Port 8080",
+			hasError: false,
+		},
+		{
+			name:     "invalid template syntax",
+			input:    "title: {{ invalid syntax",
+			expected: "",
+			hasError: true,
+		},
+		{
+			name:     "template execution error",
+			input:    "title: {{ .UnknownField }}",
+			expected: "title: <no value>",
+			hasError: false,
+		},
+		{
+			name: "complex YAML with multiple templates",
+			input: `
+apiVersion: kots.io/v1beta1
+kind: Config
+metadata:
+  name: simple-config
+spec:
+  groups:
+    - name: http_config
+      title: {{ print "HTTP Configuration" }}
+      items:
+      - name: http_enabled
+        title: {{ print "HTTP Enabled" }}
+        type: bool
+        default: {{ print "true" }}
+      - name: http_port
+        title: {{ upper "http port" }}
+        type: text
+        default: {{ print "8080" }}
+        help: {{ printf "Port number (default: %d)" 8080 }}
+`,
+			expected: `
+apiVersion: kots.io/v1beta1
+kind: Config
+metadata:
+  name: simple-config
+spec:
+  groups:
+    - name: http_config
+      title: HTTP Configuration
+      items:
+      - name: http_enabled
+        title: HTTP Enabled
+        type: bool
+        default: true
+      - name: http_port
+        title: HTTP PORT
+        type: text
+        default: 8080
+        help: Port number (default: 8080)
+`,
+			hasError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := manager.processTemplate(tt.input)
+			
+			if tt.hasError {
+				assert.Error(t, err)
+				assert.Empty(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Adds support for Go templating with Sprig functions for the app kotsv1beta1.Config resource. This allows dynamic configuration using template expressions like {{ upper "text" }}, {{ add 9000 90 }}, and {{printf "Port: %d" 8080 }} in the config. The AppConfigManager now stores the raw config internally and processes templates on-demand.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-126445](https://app.shortcut.com/replicated/story/126445)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Yes

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE