### PR TITLE
Generate Helm values for each chart using its HelmChart custom resource

### DIFF
--- a/api/internal/managers/app/release/manager.go
+++ b/api/internal/managers/app/release/manager.go
@@ -15,6 +15,7 @@ import (
 // AppReleaseManager provides methods for managing the release of an app
 type AppReleaseManager interface {
 	TemplateHelmChartCRs(ctx context.Context, configValues types.AppConfigValues) ([]*kotsv1beta2.HelmChart, error)
+	GenerateHelmValues(ctx context.Context, templatedCR *kotsv1beta2.HelmChart) (map[string]any, error)
 }
 
 type appReleaseManager struct {

--- a/api/internal/managers/app/release/template_test.go
+++ b/api/internal/managers/app/release/template_test.go
@@ -48,12 +48,24 @@ spec:
     image:
       tag: '{{repl ConfigOption "image_tag"}}'
     name: '{{repl ConfigOption "app_name" | upper}}'
+  optionalValues:
+  - when: '{{repl ConfigOption "enable_persistence"}}'
+    values:
+      persistence:
+        enabled: true
+        size: 10Gi
+  - when: '{{repl ConfigOption "disable_monitoring"}}'
+    values:
+      monitoring:
+        enabled: false
 `),
 			},
 			configValues: types.AppConfigValues{
-				"chart_name": {Value: "NGINX"},
-				"image_tag":  {Value: "1.20.0"},
-				"app_name":   {Value: "myapp"},
+				"chart_name":         {Value: "NGINX"},
+				"image_tag":          {Value: "1.20.0"},
+				"app_name":           {Value: "myapp"},
+				"enable_persistence": {Value: "true"},
+				"disable_monitoring": {Value: "false"},
 			},
 			expected: []*kotsv1beta2.HelmChart{
 				createHelmChartFromYAML(`
@@ -70,6 +82,16 @@ spec:
     image:
       tag: "1.20.0"
     name: MYAPP
+  optionalValues:
+  - when: "true"
+    values:
+      persistence:
+        enabled: true
+        size: 10Gi
+  - when: "false"
+    values:
+      monitoring:
+        enabled: false
 `),
 			},
 			expectError: false,
@@ -89,6 +111,12 @@ spec:
     chartVersion: '{{repl ConfigOption "chart1_version"}}'
   values:
     replicas: '{{repl ConfigOption "chart1_replicas"}}'
+  optionalValues:
+  - when: '{{repl ParseBool (ConfigOption "enable_resources") | not}}'
+    values:
+      resources:
+        limits:
+          memory: 128Mi
 `),
 				createHelmChartFromYAML(`
 apiVersion: kots.io/v1beta2
@@ -104,15 +132,24 @@ spec:
     service:
       type: '{{repl ConfigOption "service_type" | upper}}'
       port: '{{repl ConfigOption "service_port"}}'
+  optionalValues:
+  - when: '{{repl ConfigOptionEquals "redis_persistence" "true"}}'
+    recursiveMerge: true
+    values:
+      persistence:
+        enabled: true
+        size: 8Gi
 `),
 			},
 			configValues: types.AppConfigValues{
-				"chart1_name":     {Value: "NGINX"},
-				"chart1_version":  {Value: "1.20.0"},
-				"chart1_replicas": {Value: "3"},
-				"chart2_name":     {Value: "redis"},
-				"service_type":    {Value: "clusterip"},
-				"service_port":    {Value: "6379"},
+				"chart1_name":        {Value: "NGINX"},
+				"chart1_version":     {Value: "1.20.0"},
+				"chart1_replicas":    {Value: "3"},
+				"chart2_name":        {Value: "redis"},
+				"service_type":       {Value: "clusterip"},
+				"service_port":       {Value: "6379"},
+				"enable_resources":   {Value: "false"},
+				"redis_persistence":  {Value: "true"},
 			},
 			expected: []*kotsv1beta2.HelmChart{
 				createHelmChartFromYAML(`
@@ -127,6 +164,12 @@ spec:
     chartVersion: "1.20.0"
   values:
     replicas: "3"
+  optionalValues:
+  - when: "true"
+    values:
+      resources:
+        limits:
+          memory: 128Mi
 `),
 				createHelmChartFromYAML(`
 apiVersion: kots.io/v1beta2
@@ -142,6 +185,13 @@ spec:
     service:
       type: CLUSTERIP
       port: "6379"
+  optionalValues:
+  - when: "true"
+    recursiveMerge: true
+    values:
+      persistence:
+        enabled: true
+        size: 8Gi
 `),
 			},
 			expectError: false,
@@ -218,6 +268,370 @@ spec:
 	}
 }
 
+func TestAppReleaseManager_GenerateHelmValues(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		templatedCR *kotsv1beta2.HelmChart
+		expected    map[string]any
+		expectError bool
+	}{
+		{
+			name:        "nil templated CR",
+			templatedCR: nil,
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name: "helm chart with simple values",
+			templatedCR: createHelmChartFromYAML(`
+apiVersion: kots.io/v1beta2
+kind: HelmChart
+metadata:
+  name: nginx-chart
+  namespace: default
+spec:
+  chart:
+    name: nginx
+    chartVersion: "1.0.0"
+  values:
+    replicaCount: "3"
+    image:
+      repository: nginx
+      tag: "1.20.0"
+    service:
+      type: ClusterIP
+      port: 80
+`),
+			expected: map[string]any{
+				"replicaCount": "3", // from base values
+				"image": map[string]any{
+					"repository": "nginx",  // from base values
+					"tag":        "1.20.0", // from base values
+				},
+				"service": map[string]any{
+					"type": "ClusterIP", // from base values
+					"port": float64(80), // from base values
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "helm chart with optional values",
+			templatedCR: createHelmChartFromYAML(`
+apiVersion: kots.io/v1beta2
+kind: HelmChart
+metadata:
+  name: redis-chart
+spec:
+  chart:
+    name: redis
+    chartVersion: "2.0.0"
+  values:
+    persistence:
+      enabled: false
+  optionalValues:
+  - when: "true"
+    values:
+      persistence:
+        enabled: true
+        size: "10Gi"
+`),
+			expected: map[string]any{
+				"persistence": map[string]any{
+					"enabled": true,   // from optional values (overrode base value false)
+					"size":    "10Gi", // from optional values (new key)
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "helm chart with recursive merge",
+			templatedCR: createHelmChartFromYAML(`
+apiVersion: kots.io/v1beta2
+kind: HelmChart
+metadata:
+  name: merge-chart
+spec:
+  chart:
+    name: nginx
+    chartVersion: "1.0.0"
+  values:
+    service:
+      type: ClusterIP
+      port: 80
+    resources:
+      limits:
+        cpu: "100m"
+        memory: "64Mi"
+    replicaCount: "1"
+  optionalValues:
+  - when: "true"
+    recursiveMerge: true
+    values:
+      service:
+        type: NodePort
+        nodePort: 30080
+      resources:
+        limits:
+          memory: "128Mi"
+        requests:
+          cpu: "50m"
+      replicaCount: "3"
+`),
+			expected: map[string]any{
+				"service": map[string]any{
+					"type":     "NodePort",     // from optional values (overrode base value via recursive merge)
+					"port":     float64(80),    // from base values (preserved)
+					"nodePort": float64(30080), // from optional values (added via recursive merge)
+				},
+				"resources": map[string]any{
+					"limits": map[string]any{
+						"cpu":    "100m",  // from base values (preserved)
+						"memory": "128Mi", // from optional values (overrode base value via recursive merge)
+					},
+					"requests": map[string]any{
+						"cpu": "50m", // from optional values (added via recursive merge)
+					},
+				},
+				"replicaCount": "3", // from optional values (overrode base value via recursive merge)
+			},
+			expectError: false,
+		},
+		{
+			name: "helm chart with direct key replacement (no recursive merge)",
+			templatedCR: createHelmChartFromYAML(`
+apiVersion: kots.io/v1beta2
+kind: HelmChart
+metadata:
+  name: replace-chart
+spec:
+  chart:
+    name: nginx
+    chartVersion: "1.0.0"
+  values:
+    service:
+      type: ClusterIP
+      port: 80
+      annotations:
+        example: "original"
+    resources:
+      limits:
+        cpu: "100m"
+        memory: "128Mi"
+  optionalValues:
+  - when: "true"
+    recursiveMerge: false
+    values:
+      service:
+        type: NodePort
+        nodePort: 30080
+      resources:
+        requests:
+          cpu: "50m"
+`),
+			expected: map[string]any{
+				"service": map[string]any{
+					"type":     "NodePort",     // from optional values (direct replacement)
+					"nodePort": float64(30080), // from optional values (direct replacement)
+					// Note: port=80 and annotations are GONE because entire service key was replaced
+				},
+				"resources": map[string]any{
+					"requests": map[string]any{
+						"cpu": "50m", // from optional values (direct replacement)
+					},
+					// Note: limits.cpu and limits.memory are GONE because entire resources key was replaced
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "helm chart with when condition false",
+			templatedCR: createHelmChartFromYAML(`
+apiVersion: kots.io/v1beta2
+kind: HelmChart
+metadata:
+  name: false-when-chart
+spec:
+  chart:
+    name: nginx
+    chartVersion: "1.0.0"
+  values:
+    replicaCount: "1"
+  optionalValues:
+  - when: "false"
+    values:
+      replicaCount: "3"
+      extraConfig: "should not appear"
+`),
+			expected: map[string]any{
+				"replicaCount": "1", // from base values (optional values skipped due to when=false)
+			},
+			expectError: false,
+		},
+		{
+			name: "helm chart with multiple optional values",
+			templatedCR: createHelmChartFromYAML(`
+apiVersion: kots.io/v1beta2
+kind: HelmChart
+metadata:
+  name: multi-optional-chart
+spec:
+  chart:
+    name: nginx
+    chartVersion: "1.0.0"
+  values:
+    replicaCount: "1"
+  optionalValues:
+  - when: "true"
+    values:
+      persistence:
+        enabled: true
+  - when: "false"
+    values:
+      debugging:
+        enabled: true
+  - when: "true"
+    recursiveMerge: true
+    values:
+      persistence:
+        size: "10Gi"
+      monitoring:
+        enabled: true
+`),
+			expected: map[string]any{
+				"replicaCount": "1", // from base values
+				"persistence": map[string]any{
+					"enabled": true,   // from 1st optional values (when=true, direct replacement)
+					"size":    "10Gi", // from 3rd optional values (when=true, recursive merge)
+				},
+				"monitoring": map[string]any{
+					"enabled": true, // from 3rd optional values (when=true, recursive merge)
+				},
+				// Note: debugging is NOT present because 2nd optional values had when=false
+			},
+			expectError: false,
+		},
+		{
+			name: "helm chart with no base values",
+			templatedCR: createHelmChartFromYAML(`
+apiVersion: kots.io/v1beta2
+kind: HelmChart
+metadata:
+  name: no-base-values-chart
+spec:
+  chart:
+    name: nginx
+    chartVersion: "1.0.0"
+  optionalValues:
+  - when: "true"
+    values:
+      replicaCount: "3"
+      service:
+        type: ClusterIP
+`),
+			expected: map[string]any{
+				"replicaCount": "3", // from optional values (no base values)
+				"service": map[string]any{
+					"type": "ClusterIP", // from optional values (no base values)
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "clear example of recursive merge vs direct replacement",
+			templatedCR: createHelmChartFromYAML(`
+apiVersion: kots.io/v1beta2
+kind: HelmChart
+metadata:
+  name: merge-comparison-chart
+spec:
+  chart:
+    name: nginx
+    chartVersion: "1.0.0"
+  values:
+    database:
+      host: "localhost"
+      port: 5432
+      ssl: true
+      timeout: 10
+    cache:
+      type: "memory"
+      size: "1Gi"
+      ttl: 1800
+  optionalValues:
+  - when: "true"
+    recursiveMerge: true
+    values:
+      database:
+        host: "prod-db"
+        password: "secret"
+        timeout: 30
+  - when: "true"
+    recursiveMerge: false
+    values:
+      cache:
+        type: "redis"
+        ttl: 3600
+`),
+			expected: map[string]any{
+				"database": map[string]any{
+					"host":     "prod-db",         // from recursive merge optional values (overrode base value)
+					"port":     float64(5432),     // from base values (preserved)
+					"ssl":      true,              // from base values (preserved)
+					"password": "secret",          // from recursive merge optional values (added)
+					"timeout":  float64(30),       // from recursive merge optional values (overrode base value)
+				},
+				"cache": map[string]any{
+					"type": "redis",         // from direct replacement optional values
+					"ttl":  float64(3600),   // from direct replacement optional values
+					// Note: size="1Gi" is GONE because entire cache key was replaced
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "helm chart with invalid when condition",
+			templatedCR: createHelmChartFromYAML(`
+apiVersion: kots.io/v1beta2
+kind: HelmChart
+metadata:
+  name: invalid-when-chart
+spec:
+  chart:
+    name: nginx
+    chartVersion: "1.0.0"
+  values:
+    replicaCount: "1"
+  optionalValues:
+  - when: "invalid-boolean"
+    values:
+      replicaCount: "3"
+`),
+			expected:    nil,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := createTestConfig()
+			manager := NewAppReleaseManager(config)
+
+			result, err := manager.GenerateHelmValues(ctx, tt.templatedCR)
+
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 // Helper function to create HelmChart from YAML string
 func createHelmChartFromYAML(yamlStr string) *kotsv1beta2.HelmChart {
 	var chart kotsv1beta2.HelmChart
@@ -245,6 +659,10 @@ func createTestConfig() kotsv1beta1.Config {
 						{Name: "chart2_name", Type: "text", Value: multitype.FromString("redis")},
 						{Name: "service_type", Type: "text", Value: multitype.FromString("ClusterIP")},
 						{Name: "service_port", Type: "text", Value: multitype.FromString("6379")},
+						{Name: "enable_resources", Type: "text", Value: multitype.FromString("false")},
+						{Name: "redis_persistence", Type: "text", Value: multitype.FromString("true")},
+						{Name: "enable_persistence", Type: "text", Value: multitype.FromString("true")},
+						{Name: "disable_monitoring", Type: "text", Value: multitype.FromString("false")},
 					},
 				},
 			},


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Adds ability to generate Helm values for a chart using its HelmChart custom resource

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-127229](https://app.shortcut.com/replicated/story/127229)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Yes

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE