### PR TITLE
chore(ci): block CI on failure to build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1023,13 +1023,13 @@ jobs:
         if: needs.e2e-docker.result != 'success' && needs.e2e-docker.result != 'skipped'
         run: exit 1
       - name: fail if build-current job was not successful
-        if: needs.build-current.result != 'success'
+        if: needs.build-current.result != 'success' && needs.build-current.result != 'skipped'
         run: exit 1
       - name: fail if build-previous-k0s job was not successful
-        if: needs.build-previous-k0s.result != 'success'
+        if: needs.build-previous-k0s.result != 'success' && needs.build-previous-k0s.result != 'skipped'
         run: exit 1
       - name: fail if build-upgrade job was not successful
-        if: needs.build-upgrade.result != 'success'
+        if: needs.build-upgrade.result != 'success' && needs.build-upgrade.result != 'skipped'
         run: exit 1
       - name: fail if sanitize job was not successful
         if: needs.sanitize.result != 'success'


### PR DESCRIPTION
#### What this PR does / why we need it:
See: https://github.com/replicatedhq/embedded-cluster/pull/2584

The PR was merged even though builds were failing. Since now E2E can be skipped we need to make sure the validate step blocks CI if builds fail.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
NA

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE