### PR TITLE
feat(app): add support for the file type item

### DIFF
--- a/api/integration/kubernetes/install/app_test.go
+++ b/api/integration/kubernetes/install/app_test.go
@@ -211,6 +211,14 @@ func TestKubernetesPatchAppConfigValues(t *testing.T) {
 							Title:    "Required Item",
 							Required: true,
 						},
+						{
+							Name:     "file-item",
+							Type:     "file",
+							Title:    "File Item",
+							Filename: "file.txt",
+							Default:  multitype.BoolOrString{StrVal: "SGVsbG8="},
+							Value:    multitype.BoolOrString{StrVal: "QQ=="},
+						},
 					},
 				},
 			},
@@ -243,6 +251,7 @@ func TestKubernetesPatchAppConfigValues(t *testing.T) {
 			Values: types.AppConfigValues{
 				"test-item":     types.AppConfigValue{Value: "new-value"},
 				"required-item": types.AppConfigValue{Value: "required-value"},
+				"file-item":     types.AppConfigValue{Value: "SGVsbG8gV29ybGQ=", Filename: "new-file.txt"},
 			},
 		}
 
@@ -270,6 +279,8 @@ func TestKubernetesPatchAppConfigValues(t *testing.T) {
 		// Verify the raw app config is returned
 		assert.Equal(t, "value", response.Groups[0].Items[0].Value.String(), "first item should return raw config schema value")
 		assert.Equal(t, "value2", response.Groups[0].Items[1].Value.String(), "second item should return raw config schema value")
+		assert.Equal(t, "QQ==", response.Groups[0].Items[3].Value.String(), "fourth item should return raw config schema value for file")
+		assert.Equal(t, "file.txt", response.Groups[0].Items[3].Filename, "fourth item should contain a filename")
 	})
 
 	// Test authorization
@@ -451,6 +462,14 @@ func TestKubernetesGetAppConfigValues(t *testing.T) {
 							Default: multitype.BoolOrString{StrVal: "default"},
 							Value:   multitype.BoolOrString{StrVal: "value"},
 						},
+						{
+							Name:     "file-item",
+							Type:     "file",
+							Title:    "File Item",
+							Filename: "file.txt",
+							Default:  multitype.BoolOrString{StrVal: "SGVsbG8="},
+							Value:    multitype.BoolOrString{StrVal: "QQ=="},
+						},
 					},
 				},
 			},
@@ -460,6 +479,7 @@ func TestKubernetesGetAppConfigValues(t *testing.T) {
 	// Create config values that should be applied to the config
 	configValues := types.AppConfigValues{
 		"test-item": types.AppConfigValue{Value: "applied-value"},
+		"file-item": types.AppConfigValue{Value: "SGVsbG8gV29ybGQ=", Filename: "new-file.txt"},
 	}
 
 	// Create an install controller with the config values
@@ -550,6 +570,14 @@ func TestInstallController_PatchAppConfigValuesWithAPIClient(t *testing.T) {
 							Title:    "Required Item",
 							Required: true,
 						},
+						{
+							Name:     "file-item",
+							Type:     "file",
+							Title:    "File Item",
+							Filename: "file.txt",
+							Default:  multitype.BoolOrString{StrVal: "SGVsbG8="},
+							Value:    multitype.BoolOrString{StrVal: "QQ=="},
+						},
 					},
 				},
 			},
@@ -590,6 +618,7 @@ func TestInstallController_PatchAppConfigValuesWithAPIClient(t *testing.T) {
 		configValues := types.AppConfigValues{
 			"test-item":     types.AppConfigValue{Value: "new-value"},
 			"required-item": types.AppConfigValue{Value: "required-value"},
+			"file-item":     types.AppConfigValue{Value: "SGVsbG8gV29ybGQ=", Filename: "new-file.txt"},
 		}
 
 		// Set the app config values using the client
@@ -599,6 +628,8 @@ func TestInstallController_PatchAppConfigValuesWithAPIClient(t *testing.T) {
 		// Verify the raw app config is returned (not the applied values)
 		assert.Equal(t, "value", config.Groups[0].Items[0].Value.String(), "first item should return raw config schema value")
 		assert.Equal(t, "", config.Groups[0].Items[1].Value.String(), "second item should return empty value since it has no default")
+		assert.Equal(t, "QQ==", config.Groups[0].Items[2].Value.String(), "third item should return raw config schema value for file")
+		assert.Equal(t, "file.txt", config.Groups[0].Items[2].Filename, "third item should contain a filename")
 	})
 
 	// Test PatchKubernetesAppConfigValues with missing required item
@@ -687,6 +718,14 @@ func TestInstallController_GetAppConfigValuesWithAPIClient(t *testing.T) {
 							Default: multitype.BoolOrString{StrVal: "default"},
 							Value:   multitype.BoolOrString{StrVal: "value"},
 						},
+						{
+							Name:     "file-item",
+							Type:     "file",
+							Title:    "File Item",
+							Filename: "file.txt",
+							Default:  multitype.BoolOrString{StrVal: "SGVsbG8="},
+							Value:    multitype.BoolOrString{StrVal: "QQ=="},
+						},
 					},
 				},
 			},
@@ -696,6 +735,7 @@ func TestInstallController_GetAppConfigValuesWithAPIClient(t *testing.T) {
 	// Create config values that should be applied to the config
 	configValues := types.AppConfigValues{
 		"test-item": types.AppConfigValue{Value: "applied-value"},
+		"file-item": types.AppConfigValue{Value: "SGVsbG8gV29ybGQ=", Filename: "new-file.txt"},
 	}
 
 	// Create an install controller with the config values

--- a/api/integration/linux/install/app_test.go
+++ b/api/integration/linux/install/app_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	_ "embed"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -211,6 +212,14 @@ func TestLinuxPatchAppConfigValues(t *testing.T) {
 							Title:    "Required Item",
 							Required: true,
 						},
+						{
+							Name:     "file-item",
+							Type:     "file",
+							Title:    "File Item",
+							Filename: "file.txt",
+							Default:  multitype.BoolOrString{StrVal: "SGVsbG8="},
+							Value:    multitype.BoolOrString{StrVal: "QQ=="},
+						},
 					},
 				},
 			},
@@ -244,6 +253,7 @@ func TestLinuxPatchAppConfigValues(t *testing.T) {
 			Values: types.AppConfigValues{
 				"test-item":     types.AppConfigValue{Value: "new-value"},
 				"required-item": types.AppConfigValue{Value: "required-value"},
+				"file-item":     types.AppConfigValue{Value: "SGVsbG8gV29ybGQ=", Filename: "new-file.txt"},
 			},
 		}
 
@@ -267,10 +277,13 @@ func TestLinuxPatchAppConfigValues(t *testing.T) {
 		var response types.AppConfig
 		err = json.NewDecoder(rec.Body).Decode(&response)
 		require.NoError(t, err)
+		fmt.Printf("Response: %+v\n", response.Groups[0].Items)
 
 		// Verify the raw app config is returned
 		assert.Equal(t, "value", response.Groups[0].Items[0].Value.String(), "first item should return raw config schema value")
 		assert.Equal(t, "value2", response.Groups[0].Items[1].Value.String(), "second item should return raw config schema value")
+		assert.Equal(t, "QQ==", response.Groups[0].Items[3].Value.String(), "fourth item should return raw config schema value for file")
+		assert.Equal(t, "file.txt", response.Groups[0].Items[3].Filename, "fourth item should contain a filename")
 	})
 
 	// Test authorization
@@ -453,6 +466,14 @@ func TestLinuxGetAppConfigValues(t *testing.T) {
 							Default: multitype.BoolOrString{StrVal: "default"},
 							Value:   multitype.BoolOrString{StrVal: "value"},
 						},
+						{
+							Name:     "file-item",
+							Type:     "file",
+							Title:    "File Item",
+							Filename: "file.txt",
+							Default:  multitype.BoolOrString{StrVal: "SGVsbG8="},
+							Value:    multitype.BoolOrString{StrVal: "QQ=="},
+						},
 					},
 				},
 			},
@@ -462,6 +483,7 @@ func TestLinuxGetAppConfigValues(t *testing.T) {
 	// Create config values that should be applied to the config
 	configValues := types.AppConfigValues{
 		"test-item": types.AppConfigValue{Value: "applied-value"},
+		"file-item": types.AppConfigValue{Value: "SGVsbG8gV29ybGQ=", Filename: "new-file.txt"},
 	}
 
 	// Create an install controller with the config values
@@ -552,6 +574,14 @@ func TestInstallController_PatchAppConfigValuesWithAPIClient(t *testing.T) {
 							Title:    "Required Item",
 							Required: true,
 						},
+						{
+							Name:     "file-item",
+							Type:     "file",
+							Title:    "File Item",
+							Filename: "file.txt",
+							Default:  multitype.BoolOrString{StrVal: "SGVsbG8="},
+							Value:    multitype.BoolOrString{StrVal: "QQ=="},
+						},
 					},
 				},
 			},
