### PR TITLE
Do not fail image scan workflows until we fully utilize SecureBuild images

### DIFF
--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -135,8 +135,8 @@ jobs:
         with:
           image-ref: '${{ matrix.image }}'
           upload-sarif: ${{ github.ref == 'refs/heads/main' }}
-          # TODO: uncomment this once we are fully using securebuild images
-          # fail-build: 'true'
+          # TODO: set this to true once we are fully using securebuild images
+          fail-build: 'false'
           severity-cutoff: 'medium'
           output-file: 'results.sarif'
           retention-days: '90'

--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -135,7 +135,8 @@ jobs:
         with:
           image-ref: '${{ matrix.image }}'
           upload-sarif: ${{ github.ref == 'refs/heads/main' }}
-          fail-build: 'true'
+          # TODO: uncomment this once we are fully using securebuild images
+          # fail-build: 'true'
           severity-cutoff: 'medium'
           output-file: 'results.sarif'
           retention-days: '90'


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Right now, our CI builds on main are all red, but we release in spite of that because there errors are "expected" and should go away when we utilize fully SecureBuild images.

Having a red pipeline all the time makes it hard to determine if it's okay to release or not, and messes up with other reporting metrics around our CI.

This PR temporarily makes it so that our CI doesn't fail for image scans.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE