### PR TITLE
chore(ci): Handle exit code 143 during reset within docker based clusters

### DIFF
--- a/e2e/cluster/docker/cluster.go
+++ b/e2e/cluster/docker/cluster.go
@@ -110,9 +110,8 @@ func (c *Cluster) RunCommandOnNode(node int, line []string, envs ...map[string]s
 		if strings.Contains(err.Error(), "143") && strings.Contains(strings.Join(line, " "), "reset-installation") {
 			return stdout, stderr, nil
 		}
-		return stdout, stderr, err
 	}
-	return stdout, stderr, nil
+	return stdout, stderr, err
 }
 
 func (c *Cluster) SetupPlaywrightAndRunTest(testName string, args ...string) (string, string, error) {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

A 143 exit code is a usually a SIGTERM and can happen during a cluster reset as we reboot the nodes. This PR handles this 143 exit code gracefully similar to how we do it for LXD and CMX clusters.

Reference:
- LXD: https://github.com/replicatedhq/embedded-cluster/blob/adab66152ac7a0473da3883c9612b666ccf9d830/e2e/cluster/lxd/cluster.go#L1080-L1084
- CMX: https://github.com/replicatedhq/embedded-cluster/blob/adab66152ac7a0473da3883c9612b666ccf9d830/e2e/cluster/cmx/cluster.go#L347-L351

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-127396](https://app.shortcut.com/replicated/story/127396)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE