### PR TITLE
feat(api): config template function support

### DIFF
--- a/api/pkg/template/engine.go
+++ b/api/pkg/template/engine.go
@@ -383,7 +383,10 @@ func (e *Engine) getConfigItemValue(configItem kotsv1beta1.ConfigItem) (string, 
 		if err != nil {
 			return "", fmt.Errorf("process value template: %w", err)
 		}
-		return val, nil
+		// if the value is still empty, fallback
+		if val != "" {
+			return val, nil
+		}
 	}
 
 	// If still empty, try default
@@ -392,7 +395,10 @@ func (e *Engine) getConfigItemValue(configItem kotsv1beta1.ConfigItem) (string, 
 		if err != nil {
 			return "", fmt.Errorf("process default template: %w", err)
 		}
-		return val, nil
+		// if the value is still empty, fallback
+		if val != "" {
+			return val, nil
+		}
 	}
 
 	// If still empty, return empty string


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Adds support for ConfigOptionFilename and ConfigOptionNotEquals template functions

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
