### PR TITLE
chore(ci): conditionally run e2e tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -217,11 +217,34 @@ jobs:
           name: buildtools
           path: output/bin/buildtools
 
+  should-run-e2e:
+    name: Should run e2e
+    runs-on: ubuntu-latest
+    outputs:
+      run-e2e: ${{ steps.changed-files.outputs.e2e_any_changed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v46.0.5
+        with:
+          files_yaml: |
+            e2e:
+              - e2e/**
+            src:
+              - '**'
+              - '!api/**'
+              - 'api/types/**'
+
   build-current:
     name: Build current
     runs-on: ubuntu-latest
     needs:
       - git-sha
+      - should-run-e2e
+    if: needs.should-run-e2e.outputs.run-e2e == 'true'
     outputs:
       k0s_version: ${{ steps.export.outputs.k0s_version }}
     steps:
@@ -301,6 +324,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - git-sha
+      - should-run-e2e
+    if: needs.should-run-e2e.outputs.run-e2e == 'true'
     outputs:
       k0s_version: ${{ steps.export.outputs.k0s_version }}
     steps:
@@ -381,6 +406,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - git-sha
+      - should-run-e2e
+    if: needs.should-run-e2e.outputs.run-e2e == 'true'
     outputs:
       ec_version: ${{ steps.export.outputs.ec_version }}
       k0s_version: ${{ steps.export.outputs.k0s_version }}
@@ -415,6 +442,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - git-sha
+      - should-run-e2e
+    if: needs.should-run-e2e.outputs.run-e2e == 'true'
     outputs:
       k0s_version: ${{ steps.export.outputs.k0s_version }}
     steps:
@@ -786,7 +815,7 @@ jobs:
         run: |
           make e2e-test TEST_NAME=${{ matrix.test }}
       - name: Troubleshoot
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() }} && ${{ needs.should-run-e2e.outputs.run-e2e }}
         uses: ./.github/actions/e2e-troubleshoot
         with:
           test-name: "${{ matrix.test }}"
@@ -908,13 +937,13 @@ jobs:
     steps:
       # https://docs.github.com/en/actions/learn-github-actions/contexts#needs-context
       - name: fail if e2e job was not successful
-        if: needs.e2e.result != 'success'
+        if: needs.e2e.result != 'success' && needs.e2e.result != 'skipped'
         run: exit 1
       - name: fail if e2e-main job was not successful
         if: needs.e2e-main.result != 'success' && needs.e2e-main.result != 'skipped'
         run: exit 1
       - name: fail if e2e-docker job was not successful
-        if: needs.e2e-docker.result != 'success'
+        if: needs.e2e-docker.result != 'success' && needs.e2e-docker.result != 'skipped'
         run: exit 1
       - name: fail if sanitize job was not successful
         if: needs.sanitize.result != 'success'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -221,7 +221,7 @@ jobs:
     name: Should run e2e
     runs-on: ubuntu-latest
     outputs:
-      run-e2e: ${{ steps.changed-files.outputs.e2e_any_changed }}
+      run-e2e: ${{ steps.changed-files.outputs.any_changed }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -246,6 +246,9 @@ jobs:
               - 'go.{mod,sum}'
             build:
               - 'Makefile'
+              - 'common.mk'
+              - 'local-artifact-mirror/**'
+              - 'dagger/**'
 
   build-current:
     name: Build current

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
           cd web
           npm run test:unit
 
-  test:
+  unit-tests:
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
@@ -935,7 +935,7 @@ jobs:
       - e2e-main
       - e2e-docker
       - sanitize
-      - test
+      - unit-tests
       - int-tests
       - web-tests
       - dryrun-tests
@@ -957,8 +957,17 @@ jobs:
       - name: fail if sanitize job was not successful
         if: needs.sanitize.result != 'success'
         run: exit 1
-      - name: fail if test job was not successful
-        if: needs.test.result != 'success'
+      - name: fail if unit-tests job was not successful
+        if: needs.unit-tests.result != 'success'
+        run: exit 1
+      - name: fail if int-tests job was not successful
+        if: needs.int-tests.result != 'success'
+        run: exit 1
+      - name: fail if web-tests job was not successful
+        if: needs.web-tests.result != 'success'
+        run: exit 1
+      - name: fail if dryrun-tests job was not successful
+        if: needs.dryrun-tests.result != 'success'
         run: exit 1
       - name: fail if check-images job was not successful
         if: needs.check-images.result != 'success'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -237,18 +237,21 @@ jobs:
               - 'api/*.go'
               - 'api/types/**'
               - 'api/pkg/**'
+              - 'cmd/**'
               - 'kinds/**'
               - 'operator/**'
               - 'pkg/**'
               - 'pkg-new/**'
-              - 'scripts/**'
               - 'utils/**'
               - 'go.{mod,sum}'
             build:
               - 'Makefile'
               - 'common.mk'
-              - 'local-artifact-mirror/**'
               - 'dagger/**'
+              - 'deploy/**'
+              - 'fio/**'
+              - 'local-artifact-mirror/**'
+              - 'scripts/**'
 
   build-current:
     name: Build current

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -826,7 +826,7 @@ jobs:
         run: |
           make e2e-test TEST_NAME=${{ matrix.test }}
       - name: Troubleshoot
-        if: ${{ !cancelled() }} && ${{ needs.should-run-e2e.outputs.run-e2e }}
+        if: ${{ !cancelled() }}
         uses: ./.github/actions/e2e-troubleshoot
         with:
           test-name: "${{ matrix.test }}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -252,8 +252,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - git-sha
-      - should-run-e2e
-    if: needs.should-run-e2e.outputs.run-e2e == 'true'
     outputs:
       k0s_version: ${{ steps.export.outputs.k0s_version }}
     steps:
@@ -572,6 +570,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - git-sha
+      - should-run-e2e
+    if: needs.should-run-e2e.outputs.run-e2e == 'true'
     outputs:
       version_specifier: ${{ steps.export-version-specifier.outputs.version_specifier }}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -252,6 +252,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - git-sha
+      - should-run-e2e
+    if: needs.should-run-e2e.outputs.run-e2e == 'true'
     outputs:
       k0s_version: ${{ steps.export.outputs.k0s_version }}
     steps:
@@ -970,7 +972,7 @@ jobs:
         if: needs.dryrun-tests.result != 'success'
         run: exit 1
       - name: fail if check-images job was not successful
-        if: needs.check-images.result != 'success'
+        if: needs.check-images.result != 'success' && needs.check-images.result != 'skipped'
         run: exit 1
       - name: fail if check-operator-crds job was not successful
         if: needs.check-operator-crds.result != 'success'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -234,7 +234,9 @@ jobs:
             e2e:
               - e2e/**
             gosrc:
+              - 'api/*.go'
               - 'api/types/**'
+              - 'api/pkg/**'
               - 'kinds/**'
               - 'operator/**'
               - 'pkg/**'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -233,10 +233,17 @@ jobs:
           files_yaml: |
             e2e:
               - e2e/**
-            src:
-              - '**'
-              - '!api/**'
+            gosrc:
               - 'api/types/**'
+              - 'kinds/**'
+              - 'operator/**'
+              - 'pkg/**'
+              - 'pkg-new/**'
+              - 'scripts/**'
+              - 'utils/**'
+              - 'go.{mod,sum}'
+            build:
+              - 'Makefile'
 
   build-current:
     name: Build current


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

E2E tests do not yet test the new V3 manager experience yet we run them on all changes. This change skips E2E tests when there are only changes to the ./api directory.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
