### PR TITLE
try to resolve relative data dir paths

### DIFF
--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -503,7 +503,12 @@ func preRunInstallLinux(cmd *cobra.Command, flags *InstallCmdFlags, rc runtimeco
 	}
 
 	// TODO: validate that a single port isn't used for multiple services
-	rc.SetDataDir(flags.dataDir)
+	// resolve datadir to absolute path
+	AbsoluteDataDir, err := filepath.Abs(flags.dataDir)
+	if err != nil {
+		return fmt.Errorf("unable to construct path for directory: %w", err)
+	}
+	rc.SetDataDir(AbsoluteDataDir)
 	rc.SetLocalArtifactMirrorPort(flags.localArtifactMirrorPort)
 	rc.SetHostCABundlePath(hostCABundlePath)
 	rc.SetNetworkSpec(networkSpec)

--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -508,7 +508,7 @@ func preRunInstallLinux(cmd *cobra.Command, flags *InstallCmdFlags, rc runtimeco
 	if err != nil {
 		return fmt.Errorf("unable to construct path for directory: %w", err)
 	}
-	rc.SetDataDir(AbsoluteDataDir)
+	rc.SetDataDir(absoluteDataDir)
 	rc.SetLocalArtifactMirrorPort(flags.localArtifactMirrorPort)
 	rc.SetHostCABundlePath(hostCABundlePath)
 	rc.SetNetworkSpec(networkSpec)

--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -504,7 +504,7 @@ func preRunInstallLinux(cmd *cobra.Command, flags *InstallCmdFlags, rc runtimeco
 
 	// TODO: validate that a single port isn't used for multiple services
 	// resolve datadir to absolute path
-	AbsoluteDataDir, err := filepath.Abs(flags.dataDir)
+	absoluteDataDir, err := filepath.Abs(flags.dataDir)
 	if err != nil {
 		return fmt.Errorf("unable to construct path for directory: %w", err)
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

If you specify a relative path to the embedded cluster installer's `--data-dir` flag, the install will fail when starting the LAM service. we should resolve the path given to us to an absolute path to avoid ever dealing with relative paths. 

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixed an issue where specifying a relative path to the installer's --data-dir flag would cause the installation to fail when starting the LAM service. Paths provided to --data-dir are now resolved to absolute paths, avoiding problems related to relative directory references.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
