### PR TITLE
feat(api): static template function support

### DIFF
--- a/api/pkg/template/engine.go
+++ b/api/pkg/template/engine.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"maps"
+	"net/url"
 	"slices"
 	"strings"
 	"sync"
@@ -200,6 +201,29 @@ func (e *Engine) getFuncMap() template.FuncMap {
 		"HTTPProxy":  e.httpProxy,
 		"HTTPSProxy": e.httpsProxy,
 		"NoProxy":    e.noProxy,
+
+		"Now":          e.now,
+		"NowFmt":       e.nowFormat,
+		"ToLower":      strings.ToLower,
+		"ToUpper":      strings.ToUpper,
+		"TrimSpace":    strings.TrimSpace,
+		"Trim":         e.trim,
+		"UrlEncode":    url.QueryEscape,
+		"Base64Encode": e.base64Encode,
+		"Base64Decode": e.base64Decode,
+		"Split":        strings.Split,
+		"RandomBytes":  e.randomBytes,
+		"RandomString": e.randomString,
+		"Add":          e.add,
+		"Sub":          e.sub,
+		"Mult":         e.mult,
+		"Div":          e.div,
+		"ParseBool":    e.parseBool,
+		"ParseFloat":   e.parseFloat,
+		"ParseInt":     e.parseInt,
+		"ParseUint":    e.parseUint,
+		"HumanSize":    e.humanSize,
+		"YamlEscape":   e.yamlEscape,
 	}
 }
 

--- a/api/pkg/template/static.go
+++ b/api/pkg/template/static.go
@@ -1,7 +1,7 @@
 package template
 
 /*
-  This was taken from https://github.com/replicatedhq/replicated/blob/main/templates/context.go
+  This was taken from https://github.com/replicatedhq/kots/blob/806e07452fe244a15572b759d70b8af2cd67bfaf/pkg/template/static_context.go
 */
 
 import (

--- a/api/pkg/template/static.go
+++ b/api/pkg/template/static.go
@@ -288,5 +288,5 @@ func (e *Engine) yamlEscape(plain string) string {
 // copied from sprig
 func indent(spaces int, v string) string {
 	pad := strings.Repeat(" ", spaces)
-	return pad + strings.Replace(v, "\n", "\n"+pad, -1)
+	return pad + strings.ReplaceAll(v, "\n", "\n"+pad)
 }

--- a/api/pkg/template/static.go
+++ b/api/pkg/template/static.go
@@ -1,0 +1,292 @@
+package template
+
+/*
+  This was taken from https://github.com/replicatedhq/replicated/blob/main/templates/context.go
+*/
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"math/big"
+	"reflect"
+	"regexp/syntax"
+	"strconv"
+	"strings"
+	"time"
+
+	units "github.com/docker/go-units"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	DefaultRandomStringCharset = "[_A-Za-z0-9]"
+)
+
+func (e *Engine) now() string {
+	return e.nowFormat("")
+}
+
+func (e *Engine) nowFormat(format string) string {
+	if format == "" {
+		format = time.RFC3339
+	}
+	return time.Now().UTC().Format(format)
+}
+
+func (e *Engine) trim(s string, args ...string) string {
+	if len(args) == 0 {
+		return strings.TrimSpace(s)
+	}
+	return strings.Trim(s, args[0])
+}
+
+func (e *Engine) base64Encode(plain string) string {
+	return base64.StdEncoding.EncodeToString([]byte(plain))
+}
+
+func (e *Engine) base64Decode(encoded string) string {
+	plain, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return ""
+	}
+	return string(plain)
+}
+
+// stolen from https://github.com/replicatedhq/replicated/blob/8ce3ed40436e38b8089387d103623dbe09bbf1c0/pkg/commands/random.go#L22
+func (e *Engine) randomString(length uint64, providedCharset ...string) string {
+	charset := DefaultRandomStringCharset
+	if len(providedCharset) >= 1 {
+		charset = providedCharset[0]
+	}
+	regExp, err := syntax.Parse(charset, syntax.Perl)
+	if err != nil {
+		return ""
+	}
+
+	regExp = regExp.Simplify()
+	var b bytes.Buffer
+	for i := 0; i < int(length); i++ {
+		if err := genString(&b, regExp); err != nil {
+			return ""
+		}
+	}
+
+	result := b.String()
+	return result
+}
+
+func genString(w *bytes.Buffer, rx *syntax.Regexp) error {
+	switch rx.Op {
+	case syntax.OpCharClass:
+		sum := 0
+		for i := 0; i < len(rx.Rune); i += 2 {
+			sum += 1 + int(rx.Rune[i+1]-rx.Rune[i])
+		}
+
+		for i, nth := 0, rune(randint(sum)); i < len(rx.Rune); i += 2 {
+			min, max := rx.Rune[i], rx.Rune[i+1]
+			delta := max - min
+			if nth <= delta {
+				w.WriteRune(min + nth)
+				return nil
+			}
+			nth -= 1 + delta
+		}
+	default:
+		return errors.New("invalid charset")
+	}
+
+	return nil
+}
+
+func randint(max int) int {
+	var bigmax big.Int
+	bigmax.SetInt64(int64(max))
+
+	res, err := rand.Int(rand.Reader, &bigmax)
+	if err != nil {
+		panic(err)
+	}
+
+	return int(res.Int64())
+}
+
+// RandomBytes returns a base64-encoded byte array allowing the full range of byte values.
+func (e *Engine) randomBytes(length uint64) string {
+	buf := make([]byte, length)
+	if _, err := rand.Read(buf); err != nil {
+		return ""
+	}
+	return base64.StdEncoding.EncodeToString(buf)
+}
+
+func (e *Engine) add(a, b interface{}) interface{} {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+
+	if isFloat(av) || isFloat(bv) {
+		return reflectToFloat(av) + reflectToFloat(bv)
+	}
+	if isInt(av) {
+		return av.Int() + reflectToInt(bv)
+	}
+	if isUint(av) {
+		return av.Uint() + reflectToUint(bv)
+	}
+
+	return 0
+}
+
+func (e *Engine) sub(a, b interface{}) interface{} {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+
+	if isFloat(av) || isFloat(bv) {
+		return reflectToFloat(av) - reflectToFloat(bv)
+	}
+	if isInt(av) {
+		return av.Int() - reflectToInt(bv)
+	}
+	if isUint(av) {
+		return av.Uint() - reflectToUint(bv)
+	}
+
+	return 0
+}
+
+func (e *Engine) mult(a, b interface{}) interface{} {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+
+	if isFloat(av) || isFloat(bv) {
+		return reflectToFloat(av) * reflectToFloat(bv)
+	}
+	if isInt(av) {
+		return av.Int() * reflectToInt(bv)
+	}
+	if isUint(av) {
+		return av.Uint() * reflectToUint(bv)
+	}
+
+	return 0
+}
+
+func (e *Engine) div(a, b interface{}) interface{} {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+
+	if isFloat(av) || isFloat(bv) {
+		return reflectToFloat(av) / reflectToFloat(bv)
+	}
+	if isInt(av) {
+		return av.Int() / reflectToInt(bv)
+	}
+	if isUint(av) {
+		return av.Uint() / reflectToUint(bv)
+	}
+
+	return 0
+}
+
+func (e *Engine) parseBool(str string) bool {
+	val, _ := strconv.ParseBool(str)
+	return val
+}
+
+func (e *Engine) parseFloat(str string) float64 {
+	val, _ := strconv.ParseFloat(str, 64)
+	return val
+}
+
+func (e *Engine) parseInt(str string, args ...int) int64 {
+	base := 10
+	if len(args) > 0 {
+		base = args[0]
+	}
+	val, _ := strconv.ParseInt(str, base, 64)
+	return val
+}
+
+func (e *Engine) parseUint(str string, args ...int) uint64 {
+	base := 10
+	if len(args) > 0 {
+		base = args[0]
+	}
+	val, _ := strconv.ParseUint(str, base, 64)
+	return val
+}
+
+func reflectToFloat(val reflect.Value) float64 {
+	if isFloat(val) {
+		return val.Float()
+	}
+	if isInt(val) {
+		return float64(val.Int())
+	}
+	if isUint(val) {
+		return float64(val.Uint())
+	}
+
+	return 0
+}
+
+func reflectToInt(val reflect.Value) int64 {
+	if isFloat(val) {
+		return int64(val.Float())
+	}
+	if isInt(val) || isUint(val) {
+		return val.Int()
+	}
+
+	return 0
+}
+
+func reflectToUint(val reflect.Value) uint64 {
+	if isFloat(val) {
+		return uint64(val.Float())
+	}
+	if isInt(val) || isUint(val) {
+		return val.Uint()
+	}
+
+	return 0
+}
+
+func isFloat(val reflect.Value) bool {
+	kind := val.Kind()
+	return kind == reflect.Float32 || kind == reflect.Float64
+}
+
+func isInt(val reflect.Value) bool {
+	kind := val.Kind()
+	return kind == reflect.Int || kind == reflect.Int8 || kind == reflect.Int16 || kind == reflect.Int32 || kind == reflect.Int64
+}
+
+func isUint(val reflect.Value) bool {
+	kind := val.Kind()
+	return kind == reflect.Uint || kind == reflect.Uint8 || kind == reflect.Uint16 || kind == reflect.Uint32 || kind == reflect.Uint64
+}
+
+func (e *Engine) humanSize(size interface{}) string {
+	v := reflect.ValueOf(size)
+	return units.HumanSize(reflectToFloat(v))
+}
+
+func (e *Engine) yamlEscape(plain string) string {
+	marshalled, err := yaml.Marshal(plain)
+	if err != nil {
+		return ""
+	}
+
+	// it is possible for this function to produce multiline yaml, so we indent it a bunch for safety
+	indented := indent(20, string(marshalled))
+	return indented
+}
+
+// copied from sprig
+func indent(spaces int, v string) string {
+	pad := strings.Repeat(" ", spaces)
+	return pad + strings.Replace(v, "\n", "\n"+pad, -1)
+}

--- a/api/pkg/template/static_test.go
+++ b/api/pkg/template/static_test.go
@@ -1,0 +1,894 @@
+package template
+
+import (
+	"encoding/base64"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEngine_Now(t *testing.T) {
+	config := &kotsv1beta1.Config{
+		Spec: kotsv1beta1.ConfigSpec{
+			Groups: []kotsv1beta1.ConfigGroup{},
+		},
+	}
+
+	engine := NewEngine(config)
+
+	err := engine.Parse("{{repl Now }}")
+	require.NoError(t, err)
+	result, err := engine.Execute(nil)
+	require.NoError(t, err)
+
+	// Verify the result is a valid RFC3339 timestamp
+	_, err = time.Parse(time.RFC3339, result)
+	assert.NoError(t, err, "Result should be a valid RFC3339 timestamp")
+}
+
+func TestEngine_NowFmt(t *testing.T) {
+	config := &kotsv1beta1.Config{
+		Spec: kotsv1beta1.ConfigSpec{
+			Groups: []kotsv1beta1.ConfigGroup{},
+		},
+	}
+
+	engine := NewEngine(config)
+
+	testCases := []struct {
+		name     string
+		template string
+		validate func(string) bool
+	}{
+		{
+			name:     "RFC3339 format",
+			template: "{{repl NowFmt \"2006-01-02T15:04:05Z07:00\" }}",
+			validate: func(s string) bool {
+				_, err := time.Parse("2006-01-02T15:04:05Z07:00", s)
+				return err == nil
+			},
+		},
+		{
+			name:     "date only format",
+			template: "{{repl NowFmt \"2006-01-02\" }}",
+			validate: func(s string) bool {
+				_, err := time.Parse("2006-01-02", s)
+				return err == nil
+			},
+		},
+		{
+			name:     "time only format",
+			template: "{{repl NowFmt \"15:04:05\" }}",
+			validate: func(s string) bool {
+				_, err := time.Parse("15:04:05", s)
+				return err == nil
+			},
+		},
+		{
+			name:     "empty format defaults to RFC3339",
+			template: "{{repl NowFmt \"\" }}",
+			validate: func(s string) bool {
+				_, err := time.Parse(time.RFC3339, s)
+				return err == nil
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := engine.Parse(tc.template)
+			require.NoError(t, err)
+			result, err := engine.Execute(nil)
+			require.NoError(t, err)
+			assert.True(t, tc.validate(result), "Result should match expected format")
+		})
+	}
+}
+
+func TestEngine_Trim(t *testing.T) {
+	config := &kotsv1beta1.Config{
+		Spec: kotsv1beta1.ConfigSpec{
+			Groups: []kotsv1beta1.ConfigGroup{},
+		},
+	}
+
+	engine := NewEngine(config)
+
+	testCases := []struct {
+		name     string
+		template string
+		expected string
+	}{
+		{
+			name:     "trim whitespace",
+			template: "{{repl Trim \"  hello world  \" }}",
+			expected: "hello world",
+		},
+		{
+			name:     "trim specific characters",
+			template: "{{repl Trim \"***hello***\" \"*\" }}",
+			expected: "hello",
+		},
+		{
+			name:     "trim multiple characters",
+			template: "{{repl Trim \"###hello###\" \"#\" }}",
+			expected: "hello",
+		},
+		{
+			name:     "no trimming needed",
+			template: "{{repl Trim \"hello\" }}",
+			expected: "hello",
+		},
+		{
+			name:     "empty string",
+			template: "{{repl Trim \"\" }}",
+			expected: "",
+		},
+		{
+			name:     "only whitespace",
+			template: "{{repl Trim \"   \" }}",
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := engine.Parse(tc.template)
+			require.NoError(t, err)
+			result, err := engine.Execute(nil)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestEngine_Base64Encode(t *testing.T) {
+	config := &kotsv1beta1.Config{
+		Spec: kotsv1beta1.ConfigSpec{
+			Groups: []kotsv1beta1.ConfigGroup{},
+		},
+	}
+
+	engine := NewEngine(config)
+
+	testCases := []struct {
+		name     string
+		template string
+		expected string
+	}{
+		{
+			name:     "simple string",
+			template: "{{repl Base64Encode \"hello world\" }}",
+			expected: "aGVsbG8gd29ybGQ=",
+		},
+		{
+			name:     "empty string",
+			template: "{{repl Base64Encode \"\" }}",
+			expected: "",
+		},
+		{
+			name:     "special characters",
+			template: "{{repl Base64Encode \"hello@world.com\" }}",
+			expected: "aGVsbG9Ad29ybGQuY29t",
+		},
+		{
+			name:     "unicode characters",
+			template: "{{repl Base64Encode \"hello 世界\" }}",
+			expected: "aGVsbG8g5LiW55WM",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := engine.Parse(tc.template)
+			require.NoError(t, err)
+			result, err := engine.Execute(nil)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestEngine_Base64Decode(t *testing.T) {
+	config := &kotsv1beta1.Config{
+		Spec: kotsv1beta1.ConfigSpec{
+			Groups: []kotsv1beta1.ConfigGroup{},
+		},
+	}
+
+	engine := NewEngine(config)
+
+	testCases := []struct {
+		name     string
+		template string
+		expected string
+	}{
+		{
+			name:     "valid base64",
+			template: "{{repl Base64Decode \"aGVsbG8gd29ybGQ=\" }}",
+			expected: "hello world",
+		},
+		{
+			name:     "empty string",
+			template: "{{repl Base64Decode \"\" }}",
+			expected: "",
+		},
+		{
+			name:     "special characters",
+			template: "{{repl Base64Decode \"aGVsbG9Ad29ybGQuY29t\" }}",
+			expected: "hello@world.com",
+		},
+		{
+			name:     "unicode characters",
+			template: "{{repl Base64Decode \"aGVsbG8g5LiW55WM\" }}",
+			expected: "hello 世界",
+		},
+		{
+			name:     "invalid base64 returns empty",
+			template: "{{repl Base64Decode \"invalid-base64!@#\" }}",
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := engine.Parse(tc.template)
+			require.NoError(t, err)
+			result, err := engine.Execute(nil)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestEngine_RandomString(t *testing.T) {
+	config := &kotsv1beta1.Config{
+		Spec: kotsv1beta1.ConfigSpec{
+			Groups: []kotsv1beta1.ConfigGroup{},
+		},
+	}
+
+	engine := NewEngine(config)
+
+	testCases := []struct {
+		name     string
+		template string
+		validate func(string) bool
+	}{
+		{
+			name:     "default charset length 10",
+			template: "{{repl RandomString 10 }}",
+			validate: func(s string) bool {
+				return len(s) == 10 && regexp.MustCompile(`^[_A-Za-z0-9]+$`).MatchString(s)
+			},
+		},
+		{
+			name:     "custom charset",
+			template: "{{repl RandomString 5 \"[A-Z]\" }}",
+			validate: func(s string) bool {
+				return len(s) == 5 && regexp.MustCompile(`^[A-Z]+$`).MatchString(s)
+			},
+		},
+		{
+			name:     "numeric charset",
+			template: "{{repl RandomString 8 \"[0-9]\" }}",
+			validate: func(s string) bool {
+				return len(s) == 8 && regexp.MustCompile(`^[0-9]+$`).MatchString(s)
+			},
+		},
+		{
+			name:     "length 0",
+			template: "{{repl RandomString 0 }}",
+			validate: func(s string) bool {
+				return s == ""
+			},
+		},
+		{
+			name:     "invalid charset returns empty",
+			template: "{{repl RandomString 5 \"[invalid\" }}",
+			validate: func(s string) bool {
+				return s == ""
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := engine.Parse(tc.template)
+			require.NoError(t, err)
+			result, err := engine.Execute(nil)
+			require.NoError(t, err)
+			assert.True(t, tc.validate(result), "Result should match expected pattern")
+		})
+	}
+}
+
+func TestEngine_RandomBytes(t *testing.T) {
+	config := &kotsv1beta1.Config{
+		Spec: kotsv1beta1.ConfigSpec{
+			Groups: []kotsv1beta1.ConfigGroup{},
+		},
+	}
+
+	engine := NewEngine(config)
+
+	testCases := []struct {
+		name     string
+		template string
+		validate func(string) bool
+	}{
+		{
+			name:     "length 10",
+			template: "{{repl RandomBytes 10 }}",
+			validate: func(s string) bool {
+				decoded, err := base64.StdEncoding.DecodeString(s)
+				return err == nil && len(decoded) == 10
+			},
+		},
+		{
+			name:     "length 0",
+			template: "{{repl RandomBytes 0 }}",
+			validate: func(s string) bool {
+				decoded, err := base64.StdEncoding.DecodeString(s)
+				return err == nil && len(decoded) == 0
+			},
+		},
+		{
+			name:     "length 1",
+			template: "{{repl RandomBytes 1 }}",
+			validate: func(s string) bool {
+				decoded, err := base64.StdEncoding.DecodeString(s)
+				return err == nil && len(decoded) == 1
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := engine.Parse(tc.template)
+			require.NoError(t, err)
+			result, err := engine.Execute(nil)
+			require.NoError(t, err)
+			assert.True(t, tc.validate(result), "Result should be valid base64 with correct length")
+		})
+	}
+}
+
+func TestEngine_Add(t *testing.T) {
+	config := &kotsv1beta1.Config{
+		Spec: kotsv1beta1.ConfigSpec{
+			Groups: []kotsv1beta1.ConfigGroup{},
+		},
+	}
+
+	engine := NewEngine(config)
+
+	testCases := []struct {
+		name     string
+		template string
+		expected string
+	}{
+		{
+			name:     "int addition",
+			template: "{{repl Add 5 3 }}",
+			expected: "8",
+		},
+		{
+			name:     "float addition",
+			template: "{{repl Add 5.5 3.2 }}",
+			expected: "8.7",
+		},
+		{
+			name:     "mixed int and float",
+			template: "{{repl Add 5 3.5 }}",
+			expected: "8.5",
+		},
+		{
+			name:     "uint addition",
+			template: "{{repl Add 10 20 }}",
+			expected: "30",
+		},
+		{
+			name:     "negative numbers",
+			template: "{{repl Add -5 3 }}",
+			expected: "-2",
+		},
+		{
+			name:     "zero addition",
+			template: "{{repl Add 0 0 }}",
+			expected: "0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := engine.Parse(tc.template)
+			require.NoError(t, err)
+			result, err := engine.Execute(nil)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestEngine_Sub(t *testing.T) {
+	config := &kotsv1beta1.Config{
+		Spec: kotsv1beta1.ConfigSpec{
+			Groups: []kotsv1beta1.ConfigGroup{},
+		},
+	}
+
+	engine := NewEngine(config)
+
+	testCases := []struct {
+		name     string
+		template string
+		expected string
+	}{
+		{
+			name:     "int subtraction",
+			template: "{{repl Sub 10 3 }}",
+			expected: "7",
+		},
+		{
+			name:     "float subtraction",
+			template: "{{repl Sub 10.5 3.2 }}",
+			expected: "7.3",
+		},
+		{
+			name:     "mixed int and float",
+			template: "{{repl Sub 10 3.5 }}",
+			expected: "6.5",
+		},
+		{
+			name:     "negative result",
+			template: "{{repl Sub 3 10 }}",
+			expected: "-7",
+		},
+		{
+			name:     "zero subtraction",
+			template: "{{repl Sub 5 0 }}",
+			expected: "5",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := engine.Parse(tc.template)
+			require.NoError(t, err)
+			result, err := engine.Execute(nil)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestEngine_Mult(t *testing.T) {
+	config := &kotsv1beta1.Config{
+		Spec: kotsv1beta1.ConfigSpec{
+			Groups: []kotsv1beta1.ConfigGroup{},
+		},
+	}
+
+	engine := NewEngine(config)
+
+	testCases := []struct {
+		name     string
+		template string
+		expected string
+	}{
+		{
+			name:     "int multiplication",
+			template: "{{repl Mult 5 3 }}",
+			expected: "15",
+		},
+		{
+			name:     "float multiplication",
+			template: "{{repl Mult 5.5 3.2 }}",
+			expected: "17.6",
+		},
+		{
+			name:     "mixed int and float",
+			template: "{{repl Mult 5 3.5 }}",
+			expected: "17.5",
+		},
+		{
+			name:     "zero multiplication",
+			template: "{{repl Mult 5 0 }}",
+			expected: "0",
+		},
+		{
+			name:     "negative multiplication",
+			template: "{{repl Mult -5 3 }}",
+			expected: "-15",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := engine.Parse(tc.template)
+			require.NoError(t, err)
+			result, err := engine.Execute(nil)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestEngine_Div(t *testing.T) {
+	config := &kotsv1beta1.Config{
+		Spec: kotsv1beta1.ConfigSpec{
+			Groups: []kotsv1beta1.ConfigGroup{},
+		},
+	}
+
+	engine := NewEngine(config)
+
+	testCases := []struct {
+		name     string
+		template string
+		expected string
+	}{
+		{
+			name:     "int division",
+			template: "{{repl Div 10 2 }}",
+			expected: "5",
+		},
+		{
+			name:     "float division",
+			template: "{{repl Div 10.5 2.5 }}",
+			expected: "4.2",
+		},
+		{
+			name:     "mixed int and float",
+			template: "{{repl Div 10 2.5 }}",
+			expected: "4",
+		},
+
+		{
+			name:     "negative division",
+			template: "{{repl Div -10 2 }}",
+			expected: "-5",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := engine.Parse(tc.template)
+			require.NoError(t, err)
+			result, err := engine.Execute(nil)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestEngine_ParseBool(t *testing.T) {
+	config := &kotsv1beta1.Config{
+		Spec: kotsv1beta1.ConfigSpec{
+			Groups: []kotsv1beta1.ConfigGroup{},
+		},
+	}
+
+	engine := NewEngine(config)
+
+	testCases := []struct {
+		name     string
+		template string
+		expected string
+	}{
+		{
+			name:     "true string",
+			template: "{{repl ParseBool \"true\" }}",
+			expected: "true",
+		},
+		{
+			name:     "false string",
+			template: "{{repl ParseBool \"false\" }}",
+			expected: "false",
+		},
+		{
+			name:     "1 string",
+			template: "{{repl ParseBool \"1\" }}",
+			expected: "true",
+		},
+		{
+			name:     "0 string",
+			template: "{{repl ParseBool \"0\" }}",
+			expected: "false",
+		},
+		{
+			name:     "invalid string",
+			template: "{{repl ParseBool \"invalid\" }}",
+			expected: "false",
+		},
+		{
+			name:     "empty string",
+			template: "{{repl ParseBool \"\" }}",
+			expected: "false",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := engine.Parse(tc.template)
+			require.NoError(t, err)
+			result, err := engine.Execute(nil)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestEngine_ParseFloat(t *testing.T) {
+	config := &kotsv1beta1.Config{
+		Spec: kotsv1beta1.ConfigSpec{
+			Groups: []kotsv1beta1.ConfigGroup{},
+		},
+	}
+
+	engine := NewEngine(config)
+
+	testCases := []struct {
+		name     string
+		template string
+		expected string
+	}{
+		{
+			name:     "valid float",
+			template: "{{repl ParseFloat \"3.14\" }}",
+			expected: "3.14",
+		},
+		{
+			name:     "integer string",
+			template: "{{repl ParseFloat \"42\" }}",
+			expected: "42",
+		},
+		{
+			name:     "negative float",
+			template: "{{repl ParseFloat \"-3.14\" }}",
+			expected: "-3.14",
+		},
+		{
+			name:     "invalid string",
+			template: "{{repl ParseFloat \"invalid\" }}",
+			expected: "0",
+		},
+		{
+			name:     "empty string",
+			template: "{{repl ParseFloat \"\" }}",
+			expected: "0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := engine.Parse(tc.template)
+			require.NoError(t, err)
+			result, err := engine.Execute(nil)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestEngine_ParseInt(t *testing.T) {
+	config := &kotsv1beta1.Config{
+		Spec: kotsv1beta1.ConfigSpec{
+			Groups: []kotsv1beta1.ConfigGroup{},
+		},
+	}
+
+	engine := NewEngine(config)
+
+	testCases := []struct {
+		name     string
+		template string
+		expected string
+	}{
+		{
+			name:     "decimal string",
+			template: "{{repl ParseInt \"42\" }}",
+			expected: "42",
+		},
+		{
+			name:     "negative string",
+			template: "{{repl ParseInt \"-42\" }}",
+			expected: "-42",
+		},
+		{
+			name:     "hex string",
+			template: "{{repl ParseInt \"2A\" 16 }}",
+			expected: "42",
+		},
+		{
+			name:     "binary string",
+			template: "{{repl ParseInt \"101010\" 2 }}",
+			expected: "42",
+		},
+		{
+			name:     "invalid string",
+			template: "{{repl ParseInt \"invalid\" }}",
+			expected: "0",
+		},
+		{
+			name:     "empty string",
+			template: "{{repl ParseInt \"\" }}",
+			expected: "0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := engine.Parse(tc.template)
+			require.NoError(t, err)
+			result, err := engine.Execute(nil)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestEngine_ParseUint(t *testing.T) {
+	config := &kotsv1beta1.Config{
+		Spec: kotsv1beta1.ConfigSpec{
+			Groups: []kotsv1beta1.ConfigGroup{},
+		},
+	}
+
+	engine := NewEngine(config)
+
+	testCases := []struct {
+		name     string
+		template string
+		expected string
+	}{
+		{
+			name:     "decimal string",
+			template: "{{repl ParseUint \"42\" }}",
+			expected: "42",
+		},
+		{
+			name:     "hex string",
+			template: "{{repl ParseUint \"2A\" 16 }}",
+			expected: "42",
+		},
+		{
+			name:     "binary string",
+			template: "{{repl ParseUint \"101010\" 2 }}",
+			expected: "42",
+		},
+		{
+			name:     "invalid string",
+			template: "{{repl ParseUint \"invalid\" }}",
+			expected: "0",
+		},
+		{
+			name:     "empty string",
+			template: "{{repl ParseUint \"\" }}",
+			expected: "0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := engine.Parse(tc.template)
+			require.NoError(t, err)
+			result, err := engine.Execute(nil)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestEngine_HumanSize(t *testing.T) {
+	config := &kotsv1beta1.Config{
+		Spec: kotsv1beta1.ConfigSpec{
+			Groups: []kotsv1beta1.ConfigGroup{},
+		},
+	}
+
+	engine := NewEngine(config)
+
+	testCases := []struct {
+		name     string
+		template string
+		expected string
+	}{
+		{
+			name:     "bytes",
+			template: "{{repl HumanSize 1024 }}",
+			expected: "1.024kB",
+		},
+		{
+			name:     "kilobytes",
+			template: "{{repl HumanSize 1048576 }}",
+			expected: "1.049MB",
+		},
+		{
+			name:     "megabytes",
+			template: "{{repl HumanSize 1073741824 }}",
+			expected: "1.074GB",
+		},
+		{
+			name:     "zero",
+			template: "{{repl HumanSize 0 }}",
+			expected: "0B",
+		},
+		{
+			name:     "float input",
+			template: "{{repl HumanSize 1024.5 }}",
+			expected: "1.024kB",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := engine.Parse(tc.template)
+			require.NoError(t, err)
+			result, err := engine.Execute(nil)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestEngine_YamlEscape(t *testing.T) {
+	config := &kotsv1beta1.Config{
+		Spec: kotsv1beta1.ConfigSpec{
+			Groups: []kotsv1beta1.ConfigGroup{},
+		},
+	}
+
+	engine := NewEngine(config)
+
+	testCases := []struct {
+		name     string
+		template string
+		validate func(string) bool
+	}{
+		{
+			name:     "simple string",
+			template: "{{repl YamlEscape \"hello world\" }}",
+			validate: func(s string) bool {
+				return strings.Contains(s, "hello world") && strings.HasPrefix(s, "                    ")
+			},
+		},
+		{
+			name:     "string with quotes",
+			template: "{{repl YamlEscape \"hello \\\"world\\\"\" }}",
+			validate: func(s string) bool {
+				return strings.Contains(s, "hello") && strings.Contains(s, "world") && strings.HasPrefix(s, "                    ")
+			},
+		},
+		{
+			name:     "empty string",
+			template: "{{repl YamlEscape \"\" }}",
+			validate: func(s string) bool {
+				return strings.HasPrefix(s, "                    ")
+			},
+		},
+		{
+			name:     "multiline string",
+			template: "{{repl YamlEscape \"line1\\nline2\" }}",
+			validate: func(s string) bool {
+				return strings.Contains(s, "line1") && strings.Contains(s, "line2") && strings.HasPrefix(s, "                    ")
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := engine.Parse(tc.template)
+			require.NoError(t, err)
+			result, err := engine.Execute(nil)
+			require.NoError(t, err)
+			assert.True(t, tc.validate(result), "Result should be properly indented YAML")
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/creack/pty v1.1.24
 	github.com/distribution/reference v0.6.0
+	github.com/docker/go-units v0.5.0
 	github.com/evanphx/json-patch v5.9.11+incompatible
 	github.com/fatih/color v1.18.0
 	github.com/go-logr/logr v1.4.3
@@ -141,7 +142,6 @@ require (
 	github.com/docker/docker-credential-helpers v0.9.3 // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect
-	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.8.2 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.32.4 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.2.1 // indirect


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Support for 

| Now |
| NowFmt |
| ToLower |
| ToUpper |
| TrimSpace |
| Trim |
| UrlEncode |
| Base64Encode |
| Base64Decode |
| Split |
| RandomBytes |
| RandomString |
| Add |
| Sub |
| Mult |
| Div |
| ParseBool |
| ParseFloat |
| ParseInt |
| ParseUint |
| HumanSize |
| YamlEscape |

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
