### PR TITLE
Add ability to dryrun render Helm charts

### DIFF
--- a/api/internal/managers/app/release/manager.go
+++ b/api/internal/managers/app/release/manager.go
@@ -15,8 +15,8 @@ import (
 // AppReleaseManager provides methods for managing the release of an app
 type AppReleaseManager interface {
 	TemplateHelmChartCRs(ctx context.Context, configValues types.AppConfigValues) ([]*kotsv1beta2.HelmChart, error)
+	DryRunHelmChart(ctx context.Context, templatedCR *kotsv1beta2.HelmChart) ([][]byte, error)
 	GenerateHelmValues(ctx context.Context, templatedCR *kotsv1beta2.HelmChart) (map[string]any, error)
-	DryRunHelmChart(ctx context.Context, templatedCR *kotsv1beta2.HelmChart, helmValues map[string]any) ([][]byte, error)
 }
 
 type appReleaseManager struct {

--- a/api/internal/managers/app/release/manager.go
+++ b/api/internal/managers/app/release/manager.go
@@ -16,6 +16,7 @@ import (
 type AppReleaseManager interface {
 	TemplateHelmChartCRs(ctx context.Context, configValues types.AppConfigValues) ([]*kotsv1beta2.HelmChart, error)
 	GenerateHelmValues(ctx context.Context, templatedCR *kotsv1beta2.HelmChart) (map[string]any, error)
+	DryRunHelmChart(ctx context.Context, templatedCR *kotsv1beta2.HelmChart, helmValues map[string]any) ([][]byte, error)
 }
 
 type appReleaseManager struct {

--- a/api/internal/managers/app/release/template.go
+++ b/api/internal/managers/app/release/template.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"os"
 	"strconv"
 
 	"github.com/replicatedhq/embedded-cluster/api/types"
@@ -138,6 +139,7 @@ func (m *appReleaseManager) DryRunHelmChart(ctx context.Context, templatedCR *ko
 	if err != nil {
 		return nil, fmt.Errorf("write chart archive to temp: %w", err)
 	}
+	defer os.Remove(chartPath)
 
 	// Fallback to admin console namespace if namespace is not set
 	namespace := templatedCR.GetNamespace()

--- a/api/internal/managers/app/release/template.go
+++ b/api/internal/managers/app/release/template.go
@@ -87,16 +87,16 @@ func (m *appReleaseManager) DryRunHelmChart(ctx context.Context, templatedCR *ko
 		}
 	}
 
-	// Generate Helm values from the templated CR
-	helmValues, err := m.GenerateHelmValues(ctx, templatedCR)
-	if err != nil {
-		return nil, fmt.Errorf("generate helm values for %s: %w", templatedCR.Name, err)
-	}
-
 	// Find the corresponding chart archive for this HelmChart CR
 	chartArchive, err := findChartArchive(m.releaseData.HelmChartArchives, templatedCR)
 	if err != nil {
 		return nil, fmt.Errorf("find chart archive for %s: %w", templatedCR.Name, err)
+	}
+
+	// Generate Helm values from the templated CR
+	helmValues, err := m.GenerateHelmValues(ctx, templatedCR)
+	if err != nil {
+		return nil, fmt.Errorf("generate helm values for %s: %w", templatedCR.Name, err)
 	}
 
 	// Create a Helm client for dry run templating

--- a/api/internal/managers/app/release/template.go
+++ b/api/internal/managers/app/release/template.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 
 	"github.com/replicatedhq/embedded-cluster/api/types"
+	"github.com/replicatedhq/embedded-cluster/pkg-new/constants"
+	"github.com/replicatedhq/embedded-cluster/pkg/helm"
 	kotsv1beta2 "github.com/replicatedhq/kotskinds/apis/kots/v1beta2"
 	kyaml "sigs.k8s.io/yaml"
 )
@@ -106,4 +108,57 @@ func (m *appReleaseManager) GenerateHelmValues(ctx context.Context, templatedCR 
 	}
 
 	return chartValues, nil
+}
+
+// DryRunHelmChart finds the corresponding chart archive and performs a dry run templating of a Helm chart using the provided values
+func (m *appReleaseManager) DryRunHelmChart(ctx context.Context, templatedCR *kotsv1beta2.HelmChart, helmValues map[string]any) ([][]byte, error) {
+	if templatedCR == nil {
+		return nil, fmt.Errorf("templated CR is nil")
+	}
+
+	if m.releaseData == nil {
+		return nil, fmt.Errorf("release data not initialized")
+	}
+
+	// Find the corresponding chart archive for this HelmChart CR
+	chartArchive, err := findChartArchive(m.releaseData.HelmChartArchives, templatedCR)
+	if err != nil {
+		return nil, fmt.Errorf("find chart archive for %s: %w", templatedCR.Name, err)
+	}
+
+	// Create a Helm client for dry run templating
+	helmClient, err := helm.NewClient(helm.HelmOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("create helm client: %w", err)
+	}
+	defer helmClient.Close()
+
+	// Write chart archive to a temporary file
+	chartPath, err := writeChartArchiveToTemp(chartArchive)
+	if err != nil {
+		return nil, fmt.Errorf("write chart archive to temp: %w", err)
+	}
+
+	// Fallback to admin console namespace if namespace is not set
+	namespace := templatedCR.GetNamespace()
+	if namespace == "" {
+		namespace = constants.KotsadmNamespace
+	}
+
+	// Prepare install options for dry run
+	installOpts := helm.InstallOptions{
+		ReleaseName:  templatedCR.GetReleaseName(),
+		ChartPath:    chartPath,
+		ChartVersion: templatedCR.GetChartVersion(),
+		Values:       helmValues,
+		Namespace:    namespace,
+	}
+
+	// Perform dry run rendering
+	manifests, err := helmClient.Render(ctx, installOpts)
+	if err != nil {
+		return nil, fmt.Errorf("render helm chart %s: %w", templatedCR.Name, err)
+	}
+
+	return manifests, nil
 }

--- a/api/internal/managers/app/release/template_test.go
+++ b/api/internal/managers/app/release/template_test.go
@@ -35,7 +35,7 @@ func TestAppReleaseManager_TemplateHelmChartCRs(t *testing.T) {
 		{
 			name: "single helm chart with repl templating",
 			helmChartCRs: []*kotsv1beta2.HelmChart{
-				createHelmChartFromYAML(`
+				createHelmChartCRFromYAML(`
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
@@ -69,7 +69,7 @@ spec:
 				"disable_monitoring": {Value: "false"},
 			},
 			expected: []*kotsv1beta2.HelmChart{
-				createHelmChartFromYAML(`
+				createHelmChartCRFromYAML(`
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
@@ -100,7 +100,7 @@ spec:
 		{
 			name: "multiple helm charts with mixed templating",
 			helmChartCRs: []*kotsv1beta2.HelmChart{
-				createHelmChartFromYAML(`
+				createHelmChartCRFromYAML(`
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
@@ -119,7 +119,7 @@ spec:
         limits:
           memory: 128Mi
 `),
-				createHelmChartFromYAML(`
+				createHelmChartCRFromYAML(`
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
@@ -153,7 +153,7 @@ spec:
 				"redis_persistence": {Value: "true"},
 			},
 			expected: []*kotsv1beta2.HelmChart{
-				createHelmChartFromYAML(`
+				createHelmChartCRFromYAML(`
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
@@ -172,7 +172,7 @@ spec:
         limits:
           memory: 128Mi
 `),
-				createHelmChartFromYAML(`
+				createHelmChartCRFromYAML(`
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
@@ -201,7 +201,7 @@ spec:
 			name: "skip nil helm chart",
 			helmChartCRs: []*kotsv1beta2.HelmChart{
 				nil,
-				createHelmChartFromYAML(`
+				createHelmChartCRFromYAML(`
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
@@ -215,7 +215,7 @@ spec:
 			},
 			configValues: types.AppConfigValues{},
 			expected: []*kotsv1beta2.HelmChart{
-				createHelmChartFromYAML(`
+				createHelmChartCRFromYAML(`
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
@@ -288,7 +288,7 @@ func TestAppReleaseManager_DryRunHelmChart(t *testing.T) {
 		},
 		{
 			name: "no chart archives",
-			templatedCR: createHelmChartFromYAML(`
+			templatedCR: createHelmChartCRFromYAML(`
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
@@ -304,7 +304,7 @@ spec:
 		},
 		{
 			name: "chart archive not found",
-			templatedCR: createHelmChartFromYAML(`
+			templatedCR: createHelmChartCRFromYAML(`
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
@@ -322,7 +322,7 @@ spec:
 		},
 		{
 			name: "successful dry run with kotsadm namespace fallback",
-			templatedCR: createHelmChartFromYAML(`
+			templatedCR: createHelmChartCRFromYAML(`
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
@@ -363,7 +363,7 @@ spec:
 		},
 		{
 			name: "successful dry run with custom namespace",
-			templatedCR: createHelmChartFromYAML(`
+			templatedCR: createHelmChartCRFromYAML(`
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
@@ -410,7 +410,7 @@ spec:
 		},
 		{
 			name: "chart with exclude=false (should be processed)",
-			templatedCR: createHelmChartFromYAML(`
+			templatedCR: createHelmChartCRFromYAML(`
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
@@ -445,7 +445,7 @@ spec:
 		},
 		{
 			name: "chart with exclude=true (should be skipped)",
-			templatedCR: createHelmChartFromYAML(`
+			templatedCR: createHelmChartCRFromYAML(`
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
@@ -468,7 +468,7 @@ spec:
 		},
 		{
 			name: "chart with mixed true/false optional values",
-			templatedCR: createHelmChartFromYAML(`
+			templatedCR: createHelmChartCRFromYAML(`
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
@@ -568,7 +568,7 @@ func TestAppReleaseManager_GenerateHelmValues(t *testing.T) {
 		},
 		{
 			name: "helm chart with simple values",
-			templatedCR: createHelmChartFromYAML(`
+			templatedCR: createHelmChartCRFromYAML(`
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
@@ -602,7 +602,7 @@ spec:
 		},
 		{
 			name: "helm chart with optional values",
-			templatedCR: createHelmChartFromYAML(`
+			templatedCR: createHelmChartCRFromYAML(`
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
@@ -631,7 +631,7 @@ spec:
 		},
 		{
 			name: "helm chart with recursive merge",
-			templatedCR: createHelmChartFromYAML(`
+			templatedCR: createHelmChartCRFromYAML(`
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
@@ -684,7 +684,7 @@ spec:
 		},
 		{
 			name: "helm chart with direct key replacement (no recursive merge)",
-			templatedCR: createHelmChartFromYAML(`
+			templatedCR: createHelmChartCRFromYAML(`
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
@@ -731,7 +731,7 @@ spec:
 		},
 		{
 			name: "helm chart with when condition false",
-			templatedCR: createHelmChartFromYAML(`
+			templatedCR: createHelmChartCRFromYAML(`
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
@@ -755,7 +755,7 @@ spec:
 		},
 		{
 			name: "helm chart with multiple optional values",
-			templatedCR: createHelmChartFromYAML(`
+			templatedCR: createHelmChartCRFromYAML(`
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
@@ -798,7 +798,7 @@ spec:
 		},
 		{
 			name: "helm chart with no base values",
-			templatedCR: createHelmChartFromYAML(`
+			templatedCR: createHelmChartCRFromYAML(`
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
@@ -824,7 +824,7 @@ spec:
 		},
 		{
 			name: "clear example of recursive merge vs direct replacement",
-			templatedCR: createHelmChartFromYAML(`
+			templatedCR: createHelmChartCRFromYAML(`
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
@@ -876,7 +876,7 @@ spec:
 		},
 		{
 			name: "helm chart with invalid when condition",
-			templatedCR: createHelmChartFromYAML(`
+			templatedCR: createHelmChartCRFromYAML(`
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
@@ -916,7 +916,7 @@ spec:
 }
 
 // Helper function to create HelmChart from YAML string
-func createHelmChartFromYAML(yamlStr string) *kotsv1beta2.HelmChart {
+func createHelmChartCRFromYAML(yamlStr string) *kotsv1beta2.HelmChart {
 	var chart kotsv1beta2.HelmChart
 	err := kyaml.Unmarshal([]byte(yamlStr), &chart)
 	if err != nil {

--- a/api/internal/managers/app/release/template_test.go
+++ b/api/internal/managers/app/release/template_test.go
@@ -698,11 +698,7 @@ func TestAppReleaseManager_DryRunHelmChart(t *testing.T) {
 			helmValues: map[string]any{
 				"replicaCount": 3,
 				"image": map[string]any{
-					"repository": "nginx",
-					"tag":        "1.20.0",
-				},
-				"service": map[string]any{
-					"type": "ClusterIP",
+					"tag": "1.20.0",
 				},
 			},
 			helmChartArchives: [][]byte{
@@ -910,8 +906,26 @@ spec:
 {{- end }}
 `
 
+	valuesYaml := `replicaCount: 1
+
+image:
+  repository: nginx
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+resources: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}
+`
+
 	files := map[string]string{
 		fmt.Sprintf("%s/Chart.yaml", name):                chartYaml,
+		fmt.Sprintf("%s/values.yaml", name):               valuesYaml,
 		fmt.Sprintf("%s/templates/crd.yaml", name):        crd,
 		fmt.Sprintf("%s/templates/deployment.yaml", name): deployment,
 		fmt.Sprintf("%s/templates/service.yaml", name):    service,

--- a/api/internal/managers/app/release/util.go
+++ b/api/internal/managers/app/release/util.go
@@ -1,16 +1,12 @@
 package release
 
 import (
-	"archive/tar"
 	"bytes"
-	"compress/gzip"
 	"fmt"
-	"io"
 	"os"
-	"strings"
 
 	kotsv1beta2 "github.com/replicatedhq/kotskinds/apis/kots/v1beta2"
-	"gopkg.in/yaml.v2"
+	"helm.sh/helm/v3/pkg/chart/loader"
 )
 
 // findChartArchive finds the chart archive that corresponds to the given HelmChart CR
@@ -47,51 +43,11 @@ func findChartArchive(helmChartArchives [][]byte, templatedCR *kotsv1beta2.HelmC
 
 // extractChartMetadata extracts chart name and version from a .tgz archive
 func extractChartMetadata(archiveBytes []byte) (name, version string, err error) {
-	gzr, err := gzip.NewReader(bytes.NewReader(archiveBytes))
+	ch, err := loader.LoadArchive(bytes.NewReader(archiveBytes))
 	if err != nil {
-		return "", "", fmt.Errorf("create gzip reader: %w", err)
+		return "", "", fmt.Errorf("load archive: %w", err)
 	}
-	defer gzr.Close()
-
-	tr := tar.NewReader(gzr)
-	for {
-		header, err := tr.Next()
-		if err == io.EOF {
-			return "", "", fmt.Errorf("Chart.yaml not found")
-		}
-		if err != nil {
-			return "", "", fmt.Errorf("read tar entry: %w", err)
-		}
-
-		if header.Typeflag != tar.TypeReg {
-			continue
-		}
-
-		// Look for Chart.yaml - accept any path ending with it since archives can have a base directory
-		if !strings.HasSuffix(header.Name, "Chart.yaml") {
-			continue
-		}
-
-		// Skip subcharts (with or without a base directory)
-		if strings.Contains(header.Name, "/charts/") || strings.HasPrefix(header.Name, "charts/") {
-			continue
-		}
-
-		var buf bytes.Buffer
-		if _, err := io.Copy(&buf, tr); err != nil {
-			return "", "", fmt.Errorf("read Chart.yaml: %w", err)
-		}
-
-		var metadata struct {
-			Name    string `yaml:"name"`
-			Version string `yaml:"version"`
-		}
-		if err := yaml.Unmarshal(buf.Bytes(), &metadata); err != nil {
-			return "", "", fmt.Errorf("unmarshal Chart.yaml: %w", err)
-		}
-
-		return metadata.Name, metadata.Version, nil
-	}
+	return ch.Metadata.Name, ch.Metadata.Version, nil
 }
 
 // writeChartArchiveToTemp writes the chart archive to a temporary file and returns the path

--- a/api/internal/managers/app/release/util.go
+++ b/api/internal/managers/app/release/util.go
@@ -1,0 +1,113 @@
+package release
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	kotsv1beta2 "github.com/replicatedhq/kotskinds/apis/kots/v1beta2"
+	"gopkg.in/yaml.v2"
+)
+
+// findChartArchive finds the chart archive that corresponds to the given HelmChart CR
+func findChartArchive(helmChartArchives [][]byte, templatedCR *kotsv1beta2.HelmChart) ([]byte, error) {
+	if len(helmChartArchives) == 0 {
+		return nil, fmt.Errorf("no helm chart archives found")
+	}
+
+	// Get chart name and version from the templated CR
+	expectedName := templatedCR.GetChartName()
+	expectedVersion := templatedCR.GetChartVersion()
+
+	if expectedName == "" {
+		return nil, fmt.Errorf("chart name is empty in HelmChart CR %s", templatedCR.Name)
+	}
+	if expectedVersion == "" {
+		return nil, fmt.Errorf("chart version is empty in HelmChart CR %s", templatedCR.Name)
+	}
+
+	// Search through all chart archives to find matching name and version
+	for _, archive := range helmChartArchives {
+		chartName, chartVersion, err := extractChartMetadata(archive)
+		if err != nil {
+			return nil, fmt.Errorf("extract chart metadata: %w", err)
+		}
+
+		if chartName == expectedName && chartVersion == expectedVersion {
+			return archive, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no chart archive found for chart name %s and version %s", expectedName, expectedVersion)
+}
+
+// extractChartMetadata extracts chart name and version from a .tgz archive
+func extractChartMetadata(archiveBytes []byte) (name, version string, err error) {
+	gzr, err := gzip.NewReader(bytes.NewReader(archiveBytes))
+	if err != nil {
+		return "", "", fmt.Errorf("create gzip reader: %w", err)
+	}
+	defer gzr.Close()
+
+	tr := tar.NewReader(gzr)
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			return "", "", fmt.Errorf("Chart.yaml not found")
+		}
+		if err != nil {
+			return "", "", fmt.Errorf("read tar entry: %w", err)
+		}
+
+		if header.Typeflag != tar.TypeReg {
+			continue
+		}
+
+		// Look for Chart.yaml - accept any path ending with it since archives can have a base directory
+		if !strings.HasSuffix(header.Name, "Chart.yaml") {
+			continue
+		}
+
+		// Skip subcharts (with or without a base directory)
+		if strings.Contains(header.Name, "/charts/") || strings.HasPrefix(header.Name, "charts/") {
+			continue
+		}
+
+		var buf bytes.Buffer
+		if _, err := io.Copy(&buf, tr); err != nil {
+			return "", "", fmt.Errorf("read Chart.yaml: %w", err)
+		}
+
+		var metadata struct {
+			Name    string `yaml:"name"`
+			Version string `yaml:"version"`
+		}
+		if err := yaml.Unmarshal(buf.Bytes(), &metadata); err != nil {
+			return "", "", fmt.Errorf("unmarshal Chart.yaml: %w", err)
+		}
+
+		return metadata.Name, metadata.Version, nil
+	}
+}
+
+// writeChartArchiveToTemp writes the chart archive to a temporary file and returns the path
+func writeChartArchiveToTemp(chartArchive []byte) (string, error) {
+	// Create a temporary file for the chart archive
+	tmpFile, err := os.CreateTemp("", "helm-chart-*.tgz")
+	if err != nil {
+		return "", fmt.Errorf("create temp file: %w", err)
+	}
+	defer tmpFile.Close()
+
+	// Write the chart archive to the temporary file
+	if _, err := tmpFile.Write(chartArchive); err != nil {
+		os.Remove(tmpFile.Name())
+		return "", fmt.Errorf("write chart archive: %w", err)
+	}
+
+	return tmpFile.Name(), nil
+}

--- a/api/internal/managers/app/release/util.go
+++ b/api/internal/managers/app/release/util.go
@@ -42,8 +42,8 @@ func findChartArchive(helmChartArchives [][]byte, templatedCR *kotsv1beta2.HelmC
 }
 
 // extractChartMetadata extracts chart name and version from a .tgz archive
-func extractChartMetadata(archiveBytes []byte) (name, version string, err error) {
-	ch, err := loader.LoadArchive(bytes.NewReader(archiveBytes))
+func extractChartMetadata(chartArchive []byte) (name, version string, err error) {
+	ch, err := loader.LoadArchive(bytes.NewReader(chartArchive))
 	if err != nil {
 		return "", "", fmt.Errorf("load archive: %w", err)
 	}

--- a/api/internal/managers/app/release/util_test.go
+++ b/api/internal/managers/app/release/util_test.go
@@ -1,0 +1,401 @@
+package release
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"os"
+	"testing"
+
+	kotsv1beta2 "github.com/replicatedhq/kotskinds/apis/kots/v1beta2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindChartArchive(t *testing.T) {
+	tests := []struct {
+		name              string
+		helmChartArchives [][]byte
+		templatedCR       *kotsv1beta2.HelmChart
+		expectedArchive   []byte
+		expectError       bool
+		errorContains     string
+	}{
+		{
+			name:              "empty archives",
+			helmChartArchives: [][]byte{},
+			templatedCR: &kotsv1beta2.HelmChart{
+				Spec: kotsv1beta2.HelmChartSpec{
+					Chart: kotsv1beta2.ChartIdentifier{
+						Name:         "nginx",
+						ChartVersion: "1.0.0",
+					},
+				},
+			},
+			expectError:   true,
+			errorContains: "no helm chart archives found",
+		},
+		{
+			name:              "nil archives",
+			helmChartArchives: nil,
+			templatedCR: &kotsv1beta2.HelmChart{
+				Spec: kotsv1beta2.HelmChartSpec{
+					Chart: kotsv1beta2.ChartIdentifier{
+						Name:         "nginx",
+						ChartVersion: "1.0.0",
+					},
+				},
+			},
+			expectError:   true,
+			errorContains: "no helm chart archives found",
+		},
+		{
+			name:              "empty chart name",
+			helmChartArchives: [][]byte{createTestChartArchive(t, "nginx", "1.0.0", "")},
+			templatedCR: &kotsv1beta2.HelmChart{
+				Spec: kotsv1beta2.HelmChartSpec{
+					Chart: kotsv1beta2.ChartIdentifier{
+						Name:         "",
+						ChartVersion: "1.0.0",
+					},
+				},
+			},
+			expectError:   true,
+			errorContains: "chart name is empty",
+		},
+		{
+			name:              "empty chart version",
+			helmChartArchives: [][]byte{createTestChartArchive(t, "nginx", "1.0.0", "")},
+			templatedCR: &kotsv1beta2.HelmChart{
+				Spec: kotsv1beta2.HelmChartSpec{
+					Chart: kotsv1beta2.ChartIdentifier{
+						Name:         "nginx",
+						ChartVersion: "",
+					},
+				},
+			},
+			expectError:   true,
+			errorContains: "chart version is empty",
+		},
+		{
+			name: "successful match",
+			helmChartArchives: [][]byte{
+				createTestChartArchive(t, "redis", "2.0.0", ""),
+				createTestChartArchive(t, "nginx", "1.0.0", ""),
+				createTestChartArchive(t, "postgres", "3.0.0", ""),
+			},
+			templatedCR: &kotsv1beta2.HelmChart{
+				Spec: kotsv1beta2.HelmChartSpec{
+					Chart: kotsv1beta2.ChartIdentifier{
+						Name:         "nginx",
+						ChartVersion: "1.0.0",
+					},
+				},
+			},
+			expectedArchive: createTestChartArchive(t, "nginx", "1.0.0", ""),
+			expectError:     false,
+		},
+		{
+			name: "successful match with base directory chart",
+			helmChartArchives: [][]byte{
+				createTestChartArchive(t, "redis", "2.0.0", ""),
+				createTestChartArchive(t, "myapp", "1.5.0", "myapp"),
+			},
+			templatedCR: &kotsv1beta2.HelmChart{
+				Spec: kotsv1beta2.HelmChartSpec{
+					Chart: kotsv1beta2.ChartIdentifier{
+						Name:         "myapp",
+						ChartVersion: "1.5.0",
+					},
+				},
+			},
+			expectedArchive: createTestChartArchive(t, "myapp", "1.5.0", "myapp"),
+			expectError:     false,
+		},
+		{
+			name: "no matching chart",
+			helmChartArchives: [][]byte{
+				createTestChartArchive(t, "redis", "2.0.0", ""),
+				createTestChartArchive(t, "postgres", "3.0.0", ""),
+			},
+			templatedCR: &kotsv1beta2.HelmChart{
+				Spec: kotsv1beta2.HelmChartSpec{
+					Chart: kotsv1beta2.ChartIdentifier{
+						Name:         "nginx",
+						ChartVersion: "1.0.0",
+					},
+				},
+			},
+			expectError:   true,
+			errorContains: "no chart archive found for chart name nginx and version 1.0.0",
+		},
+		{
+			name: "subchart matching name/version but no top-level chart",
+			helmChartArchives: [][]byte{
+				createArchiveWithSubchart(t, "nginx", "1.0.0", ""),
+			},
+			templatedCR: &kotsv1beta2.HelmChart{
+				Spec: kotsv1beta2.HelmChartSpec{
+					Chart: kotsv1beta2.ChartIdentifier{
+						Name:         "nginx",
+						ChartVersion: "1.0.0",
+					},
+				},
+			},
+			expectError:   true,
+			errorContains: "Chart.yaml not found",
+		},
+		{
+			name: "invalid archive in collection",
+			helmChartArchives: [][]byte{
+				[]byte("invalid-archive-data"),
+			},
+			templatedCR: &kotsv1beta2.HelmChart{
+				Spec: kotsv1beta2.HelmChartSpec{
+					Chart: kotsv1beta2.ChartIdentifier{
+						Name:         "nginx",
+						ChartVersion: "1.0.0",
+					},
+				},
+			},
+			expectError:   true,
+			errorContains: "extract chart metadata",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := findChartArchive(tt.helmChartArchives, tt.templatedCR)
+
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+				assert.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, result)
+				assert.NotEmpty(t, result)
+
+				// Validate that the returned archive content matches expected
+				assert.Equal(t, tt.expectedArchive, result, "returned archive content should match expected archive")
+			}
+		})
+	}
+}
+
+func TestExtractChartMetadata(t *testing.T) {
+	tests := []struct {
+		name            string
+		archiveBytes    []byte
+		expectedName    string
+		expectedVersion string
+		expectError     bool
+		errorContains   string
+	}{
+		{
+			name:            "valid chart archive",
+			archiveBytes:    createTestChartArchive(t, "nginx", "1.2.3", ""),
+			expectedName:    "nginx",
+			expectedVersion: "1.2.3",
+			expectError:     false,
+		},
+		{
+			name:            "chart with subdirectory",
+			archiveBytes:    createTestChartArchive(t, "myapp", "2.1.0", "myapp"),
+			expectedName:    "myapp",
+			expectedVersion: "2.1.0",
+			expectError:     false,
+		},
+		{
+			name:          "invalid gzip data",
+			archiveBytes:  []byte("not-a-gzip-file"),
+			expectError:   true,
+			errorContains: "create gzip reader",
+		},
+		{
+			name:          "empty archive",
+			archiveBytes:  createEmptyArchive(t),
+			expectError:   true,
+			errorContains: "Chart.yaml not found",
+		},
+		{
+			name:          "archive without Chart.yaml",
+			archiveBytes:  createArchiveWithoutChart(t),
+			expectError:   true,
+			errorContains: "Chart.yaml not found",
+		},
+		{
+			name:          "invalid Chart.yaml content",
+			archiveBytes:  createArchiveWithInvalidChart(t),
+			expectError:   true,
+			errorContains: "unmarshal Chart.yaml",
+		},
+		{
+			name:          "Chart.yaml in subchart directory (should be skipped)",
+			archiveBytes:  createArchiveWithSubchart(t, "nginx", "1.0.0", ""),
+			expectError:   true,
+			errorContains: "Chart.yaml not found",
+		},
+		{
+			name:          "Chart.yaml in nested subchart directory (should be skipped)",
+			archiveBytes:  createArchiveWithSubchart(t, "nginx", "1.0.0", "myapp"),
+			expectError:   true,
+			errorContains: "Chart.yaml not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, version, err := extractChartMetadata(tt.archiveBytes)
+
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+				assert.Empty(t, name)
+				assert.Empty(t, version)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedName, name)
+				assert.Equal(t, tt.expectedVersion, version)
+			}
+		})
+	}
+}
+
+func TestWriteChartArchiveToTemp(t *testing.T) {
+	tests := []struct {
+		name         string
+		chartArchive []byte
+		expectError  bool
+	}{
+		{
+			name:         "valid chart archive",
+			chartArchive: createTestChartArchive(t, "nginx", "1.0.0", ""),
+			expectError:  false,
+		},
+		{
+			name:         "empty archive",
+			chartArchive: []byte{},
+			expectError:  false,
+		},
+		{
+			name:         "large archive",
+			chartArchive: bytes.Repeat([]byte("test-data"), 1000),
+			expectError:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filePath, err := writeChartArchiveToTemp(tt.chartArchive)
+
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Empty(t, filePath)
+			} else {
+				require.NoError(t, err)
+				assert.NotEmpty(t, filePath)
+
+				// Verify file exists and has correct content
+				fileContent, err := os.ReadFile(filePath)
+				require.NoError(t, err)
+				assert.Equal(t, tt.chartArchive, fileContent)
+
+				// Clean up
+				err = os.Remove(filePath)
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// Helper functions for creating test archives
+
+// createTarGzArchive creates a tar.gz archive with the given files
+func createTarGzArchive(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	for filename, content := range files {
+		header := &tar.Header{
+			Name: filename,
+			Mode: 0600,
+			Size: int64(len(content)),
+		}
+		require.NoError(t, tw.WriteHeader(header))
+		_, err := tw.Write([]byte(content))
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+
+	return buf.Bytes()
+}
+
+func createTestChartArchive(t *testing.T, name, version, baseDir string) []byte {
+	var description string
+	var chartYamlPath string
+
+	if baseDir != "" {
+		description = "A test Helm chart with subdirectory"
+		chartYamlPath = fmt.Sprintf("%s/Chart.yaml", baseDir)
+	} else {
+		description = "A test Helm chart"
+		chartYamlPath = "Chart.yaml"
+	}
+
+	chartYaml := fmt.Sprintf(`apiVersion: v2
+name: %s
+version: %s
+description: %s
+type: application
+`, name, version, description)
+
+	return createTarGzArchive(t, map[string]string{
+		chartYamlPath: chartYaml,
+	})
+}
+
+func createEmptyArchive(t *testing.T) []byte {
+	return createTarGzArchive(t, map[string]string{})
+}
+
+func createArchiveWithoutChart(t *testing.T) []byte {
+	return createTarGzArchive(t, map[string]string{
+		"README.md": "some random content",
+	})
+}
+
+func createArchiveWithInvalidChart(t *testing.T) []byte {
+	return createTarGzArchive(t, map[string]string{
+		"Chart.yaml": "invalid: yaml: content: [",
+	})
+}
+
+func createArchiveWithSubchart(t *testing.T, name, version, baseDir string) []byte {
+	chartYaml := fmt.Sprintf(`apiVersion: v2
+name: %s
+version: %s
+description: A subchart that should be ignored
+type: application
+`, name, version)
+
+	var chartYamlPath string
+	if baseDir == "" {
+		chartYamlPath = "charts/subchart/Chart.yaml"
+	} else {
+		chartYamlPath = fmt.Sprintf("%s/charts/subchart/Chart.yaml", baseDir)
+	}
+	return createTarGzArchive(t, map[string]string{
+		chartYamlPath: chartYaml,
+	})
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Adds ability to dryrun render Helm charts from a templated HelmChart custom resource.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-127236](https://app.shortcut.com/replicated/story/127236)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Yes

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE