### PR TITLE
chore(ci): fix github rate limiting with auth token

### DIFF
--- a/.github/workflows/image-deps-updater.yaml
+++ b/.github/workflows/image-deps-updater.yaml
@@ -80,6 +80,7 @@ jobs:
         INPUT_KUBECTL_VERSION: ${{ github.event.inputs.kubectl_version }}
         INPUT_SEAWEEDFS_VERSION: ${{ github.event.inputs.seaweedfs_version }}
         ARCHS: "amd64,arm64"
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         chmod +x ./output/bin/buildtools
         ./output/bin/buildtools update images ${{ matrix.addon }}

--- a/.github/workflows/update-addons.yaml
+++ b/.github/workflows/update-addons.yaml
@@ -69,6 +69,7 @@ jobs:
           INPUT_VELERO_CHART_VERSION: ${{ github.event.inputs.velero_chart_version }}
           INPUT_SEAWEEDFS_CHART_VERSION: ${{ github.event.inputs.seaweedfs_chart_version }}
           ARCHS: "amd64,arm64"
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           chmod 755 ./output/bin/buildtools
           ./output/bin/buildtools update addon ${{ matrix.addon }}

--- a/cmd/buildtools/utils.go
+++ b/cmd/buildtools/utils.go
@@ -183,6 +183,9 @@ type filterFn func(string) bool
 
 func GetGitHubRelease(ctx context.Context, owner, repo string, filter filterFn) (string, error) {
 	client := github.NewClient(nil)
+	if token := os.Getenv("GH_TOKEN"); token != "" {
+		client = client.WithAuthToken(token)
+	}
 	releases, _, err := client.Repositories.ListReleases(
 		ctx, owner, repo, &github.ListOptions{},
 	)
@@ -201,6 +204,9 @@ func GetGitHubRelease(ctx context.Context, owner, repo string, filter filterFn) 
 // GetLatestGitHubTag returns the latest tag from a GitHub repository.
 func GetLatestGitHubTag(ctx context.Context, owner, repo string) (string, error) {
 	client := github.NewClient(nil)
+	if token := os.Getenv("GH_TOKEN"); token != "" {
+		client = client.WithAuthToken(token)
+	}
 	tags, _, err := client.Repositories.ListTags(ctx, owner, repo, &github.ListOptions{})
 	if err != nil {
 		return "", fmt.Errorf("list tags: %w", err)
@@ -216,6 +222,9 @@ func GetLatestGitHubTag(ctx context.Context, owner, repo string) (string, error)
 // will list "v1.124.12" as being newer than "v1.124.12-build.0" and it is not in our usage.
 func GetLatestKotsHelmTag(ctx context.Context) (string, error) {
 	client := github.NewClient(nil)
+	if token := os.Getenv("GH_TOKEN"); token != "" {
+		client = client.WithAuthToken(token)
+	}
 	tags, _, err := client.Repositories.ListTags(ctx, "replicatedhq", "kots-helm", &github.ListOptions{PerPage: 100})
 	if err != nil {
 		return "", fmt.Errorf("list tags: %w", err)
@@ -250,6 +259,9 @@ func GetLatestKotsHelmTag(ctx context.Context) (string, error) {
 // that matches the provided constraints.
 func GetGreatestGitHubTag(ctx context.Context, owner, repo string, constrants *semver.Constraints) (string, error) {
 	client := github.NewClient(nil)
+	if token := os.Getenv("GH_TOKEN"); token != "" {
+		client = client.WithAuthToken(token)
+	}
 	tags, _, err := client.Repositories.ListTags(ctx, owner, repo, &github.ListOptions{PerPage: 100})
 	if err != nil {
 		return "", fmt.Errorf("list tags: %w", err)


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

these workflows keep getting rate limited

> failed to update images: resolve image and tag for quay.io/k0sproject/calico-cni:v3.28.2-0 (amd64): resolve custom image repo and tag: failed to get image name for calico-cni: failed to get calico tag: failed to get calico release: list tags: GET https://api.github.com/repos/projectcalico/calico/tags?per_page=100: 403 API rate limit exceeded for 172.178.118.195. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) [rate reset in 6m05s]

https://github.com/replicatedhq/embedded-cluster/actions/runs/16428587440

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
