### PR TITLE
Support repl templates - Optimize template performance

### DIFF
--- a/api/pkg/template/engine.go
+++ b/api/pkg/template/engine.go
@@ -16,7 +16,6 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/netutils"
 	"github.com/replicatedhq/embedded-cluster/pkg/release"
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
-	"github.com/tiendc/go-deepcopy"
 )
 
 type Engine struct {
@@ -110,14 +109,8 @@ func (e *Engine) Execute(configValues types.AppConfigValues) (string, error) {
 	defer e.mtx.Unlock()
 
 	// Store previous config values
-	if err := deepcopy.Copy(&e.prevConfigValues, &e.configValues); err != nil {
-		return "", fmt.Errorf("copy previous config values: %w", err)
-	}
-
-	// Store new config values
-	if err := deepcopy.Copy(&e.configValues, &configValues); err != nil {
-		return "", fmt.Errorf("copy new config values: %w", err)
-	}
+	e.prevConfigValues = e.configValues
+	e.configValues = configValues
 
 	// Mark all cached values as not yet processed in this execution
 	for name, cacheVal := range e.cache {

--- a/api/pkg/template/engine_test.go
+++ b/api/pkg/template/engine_test.go
@@ -932,6 +932,7 @@ func TestEngine_DependencyTreeAndCaching(t *testing.T) {
 	// Test 10: Reset to no user values, then change middle item (database_url) directly - should only affect itself and dependents
 	result, err = engine.Execute(nil)
 	require.NoError(t, err)
+	assert.Equal(t, "redis://postgres://staging:staging-region/app/0", result)
 	assert.Equal(t, expectedDepsTree, engine.depsTree)
 
 	configValues = types.AppConfigValues{


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

This PR implements a dependency tree tracking system in the template engine to optimize performance by avoiding unnecessary reprocessing of config items. Previously, all config items were recomputed on every template execution. Now, the engine tracks dependencies between config items and only invalidates cached values when the item itself or any of its dependencies have changed.

The optimization works by:
  - Building a dependency tree during template resolution to track which config items depend on others
  - Caching resolved values with a "processed" flag to track execution state
  - Using cache invalidation logic that recursively checks if an item or any of its dependencies have changed
  - Only recomputing values when necessary, significantly improving performance for large config template

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-127009](https://app.shortcut.com/replicated/story/127009)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Yes

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE