### PR TITLE
Extract Charts tarballs and v1beta2 HelmChart custom resources

### DIFF
--- a/api/pkg/template/engine_test.go
+++ b/api/pkg/template/engine_test.go
@@ -1079,8 +1079,8 @@ repl{{ toJson $tls }}`),
 	assert.True(t, firstCachedDuration < time.Millisecond*20, "First cached execution should be under 20ms")
 
 	// Verify caching provides significant speedup
-	assert.True(t, firstCachedDuration < firstDuration/2,
-		"Cached execution should be at least 2x faster. First: %v, Cached: %v",
+	assert.True(t, firstCachedDuration < firstDuration/5,
+		"Cached execution should be at least 5x faster. First: %v, Cached: %v",
 		firstDuration, firstCachedDuration)
 
 	// Verify cached result is identical to first execution
@@ -1103,6 +1103,11 @@ repl{{ toJson $tls }}`),
 	// Verify performance characteristics for second hostname
 	assert.True(t, secondDuration > time.Millisecond*100, "Second execution should take at least 100ms (cert generation)")
 	assert.True(t, secondCachedDuration < time.Millisecond*20, "Second cached execution should be under 20ms")
+
+	// Verify caching provides significant speedup
+	assert.True(t, secondCachedDuration < secondDuration/5,
+		"Cached execution should be at least 5x faster. Second: %v, Cached: %v",
+		secondDuration, secondCachedDuration)
 
 	// Verify second cached result is identical to second execution
 	assert.Equal(t, secondResult, secondCachedResult, "Second cached execution should return identical result")

--- a/pkg/release/testdata/release.yaml
+++ b/pkg/release/testdata/release.yaml
@@ -64,3 +64,22 @@ host-preflights.yaml: |-
               message: The filesystem at {{ .DataDir }} is more than 80% full. Ensure sufficient space is available, or use --data-dir to specify an alternative data directory.
           - pass:
               message: The filesystem at {{ .DataDir }} has sufficient space
+
+helmchart.yaml: |-
+  apiVersion: kots.io/v1beta2
+  kind: HelmChart
+  metadata:
+    name: test-chart
+  spec:
+    chart:
+      name: test-chart
+      chartVersion: "1.0.0"
+    namespace: test-namespace
+    values:
+      replicaCount: 1
+      image:
+        repository: nginx
+        tag: "1.21"
+
+test-chart-1.0.0.tgz: |-
+  fake-chart-archive-content-for-testing


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Extracts Charts tarballs and v1beta2 HelmChart custom resources from the embedded release.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-127223](https://app.shortcut.com/replicated/story/127223)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Yes

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE