### PR TITLE
chore: use official calico images

### DIFF
--- a/cmd/buildtools/k0s.go
+++ b/cmd/buildtools/k0s.go
@@ -21,29 +21,38 @@ var k0sImageComponents = map[string]addonComponent{
 	},
 	"quay.io/k0sproject/calico-node": {
 		name: "calico-node",
-		getWolfiPackageName: func(opts addonComponentOptions) string {
-			return "calico-node"
-		},
-		getWolfiPackageVersion: func(opts addonComponentOptions) string {
-			return getCalicoVersion(opts)
+		getCustomImageName: func(opts addonComponentOptions) (string, error) {
+			// latest patch version of the current minor version
+			constraints := mustParseSemverConstraints(latestPatchConstraint(opts.upstreamVersion))
+			tag, err := GetGreatestGitHubTag(opts.ctx, "projectcalico", "calico", constraints)
+			if err != nil {
+				return "", fmt.Errorf("failed to get gh release: %w", err)
+			}
+			return fmt.Sprintf("docker.io/calico/node:%s", tag), nil
 		},
 	},
 	"quay.io/k0sproject/calico-cni": {
 		name: "calico-cni",
-		getWolfiPackageName: func(opts addonComponentOptions) string {
-			return "calico-cni"
-		},
-		getWolfiPackageVersion: func(opts addonComponentOptions) string {
-			return getCalicoVersion(opts)
+		getCustomImageName: func(opts addonComponentOptions) (string, error) {
+			// latest patch version of the current minor version
+			constraints := mustParseSemverConstraints(latestPatchConstraint(opts.upstreamVersion))
+			tag, err := GetGreatestGitHubTag(opts.ctx, "projectcalico", "calico", constraints)
+			if err != nil {
+				return "", fmt.Errorf("failed to get gh release: %w", err)
+			}
+			return fmt.Sprintf("docker.io/calico/cni:%s", tag), nil
 		},
 	},
 	"quay.io/k0sproject/calico-kube-controllers": {
 		name: "calico-kube-controllers",
-		getWolfiPackageName: func(opts addonComponentOptions) string {
-			return "calico-kube-controllers"
-		},
-		getWolfiPackageVersion: func(opts addonComponentOptions) string {
-			return getCalicoVersion(opts)
+		getCustomImageName: func(opts addonComponentOptions) (string, error) {
+			// latest patch version of the current minor version
+			constraints := mustParseSemverConstraints(latestPatchConstraint(opts.upstreamVersion))
+			tag, err := GetGreatestGitHubTag(opts.ctx, "projectcalico", "calico", constraints)
+			if err != nil {
+				return "", fmt.Errorf("failed to get gh release: %w", err)
+			}
+			return fmt.Sprintf("docker.io/calico/kube-controllers:%s", tag), nil
 		},
 	},
 	"registry.k8s.io/metrics-server/metrics-server": {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Use official calico images rather than wolfi images as the 3.28 images are too out of date.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
