### PR TITLE
bug: Fix markdown paragraph and line breaks

### DIFF
--- a/web/src/components/common/HelpText.tsx
+++ b/web/src/components/common/HelpText.tsx
@@ -10,16 +10,16 @@ interface HelpTextProps {
 
 const HelpText: React.FC<HelpTextProps> = ({ helpText, defaultValue, error }) => {
   if ((!helpText && !defaultValue) || error) return null;
-  
+
   // Build the combined text with markdown formatting
   let combinedText = helpText || '';
   if (defaultValue) {
     const defaultText = `(Default: \`${defaultValue}\`)`;
     combinedText = helpText ? `${helpText} ${defaultText}` : defaultText;
   }
-  
+
   return (
-    <div className="mt-1 text-sm text-gray-500">
+    <div className="mt-1 text-sm text-gray-500 [&_p]:inline [&_p]:mb-0">
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
@@ -36,7 +36,6 @@ const HelpText: React.FC<HelpTextProps> = ({ helpText, defaultValue, error }) =>
               {children}
             </code>
           ),
-          p: ({ children }) => <span>{children}</span>, // Render as span instead of paragraph
         }}
       >
         {combinedText}

--- a/web/src/components/common/Label.tsx
+++ b/web/src/components/common/Label.tsx
@@ -32,7 +32,6 @@ const Label: React.FC<LabelProps> = ({
                 {children}
               </code>
             ),
-            p: ({ children }) => <span>{children}</span>,
           }}
         >
           {content}

--- a/web/src/components/common/tests/HelpText.test.tsx
+++ b/web/src/components/common/tests/HelpText.test.tsx
@@ -69,12 +69,13 @@ describe('HelpText', () => {
     expect(screen.getByText('default-value')).toBeInTheDocument();
   });
 
-  it('renders as span instead of paragraph', () => {
+  it('renders paragraphs with inline styling', () => {
     const { container } = render(<HelpText helpText="Help text" />);
-    // The ReactMarkdown should render p tags as spans based on our custom components
-    const spans = container.querySelectorAll('span');
-    expect(spans.length).toBeGreaterThan(0);
+    // The ReactMarkdown should render p tags with inline styling via CSS
     const paragraphs = container.querySelectorAll('p');
-    expect(paragraphs.length).toBe(0);
+    expect(paragraphs.length).toBeGreaterThan(0);
+    // Check that the container has the inline styling classes
+    const helpDiv = container.querySelector('div');
+    expect(helpDiv).toHaveClass('[&_p]:inline', '[&_p]:mb-0');
   });
 });


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Fixes rendering of markdown new paragraphs and line breaks for Label and Help Text components


#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/126828/fix-markdown-handling-of-new-paragraphs-and-line-breaks

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Tests were updated

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE

Screenshots post changes:
<img width="478" height="207" alt="image" src="https://github.com/user-attachments/assets/5af63f54-19a4-4121-9cd0-6467bd8d9eae" />

<img width="531" height="114" alt="image" src="https://github.com/user-attachments/assets/0c9b0048-1dad-460c-a871-e635206e1dcb" />