@@ -592,6 +622,7 @@ func TestInstallController_PatchAppConfigValuesWithAPIClient(t *testing.T) {
 		configValues := types.AppConfigValues{
 			"test-item":     types.AppConfigValue{Value: "new-value"},
 			"required-item": types.AppConfigValue{Value: "required-value"},
+			"file-item":     types.AppConfigValue{Value: "SGVsbG8gV29ybGQ=", Filename: "new-file.txt"},
 		}
 
 		// Set the app config values using the client
@@ -601,6 +632,8 @@ func TestInstallController_PatchAppConfigValuesWithAPIClient(t *testing.T) {
 		// Verify the raw app config is returned (not the applied values)
 		assert.Equal(t, "value", config.Groups[0].Items[0].Value.String(), "first item should return raw config schema value")
 		assert.Equal(t, "", config.Groups[0].Items[1].Value.String(), "second item should return empty value since it has no default")
+		assert.Equal(t, "QQ==", config.Groups[0].Items[2].Value.String(), "third item should return raw config schema value for file")
+		assert.Equal(t, "file.txt", config.Groups[0].Items[2].Filename, "third item should contain a filename")
 	})
 
 	// Test PatchLinuxAppConfigValues with missing required item
@@ -689,6 +722,14 @@ func TestInstallController_GetAppConfigValuesWithAPIClient(t *testing.T) {
 							Default: multitype.BoolOrString{StrVal: "default"},
 							Value:   multitype.BoolOrString{StrVal: "value"},
 						},
+						{
+							Name:     "file-item",
+							Type:     "file",
+							Title:    "File Item",
+							Filename: "file.txt",
+							Default:  multitype.BoolOrString{StrVal: "SGVsbG8="},
+							Value:    multitype.BoolOrString{StrVal: "QQ=="},
+						},
 					},
 				},
 			},
