### PR TITLE
Jgantunes/sc 126775/UI config values do not persist

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -18,7 +18,7 @@ type Client interface {
 	GetLinuxInfraStatus() (types.Infra, error)
 	GetLinuxAppConfig() (types.AppConfig, error)
 	GetLinuxAppConfigValues() (types.AppConfigValues, error)
-	PatchLinuxAppConfigValues(types.AppConfigValues) (types.AppConfig, error)
+	PatchLinuxAppConfigValues(types.AppConfigValues) (types.AppConfigValues, error)
 
 	GetKubernetesInstallationConfig() (types.KubernetesInstallationConfig, error)
 	ConfigureKubernetesInstallation(config types.KubernetesInstallationConfig) (types.Status, error)
@@ -27,7 +27,7 @@ type Client interface {
 	GetKubernetesInfraStatus() (types.Infra, error)
 	GetKubernetesAppConfig() (types.AppConfig, error)
 	GetKubernetesAppConfigValues() (types.AppConfigValues, error)
-	PatchKubernetesAppConfigValues(types.AppConfigValues) (types.AppConfig, error)
+	PatchKubernetesAppConfigValues(types.AppConfigValues) (types.AppConfigValues, error)
 }
 
 type client struct {

--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -860,23 +860,9 @@ func TestKubernetesGetAppConfigValues(t *testing.T) {
 }
 
 func TestLinuxPatchAppConfigValues(t *testing.T) {
-	// Define expected config once
-	expectedConfig := types.AppConfig{
-		Groups: []kotsv1beta1.ConfigGroup{
-			{
-				Name:  "test-group",
-				Title: "Test Group",
-				Items: []kotsv1beta1.ConfigItem{
-					{
-						Name:    "test-item",
-						Type:    "text",
-						Title:   "Test Item",
-						Default: multitype.BoolOrString{StrVal: "default"},
-						Value:   multitype.BoolOrString{StrVal: "value"},
-					},
-				},
-			},
-		},
+	// Define expected config values once
+	expectedValues := types.AppConfigValues{
+		"test-item": types.AppConfigValue{Value: "new-value"},
 	}
 
 	// Create a test server
@@ -900,11 +886,11 @@ func TestLinuxPatchAppConfigValues(t *testing.T) {
 
 		// Return successful response
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(expectedConfig)
+		json.NewEncoder(w).Encode(expectedValues)
 	}))
 	defer server.Close()
 
-	// Test successful set
+	// Test successful patch
 	c := New(server.URL, WithToken("test-token"))
 	configValues := types.AppConfigValues{
 		"test-item":     types.AppConfigValue{Value: "new-value"},
@@ -912,7 +898,7 @@ func TestLinuxPatchAppConfigValues(t *testing.T) {
 	}
 	config, err := c.PatchLinuxAppConfigValues(configValues)
 	require.NoError(t, err)
-	assert.Equal(t, expectedConfig, config)
+	assert.Equal(t, expectedValues, config)
 
 	// Test error response
 	errorServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -925,9 +911,9 @@ func TestLinuxPatchAppConfigValues(t *testing.T) {
 	defer errorServer.Close()
 
 	c = New(errorServer.URL, WithToken("test-token"))
-	config, err = c.PatchLinuxAppConfigValues(configValues)
+	configValues, err = c.PatchLinuxAppConfigValues(configValues)
 	assert.Error(t, err)
-	assert.Equal(t, types.AppConfig{}, config)
+	assert.Equal(t, types.AppConfigValues{}, configValues)
 
 	apiErr, ok := err.(*types.APIError)
 	require.True(t, ok, "Expected err to be of type *types.APIError")
@@ -936,23 +922,9 @@ func TestLinuxPatchAppConfigValues(t *testing.T) {
 }
 
 func TestKubernetesPatchAppConfigValues(t *testing.T) {
-	// Define expected config once
-	expectedConfig := types.AppConfig{
-		Groups: []kotsv1beta1.ConfigGroup{
-			{
-				Name:  "test-group",
-				Title: "Test Group",
-				Items: []kotsv1beta1.ConfigItem{
-					{
-						Name:    "test-item",
-						Type:    "text",
-						Title:   "Test Item",
-						Default: multitype.BoolOrString{StrVal: "default"},
-						Value:   multitype.BoolOrString{StrVal: "value"},
-					},
-				},
-			},
-		},
+	// Define expected config values once
+	expectedValues := types.AppConfigValues{
+		"test-item": types.AppConfigValue{Value: "new-value"},
 	}
 
 	// Create a test server
@@ -976,19 +948,19 @@ func TestKubernetesPatchAppConfigValues(t *testing.T) {
 
 		// Return successful response
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(expectedConfig)
+		json.NewEncoder(w).Encode(expectedValues)
 	}))
 	defer server.Close()
 
-	// Test successful set
+	// Test successful patch
 	c := New(server.URL, WithToken("test-token"))
 	configValues := types.AppConfigValues{
 		"test-item":     types.AppConfigValue{Value: "new-value"},
 		"required-item": types.AppConfigValue{Value: "required-value"},
 	}
-	config, err := c.PatchKubernetesAppConfigValues(configValues)
+	configValuesResponse, err := c.PatchKubernetesAppConfigValues(configValues)
 	assert.NoError(t, err)
-	assert.Equal(t, expectedConfig, config)
+	assert.Equal(t, expectedValues, configValuesResponse)
 
 	// Test error response
 	errorServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1001,9 +973,9 @@ func TestKubernetesPatchAppConfigValues(t *testing.T) {
 	defer errorServer.Close()
 
 	c = New(errorServer.URL, WithToken("test-token"))
-	config, err = c.PatchKubernetesAppConfigValues(configValues)
+	configValuesResponse, err = c.PatchKubernetesAppConfigValues(configValues)
 	assert.Error(t, err)
-	assert.Equal(t, types.AppConfig{}, config)
+	assert.Equal(t, types.AppConfigValues{}, configValuesResponse)
 
 	apiErr, ok := err.(*types.APIError)
 	require.True(t, ok, "Expected err to be of type *types.APIError")

--- a/api/client/install.go
+++ b/api/client/install.go
@@ -349,39 +349,39 @@ func (c *client) GetLinuxAppConfigValues() (types.AppConfigValues, error) {
 	return response.Values, nil
 }
 
-func (c *client) PatchLinuxAppConfigValues(values types.AppConfigValues) (types.AppConfig, error) {
+func (c *client) PatchLinuxAppConfigValues(values types.AppConfigValues) (types.AppConfigValues, error) {
 	req := types.PatchAppConfigValuesRequest{
 		Values: values,
 	}
 	b, err := json.Marshal(req)
 	if err != nil {
-		return types.AppConfig{}, err
+		return types.AppConfigValues{}, err
 	}
 
 	httpReq, err := http.NewRequest("PATCH", c.apiURL+"/api/linux/install/app/config/values", bytes.NewBuffer(b))
 	if err != nil {
-		return types.AppConfig{}, err
+		return types.AppConfigValues{}, err
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	setAuthorizationHeader(httpReq, c.token)
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
-		return types.AppConfig{}, err
+		return types.AppConfigValues{}, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return types.AppConfig{}, errorFromResponse(resp)
+		return types.AppConfigValues{}, errorFromResponse(resp)
 	}
 
-	var config types.AppConfig
+	var config types.AppConfigValuesResponse
 	err = json.NewDecoder(resp.Body).Decode(&config)
 	if err != nil {
-		return types.AppConfig{}, err
+		return types.AppConfigValues{}, err
 	}
 
-	return config, nil
+	return config.Values, nil
 }
 
 func (c *client) GetKubernetesAppConfig() (types.AppConfig, error) {
@@ -438,38 +438,38 @@ func (c *client) GetKubernetesAppConfigValues() (types.AppConfigValues, error) {
 	return response.Values, nil
 }
 
-func (c *client) PatchKubernetesAppConfigValues(values types.AppConfigValues) (types.AppConfig, error) {
+func (c *client) PatchKubernetesAppConfigValues(values types.AppConfigValues) (types.AppConfigValues, error) {
 	request := types.PatchAppConfigValuesRequest{
 		Values: values,
 	}
 
 	b, err := json.Marshal(request)
 	if err != nil {
-		return types.AppConfig{}, err
+		return types.AppConfigValues{}, err
 	}
 
 	httpReq, err := http.NewRequest("PATCH", c.apiURL+"/api/kubernetes/install/app/config/values", bytes.NewBuffer(b))
 	if err != nil {
-		return types.AppConfig{}, err
+		return types.AppConfigValues{}, err
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	setAuthorizationHeader(httpReq, c.token)
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
-		return types.AppConfig{}, err
+		return types.AppConfigValues{}, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return types.AppConfig{}, errorFromResponse(resp)
+		return types.AppConfigValues{}, errorFromResponse(resp)
 	}
 
-	var config types.AppConfig
+	var config types.AppConfigValuesResponse
 	err = json.NewDecoder(resp.Body).Decode(&config)
 	if err != nil {
-		return types.AppConfig{}, err
+		return types.AppConfigValues{}, err
 	}
 
-	return config, nil
+	return config.Values, nil
 }

--- a/api/integration/linux/install/app_test.go
+++ b/api/integration/linux/install/app_test.go
@@ -247,7 +247,7 @@ func TestLinuxPatchAppConfigValues(t *testing.T) {
 		router := mux.NewRouter()
 		apiInstance.RegisterRoutes(router)
 
-		// Create a request to set config values
+		// Create a request to patch config values
 		patchRequest := types.PatchAppConfigValuesRequest{
 			Values: types.AppConfigValues{
 				"test-item":     types.AppConfigValue{Value: "new-value"},
@@ -259,7 +259,7 @@ func TestLinuxPatchAppConfigValues(t *testing.T) {
 		reqBodyBytes, err := json.Marshal(patchRequest)
 		require.NoError(t, err)
 
-		// Create a request to set config values
+		// Create a request to patch config values
 		req := httptest.NewRequest(http.MethodPatch, "/linux/install/app/config/values", bytes.NewReader(reqBodyBytes))
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Authorization", "Bearer "+"TOKEN")
@@ -273,15 +273,16 @@ func TestLinuxPatchAppConfigValues(t *testing.T) {
 		assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
 
 		// Parse the response body
-		var response types.AppConfig
+		var response types.AppConfigValuesResponse
 		err = json.NewDecoder(rec.Body).Decode(&response)
 		require.NoError(t, err)
+		require.NotNil(t, response.Values, "response values should not be nil")
 
-		// Verify the raw app config is returned
-		assert.Equal(t, "value", response.Groups[0].Items[0].Value.String(), "first item should return raw config schema value")
-		assert.Equal(t, "value2", response.Groups[0].Items[1].Value.String(), "second item should return raw config schema value")
-		assert.Equal(t, "QQ==", response.Groups[0].Items[3].Value.String(), "fourth item should return raw config schema value for file")
-		assert.Equal(t, "file.txt", response.Groups[0].Items[3].Filename, "fourth item should contain a filename")
+		// Verify the app config values are returned from the store
+		assert.Equal(t, "new-value", response.Values["test-item"].Value, "test-item should be updated")
+		assert.Equal(t, "required-value", response.Values["required-item"].Value, "required-item should be updated")
+		assert.Equal(t, "SGVsbG8gV29ybGQ=", response.Values["file-item"].Value, "file-item value should be updated")
+		assert.Equal(t, "new-file.txt", response.Values["file-item"].Filename, "file-item value should contain a filename")
 	})
 
 	// Test authorization
@@ -306,7 +307,7 @@ func TestLinuxPatchAppConfigValues(t *testing.T) {
 		router := mux.NewRouter()
 		apiInstance.RegisterRoutes(router)
 
-		// Create a request to set config values
+		// Create a request to patch config values
 		patchRequest := types.PatchAppConfigValuesRequest{
 			Values: types.AppConfigValues{
 				"test-item":     types.AppConfigValue{Value: "new-value"},
@@ -359,7 +360,7 @@ func TestLinuxPatchAppConfigValues(t *testing.T) {
 		router := mux.NewRouter()
 		apiInstance.RegisterRoutes(router)
 
-		// Create a request to set config values
+		// Create a request to patch config values
 		patchRequest := types.PatchAppConfigValuesRequest{
 			Values: types.AppConfigValues{
 				"test-item":     types.AppConfigValue{Value: "new-value"},
@@ -413,7 +414,7 @@ func TestLinuxPatchAppConfigValues(t *testing.T) {
 		router := mux.NewRouter()
 		apiInstance.RegisterRoutes(router)
 
-		// Create a request to set config values without the required item
+		// Create a request to patch config values without the required item
 		setRequest := types.PatchAppConfigValuesRequest{
 			Values: types.AppConfigValues{
 				"test-item": types.AppConfigValue{Value: "new-value"},
@@ -627,11 +628,11 @@ func TestInstallController_PatchAppConfigValuesWithAPIClient(t *testing.T) {
 		config, err := c.PatchLinuxAppConfigValues(configValues)
 		require.NoError(t, err, "PatchLinuxAppConfigValues should succeed")
 
-		// Verify the raw app config is returned (not the applied values)
-		assert.Equal(t, "value", config.Groups[0].Items[0].Value.String(), "first item should return raw config schema value")
-		assert.Equal(t, "", config.Groups[0].Items[1].Value.String(), "second item should return empty value since it has no default")
-		assert.Equal(t, "QQ==", config.Groups[0].Items[2].Value.String(), "third item should return raw config schema value for file")
-		assert.Equal(t, "file.txt", config.Groups[0].Items[2].Filename, "third item should contain a filename")
+		// Verify the app config values are returned from the store
+		assert.Equal(t, "new-value", config["test-item"].Value, "test-item should be updated")
+		assert.Equal(t, "required-value", config["required-item"].Value, "required-item should be updated")
+		assert.Equal(t, "SGVsbG8gV29ybGQ=", config["file-item"].Value, "file-item value should be updated")
+		assert.Equal(t, "new-file.txt", config["file-item"].Filename, "file-item value should contain a filename")
 	})
 
 	// Test PatchLinuxAppConfigValues with missing required item

--- a/api/internal/handlers/kubernetes/install.go
+++ b/api/internal/handlers/kubernetes/install.go
@@ -151,7 +151,7 @@ func (h *Handler) GetAppConfig(w http.ResponseWriter, r *http.Request) {
 //	@Accept			json
 //	@Produce		json
 //	@Param			request	body		types.PatchAppConfigValuesRequest	true	"Patch App Config Values Request"
-//	@Success		200		{object}	types.AppConfig
+//	@Success		200		{object}	types.AppConfigValuesResponse
 //	@Failure		400		{object}	types.APIError
 //	@Router			/kubernetes/install/app/config/values [patch]
 func (h *Handler) PatchConfigValues(w http.ResponseWriter, r *http.Request) {
@@ -167,7 +167,7 @@ func (h *Handler) PatchConfigValues(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.GetAppConfig(w, r)
+	h.GetAppConfigValues(w, r)
 }
 
 // GetAppConfigValues handler to get the app config values

--- a/api/internal/handlers/linux/install.go
+++ b/api/internal/handlers/linux/install.go
@@ -230,7 +230,7 @@ func (h *Handler) GetAppConfig(w http.ResponseWriter, r *http.Request) {
 //	@Accept			json
 //	@Produce		json
 //	@Param			request	body		types.PatchAppConfigValuesRequest	true	"Patch App Config Values Request"
-//	@Success		200		{object}	types.AppConfig
+//	@Success		200		{object}	types.AppConfigValuesResponse
 //	@Failure		400		{object}	types.APIError
 //	@Router			/linux/install/app/config/values [patch]
 func (h *Handler) PatchConfigValues(w http.ResponseWriter, r *http.Request) {
@@ -246,7 +246,7 @@ func (h *Handler) PatchConfigValues(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.GetAppConfig(w, r)
+	h.GetAppConfigValues(w, r)
 }
 
 // GetAppConfigValues handler to get the app config values

--- a/web/src/components/wizard/WelcomeStep.tsx
+++ b/web/src/components/wizard/WelcomeStep.tsx
@@ -77,7 +77,7 @@ const WelcomeStep: React.FC<WelcomeStepProps> = ({ onNext }) => {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6" data-testid="welcome-step">
       <Card>
         <div className="flex flex-col items-center text-center py-12">
           <AppIcon className="h-20 w-20 mb-6" />
@@ -95,6 +95,7 @@ const WelcomeStep: React.FC<WelcomeStepProps> = ({ onNext }) => {
               required
               icon={<Lock className="w-5 h-5" />}
               className="w-full"
+              dataTestId="password-input"
             />
 
             <Button
@@ -103,6 +104,7 @@ const WelcomeStep: React.FC<WelcomeStepProps> = ({ onNext }) => {
               className="w-full mt-4"
               icon={<ChevronRight className="w-5 h-5" />}
               disabled={isLoading}
+              dataTestId="welcome-button-next"
             >
               {text.welcomeButtonText}
             </Button>

--- a/web/src/components/wizard/setup/KubernetesSetupStep.tsx
+++ b/web/src/components/wizard/setup/KubernetesSetupStep.tsx
@@ -17,10 +17,10 @@ import { ChevronRight, ChevronLeft } from "lucide-react";
  * - Error formatting: formatErrorMessage("adminConsolePort invalid") -> "Admin Console Port invalid"
  */
 const fieldNames = {
-   adminConsolePort: "Admin Console Port",
-   httpProxy: "HTTP Proxy",
-   httpsProxy: "HTTPS Proxy",
-   noProxy: "Proxy Bypass List",
+  adminConsolePort: "Admin Console Port",
+  httpProxy: "HTTP Proxy",
+  httpsProxy: "HTTPS Proxy",
+  noProxy: "Proxy Bypass List",
 }
 
 interface KubernetesSetupStepProps {
@@ -216,7 +216,7 @@ const KubernetesSetupStep: React.FC<KubernetesSetupStepProps> = ({ onNext, onBac
 
             {error && (
               <div className="mt-6 p-3 bg-red-50 text-red-500 rounded-md">
-                {submitError?.errors && submitError.errors.length > 0 
+                {submitError?.errors && submitError.errors.length > 0
                   ? "Please fix the errors in the form above before proceeding."
                   : error
                 }
@@ -227,7 +227,7 @@ const KubernetesSetupStep: React.FC<KubernetesSetupStepProps> = ({ onNext, onBac
       </Card>
 
       <div className="flex justify-between">
-        <Button variant="outline" onClick={onBack} icon={<ChevronLeft className="w-5 h-5" />}>
+        <Button variant="outline" onClick={onBack} dataTestId="kubernetes-setup-button-back" icon={<ChevronLeft className="w-5 h-5" />}>
           Back
         </Button>
         <Button onClick={() => submitConfig(config)} icon={<ChevronRight className="w-5 h-5" />}>
@@ -246,13 +246,13 @@ const KubernetesSetupStep: React.FC<KubernetesSetupStepProps> = ({ onNext, onBac
  * @returns The formatted error message with replaced field names
  */
 export function formatErrorMessage(message: string) {
-   let finalMsg = message
-   for (const [field, fieldName] of Object.entries(fieldNames)) {
-      // Case-insensitive regex that matches whole words only
-      // Example: "podCidr", "PodCidr", "PODCIDR" all become "Pod CIDR"
-      finalMsg = finalMsg.replace(new RegExp(`\\b${field}\\b`, 'gi'), fieldName)
-   }
-   return finalMsg
+  let finalMsg = message
+  for (const [field, fieldName] of Object.entries(fieldNames)) {
+    // Case-insensitive regex that matches whole words only
+    // Example: "podCidr", "PodCidr", "PODCIDR" all become "Pod CIDR"
+    finalMsg = finalMsg.replace(new RegExp(`\\b${field}\\b`, 'gi'), fieldName)
+  }
+  return finalMsg
 }
 
 export default KubernetesSetupStep;

--- a/web/src/components/wizard/setup/LinuxSetupStep.tsx
+++ b/web/src/components/wizard/setup/LinuxSetupStep.tsx
@@ -319,7 +319,7 @@ const LinuxSetupStep: React.FC<LinuxSetupStepProps> = ({ onNext, onBack }) => {
       </Card>
 
       <div className="flex justify-between">
-        <Button variant="outline" onClick={onBack} icon={<ChevronLeft className="w-5 h-5" />}>
+        <Button variant="outline" onClick={onBack} dataTestId="linux-setup-button-back" icon={<ChevronLeft className="w-5 h-5" />}>
           Back
         </Button>
         <Button onClick={() => submitConfig(config)} icon={<ChevronRight className="w-5 h-5" />}>

--- a/web/src/components/wizard/tests/ConfigurationStep.test.tsx
+++ b/web/src/components/wizard/tests/ConfigurationStep.test.tsx
@@ -1550,10 +1550,10 @@ describe.each([
       });
 
       const fileInput = screen.getByTestId("file-input-ssl_certificate");
-      
+
       // Create a mock file
       const file = new File(['certificate content'], 'cert.pem', { type: 'text/plain' });
-      
+
       // Mock FileReader
       const mockFileReader = {
         readAsDataURL: vi.fn().mockImplementation(() => {
@@ -1571,13 +1571,13 @@ describe.each([
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         onerror: null as any
       };
-      
+
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       vi.spyOn(global, 'FileReader').mockImplementation(() => mockFileReader as any);
-      
+
       // Simulate file selection
       fireEvent.change(fileInput, { target: { files: [file] } });
-      
+
       // Wait for the async file reading to complete
       await waitFor(() => {
         expect(mockFileReader.readAsDataURL).toHaveBeenCalledWith(file);
@@ -1624,10 +1624,10 @@ describe.each([
       });
 
       const fileInput = screen.getByTestId("file-input-ssl_certificate");
-      
+
       // Create a mock file
       const file = new File(['certificate content'], 'cert.pem', { type: 'text/plain' });
-      
+
       // Mock FileReader
       const mockFileReader = {
         readAsDataURL: vi.fn().mockImplementation(() => {
@@ -1645,13 +1645,13 @@ describe.each([
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         onerror: null as any
       };
-      
+
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       vi.spyOn(global, 'FileReader').mockImplementation(() => mockFileReader as any);
-      
+
       // Simulate file selection
       fireEvent.change(fileInput, { target: { files: [file] } });
-      
+
       // Wait for the async file reading to complete
       await waitFor(() => {
         expect(mockFileReader.readAsDataURL).toHaveBeenCalledWith(file);

--- a/web/src/components/wizard/tests/InstallWizard.test.tsx
+++ b/web/src/components/wizard/tests/InstallWizard.test.tsx
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi, beforeAll, afterEach, afterAll, beforeEach } from "vitest";
+import { screen, waitFor, fireEvent } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { renderWithProviders } from "../../../test/setup.tsx";
+import InstallWizard from "../InstallWizard";
+import { AppConfig, AppConfigValues } from "../../../types";
+
+const MOCK_APP_CONFIG: AppConfig = {
+  groups: [
+    {
+      name: "settings",
+      title: "Settings",
+      description: "Configure application settings",
+      items: [
+        {
+          name: "app_name",
+          title: "Application Name",
+          type: "text",
+          value: "Default App",
+          default: "Default App",
+          help_text: "Enter the name of your application"
+        },
+        {
+          name: "enable_feature",
+          title: "Enable Feature",
+          type: "bool",
+          value: "0",
+          default: "0"
+        }
+      ]
+    }
+  ]
+};
+
+const createServer = (target: string) => setupServer(
+  // Mock app config endpoint
+  http.get(`*/api/${target}/install/app/config`, () => {
+    return HttpResponse.json(MOCK_APP_CONFIG);
+  }),
+
+  // Mock config values fetch endpoint
+  http.get(`*/api/${target}/install/app/config/values`, () => {
+    return HttpResponse.json({ values: {} });
+  }),
+
+  // Mock config values submission endpoint
+  http.patch(`*/api/${target}/install/app/config/values`, async ({ request }) => {
+    const body = await request.json() as { values: AppConfigValues };
+    // Return the submitted values as saved values
+    return HttpResponse.json({ values: body.values });
+  })
+);
+
+describe.each([
+  { target: "kubernetes" as const, displayName: "Kubernetes" },
+  { target: "linux" as const, displayName: "Linux" }
+])("InstallWizard - $displayName", ({ target }) => {
+  let server: ReturnType<typeof createServer>;
+
+  beforeAll(() => {
+    server = createServer(target);
+    server.listen();
+  });
+
+  beforeEach(() => {
+    // Reset any mocks
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it("preserves saved config values when navigating back from next step", async () => {
+    // This test simulates the original bug scenario:
+    // 1. User changes value in configuration step
+    // 2. User clicks Next (saves config and goes to next step)
+    // 3. User clicks Back (returns to configuration step)
+    // 4. The value should show the saved value, not the original value
+
+    let savedConfigValues: AppConfigValues = {};
+
+    // Mock the server to track what gets saved
+    server.use(
+      http.patch(`*/api/${target}/install/app/config/values`, async ({ request }) => {
+        const body = await request.json() as { values: AppConfigValues };
+        savedConfigValues = body.values;
+        return HttpResponse.json({ values: body.values });
+      }),
+
+      // When fetching config values, return the saved values
+      http.get(`*/api/${target}/install/app/config/values`, () => {
+        return HttpResponse.json({ values: savedConfigValues });
+      })
+    );
+
+    renderWithProviders(<InstallWizard />, {
+      wrapperProps: {
+        authenticated: true,
+        target: target,
+      },
+    });
+
+    // Wait for configuration step to load
+    await waitFor(() => {
+      expect(screen.getByTestId("configuration-step")).toBeInTheDocument();
+    });
+
+    // Wait for form to be ready
+    await waitFor(() => {
+      expect(screen.getByTestId("text-input-app_name")).toBeInTheDocument();
+    });
+
+    // Change the app name from "Default App" to "My Custom App"
+    const appNameInput = screen.getByTestId("text-input-app_name");
+    fireEvent.change(appNameInput, { target: { value: "My Custom App" } });
+
+    // Verify the value was changed
+    expect(appNameInput).toHaveValue("My Custom App");
+
+    // Click Next to save and go to next step
+    const configNextButton = screen.getByTestId("config-next-button");
+    fireEvent.click(configNextButton);
+
+    // Wait for next step to load (setup step)
+    await waitFor(() => {
+      expect(screen.getByTestId(`${target}-setup`)).toBeInTheDocument();
+    });
+
+    // Verify the config was saved
+    expect(savedConfigValues).toEqual({
+      app_name: { value: "My Custom App" }
+    });
+
+    // Now navigate back to configuration step
+    const backButton = screen.getByTestId(`${target}-setup-button-back`);
+    fireEvent.click(backButton);
+
+    // Wait for configuration step to load again
+    await waitFor(() => {
+      expect(screen.getByTestId("configuration-step")).toBeInTheDocument();
+    });
+
+    // Wait for form to be ready
+    await waitFor(() => {
+      expect(screen.getByTestId("text-input-app_name")).toBeInTheDocument();
+    });
+
+    // The correct updated value should be present
+    const appNameInputAfterBack = screen.getByTestId("text-input-app_name");
+    expect(appNameInputAfterBack).toHaveValue("My Custom App");
+  });
+
+  it("handles multiple field changes during navigation", async () => {
+    let savedConfigValues: AppConfigValues = {};
+
+    server.use(
+      http.patch(`*/api/${target}/install/app/config/values`, async ({ request }) => {
+        const body = await request.json() as { values: AppConfigValues };
+        savedConfigValues = body.values;
+        return HttpResponse.json({ values: body.values });
+      }),
+
+      http.get(`*/api/${target}/install/app/config/values`, () => {
+        return HttpResponse.json({ values: savedConfigValues });
+      })
+    );
+
+    renderWithProviders(<InstallWizard />, {
+      wrapperProps: {
+        authenticated: true,
+        target: target,
+      },
+    });
+
+    // Wait for configuration step
+    await waitFor(() => {
+      expect(screen.getByTestId("configuration-step")).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("text-input-app_name")).toBeInTheDocument();
+    });
+
+    // Change multiple fields
+    const appNameInput = screen.getByTestId("text-input-app_name");
+    fireEvent.change(appNameInput, { target: { value: "Multi Field App" } });
+
+    const enableFeatureCheckbox = screen.getByTestId("bool-input-enable_feature");
+    fireEvent.click(enableFeatureCheckbox);
+
+    // Verify changes
+    expect(appNameInput).toHaveValue("Multi Field App");
+    expect(enableFeatureCheckbox).toBeChecked();
+
+    // Click Next to save and go to next step
+    const configNextButton = screen.getByTestId("config-next-button");
+    fireEvent.click(configNextButton);
+
+    // Wait for next step to load (setup step)
+    await waitFor(() => {
+      expect(screen.getByTestId(`${target}-setup`)).toBeInTheDocument();
+    });
+
+    // Verify both fields were saved
+    expect(savedConfigValues).toEqual({
+      app_name: { value: "Multi Field App" },
+      enable_feature: { value: "1" }
+    });
+
+    // Now navigate back to configuration step
+    const backButton = screen.getByTestId(`${target}-setup-button-back`);
+    fireEvent.click(backButton);
+
+    // Wait for configuration step to reload
+    await waitFor(() => {
+      expect(screen.getByTestId("configuration-step")).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("text-input-app_name")).toBeInTheDocument();
+    });
+
+    // Verify both saved values are restored
+    const appNameInputAfterBack = screen.getByTestId("text-input-app_name");
+    const enableFeatureCheckboxAfterBack = screen.getByTestId("bool-input-enable_feature");
+
+    expect(appNameInputAfterBack).toHaveValue("Multi Field App");
+    expect(enableFeatureCheckboxAfterBack).toBeChecked();
+  });
+});

--- a/web/src/components/wizard/tests/WelcomeStep.test.tsx
+++ b/web/src/components/wizard/tests/WelcomeStep.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { describe, it, expect, vi, beforeAll, afterEach, afterAll } from "vitest";
 import { screen, fireEvent, waitFor } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
@@ -57,8 +56,8 @@ describe("WelcomeStep", () => {
     renderWithProviders(<WelcomeStep onNext={mockOnNext} />);
 
     // Check if welcome content is rendered
-    expect(screen.getByText(/Welcome to/)).toBeInTheDocument();
-    expect(screen.getByText(/Enter Password/)).toBeInTheDocument();
+    expect(screen.getByTestId("welcome-step")).toBeInTheDocument();
+    expect(screen.getByTestId("password-input")).toBeInTheDocument();
   });
 
   it("handles password submission successfully", async () => {
@@ -75,7 +74,7 @@ describe("WelcomeStep", () => {
     renderWithProviders(<WelcomeStep onNext={mockOnNext} />);
 
     // Fill in password
-    const passwordInput = screen.getByLabelText(/Enter Password/);
+    const passwordInput = screen.getByTestId("password-input");
     fireEvent.change(passwordInput, { target: { value: "password" } });
 
     // Submit form


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

The way the data was being stored in the UI when updating the config meant that when the config component was mounted again we would be showing a stale set of data values. This should fix it.

See fix in action:
https://www.loom.com/share/dd0705a89cf84e52b0750323c182b9aa?sid=9b26275f-71ca-483d-8c05-e53f15849719

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/126775/ui-config-values-do-not-persist

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Yes

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
