### PR TITLE
feat: skip KOTS app preflights when manager experience installer is enabled

### DIFF
--- a/api/internal/managers/linux/infra/install.go
+++ b/api/internal/managers/linux/infra/install.go
@@ -29,7 +29,12 @@ import (
 	kyaml "sigs.k8s.io/yaml"
 )
 
-const K0sComponentName = "Runtime"
+const (
+	// Skip running the KOTS app preflights in the Admin Console; we run them in the manager experience installer when ENABLE_V3 is enabled
+	SkipPreflights = true
+
+	K0sComponentName = "Runtime"
+)
 
 func AlreadyInstalledError() error {
 	//nolint:staticcheck // ST1005 TODO: use a constant here and print a better error message
@@ -314,6 +319,7 @@ func (m *infraManager) getAddonInstallOpts(license *kotsv1beta1.License, rc runt
 			Namespace:             constants.KotsadmNamespace,
 			ClusterID:             m.clusterID,
 			AirgapBundle:          m.airgapBundle,
+			SkipPreflights:        SkipPreflights,
 			ReplicatedAppEndpoint: netutils.MaybeAddHTTPS(ecDomains.ReplicatedAppDomain),
 			// TODO (@salah): capture kots install logs
 			// Stdout:                stdout,

--- a/api/internal/managers/linux/infra/install.go
+++ b/api/internal/managers/linux/infra/install.go
@@ -29,12 +29,7 @@ import (
 	kyaml "sigs.k8s.io/yaml"
 )
 
-const (
-	// Skip running the KOTS app preflights in the Admin Console; we run them in the manager experience installer when ENABLE_V3 is enabled
-	SkipPreflights = true
-
-	K0sComponentName = "Runtime"
-)
+const K0sComponentName = "Runtime"
 
 func AlreadyInstalledError() error {
 	//nolint:staticcheck // ST1005 TODO: use a constant here and print a better error message
@@ -313,13 +308,14 @@ func (m *infraManager) getAddonInstallOpts(license *kotsv1beta1.License, rc runt
 	// TODO: move creation of the KotsInstaller to the AppConfigManager, rename to AppInstallManager
 	opts.KotsInstaller = func() error {
 		installOpts := kotscli.InstallOptions{
-			RuntimeConfig:         rc,
-			AppSlug:               license.Spec.AppSlug,
-			License:               m.license,
-			Namespace:             constants.KotsadmNamespace,
-			ClusterID:             m.clusterID,
-			AirgapBundle:          m.airgapBundle,
-			SkipPreflights:        SkipPreflights,
+			RuntimeConfig: rc,
+			AppSlug:       license.Spec.AppSlug,
+			License:       m.license,
+			Namespace:     constants.KotsadmNamespace,
+			ClusterID:     m.clusterID,
+			AirgapBundle:  m.airgapBundle,
+			// Skip running the KOTS app preflights in the Admin Console; they run in the manager experience installer when ENABLE_V3 is enabled
+			SkipPreflights:        os.Getenv("ENABLE_V3") == "1",
 			ReplicatedAppEndpoint: netutils.MaybeAddHTTPS(ecDomains.ReplicatedAppDomain),
 			// TODO (@salah): capture kots install logs
 			// Stdout:                stdout,

--- a/cmd/installer/kotscli/kotscli.go
+++ b/cmd/installer/kotscli/kotscli.go
@@ -30,6 +30,7 @@ type InstallOptions struct {
 	AirgapBundle          string
 	ConfigValuesFile      string
 	ReplicatedAppEndpoint string
+	SkipPreflights        bool
 	Stdout                io.Writer
 }
 
@@ -82,6 +83,10 @@ func Install(opts InstallOptions) error {
 
 	if opts.ConfigValuesFile != "" {
 		installArgs = append(installArgs, "--config-values", opts.ConfigValuesFile)
+	}
+
+	if opts.SkipPreflights {
+		installArgs = append(installArgs, "--skip-preflights")
 	}
 
 	if msg, ok := opts.Stdout.(*spinner.MessageWriter); ok && msg != nil {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Skips running KOTS app preflights when the manager experience installer is enabled 

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/127247/pass-the-skip-preflights-flag-to-kots-install

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```
#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