@@ -698,6 +739,7 @@ func TestInstallController_GetAppConfigValuesWithAPIClient(t *testing.T) {
 	// Create config values that should be applied to the config
 	configValues := types.AppConfigValues{
 		"test-item": types.AppConfigValue{Value: "applied-value"},
+		"file-item": types.AppConfigValue{Value: "SGVsbG8gV29ybGQ=", Filename: "new-file.txt"},
 	}
 
 	// Create an install controller with the config values

--- a/api/integration/linux/install/app_test.go
+++ b/api/integration/linux/install/app_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	_ "embed"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -277,7 +276,6 @@ func TestLinuxPatchAppConfigValues(t *testing.T) {
 		var response types.AppConfig
 		err = json.NewDecoder(rec.Body).Decode(&response)
 		require.NoError(t, err)
-		fmt.Printf("Response: %+v\n", response.Groups[0].Items)
 
 		// Verify the raw app config is returned
 		assert.Equal(t, "value", response.Groups[0].Items[0].Value.String(), "first item should return raw config schema value")

--- a/api/internal/managers/app/config/config.go
+++ b/api/internal/managers/app/config/config.go
@@ -309,6 +309,7 @@ func isFileType(item kotsv1beta1.ConfigItem) bool {
 	return item.Type == "file"
 }
 
+// isValueBase64Encoded checks if the value of a ConfigValue is base64 encoded, this is used for file items
 func isValueBase64Encoded(configValue kotsv1beta1.ConfigValue) bool {
 	if configValue.Value == "" {
 		return true // empty values are considered valid

--- a/api/internal/managers/app/config/config.go
+++ b/api/internal/managers/app/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"maps"
@@ -21,6 +22,8 @@ const (
 var (
 	// ErrConfigItemRequired is returned when a required item is not set
 	ErrConfigItemRequired = errors.New("item is required")
+	// ErrValueNotBase64Encoded is returned when a file item value is not base64 encoded
+	ErrValueNotBase64Encoded = errors.New("value must be base64 encoded for file items")
 )
 
 func (m *appConfigManager) GetConfig() (kotsv1beta1.Config, error) {
@@ -47,12 +50,16 @@ func (m *appConfigManager) ValidateConfigValues(configValues types.AppConfigValu
 		return fmt.Errorf("get config: %w", err)
 	}
 
-	// check required items
 	for _, group := range processedConfig.Spec.Groups {
 		for _, item := range group.Items {
 			configValue := getConfigValueFromItem(item, configValues)
+			// check required items
 			if isRequiredItem(item) && isUnsetItem(configValue) {
 				ve = types.AppendFieldError(ve, item.Name, ErrConfigItemRequired)
+			}
+			// check value is base64 encoded for file items
+			if isFileType(item) && !isValueBase64Encoded(configValue) {
+				ve = types.AppendFieldError(ve, item.Name, ErrValueNotBase64Encoded)
 			}
 		}
 	}
@@ -182,7 +189,7 @@ func (m *appConfigManager) GetKotsadmConfigValues() (kotsv1beta1.ConfigValues, e
 			kotsadmConfigValues.Spec.Values[item.Name] = getConfigValueFromItem(item, storedValues)
 
 			for _, childItem := range item.Items {
-				kotsadmConfigValues.Spec.Values[childItem.Name] = getConfigValueFromChildItem(item.Type, childItem, storedValues)
+				kotsadmConfigValues.Spec.Values[childItem.Name] = getConfigValueFromChildItem(item, childItem, storedValues)
 			}
 		}
 	}
@@ -190,48 +197,56 @@ func (m *appConfigManager) GetKotsadmConfigValues() (kotsv1beta1.ConfigValues, e
 	return kotsadmConfigValues, nil
 }
 
-func getConfigValueFromItem(item kotsv1beta1.ConfigItem, configValues types.AppConfigValues) kotsv1beta1.ConfigValue {
-	configValue := kotsv1beta1.ConfigValue{
-		Default: item.Default.String(),
-	}
-	if item.Type == "password" {
-		configValue.ValuePlaintext = item.Value.String()
+// setConfigValueByType sets either Value or ValuePlaintext based on the item type
+func setConfigValueByType(cv *kotsv1beta1.ConfigValue, itemType string, value string) {
+	if itemType == "password" {
+		cv.ValuePlaintext = value
 	} else {
-		configValue.Value = item.Value.String()
+		cv.Value = value
+	}
+}
+
+// applyStoredValueOverride applies stored values from configValues if they exist
+func applyStoredValueOverride(cv *kotsv1beta1.ConfigValue, itemType string, itemName string, configValues types.AppConfigValues) {
+	if v, ok := configValues[itemName]; ok {
+		setConfigValueByType(cv, itemType, v.Value)
+		cv.Filename = v.Filename
+	}
+}
+
+// createConfigValue creates a ConfigValue with the given parameters and applies overrides
+func createConfigValue(defaultValue, initialValue, itemType, filename, itemName string, configValues types.AppConfigValues) kotsv1beta1.ConfigValue {
+	configValue := kotsv1beta1.ConfigValue{
+		Default:  defaultValue,
+		Filename: filename,
 	}
 
-	// override values from the config values store
-	if v, ok := configValues[item.Name]; ok {
-		if item.Type == "password" {
-			configValue.ValuePlaintext = v.Value
-		} else {
-			configValue.Value = v.Value
-		}
-	}
+	setConfigValueByType(&configValue, itemType, initialValue)
+	applyStoredValueOverride(&configValue, itemType, itemName, configValues)
 
 	return configValue
 }
 
-func getConfigValueFromChildItem(itemType string, childItem kotsv1beta1.ConfigChildItem, configValues types.AppConfigValues) kotsv1beta1.ConfigValue {
-	configValue := kotsv1beta1.ConfigValue{
-		Default: childItem.Default.String(),
-	}
-	if itemType == "password" {
-		configValue.ValuePlaintext = childItem.Value.String()
-	} else {
-		configValue.Value = childItem.Value.String()
-	}
+func getConfigValueFromItem(item kotsv1beta1.ConfigItem, configValues types.AppConfigValues) kotsv1beta1.ConfigValue {
+	return createConfigValue(
+		item.Default.String(),
+		item.Value.String(),
+		item.Type,
+		item.Filename,
+		item.Name,
+		configValues,
+	)
+}
 
-	// override values from the config values store
-	if v, ok := configValues[childItem.Name]; ok {
-		if itemType == "password" {
-			configValue.ValuePlaintext = v.Value
-		} else {
-			configValue.Value = v.Value
-		}
-	}
-
-	return configValue
+func getConfigValueFromChildItem(item kotsv1beta1.ConfigItem, childItem kotsv1beta1.ConfigChildItem, configValues types.AppConfigValues) kotsv1beta1.ConfigValue {
+	return createConfigValue(
+		childItem.Default.String(),
+		childItem.Value.String(),
+		item.Type,
+		item.Filename,
+		childItem.Name,
+		configValues,
+	)
 }
 
 // filterAppConfig filters out disabled groups and items based on their 'when' condition
@@ -287,4 +302,19 @@ func isRequiredItem(item kotsv1beta1.ConfigItem) bool {
 func isUnsetItem(configValue kotsv1beta1.ConfigValue) bool {
 	// TODO: repeatable items
 	return configValue.Value == "" && configValue.Default == ""
+}
+
+// isFileType checks if the item type is "file"
+func isFileType(item kotsv1beta1.ConfigItem) bool {
+	return item.Type == "file"
+}
+
+func isValueBase64Encoded(configValue kotsv1beta1.ConfigValue) bool {
+	if configValue.Value == "" {
+		return true // empty values are considered valid
+	}
+	if _, err := base64.StdEncoding.DecodeString(configValue.Value); err != nil {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
This PR adds actual support for the config item file type, validating the its value and setting the correct `Filename` property based on pre-existing values or the parent item filename.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
Closes https://app.shortcut.com/replicated/story/126680/add-file-config-item-type-backend-foundation

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Yes

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE