### PR TITLE
fix(ui): show error message for empty password in UI

### DIFF
--- a/web/src/components/wizard/WelcomeStep.tsx
+++ b/web/src/components/wizard/WelcomeStep.tsx
@@ -16,9 +16,12 @@ interface LoginResponse {
   token: string;
 }
 
+const INCORRECT_PASSWORD_ERROR = "Incorrect password";
+
 const WelcomeStep: React.FC<WelcomeStepProps> = ({ onNext }) => {
   const { text } = useWizard();
   const [password, setPassword] = useState("");
+  const [loginError, setLoginError] = useState<string | undefined>();
   const { setToken, isAuthenticated } = useAuth();
 
   // Automatically redirect to SetupStep if already authenticated
@@ -31,9 +34,16 @@ const WelcomeStep: React.FC<WelcomeStepProps> = ({ onNext }) => {
   const {
     mutate: login,
     isPending: isLoading,
-    error: loginError,
   } = useMutation<LoginResponse, Error, string>({
+    retry(failureCount, error) {
+      if (error.message === INCORRECT_PASSWORD_ERROR) {
+        return false; // Don't retry on incorrect password
+      }
+      // Otherwise retry once, keep the default retry logic
+      return failureCount < 1;
+    },
     mutationFn: async (password: string) => {
+
       const response = await fetch("/api/auth/login", {
         method: "POST",
         body: JSON.stringify({ password }),
@@ -43,7 +53,11 @@ const WelcomeStep: React.FC<WelcomeStepProps> = ({ onNext }) => {
       });
 
       if (!response.ok) {
-        throw new Error("Invalid password");
+        if (response.status === 401) {
+          throw new Error(INCORRECT_PASSWORD_ERROR);
+        } else {
+          throw new Error(`Login failed: ${response.statusText}`);
+        }
       }
 
       return response.json();
@@ -52,6 +66,9 @@ const WelcomeStep: React.FC<WelcomeStepProps> = ({ onNext }) => {
       setToken(data.token);
       onNext();
     },
+    onError: (error) => {
+      setLoginError(error.message);
+    },
   });
 
   const handlePasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -59,10 +76,11 @@ const WelcomeStep: React.FC<WelcomeStepProps> = ({ onNext }) => {
   };
 
   const handleSubmit = () => {
-    if (!password.trim()) {
-      return;
+    // No point in making a request if password is empty
+    if (!password) {
+      setLoginError(INCORRECT_PASSWORD_ERROR);
+      return
     }
-
     login(password);
   };
 
@@ -91,7 +109,7 @@ const WelcomeStep: React.FC<WelcomeStepProps> = ({ onNext }) => {
               value={password}
               onChange={handlePasswordChange}
               onKeyDown={handleKeyDown}
-              error={loginError?.message}
+              error={loginError}
               required
               icon={<Lock className="w-5 h-5" />}
               className="w-full"

--- a/web/src/components/wizard/tests/WelcomeStep.test.tsx
+++ b/web/src/components/wizard/tests/WelcomeStep.test.tsx
@@ -78,7 +78,7 @@ describe("WelcomeStep", () => {
     fireEvent.change(passwordInput, { target: { value: "password" } });
 
     // Submit form
-    const submitButton = screen.getByRole("button", { name: /Start/ });
+    const submitButton = screen.getByTestId("welcome-button-next");
     fireEvent.click(submitButton);
 
     // Wait for the mutation to complete and verify onNext was called
@@ -94,19 +94,149 @@ describe("WelcomeStep", () => {
     renderWithProviders(<WelcomeStep onNext={mockOnNext} />);
 
     // Fill in incorrect password
-    const passwordInput = screen.getByLabelText(/Enter Password/);
+    const passwordInput = screen.getByTestId("password-input");
     fireEvent.change(passwordInput, { target: { value: "wrong-password" } });
 
     // Submit form
-    const submitButton = screen.getByRole("button", { name: /Start/ });
+    const submitButton = screen.getByTestId("welcome-button-next");
     fireEvent.click(submitButton);
 
     // Wait for error message
     await waitFor(() => {
-      expect(screen.getByText(/Invalid password/)).toBeInTheDocument();
+      expect(screen.getByText(/Incorrect password/)).toBeInTheDocument();
     });
 
     // Verify onNext was not called
     expect(mockOnNext).not.toHaveBeenCalled();
   });
+
+  it("does not retry on 401 authentication errors", async () => {
+    let requestCount = 0;
+    server.use(
+      http.post("*/api/auth/login", () => {
+        requestCount++;
+        return new HttpResponse(JSON.stringify({ message: "Invalid password" }), {
+          status: 401,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        });
+      })
+    );
+
+    renderWithProviders(<WelcomeStep onNext={mockOnNext} />);
+
+    // Fill in password and submit
+    const passwordInput = screen.getByTestId("password-input");
+    fireEvent.change(passwordInput, { target: { value: "wrong-password" } });
+
+    const submitButton = screen.getByTestId("welcome-button-next");
+    fireEvent.click(submitButton);
+
+    // Wait for error to appear
+    await waitFor(() => {
+      expect(screen.getByText(/Incorrect password/)).toBeInTheDocument();
+    });
+
+    // Should only make one request, no retries for 401
+    expect(requestCount).toBe(1);
+    expect(mockOnNext).not.toHaveBeenCalled();
+  });
+
+  it("retries once for server errors then shows error", async () => {
+    let requestCount = 0;
+    server.use(
+      http.post("*/api/auth/login", () => {
+        requestCount++;
+        return new HttpResponse(JSON.stringify({ message: "Internal server error" }), {
+          status: 500,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        });
+      })
+    );
+
+    renderWithProviders(<WelcomeStep onNext={mockOnNext} />);
+
+    // Fill in password and submit
+    const passwordInput = screen.getByTestId("password-input");
+    fireEvent.change(passwordInput, { target: { value: "password" } });
+
+    const submitButton = screen.getByTestId("welcome-button-next");
+    fireEvent.click(submitButton);
+
+    // Wait for error to appear
+    await waitFor(() => {
+      expect(screen.getByText(/Login failed/)).toBeInTheDocument();
+    }, { timeout: 5000 });
+
+    // Should make 2 requests: initial + 1 retry
+    expect(requestCount).toBe(2);
+    expect(mockOnNext).not.toHaveBeenCalled();
+  });
+
+  it("retries once for network errors then succeeds", async () => {
+    let requestCount = 0;
+    server.use(
+      http.post("*/api/auth/login", () => {
+        requestCount++;
+        if (requestCount === 1) {
+          // First request fails with 503
+          return new HttpResponse(JSON.stringify({ message: "Service unavailable" }), {
+            status: 503,
+            headers: {
+              "Content-Type": "application/json",
+            },
+          });
+        } else {
+          // Second request (retry) succeeds
+          return new HttpResponse(JSON.stringify({ token: "mock-token" }), {
+            status: 200,
+            headers: {
+              "Content-Type": "application/json",
+            },
+          });
+        }
+      })
+    );
+
+    renderWithProviders(<WelcomeStep onNext={mockOnNext} />);
+
+    // Fill in password and submit
+    const passwordInput = screen.getByTestId("password-input");
+    fireEvent.change(passwordInput, { target: { value: "password" } });
+
+    const submitButton = screen.getByTestId("welcome-button-next");
+    fireEvent.click(submitButton);
+
+    // Wait for successful login
+    await waitFor(() => {
+      expect(mockOnNext).toHaveBeenCalled();
+    }, { timeout: 5000 });
+
+    // Should make 2 requests: initial failure + 1 successful retry
+    expect(requestCount).toBe(2);
+  });
+
+  it("shows error message for empty password", async () => {
+    renderWithProviders(<WelcomeStep onNext={mockOnNext} />);
+
+    // Fill in incorrect password
+    const passwordInput = screen.getByTestId("password-input");
+    fireEvent.change(passwordInput, { target: { value: "" } });
+
+    // Submit form
+    const submitButton = screen.getByTestId("welcome-button-next");
+    fireEvent.click(submitButton);
+
+    // Wait for error message
+    await waitFor(() => {
+      expect(screen.getByText(/Incorrect password/)).toBeInTheDocument();
+    });
+
+    // Verify onNext was not called
+    expect(mockOnNext).not.toHaveBeenCalled();
+  });
+
 });


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

- Changed the password error copy to match the mockup
- Show error for empty password
- Distinguish between 401 and other errors
- Do not retry incorrect password attempts
- Tests

Loom:
- https://www.loom.com/share/dce97fa3d78a42abb0ef66268c29aeec?sid=7081667d-e745-4c58-81ce-b2697850abbb

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/126447/highlight-missing-password-on-welcome-page

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Yes

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE