### PR TITLE
chore(ci): Handle exit code 143 during reset within CMX

### DIFF
--- a/e2e/cluster/cmx/cluster.go
+++ b/e2e/cluster/cmx/cluster.go
@@ -343,8 +343,8 @@ func runCommandOnNode(node Node, line []string, envs ...map[string]string) (stri
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 
-	if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 255 {
-		// check if this is a reset-installation command that resulted in exit code 255
+	if exitErr, ok := err.(*exec.ExitError); ok && (exitErr.ExitCode() == 255 || exitErr.ExitCode() == 143) {
+		// check if this is a reset-installation command that resulted in exit code 255 or 143
 		// as this is expected behavior when the node reboots and the ssh connection is lost
 		if strings.Contains(strings.Join(line, " "), "reset-installation") {
 			return stdout.String(), stderr.String(), nil


### PR DESCRIPTION
#### What this PR does / why we need it:
This handles an expected error from the CMX node rebooting as part of the EC reset process.  In CI exit code 143 sometimes occurs, for example: Reference: https://github.com/replicatedhq/embedded-cluster/actions/runs/15742928677/job/44373346807?pr=2340#step:8:139

Exit status 143 indicates SIGTERM, looking at `reset-installation.sh` the EC reset command is ran which calls [reboot](https://github.com/replicatedhq/embedded-cluster/blob/3fac95992bbebc33e4e2e482ca07c054cfa37a84/cmd/installer/cli/reset.go#L212) and then the ssh connection that's running the command is terminated early before response.  I think it's a chance you'll get 255 which is just a connection closed error which is already being handled OR you'll get SIGTERM like in this case, I think handling both is the right call.  This adds the handling for 143.

#### Which issue(s) this PR fixes:
SC: https://app.shortcut.com/replicated/story/127377/exit-status-143-error-on-node-resets-in-ec-ci-only-on-cmx

#### Does this PR require a test?
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
NONE