### PR TITLE
feat(api): don't show hidden app config items to the client

### DIFF
--- a/api/controllers/app/install/config.go
+++ b/api/controllers/app/install/config.go
@@ -57,7 +57,7 @@ func (c *InstallController) PatchAppConfigValues(ctx context.Context, values typ
 }
 
 func (c *InstallController) TemplateAppConfig(ctx context.Context, values types.AppConfigValues, maskPasswords bool) (types.AppConfig, error) {
-	return c.appConfigManager.TemplateConfig(values, maskPasswords)
+	return c.appConfigManager.TemplateConfig(values, maskPasswords, true)
 }
 
 func (c *InstallController) GetAppConfigValues(ctx context.Context) (types.AppConfigValues, error) {

--- a/api/internal/managers/app/config/manager.go
+++ b/api/internal/managers/app/config/manager.go
@@ -19,7 +19,7 @@ type AppConfigManager interface {
 	// PatchConfigValues patches the current config values
 	PatchConfigValues(values types.AppConfigValues) error
 	// TemplateConfig templates the config with provided values and returns the templated config
-	TemplateConfig(configValues types.AppConfigValues, maskPasswords bool) (types.AppConfig, error)
+	TemplateConfig(configValues types.AppConfigValues, maskPasswords bool, filterHiddenItems bool) (types.AppConfig, error)
 	// GetConfigValues gets the current config values
 	GetConfigValues() (types.AppConfigValues, error)
 	// GetKotsadmConfigValues merges the config values with the app config defaults and returns a

--- a/api/internal/managers/app/config/manager_mock.go
+++ b/api/internal/managers/app/config/manager_mock.go
@@ -26,7 +26,7 @@ func (m *MockAppConfigManager) PatchConfigValues(values types.AppConfigValues) e
 }
 
 // TemplateConfig mocks the TemplateConfig method
-func (m *MockAppConfigManager) TemplateConfig(configValues types.AppConfigValues, maskPasswords bool) (types.AppConfig, error) {
+func (m *MockAppConfigManager) TemplateConfig(configValues types.AppConfigValues, maskPasswords bool, filterHiddenItems bool) (types.AppConfig, error) {
 	args := m.Called(configValues, maskPasswords)
 	return args.Get(0).(types.AppConfig), args.Error(1)
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

Follow up to #2574, have the API not return hidden config items altogether

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/127292/support-for-hidden-fields-in-ui

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Yes

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
