### PR TITLE
Fix scanning images with same tags but different digests

### DIFF
--- a/.github/actions/scan-image/action.yml
+++ b/.github/actions/scan-image/action.yml
@@ -51,17 +51,32 @@ runs:
       id: image_details
       shell: bash
       run: |
+        # Extract base image name and tag
         IMAGE_NAME=$(echo "${{ inputs.image-ref }}" | cut -d':' -f1)
         IMAGE_TAG=$(echo "${{ inputs.image-ref }}" | cut -d':' -f2 | cut -d'@' -f1)
-        [[ "$IMAGE_TAG" == "$IMAGE_NAME" ]] && IMAGE_TAG="latest"
-        SAFE_NAME=$(echo "${IMAGE_NAME}-${IMAGE_TAG}" | sed 's/[\/:]/-/g')
-        SAFE_IMAGE_NAME=$(echo "${IMAGE_NAME}" | sed 's/[\/:]/-/g')
-        {
-          echo "image_name=${IMAGE_NAME}"
-          echo "image_tag=${IMAGE_TAG}"
-          echo "safe_name=${SAFE_NAME}"
-          echo "safe_image_name=${SAFE_IMAGE_NAME}"
 
+        # Default to latest tag if none specified
+        [[ "$IMAGE_TAG" == "$IMAGE_NAME" ]] && IMAGE_TAG="latest"
+
+        # Extract digest if present
+        IMAGE_DIGEST=$(echo "${{ inputs.image-ref }}" | grep -o 'sha256:[a-f0-9]*' || true)
+
+        # Create safe names for file paths and identifiers
+        if [[ -n "$IMAGE_DIGEST" ]]; then
+            DIGEST_SHORT=$(echo "$IMAGE_DIGEST" | cut -c1-15)
+            SAFE_NAME="${IMAGE_NAME}-${IMAGE_TAG}-${DIGEST_SHORT}"
+        else
+            SAFE_NAME="${IMAGE_NAME}-${IMAGE_TAG}"
+        fi
+        SAFE_NAME=$(echo "$SAFE_NAME" | sed 's/[\/:]/-/g')
+        SAFE_IMAGE_NAME=$(echo "${IMAGE_NAME}" | sed 's/[\/:]/-/g')
+
+        # Output variables for use in subsequent steps
+        {
+            echo "image_name=${IMAGE_NAME}"
+            echo "image_tag=${IMAGE_TAG}"
+            echo "safe_name=${SAFE_NAME}"
+            echo "safe_image_name=${SAFE_IMAGE_NAME}"
         } >> "$GITHUB_OUTPUT"
 
     - name: Scan image with Grype


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Fixes an issue where uploading the sarif file to a scanned image fails due to the file already existing. This happens because the image name and tag and be duplicated, but not the digest.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
N/A

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE