### PR TITLE
Move app installation logic out of infrastructure setup

### DIFF
--- a/api/controllers/app/install/apppreflight.go
+++ b/api/controllers/app/install/apppreflight.go
@@ -44,6 +44,9 @@ func (c *InstallController) RunAppPreflights(ctx context.Context, opts RunAppPre
 	if err != nil {
 		return fmt.Errorf("extract app preflight spec: %w", err)
 	}
+	if appPreflightSpec == nil {
+		return fmt.Errorf("no app preflight spec found")
+	}
 
 	err = c.stateMachine.Transition(lock, states.StateAppPreflightsRunning)
 	if err != nil {

--- a/api/controllers/app/install/controller.go
+++ b/api/controllers/app/install/controller.go
@@ -194,5 +194,11 @@ func (c *InstallController) validateInit() error {
 	if c.stateMachine == nil {
 		return errors.New("stateMachine is required for App Install Controller")
 	}
+	if c.store == nil {
+		return errors.New("store is required for App Install Controller")
+	}
+	if c.releaseData == nil {
+		return errors.New("releaseData is required for App Install Controller")
+	}
 	return nil
 }

--- a/api/controllers/app/install/controller.go
+++ b/api/controllers/app/install/controller.go
@@ -41,6 +41,8 @@ type InstallController struct {
 	releaseData         *release.ReleaseData
 	store               store.Store
 	configValues        types.AppConfigValues
+	clusterID           string
+	airgapBundle        string
 }
 
 type InstallControllerOption func(*InstallController)
@@ -105,6 +107,18 @@ func WithConfigValues(configValues types.AppConfigValues) InstallControllerOptio
 	}
 }
 
+func WithClusterID(clusterID string) InstallControllerOption {
+	return func(c *InstallController) {
+		c.clusterID = clusterID
+	}
+}
+
+func WithAirgapBundle(airgapBundle string) InstallControllerOption {
+	return func(c *InstallController) {
+		c.airgapBundle = airgapBundle
+	}
+}
+
 func NewInstallController(opts ...InstallControllerOption) (*InstallController, error) {
 	controller := &InstallController{
 		logger: logger.NewDiscardLogger(),
@@ -163,6 +177,9 @@ func NewInstallController(opts ...InstallControllerOption) (*InstallController, 
 		appInstallManager, err := appinstallmanager.NewAppInstallManager(
 			appinstallmanager.WithLogger(controller.logger),
 			appinstallmanager.WithLicense(controller.license),
+			appinstallmanager.WithReleaseData(controller.releaseData),
+			appinstallmanager.WithClusterID(controller.clusterID),
+			appinstallmanager.WithAirgapBundle(controller.airgapBundle),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("create app install manager: %w", err)

--- a/api/controllers/app/install/controller.go
+++ b/api/controllers/app/install/controller.go
@@ -3,13 +3,17 @@ package install
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	appconfig "github.com/replicatedhq/embedded-cluster/api/internal/managers/app/config"
+	appinstallmanager "github.com/replicatedhq/embedded-cluster/api/internal/managers/app/install"
 	apppreflightmanager "github.com/replicatedhq/embedded-cluster/api/internal/managers/app/preflight"
 	appreleasemanager "github.com/replicatedhq/embedded-cluster/api/internal/managers/app/release"
 	"github.com/replicatedhq/embedded-cluster/api/internal/statemachine"
+	"github.com/replicatedhq/embedded-cluster/api/internal/store"
 	"github.com/replicatedhq/embedded-cluster/api/pkg/logger"
 	"github.com/replicatedhq/embedded-cluster/api/types"
+	"github.com/replicatedhq/embedded-cluster/pkg/release"
 	"github.com/sirupsen/logrus"
 )
 
@@ -21,16 +25,22 @@ type Controller interface {
 	GetAppPreflightStatus(ctx context.Context) (types.Status, error)
 	GetAppPreflightOutput(ctx context.Context) (*types.PreflightsOutput, error)
 	GetAppPreflightTitles(ctx context.Context) ([]string, error)
+	InstallApp(ctx context.Context) error
 }
 
 var _ Controller = (*InstallController)(nil)
 
 type InstallController struct {
 	appConfigManager    appconfig.AppConfigManager
+	appInstallManager   appinstallmanager.AppInstallManager
 	appPreflightManager apppreflightmanager.AppPreflightManager
 	appReleaseManager   appreleasemanager.AppReleaseManager
 	stateMachine        statemachine.Interface
 	logger              logrus.FieldLogger
+	license             []byte
+	releaseData         *release.ReleaseData
+	store               store.Store
+	configValues        types.AppConfigValues
 }
 
 type InstallControllerOption func(*InstallController)
@@ -44,6 +54,12 @@ func WithLogger(logger logrus.FieldLogger) InstallControllerOption {
 func WithAppConfigManager(appConfigManager appconfig.AppConfigManager) InstallControllerOption {
 	return func(c *InstallController) {
 		c.appConfigManager = appConfigManager
+	}
+}
+
+func WithAppInstallManager(appInstallManager appinstallmanager.AppInstallManager) InstallControllerOption {
+	return func(c *InstallController) {
+		c.appInstallManager = appInstallManager
 	}
 }
 
@@ -65,6 +81,30 @@ func WithAppReleaseManager(appReleaseManager appreleasemanager.AppReleaseManager
 	}
 }
 
+func WithStore(store store.Store) InstallControllerOption {
+	return func(c *InstallController) {
+		c.store = store
+	}
+}
+
+func WithLicense(license []byte) InstallControllerOption {
+	return func(c *InstallController) {
+		c.license = license
+	}
+}
+
+func WithReleaseData(releaseData *release.ReleaseData) InstallControllerOption {
+	return func(c *InstallController) {
+		c.releaseData = releaseData
+	}
+}
+
+func WithConfigValues(configValues types.AppConfigValues) InstallControllerOption {
+	return func(c *InstallController) {
+		c.configValues = configValues
+	}
+}
+
 func NewInstallController(opts ...InstallControllerOption) (*InstallController, error) {
 	controller := &InstallController{
 		logger: logger.NewDiscardLogger(),
@@ -78,21 +118,64 @@ func NewInstallController(opts ...InstallControllerOption) (*InstallController, 
 		return nil, err
 	}
 
+	if controller.appConfigManager == nil {
+		appConfigManager, err := appconfig.NewAppConfigManager(
+			*controller.releaseData.AppConfig,
+			appconfig.WithLogger(controller.logger),
+			appconfig.WithAppConfigStore(controller.store.AppConfigStore()),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create app config manager: %w", err)
+		}
+		controller.appConfigManager = appConfigManager
+	}
+
+	if controller.configValues != nil {
+		err := controller.appConfigManager.ValidateConfigValues(controller.configValues)
+		if err != nil {
+			return nil, fmt.Errorf("validate app config values: %w", err)
+		}
+		err = controller.appConfigManager.PatchConfigValues(controller.configValues)
+		if err != nil {
+			return nil, fmt.Errorf("patch app config values: %w", err)
+		}
+	}
+
+	if controller.appPreflightManager == nil {
+		controller.appPreflightManager = apppreflightmanager.NewAppPreflightManager(
+			apppreflightmanager.WithLogger(controller.logger),
+		)
+	}
+
+	if controller.appReleaseManager == nil {
+		appReleaseManager, err := appreleasemanager.NewAppReleaseManager(
+			*controller.releaseData.AppConfig,
+			appreleasemanager.WithLogger(controller.logger),
+			appreleasemanager.WithReleaseData(controller.releaseData),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("create app release manager: %w", err)
+		}
+		controller.appReleaseManager = appReleaseManager
+	}
+
+	if controller.appInstallManager == nil {
+		appInstallManager, err := appinstallmanager.NewAppInstallManager(
+			appinstallmanager.WithLogger(controller.logger),
+			appinstallmanager.WithLicense(controller.license),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("create app install manager: %w", err)
+		}
+		controller.appInstallManager = appInstallManager
+	}
+
 	return controller, nil
 }
 
 func (c *InstallController) validateInit() error {
-	if c.appConfigManager == nil {
-		return errors.New("appConfigManager is required for App Install Controller")
-	}
 	if c.stateMachine == nil {
 		return errors.New("stateMachine is required for App Install Controller")
-	}
-	if c.appPreflightManager == nil {
-		return errors.New("appPreflightManager is required for App Install Controller")
-	}
-	if c.appReleaseManager == nil {
-		return errors.New("appReleaseManager is required for App Install Controller")
 	}
 	return nil
 }

--- a/api/controllers/app/install/controller_mock.go
+++ b/api/controllers/app/install/controller_mock.go
@@ -67,3 +67,9 @@ func (m *MockController) GetAppPreflightTitles(ctx context.Context) ([]string, e
 	}
 	return args.Get(0).([]string), args.Error(1)
 }
+
+// InstallApp mocks the InstallApp method
+func (m *MockController) InstallApp(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}

--- a/api/controllers/app/install/install.go
+++ b/api/controllers/app/install/install.go
@@ -1,0 +1,69 @@
+package install
+
+import (
+	"context"
+	"fmt"
+	"runtime/debug"
+
+	states "github.com/replicatedhq/embedded-cluster/api/internal/states/install"
+)
+
+// InstallApp triggers app installation with proper state transitions and panic handling
+func (c *InstallController) InstallApp(ctx context.Context) (finalErr error) {
+	lock, err := c.stateMachine.AcquireLock()
+	if err != nil {
+		return fmt.Errorf("acquire state machine lock for app install: %w", err)
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			finalErr = fmt.Errorf("panic: %v: %s", r, string(debug.Stack()))
+		}
+		if finalErr != nil {
+			c.logger.Error(finalErr)
+			if err := c.stateMachine.Transition(lock, states.StateAppInstallFailed); err != nil {
+				c.logger.Errorf("failed to transition to app install failed state: %w", err)
+			}
+		} else {
+			if err := c.stateMachine.Transition(lock, states.StateSucceeded); err != nil {
+				c.logger.Errorf("failed to transition to succeeded state: %w", err)
+			}
+		}
+		lock.Release()
+	}()
+
+	// Transition to app installing state
+	if err := c.stateMachine.Transition(lock, states.StateAppInstalling); err != nil {
+		return fmt.Errorf("transition to app installing state: %w", err)
+	}
+
+	// Get config values for app installation
+	configValues, err := c.appConfigManager.GetKotsadmConfigValues()
+	if err != nil {
+		return fmt.Errorf("get kotsadm config values for app install: %w", err)
+	}
+
+	// Install the app using the app install manager
+	if err := c.appInstallManager.Install(ctx, configValues); err != nil {
+		return fmt.Errorf("install app: %w", err)
+	}
+
+	return nil
+}
+
+// TODO: remove this once we have endpoints to trigger app installation and report status
+// and the app installation is decoupled from the infra installation
+func (c *InstallController) InstallAppNoState(ctx context.Context) error {
+	// Get config values for app installation
+	configValues, err := c.appConfigManager.GetKotsadmConfigValues()
+	if err != nil {
+		return fmt.Errorf("get kotsadm config values for app install: %w", err)
+	}
+
+	// Install the app using the app install manager
+	if err := c.appInstallManager.Install(ctx, configValues); err != nil {
+		return fmt.Errorf("install app: %w", err)
+	}
+
+	return nil
+}

--- a/api/controllers/app/install/test_suite.go
+++ b/api/controllers/app/install/test_suite.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	appconfig "github.com/replicatedhq/embedded-cluster/api/internal/managers/app/config"
+	appinstallmanager "github.com/replicatedhq/embedded-cluster/api/internal/managers/app/install"
 	apppreflightmanager "github.com/replicatedhq/embedded-cluster/api/internal/managers/app/preflight"
 	appreleasemanager "github.com/replicatedhq/embedded-cluster/api/internal/managers/app/release"
 	"github.com/replicatedhq/embedded-cluster/api/internal/statemachine"
@@ -125,12 +126,15 @@ func (s *AppInstallControllerTestSuite) TestPatchAppConfigValues() {
 			appConfigManager := &appconfig.MockAppConfigManager{}
 			appPreflightManager := &apppreflightmanager.MockAppPreflightManager{}
 			appReleaseManager := &appreleasemanager.MockAppReleaseManager{}
+			appInstallManager := &appinstallmanager.MockAppInstallManager{}
 			sm := s.CreateStateMachine(tt.currentState)
+
 			controller, err := NewInstallController(
 				WithStateMachine(sm),
 				WithAppConfigManager(appConfigManager),
 				WithAppPreflightManager(appPreflightManager),
 				WithAppReleaseManager(appReleaseManager),
+				WithAppInstallManager(appInstallManager),
 			)
 			require.NoError(t, err, "failed to create install controller")
 

--- a/api/controllers/app/install/test_suite.go
+++ b/api/controllers/app/install/test_suite.go
@@ -11,7 +11,9 @@ import (
 	appreleasemanager "github.com/replicatedhq/embedded-cluster/api/internal/managers/app/release"
 	"github.com/replicatedhq/embedded-cluster/api/internal/statemachine"
 	states "github.com/replicatedhq/embedded-cluster/api/internal/states/install"
+	"github.com/replicatedhq/embedded-cluster/api/internal/store"
 	"github.com/replicatedhq/embedded-cluster/api/types"
+	"github.com/replicatedhq/embedded-cluster/pkg/release"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -135,6 +137,8 @@ func (s *AppInstallControllerTestSuite) TestPatchAppConfigValues() {
 				WithAppPreflightManager(appPreflightManager),
 				WithAppReleaseManager(appReleaseManager),
 				WithAppInstallManager(appInstallManager),
+				WithStore(&store.MockStore{}),
+				WithReleaseData(&release.ReleaseData{}),
 			)
 			require.NoError(t, err, "failed to create install controller")
 

--- a/api/controllers/kubernetes/install/controller.go
+++ b/api/controllers/kubernetes/install/controller.go
@@ -181,6 +181,23 @@ func NewInstallController(opts ...InstallControllerOption) (*InstallController, 
 		)
 	}
 
+	// Initialize the app controller with the state machine
+	if controller.InstallController == nil {
+		appInstallController, err := appcontroller.NewInstallController(
+			appcontroller.WithStateMachine(controller.stateMachine),
+			appcontroller.WithLogger(controller.logger),
+			appcontroller.WithStore(controller.store),
+			appcontroller.WithLicense(controller.license),
+			appcontroller.WithReleaseData(controller.releaseData),
+			appcontroller.WithConfigValues(controller.configValues),
+			appcontroller.WithAirgapBundle(controller.airgapBundle),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("create app install controller: %w", err)
+		}
+		controller.InstallController = appInstallController
+	}
+
 	if controller.infraManager == nil {
 		infraManager, err := infra.NewInfraManager(
 			infra.WithLogger(controller.logger),
@@ -197,22 +214,6 @@ func NewInstallController(opts ...InstallControllerOption) (*InstallController, 
 			return nil, fmt.Errorf("create infra manager: %w", err)
 		}
 		controller.infraManager = infraManager
-	}
-
-	// Initialize the app controller with the state machine
-	if controller.InstallController == nil {
-		appInstallController, err := appcontroller.NewInstallController(
-			appcontroller.WithStateMachine(controller.stateMachine),
-			appcontroller.WithLogger(controller.logger),
-			appcontroller.WithStore(controller.store),
-			appcontroller.WithLicense(controller.license),
-			appcontroller.WithReleaseData(controller.releaseData),
-			appcontroller.WithConfigValues(controller.configValues),
-		)
-		if err != nil {
-			return nil, fmt.Errorf("create app install controller: %w", err)
-		}
-		controller.InstallController = appInstallController
 	}
 
 	return controller, nil

--- a/api/controllers/kubernetes/install/controller.go
+++ b/api/controllers/kubernetes/install/controller.go
@@ -6,9 +6,6 @@ import (
 	"fmt"
 
 	appcontroller "github.com/replicatedhq/embedded-cluster/api/controllers/app/install"
-	appconfig "github.com/replicatedhq/embedded-cluster/api/internal/managers/app/config"
-	apppreflightmanager "github.com/replicatedhq/embedded-cluster/api/internal/managers/app/preflight"
-	appreleasemanager "github.com/replicatedhq/embedded-cluster/api/internal/managers/app/release"
 	"github.com/replicatedhq/embedded-cluster/api/internal/managers/kubernetes/infra"
 	"github.com/replicatedhq/embedded-cluster/api/internal/managers/kubernetes/installation"
 	"github.com/replicatedhq/embedded-cluster/api/internal/statemachine"
@@ -39,9 +36,6 @@ var _ Controller = (*InstallController)(nil)
 type InstallController struct {
 	installationManager installation.InstallationManager
 	infraManager        infra.InfraManager
-	appConfigManager    appconfig.AppConfigManager
-	appPreflightManager apppreflightmanager.AppPreflightManager
-	appReleaseManager   appreleasemanager.AppReleaseManager
 	metricsReporter     metrics.ReporterInterface
 	restClientGetter    genericclioptions.RESTClientGetter
 	releaseData         *release.ReleaseData
@@ -139,9 +133,9 @@ func WithInfraManager(infraManager infra.InfraManager) InstallControllerOption {
 	}
 }
 
-func WithAppConfigManager(appConfigManager appconfig.AppConfigManager) InstallControllerOption {
+func WithAppInstallController(appInstallController *appcontroller.InstallController) InstallControllerOption {
 	return func(c *InstallController) {
-		c.appConfigManager = appConfigManager
+		c.InstallController = appInstallController
 	}
 }
 
@@ -205,60 +199,21 @@ func NewInstallController(opts ...InstallControllerOption) (*InstallController, 
 		controller.infraManager = infraManager
 	}
 
-	if controller.appConfigManager == nil {
-		appConfigManager, err := appconfig.NewAppConfigManager(
-			*controller.releaseData.AppConfig,
-			appconfig.WithLogger(controller.logger),
-			appconfig.WithAppConfigStore(controller.store.AppConfigStore()),
+	// Initialize the app controller with the state machine
+	if controller.InstallController == nil {
+		appInstallController, err := appcontroller.NewInstallController(
+			appcontroller.WithStateMachine(controller.stateMachine),
+			appcontroller.WithLogger(controller.logger),
+			appcontroller.WithStore(controller.store),
+			appcontroller.WithLicense(controller.license),
+			appcontroller.WithReleaseData(controller.releaseData),
+			appcontroller.WithConfigValues(controller.configValues),
 		)
 		if err != nil {
-			return nil, fmt.Errorf("create app config manager: %w", err)
+			return nil, fmt.Errorf("create app install controller: %w", err)
 		}
-		controller.appConfigManager = appConfigManager
+		controller.InstallController = appInstallController
 	}
-
-	if controller.configValues != nil {
-		err := controller.appConfigManager.ValidateConfigValues(controller.configValues)
-		if err != nil {
-			return nil, fmt.Errorf("validate app config values: %w", err)
-		}
-		err = controller.appConfigManager.PatchConfigValues(controller.configValues)
-		if err != nil {
-			return nil, fmt.Errorf("patch app config values: %w", err)
-		}
-	}
-
-	if controller.appPreflightManager == nil {
-		controller.appPreflightManager = apppreflightmanager.NewAppPreflightManager(
-			apppreflightmanager.WithLogger(controller.logger),
-		)
-	}
-
-	if controller.appReleaseManager == nil {
-		appReleaseManager, err := appreleasemanager.NewAppReleaseManager(
-			*controller.releaseData.AppConfig,
-			appreleasemanager.WithLogger(controller.logger),
-			appreleasemanager.WithReleaseData(controller.releaseData),
-		)
-		if err != nil {
-			return nil, fmt.Errorf("create app release manager: %w", err)
-		}
-		controller.appReleaseManager = appReleaseManager
-	}
-
-	// Initialize the app controller with the app config manager and state machine
-	appInstallController, err := appcontroller.NewInstallController(
-		appcontroller.WithAppConfigManager(controller.appConfigManager),
-		appcontroller.WithAppPreflightManager(controller.appPreflightManager),
-		appcontroller.WithAppReleaseManager(controller.appReleaseManager),
-		appcontroller.WithStateMachine(controller.stateMachine),
-		appcontroller.WithLogger(controller.logger),
-	)
-
-	if err != nil {
-		return nil, fmt.Errorf("create app install controller: %w", err)
-	}
-	controller.InstallController = appInstallController
 
 	return controller, nil
 }

--- a/api/controllers/kubernetes/install/controller_mock.go
+++ b/api/controllers/kubernetes/install/controller_mock.go
@@ -107,3 +107,9 @@ func (m *MockController) RunAppPreflights(ctx context.Context, opts appcontrolle
 	args := m.Called(ctx, opts)
 	return args.Error(0)
 }
+
+// InstallApp mocks the InstallApp method
+func (m *MockController) InstallApp(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}

--- a/api/controllers/kubernetes/install/controller_test.go
+++ b/api/controllers/kubernetes/install/controller_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	appcontroller "github.com/replicatedhq/embedded-cluster/api/controllers/app/install"
 	appconfig "github.com/replicatedhq/embedded-cluster/api/internal/managers/app/config"
 	"github.com/replicatedhq/embedded-cluster/api/internal/managers/kubernetes/infra"
 	"github.com/replicatedhq/embedded-cluster/api/internal/managers/kubernetes/installation"
@@ -284,13 +285,6 @@ func TestSetupInfra(t *testing.T) {
 			},
 		},
 	}
-	configValues := kotsv1beta1.ConfigValues{
-		Spec: kotsv1beta1.ConfigValuesSpec{
-			Values: map[string]kotsv1beta1.ConfigValue{
-				"test-item": {Default: "default", Value: "value"},
-			},
-		},
-	}
 
 	tests := []struct {
 		name          string
@@ -305,8 +299,7 @@ func TestSetupInfra(t *testing.T) {
 			expectedState: states.StateSucceeded,
 			setupMocks: func(ki kubernetesinstallation.Installation, im *installation.MockInstallationManager, fm *infra.MockInfraManager, mr *metrics.MockReporter, st *store.MockStore, am *appconfig.MockAppConfigManager) {
 				mock.InOrder(
-					am.On("GetKotsadmConfigValues").Return(configValues, nil),
-					fm.On("Install", mock.Anything, ki, configValues).Return(nil),
+					fm.On("Install", mock.Anything, ki).Return(nil),
 					// TODO: we are not yet reporting
 					// mr.On("ReportInstallationSucceeded", mock.Anything),
 				)
@@ -319,8 +312,7 @@ func TestSetupInfra(t *testing.T) {
 			expectedState: states.StateInfrastructureInstallFailed,
 			setupMocks: func(ki kubernetesinstallation.Installation, im *installation.MockInstallationManager, fm *infra.MockInfraManager, mr *metrics.MockReporter, st *store.MockStore, am *appconfig.MockAppConfigManager) {
 				mock.InOrder(
-					am.On("GetKotsadmConfigValues").Return(configValues, nil),
-					fm.On("Install", mock.Anything, ki, configValues).Return(errors.New("install error")),
+					fm.On("Install", mock.Anything, ki).Return(errors.New("install error")),
 					st.LinuxInfraMockStore.On("GetStatus").Return(types.Status{Description: "install error"}, nil),
 					// TODO: we are not yet reporting
 					// mr.On("ReportInstallationFailed", mock.Anything, errors.New("install error")),
@@ -334,8 +326,7 @@ func TestSetupInfra(t *testing.T) {
 			expectedState: states.StateInfrastructureInstallFailed,
 			setupMocks: func(ki kubernetesinstallation.Installation, im *installation.MockInstallationManager, fm *infra.MockInfraManager, mr *metrics.MockReporter, st *store.MockStore, am *appconfig.MockAppConfigManager) {
 				mock.InOrder(
-					am.On("GetKotsadmConfigValues").Return(configValues, nil),
-					fm.On("Install", mock.Anything, ki, configValues).Return(errors.New("install error")),
+					fm.On("Install", mock.Anything, ki).Return(errors.New("install error")),
 					st.LinuxInfraMockStore.On("GetStatus").Return(nil, assert.AnError),
 				)
 			},
@@ -347,8 +338,7 @@ func TestSetupInfra(t *testing.T) {
 			expectedState: states.StateInfrastructureInstallFailed,
 			setupMocks: func(ki kubernetesinstallation.Installation, im *installation.MockInstallationManager, fm *infra.MockInfraManager, mr *metrics.MockReporter, st *store.MockStore, am *appconfig.MockAppConfigManager) {
 				mock.InOrder(
-					am.On("GetKotsadmConfigValues").Return(configValues, nil),
-					fm.On("Install", mock.Anything, ki, configValues).Panic("this is a panic"),
+					fm.On("Install", mock.Anything, ki).Panic("this is a panic"),
 					st.LinuxInfraMockStore.On("GetStatus").Return(types.Status{Description: "this is a panic"}, nil),
 					// TODO: we are not yet reporting
 					// mr.On("ReportInstallationFailed", mock.Anything, errors.New("this is a panic")),
@@ -363,17 +353,6 @@ func TestSetupInfra(t *testing.T) {
 			setupMocks: func(ki kubernetesinstallation.Installation, im *installation.MockInstallationManager, fm *infra.MockInfraManager, mr *metrics.MockReporter, st *store.MockStore, am *appconfig.MockAppConfigManager) {
 			},
 			expectedErr: assert.AnError, // Just check that an error occurs, don't care about exact message
-		},
-		{
-			name:          "config values error",
-			currentState:  states.StateInstallationConfigured,
-			expectedState: states.StateInstallationConfigured,
-			setupMocks: func(ki kubernetesinstallation.Installation, im *installation.MockInstallationManager, fm *infra.MockInfraManager, mr *metrics.MockReporter, st *store.MockStore, am *appconfig.MockAppConfigManager) {
-				mock.InOrder(
-					am.On("GetKotsadmConfigValues").Return(kotsv1beta1.ConfigValues{}, assert.AnError),
-				)
-			},
-			expectedErr: assert.AnError,
 		},
 	}
 
@@ -391,12 +370,20 @@ func TestSetupInfra(t *testing.T) {
 			mockAppConfigManager := &appconfig.MockAppConfigManager{}
 			tt.setupMocks(ki, mockInstallationManager, mockInfraManager, mockMetricsReporter, mockStore, mockAppConfigManager)
 
+			appInstallController, err := appcontroller.NewInstallController(
+				appcontroller.WithStateMachine(sm),
+				appcontroller.WithStore(mockStore),
+				appcontroller.WithReleaseData(getTestReleaseData(&appConfig)),
+				appcontroller.WithAppConfigManager(mockAppConfigManager),
+			)
+			require.NoError(t, err)
+
 			controller, err := NewInstallController(
 				WithInstallation(ki),
 				WithStateMachine(sm),
 				WithInstallationManager(mockInstallationManager),
 				WithInfraManager(mockInfraManager),
-				WithAppConfigManager(mockAppConfigManager),
+				WithAppInstallController(appInstallController),
 				WithMetricsReporter(mockMetricsReporter),
 				WithReleaseData(getTestReleaseData(&appConfig)),
 				WithStore(mockStore),

--- a/api/controllers/kubernetes/install/infra.go
+++ b/api/controllers/kubernetes/install/infra.go
@@ -24,11 +24,6 @@ func (c *InstallController) SetupInfra(ctx context.Context) (finalErr error) {
 		}
 	}()
 
-	configValues, err := c.appConfigManager.GetKotsadmConfigValues()
-	if err != nil {
-		return fmt.Errorf("failed to get kotsadm config values: %w", err)
-	}
-
 	err = c.stateMachine.Transition(lock, states.StateInfrastructureInstalling)
 	if err != nil {
 		return types.NewConflictError(err)
@@ -51,13 +46,14 @@ func (c *InstallController) SetupInfra(ctx context.Context) (finalErr error) {
 					c.logger.Errorf("failed to transition states: %w", err)
 				}
 			} else {
+				// TODO: change to StateInfrastructureInstallSucceeded once app installation is decoupled from infra installation
 				if err := c.stateMachine.Transition(lock, states.StateSucceeded); err != nil {
 					c.logger.Errorf("failed to transition states: %w", err)
 				}
 			}
 		}()
 
-		if err := c.infraManager.Install(ctx, c.ki, configValues); err != nil {
+		if err := c.infraManager.Install(ctx, c.ki); err != nil {
 			return fmt.Errorf("failed to install infrastructure: %w", err)
 		}
 

--- a/api/controllers/linux/install/controller.go
+++ b/api/controllers/linux/install/controller.go
@@ -260,6 +260,8 @@ func NewInstallController(opts ...InstallControllerOption) (*InstallController, 
 			appcontroller.WithLicense(controller.license),
 			appcontroller.WithReleaseData(controller.releaseData),
 			appcontroller.WithConfigValues(controller.configValues),
+			appcontroller.WithClusterID(controller.clusterID),
+			appcontroller.WithAirgapBundle(controller.airgapBundle),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("create app install controller: %w", err)

--- a/api/controllers/linux/install/controller.go
+++ b/api/controllers/linux/install/controller.go
@@ -6,9 +6,6 @@ import (
 	"fmt"
 
 	appcontroller "github.com/replicatedhq/embedded-cluster/api/controllers/app/install"
-	appconfig "github.com/replicatedhq/embedded-cluster/api/internal/managers/app/config"
-	apppreflightmanager "github.com/replicatedhq/embedded-cluster/api/internal/managers/app/preflight"
-	appreleasemanager "github.com/replicatedhq/embedded-cluster/api/internal/managers/app/release"
 	"github.com/replicatedhq/embedded-cluster/api/internal/managers/linux/infra"
 	"github.com/replicatedhq/embedded-cluster/api/internal/managers/linux/installation"
 	"github.com/replicatedhq/embedded-cluster/api/internal/managers/linux/preflight"
@@ -50,9 +47,6 @@ type InstallController struct {
 	installationManager       installation.InstallationManager
 	hostPreflightManager      preflight.HostPreflightManager
 	infraManager              infra.InfraManager
-	appConfigManager          appconfig.AppConfigManager
-	appPreflightManager       apppreflightmanager.AppPreflightManager
-	appReleaseManager         appreleasemanager.AppReleaseManager
 	hostUtils                 hostutils.HostUtilsInterface
 	netUtils                  utils.NetUtils
 	metricsReporter           metrics.ReporterInterface
@@ -191,9 +185,9 @@ func WithInfraManager(infraManager infra.InfraManager) InstallControllerOption {
 	}
 }
 
-func WithAppConfigManager(appConfigManager appconfig.AppConfigManager) InstallControllerOption {
+func WithAppInstallController(appInstallController *appcontroller.InstallController) InstallControllerOption {
 	return func(c *InstallController) {
-		c.appConfigManager = appConfigManager
+		c.InstallController = appInstallController
 	}
 }
 
@@ -257,6 +251,22 @@ func NewInstallController(opts ...InstallControllerOption) (*InstallController, 
 		)
 	}
 
+	// Initialize the app controller with the state machine first
+	if controller.InstallController == nil {
+		appInstallController, err := appcontroller.NewInstallController(
+			appcontroller.WithStateMachine(controller.stateMachine),
+			appcontroller.WithLogger(controller.logger),
+			appcontroller.WithStore(controller.store),
+			appcontroller.WithLicense(controller.license),
+			appcontroller.WithReleaseData(controller.releaseData),
+			appcontroller.WithConfigValues(controller.configValues),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("create app install controller: %w", err)
+		}
+		controller.InstallController = appInstallController
+	}
+
 	if controller.infraManager == nil {
 		controller.infraManager = infra.NewInfraManager(
 			infra.WithLogger(controller.logger),
@@ -270,63 +280,10 @@ func NewInstallController(opts ...InstallControllerOption) (*InstallController, 
 			infra.WithReleaseData(controller.releaseData),
 			infra.WithEndUserConfig(controller.endUserConfig),
 			infra.WithClusterID(controller.clusterID),
+			// TODO: remove this one app installation is decoupled from infra installation
+			infra.WithAppInstaller(controller.InstallAppNoState),
 		)
 	}
-
-	if controller.appConfigManager == nil {
-		appConfigManager, err := appconfig.NewAppConfigManager(
-			*controller.releaseData.AppConfig,
-			appconfig.WithLogger(controller.logger),
-			appconfig.WithAppConfigStore(controller.store.AppConfigStore()),
-		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create app config manager: %w", err)
-		}
-		controller.appConfigManager = appConfigManager
-	}
-
-	if controller.configValues != nil {
-		err := controller.appConfigManager.ValidateConfigValues(controller.configValues)
-		if err != nil {
-			return nil, fmt.Errorf("validate app config values: %w", err)
-		}
-		err = controller.appConfigManager.PatchConfigValues(controller.configValues)
-		if err != nil {
-			return nil, fmt.Errorf("patch app config values: %w", err)
-		}
-	}
-
-	if controller.appPreflightManager == nil {
-		controller.appPreflightManager = apppreflightmanager.NewAppPreflightManager(
-			apppreflightmanager.WithLogger(controller.logger),
-		)
-	}
-
-	if controller.appReleaseManager == nil {
-		appReleaseManager, err := appreleasemanager.NewAppReleaseManager(
-			*controller.releaseData.AppConfig,
-			appreleasemanager.WithLogger(controller.logger),
-			appreleasemanager.WithReleaseData(controller.releaseData),
-		)
-		if err != nil {
-			return nil, fmt.Errorf("create app release manager: %w", err)
-		}
-		controller.appReleaseManager = appReleaseManager
-	}
-
-	// Initialize the app controller with the app config manager and state machine
-	appInstallController, err := appcontroller.NewInstallController(
-		appcontroller.WithAppConfigManager(controller.appConfigManager),
-		appcontroller.WithStateMachine(controller.stateMachine),
-		appcontroller.WithLogger(controller.logger),
-		appcontroller.WithAppPreflightManager(controller.appPreflightManager),
-		appcontroller.WithAppReleaseManager(controller.appReleaseManager),
-	)
-
-	if err != nil {
-		return nil, fmt.Errorf("create app install controller: %w", err)
-	}
-	controller.InstallController = appInstallController
 
 	controller.registerReportingHandlers()
 

--- a/api/controllers/linux/install/controller_mock.go
+++ b/api/controllers/linux/install/controller_mock.go
@@ -140,3 +140,9 @@ func (m *MockController) RunAppPreflights(ctx context.Context, opts appcontrolle
 	args := m.Called(ctx, opts)
 	return args.Error(0)
 }
+
+// InstallApp mocks the InstallApp method
+func (m *MockController) InstallApp(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}

--- a/api/controllers/linux/install/infra.go
+++ b/api/controllers/linux/install/infra.go
@@ -40,11 +40,6 @@ func (c *InstallController) SetupInfra(ctx context.Context, ignoreHostPreflights
 		}
 	}
 
-	configValues, err := c.appConfigManager.GetKotsadmConfigValues()
-	if err != nil {
-		return fmt.Errorf("failed to get kotsadm config values: %w", err)
-	}
-
 	err = c.stateMachine.Transition(lock, states.StateInfrastructureInstalling)
 	if err != nil {
 		return types.NewConflictError(err)
@@ -67,13 +62,14 @@ func (c *InstallController) SetupInfra(ctx context.Context, ignoreHostPreflights
 					c.logger.Errorf("failed to transition states: %w", err)
 				}
 			} else {
+				// TODO: change to StateInfrastructureInstallSucceeded once app installation is decoupled from infra installation
 				if err := c.stateMachine.Transition(lock, states.StateSucceeded); err != nil {
 					c.logger.Errorf("failed to transition states: %w", err)
 				}
 			}
 		}()
 
-		if err := c.infraManager.Install(ctx, c.rc, configValues); err != nil {
+		if err := c.infraManager.Install(ctx, c.rc); err != nil {
 			return fmt.Errorf("failed to install infrastructure: %w", err)
 		}
 

--- a/api/integration/kubernetes/install/infra_test.go
+++ b/api/integration/kubernetes/install/infra_test.go
@@ -1,6 +1,7 @@
 package install
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"net/http"
@@ -20,7 +21,6 @@ import (
 	states "github.com/replicatedhq/embedded-cluster/api/internal/states/install"
 	"github.com/replicatedhq/embedded-cluster/api/pkg/logger"
 	"github.com/replicatedhq/embedded-cluster/api/types"
-	"github.com/replicatedhq/embedded-cluster/cmd/installer/kotscli"
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg-new/constants"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
@@ -102,7 +102,9 @@ func TestKubernetesPostSetupInfra(t *testing.T) {
 			kubernetesinfra.WithMetadataClient(fakeMcli),
 			kubernetesinfra.WithHelmClient(helmMock),
 			kubernetesinfra.WithLicense(assets.LicenseData),
-			kubernetesinfra.WithKotsCLIInstaller(&MockKotsCLIInstaller{}),
+			kubernetesinfra.WithAppInstaller(func(ctx context.Context) error {
+				return nil
+			}),
 			kubernetesinfra.WithReleaseData(&release.ReleaseData{
 				EmbeddedClusterConfig: &ecv1beta1.Config{},
 				ChannelRelease: &release.ChannelRelease{
@@ -282,7 +284,9 @@ func TestKubernetesPostSetupInfra(t *testing.T) {
 			kubernetesinfra.WithMetadataClient(fakeMcli),
 			kubernetesinfra.WithHelmClient(helmMock),
 			kubernetesinfra.WithLicense(assets.LicenseData),
-			kubernetesinfra.WithKotsCLIInstaller(&MockKotsCLIInstaller{}),
+			kubernetesinfra.WithAppInstaller(func(ctx context.Context) error {
+				return nil
+			}),
 			kubernetesinfra.WithReleaseData(&release.ReleaseData{
 				EmbeddedClusterConfig: &ecv1beta1.Config{},
 				ChannelRelease: &release.ChannelRelease{
@@ -368,11 +372,4 @@ func TestKubernetesPostSetupInfra(t *testing.T) {
 		// Verify that the mock expectations were met
 		helmMock.AssertExpectations(t)
 	})
-}
-
-type MockKotsCLIInstaller struct {
-}
-
-func (m *MockKotsCLIInstaller) Install(opts kotscli.InstallOptions) error {
-	return nil
 }

--- a/api/integration/linux/install/infra_test.go
+++ b/api/integration/linux/install/infra_test.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"bytes"
+	"context"
 	_ "embed"
 	"encoding/json"
 	"errors"
@@ -25,7 +26,6 @@ import (
 	linuxpreflightstore "github.com/replicatedhq/embedded-cluster/api/internal/store/linux/preflight"
 	"github.com/replicatedhq/embedded-cluster/api/pkg/logger"
 	"github.com/replicatedhq/embedded-cluster/api/types"
-	"github.com/replicatedhq/embedded-cluster/cmd/installer/kotscli"
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg-new/constants"
 	"github.com/replicatedhq/embedded-cluster/pkg-new/hostutils"
@@ -132,7 +132,9 @@ func TestLinuxPostSetupInfra(t *testing.T) {
 			linuxinfra.WithHelmClient(helmMock),
 			linuxinfra.WithLicense(assets.LicenseData),
 			linuxinfra.WithHostUtils(hostutilsMock),
-			linuxinfra.WithKotsCLIInstaller(&MockKotsCLIInstaller{}),
+			linuxinfra.WithAppInstaller(func(ctx context.Context) error {
+				return nil
+			}),
 			linuxinfra.WithReleaseData(&release.ReleaseData{
 				EmbeddedClusterConfig: &ecv1beta1.Config{},
 				ChannelRelease: &release.ChannelRelease{
@@ -748,11 +750,4 @@ func TestLinuxPostSetupInfra(t *testing.T) {
 		k0sMock.AssertExpectations(t)
 		hostutilsMock.AssertExpectations(t)
 	})
-}
-
-type MockKotsCLIInstaller struct {
-}
-
-func (m *MockKotsCLIInstaller) Install(opts kotscli.InstallOptions) error {
-	return nil
 }

--- a/api/internal/managers/app/install/install.go
+++ b/api/internal/managers/app/install/install.go
@@ -58,8 +58,10 @@ func (m *appInstallManager) createConfigValuesFile(configValues kotsv1beta1.Conf
 	if err != nil {
 		return "", fmt.Errorf("create temp file: %w", err)
 	}
+	defer configValuesFile.Close()
 
 	if _, err := configValuesFile.Write(data); err != nil {
+		os.Remove(configValuesFile.Name())
 		return "", fmt.Errorf("write config values to temp file: %w", err)
 	}
 

--- a/api/internal/managers/app/install/install.go
+++ b/api/internal/managers/app/install/install.go
@@ -61,7 +61,7 @@ func (m *appInstallManager) createConfigValuesFile(configValues kotsv1beta1.Conf
 	defer configValuesFile.Close()
 
 	if _, err := configValuesFile.Write(data); err != nil {
-		os.Remove(configValuesFile.Name())
+		_ = os.Remove(configValuesFile.Name())
 		return "", fmt.Errorf("write config values to temp file: %w", err)
 	}
 

--- a/api/internal/managers/app/install/install.go
+++ b/api/internal/managers/app/install/install.go
@@ -1,0 +1,67 @@
+package install
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/replicatedhq/embedded-cluster/api/internal/utils"
+	kotscli "github.com/replicatedhq/embedded-cluster/cmd/installer/kotscli"
+	"github.com/replicatedhq/embedded-cluster/pkg-new/constants"
+	"github.com/replicatedhq/embedded-cluster/pkg/netutils"
+	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
+	kyaml "sigs.k8s.io/yaml"
+)
+
+// Install installs the app with the provided config values
+func (m *appInstallManager) Install(ctx context.Context, configValues kotsv1beta1.ConfigValues) error {
+	license := &kotsv1beta1.License{}
+	if err := kyaml.Unmarshal(m.license, license); err != nil {
+		return fmt.Errorf("parse license: %w", err)
+	}
+
+	ecDomains := utils.GetDomains(m.releaseData)
+
+	installOpts := kotscli.InstallOptions{
+		AppSlug:      license.Spec.AppSlug,
+		License:      m.license,
+		Namespace:    constants.KotsadmNamespace,
+		ClusterID:    m.clusterID,
+		AirgapBundle: m.airgapBundle,
+		// Skip running the KOTS app preflights in the Admin Console; they run in the manager experience installer when ENABLE_V3 is enabled
+		SkipPreflights:        os.Getenv("ENABLE_V3") == "1",
+		ReplicatedAppEndpoint: netutils.MaybeAddHTTPS(ecDomains.ReplicatedAppDomain),
+	}
+
+	configValuesFile, err := m.createConfigValuesFile(configValues)
+	if err != nil {
+		return fmt.Errorf("creating config values file: %w", err)
+	}
+	installOpts.ConfigValuesFile = configValuesFile
+
+	if m.kotsCLI != nil {
+		return m.kotsCLI.Install(installOpts)
+	}
+
+	return kotscli.Install(installOpts)
+}
+
+// createConfigValuesFile creates a temporary file with the config values
+func (m *appInstallManager) createConfigValuesFile(configValues kotsv1beta1.ConfigValues) (string, error) {
+	// Use Kubernetes-specific YAML serialization to properly handle TypeMeta and ObjectMeta
+	data, err := kyaml.Marshal(configValues)
+	if err != nil {
+		return "", fmt.Errorf("marshaling config values: %w", err)
+	}
+
+	configValuesFile, err := os.CreateTemp("", "config-values*.yaml")
+	if err != nil {
+		return "", fmt.Errorf("create temp file: %w", err)
+	}
+
+	if _, err := configValuesFile.Write(data); err != nil {
+		return "", fmt.Errorf("write config values to temp file: %w", err)
+	}
+
+	return configValuesFile.Name(), nil
+}

--- a/api/internal/managers/app/install/install_test.go
+++ b/api/internal/managers/app/install/install_test.go
@@ -1,0 +1,180 @@
+package install
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	kotscli "github.com/replicatedhq/embedded-cluster/cmd/installer/kotscli"
+	"github.com/replicatedhq/embedded-cluster/pkg/release"
+	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	kyaml "sigs.k8s.io/yaml"
+)
+
+func TestAppInstallManager_Install(t *testing.T) {
+	tests := []struct {
+		name         string
+		configValues kotsv1beta1.ConfigValues
+		setupMock    func(t *testing.T, m *MockKotsCLIInstaller)
+		expectError  bool
+	}{
+		{
+			name: "Config values should be passed to the installer",
+			configValues: kotsv1beta1.ConfigValues{
+				Spec: kotsv1beta1.ConfigValuesSpec{
+					Values: map[string]kotsv1beta1.ConfigValue{
+						"key1": {
+							Value: "value1",
+						},
+						"key2": {
+							Value: "value2",
+						},
+					},
+				},
+			},
+			setupMock: func(t *testing.T, m *MockKotsCLIInstaller) {
+				m.On("Install", mock.MatchedBy(func(opts kotscli.InstallOptions) bool {
+					// Verify basic install options
+					if opts.AppSlug != "test-app" {
+						t.Logf("AppSlug mismatch: expected 'test-app', got '%s'", opts.AppSlug)
+						return false
+					}
+					if opts.License == nil {
+						t.Logf("License is nil")
+						return false
+					}
+					if opts.Namespace != "kotsadm" {
+						t.Logf("Namespace mismatch: expected 'kotsadm', got '%s'", opts.Namespace)
+						return false
+					}
+					if opts.ClusterID != "test-cluster" {
+						t.Logf("ClusterID mismatch: expected 'test-cluster', got '%s'", opts.ClusterID)
+						return false
+					}
+					if opts.AirgapBundle != "test-airgap.tar.gz" {
+						t.Logf("AirgapBundle mismatch: expected 'test-airgap.tar.gz', got '%s'", opts.AirgapBundle)
+						return false
+					}
+					if opts.ReplicatedAppEndpoint == "" {
+						t.Logf("ReplicatedAppEndpoint is empty")
+						return false
+					}
+					if opts.ConfigValuesFile == "" {
+						t.Logf("ConfigValuesFile is empty")
+						return false
+					}
+
+					// Verify config values file content
+					b, err := os.ReadFile(opts.ConfigValuesFile)
+					if err != nil {
+						t.Logf("Failed to read config values file: %v", err)
+						return false
+					}
+					var cv kotsv1beta1.ConfigValues
+					if err := kyaml.Unmarshal(b, &cv); err != nil {
+						t.Logf("Failed to unmarshal config values: %v", err)
+						return false
+					}
+					if cv.Spec.Values["key1"].Value != "value1" {
+						t.Logf("Config value key1 mismatch: expected 'value1', got '%s'", cv.Spec.Values["key1"].Value)
+						return false
+					}
+					if cv.Spec.Values["key2"].Value != "value2" {
+						t.Logf("Config value key2 mismatch: expected 'value2', got '%s'", cv.Spec.Values["key2"].Value)
+						return false
+					}
+					return true
+				})).Return(nil)
+			},
+			expectError: false,
+		},
+		{
+			name:         "Install error should be propagated",
+			configValues: kotsv1beta1.ConfigValues{},
+			setupMock: func(t *testing.T, m *MockKotsCLIInstaller) {
+				m.On("Install", mock.Anything).Return(assert.AnError)
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test license
+			license := &kotsv1beta1.License{
+				Spec: kotsv1beta1.LicenseSpec{
+					AppSlug: "test-app",
+				},
+			}
+			licenseBytes, err := kyaml.Marshal(license)
+			assert.NoError(t, err)
+
+			// Create test release data with minimal ChannelRelease
+			releaseData := &release.ReleaseData{
+				ChannelRelease: &release.ChannelRelease{
+					DefaultDomains: release.Domains{
+						ReplicatedAppDomain: "replicated.app",
+					},
+				},
+			}
+
+			// Create mock installer
+			mockInstaller := &MockKotsCLIInstaller{}
+			tt.setupMock(t, mockInstaller)
+
+			// Create app install manager
+			manager, err := NewAppInstallManager(
+				WithLicense(licenseBytes),
+				WithClusterID("test-cluster"),
+				WithAirgapBundle("test-airgap.tar.gz"),
+				WithReleaseData(releaseData),
+				WithKotsCLI(mockInstaller),
+			)
+			assert.NoError(t, err)
+
+			// Test the Install method
+			err = manager.Install(context.Background(), tt.configValues)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			// Verify mock expectations
+			mockInstaller.AssertExpectations(t)
+		})
+	}
+}
+
+func TestAppInstallManager_createConfigValuesFile(t *testing.T) {
+	manager := &appInstallManager{}
+
+	configValues := kotsv1beta1.ConfigValues{
+		Spec: kotsv1beta1.ConfigValuesSpec{
+			Values: map[string]kotsv1beta1.ConfigValue{
+				"testKey": {
+					Value: "testValue",
+				},
+			},
+		},
+	}
+
+	filename, err := manager.createConfigValuesFile(configValues)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, filename)
+
+	// Verify file exists and contains correct content
+	data, err := os.ReadFile(filename)
+	assert.NoError(t, err)
+
+	var unmarshaled kotsv1beta1.ConfigValues
+	err = kyaml.Unmarshal(data, &unmarshaled)
+	assert.NoError(t, err)
+	assert.Equal(t, "testValue", unmarshaled.Spec.Values["testKey"].Value)
+
+	// Clean up
+	os.Remove(filename)
+}

--- a/api/internal/managers/app/install/mock.go
+++ b/api/internal/managers/app/install/mock.go
@@ -1,0 +1,31 @@
+package install
+
+import (
+	"context"
+
+	kotscli "github.com/replicatedhq/embedded-cluster/cmd/installer/kotscli"
+	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockAppInstallManager is a mock implementation of the AppInstallManager interface
+type MockAppInstallManager struct {
+	mock.Mock
+}
+
+// Install mocks the Install method
+func (m *MockAppInstallManager) Install(ctx context.Context, configValues kotsv1beta1.ConfigValues) error {
+	args := m.Called(ctx, configValues)
+	return args.Error(0)
+}
+
+// MockKotsCLIInstaller is a mock implementation of the KotsCLIInstaller interface
+type MockKotsCLIInstaller struct {
+	mock.Mock
+}
+
+// Install mocks the Install method from the kotscli package
+func (m *MockKotsCLIInstaller) Install(opts kotscli.InstallOptions) error {
+	args := m.Called(opts)
+	return args.Error(0)
+}

--- a/api/internal/managers/kubernetes/infra/install.go
+++ b/api/internal/managers/kubernetes/infra/install.go
@@ -20,7 +20,7 @@ import (
 	kyaml "sigs.k8s.io/yaml"
 )
 
-func (m *infraManager) Install(ctx context.Context, ki kubernetesinstallation.Installation, configValues kotsv1beta1.ConfigValues) (finalErr error) {
+func (m *infraManager) Install(ctx context.Context, ki kubernetesinstallation.Installation) (finalErr error) {
 	// TODO: check if kots is already installed
 
 	if err := m.setStatus(types.StateRunning, ""); err != nil {
@@ -42,17 +42,17 @@ func (m *infraManager) Install(ctx context.Context, ki kubernetesinstallation.In
 		}
 	}()
 
-	if err := m.install(ctx, ki, configValues); err != nil {
+	if err := m.install(ctx, ki); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (m *infraManager) initComponentsList(license *kotsv1beta1.License, ki kubernetesinstallation.Installation, configValues kotsv1beta1.ConfigValues) error {
+func (m *infraManager) initComponentsList(license *kotsv1beta1.License, ki kubernetesinstallation.Installation) error {
 	components := []types.InfraComponent{}
 
-	addOns := addons.GetAddOnsForKubernetesInstall(m.getAddonInstallOpts(license, ki, configValues))
+	addOns := addons.GetAddOnsForKubernetesInstall(m.getAddonInstallOpts(license, ki))
 	for _, addOn := range addOns {
 		components = append(components, types.InfraComponent{Name: addOn.Name()})
 	}
@@ -65,13 +65,13 @@ func (m *infraManager) initComponentsList(license *kotsv1beta1.License, ki kuber
 	return nil
 }
 
-func (m *infraManager) install(ctx context.Context, ki kubernetesinstallation.Installation, configValues kotsv1beta1.ConfigValues) error {
+func (m *infraManager) install(ctx context.Context, ki kubernetesinstallation.Installation) error {
 	license := &kotsv1beta1.License{}
 	if err := kyaml.Unmarshal(m.license, license); err != nil {
 		return fmt.Errorf("parse license: %w", err)
 	}
 
-	if err := m.initComponentsList(license, ki, configValues); err != nil {
+	if err := m.initComponentsList(license, ki); err != nil {
 		return fmt.Errorf("init components: %w", err)
 	}
 
@@ -80,7 +80,7 @@ func (m *infraManager) install(ctx context.Context, ki kubernetesinstallation.In
 		return fmt.Errorf("record installation: %w", err)
 	}
 
-	if err := m.installAddOns(ctx, m.kcli, m.mcli, m.hcli, license, ki, configValues); err != nil {
+	if err := m.installAddOns(ctx, m.kcli, m.mcli, m.hcli, license, ki); err != nil {
 		return fmt.Errorf("install addons: %w", err)
 	}
 
@@ -102,7 +102,7 @@ func (m *infraManager) recordInstallation(ctx context.Context, kcli client.Clien
 	return nil, nil
 }
 
-func (m *infraManager) installAddOns(ctx context.Context, kcli client.Client, mcli metadata.Interface, hcli helm.Client, license *kotsv1beta1.License, ki kubernetesinstallation.Installation, configValues kotsv1beta1.ConfigValues) error {
+func (m *infraManager) installAddOns(ctx context.Context, kcli client.Client, mcli metadata.Interface, hcli helm.Client, license *kotsv1beta1.License, ki kubernetesinstallation.Installation) error {
 	progressChan := make(chan addontypes.AddOnProgress)
 	defer close(progressChan)
 
@@ -134,7 +134,7 @@ func (m *infraManager) installAddOns(ctx context.Context, kcli client.Client, mc
 		addons.WithProgressChannel(progressChan),
 	)
 
-	opts := m.getAddonInstallOpts(license, ki, configValues)
+	opts := m.getAddonInstallOpts(license, ki)
 
 	logFn("installing addons")
 	if err := addOns.InstallKubernetes(ctx, opts); err != nil {
@@ -144,7 +144,7 @@ func (m *infraManager) installAddOns(ctx context.Context, kcli client.Client, mc
 	return nil
 }
 
-func (m *infraManager) getAddonInstallOpts(license *kotsv1beta1.License, ki kubernetesinstallation.Installation, configValues kotsv1beta1.ConfigValues) addons.KubernetesInstallOptions {
+func (m *infraManager) getAddonInstallOpts(license *kotsv1beta1.License, ki kubernetesinstallation.Installation) addons.KubernetesInstallOptions {
 	opts := addons.KubernetesInstallOptions{
 		AdminConsolePwd:    m.password,
 		AdminConsolePort:   ki.AdminConsolePort(),

--- a/api/internal/managers/kubernetes/infra/manager.go
+++ b/api/internal/managers/kubernetes/infra/manager.go
@@ -14,7 +14,6 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
 	"github.com/replicatedhq/embedded-cluster/pkg/kubernetesinstallation"
 	"github.com/replicatedhq/embedded-cluster/pkg/release"
-	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	"github.com/sirupsen/logrus"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/metadata"
@@ -26,7 +25,7 @@ var _ InfraManager = &infraManager{}
 // InfraManager provides methods for managing infrastructure setup
 type InfraManager interface {
 	Get() (types.Infra, error)
-	Install(ctx context.Context, ki kubernetesinstallation.Installation, configValues kotsv1beta1.ConfigValues) error
+	Install(ctx context.Context, ki kubernetesinstallation.Installation) error
 }
 
 // KotsCLIInstaller is an interface that wraps the Install method from the kotscli package
@@ -48,7 +47,7 @@ type infraManager struct {
 	mcli             metadata.Interface
 	hcli             helm.Client
 	restClientGetter genericclioptions.RESTClientGetter
-	kotsCLI          KotsCLIInstaller
+	appInstaller     func(ctx context.Context) error
 	mu               sync.RWMutex
 }
 
@@ -126,9 +125,9 @@ func WithRESTClientGetter(restClientGetter genericclioptions.RESTClientGetter) I
 	}
 }
 
-func WithKotsCLIInstaller(kotsCLI KotsCLIInstaller) InfraManagerOption {
+func WithAppInstaller(appInstaller func(ctx context.Context) error) InfraManagerOption {
 	return func(c *infraManager) {
-		c.kotsCLI = kotsCLI
+		c.appInstaller = appInstaller
 	}
 }
 

--- a/api/internal/managers/kubernetes/infra/manager_mock.go
+++ b/api/internal/managers/kubernetes/infra/manager_mock.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/replicatedhq/embedded-cluster/api/types"
 	"github.com/replicatedhq/embedded-cluster/pkg/kubernetesinstallation"
-	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -16,8 +15,8 @@ type MockInfraManager struct {
 	mock.Mock
 }
 
-func (m *MockInfraManager) Install(ctx context.Context, ki kubernetesinstallation.Installation, configValues kotsv1beta1.ConfigValues) error {
-	args := m.Called(ctx, ki, configValues)
+func (m *MockInfraManager) Install(ctx context.Context, ki kubernetesinstallation.Installation) error {
+	args := m.Called(ctx, ki)
 	return args.Error(0)
 }
 

--- a/api/internal/managers/linux/infra/install.go
+++ b/api/internal/managers/linux/infra/install.go
@@ -3,15 +3,12 @@ package infra
 import (
 	"context"
 	"fmt"
-	"os"
 	"runtime/debug"
 
 	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/api/internal/utils"
 	"github.com/replicatedhq/embedded-cluster/api/types"
-	"github.com/replicatedhq/embedded-cluster/cmd/installer/kotscli"
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
-	"github.com/replicatedhq/embedded-cluster/pkg-new/constants"
 	ecmetadata "github.com/replicatedhq/embedded-cluster/pkg-new/metadata"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/registry"
@@ -39,7 +36,7 @@ func AlreadyInstalledError() error {
 	)
 }
 
-func (m *infraManager) Install(ctx context.Context, rc runtimeconfig.RuntimeConfig, configValues kotsv1beta1.ConfigValues) (finalErr error) {
+func (m *infraManager) Install(ctx context.Context, rc runtimeconfig.RuntimeConfig) (finalErr error) {
 	installed, err := m.k0scli.IsInstalled()
 	if err != nil {
 		return fmt.Errorf("check if k0s is installed: %w", err)
@@ -67,17 +64,17 @@ func (m *infraManager) Install(ctx context.Context, rc runtimeconfig.RuntimeConf
 		}
 	}()
 
-	if err := m.install(ctx, rc, configValues); err != nil {
+	if err := m.install(ctx, rc); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (m *infraManager) initComponentsList(license *kotsv1beta1.License, rc runtimeconfig.RuntimeConfig, configValues kotsv1beta1.ConfigValues) error {
+func (m *infraManager) initComponentsList(ctx context.Context, license *kotsv1beta1.License, rc runtimeconfig.RuntimeConfig) error {
 	components := []types.InfraComponent{{Name: K0sComponentName}}
 
-	addOns := addons.GetAddOnsForInstall(m.getAddonInstallOpts(license, rc, configValues))
+	addOns := addons.GetAddOnsForInstall(m.getAddonInstallOpts(ctx, license, rc))
 	for _, addOn := range addOns {
 		components = append(components, types.InfraComponent{Name: addOn.Name()})
 	}
@@ -92,13 +89,13 @@ func (m *infraManager) initComponentsList(license *kotsv1beta1.License, rc runti
 	return nil
 }
 
-func (m *infraManager) install(ctx context.Context, rc runtimeconfig.RuntimeConfig, configValues kotsv1beta1.ConfigValues) error {
+func (m *infraManager) install(ctx context.Context, rc runtimeconfig.RuntimeConfig) error {
 	license := &kotsv1beta1.License{}
 	if err := kyaml.Unmarshal(m.license, license); err != nil {
 		return fmt.Errorf("parse license: %w", err)
 	}
 
-	if err := m.initComponentsList(license, rc, configValues); err != nil {
+	if err := m.initComponentsList(ctx, license, rc); err != nil {
 		return fmt.Errorf("init components: %w", err)
 	}
 
@@ -112,7 +109,7 @@ func (m *infraManager) install(ctx context.Context, rc runtimeconfig.RuntimeConf
 		return fmt.Errorf("record installation: %w", err)
 	}
 
-	if err := m.installAddOns(ctx, m.kcli, m.mcli, m.hcli, license, rc, configValues); err != nil {
+	if err := m.installAddOns(ctx, m.kcli, m.mcli, m.hcli, license, rc); err != nil {
 		return fmt.Errorf("install addons: %w", err)
 	}
 
@@ -239,7 +236,7 @@ func (m *infraManager) recordInstallation(ctx context.Context, kcli client.Clien
 	return in, nil
 }
 
-func (m *infraManager) installAddOns(ctx context.Context, kcli client.Client, mcli metadata.Interface, hcli helm.Client, license *kotsv1beta1.License, rc runtimeconfig.RuntimeConfig, configValues kotsv1beta1.ConfigValues) error {
+func (m *infraManager) installAddOns(ctx context.Context, kcli client.Client, mcli metadata.Interface, hcli helm.Client, license *kotsv1beta1.License, rc runtimeconfig.RuntimeConfig) error {
 	progressChan := make(chan addontypes.AddOnProgress)
 	defer close(progressChan)
 
@@ -271,7 +268,7 @@ func (m *infraManager) installAddOns(ctx context.Context, kcli client.Client, mc
 		addons.WithProgressChannel(progressChan),
 	)
 
-	opts := m.getAddonInstallOpts(license, rc, configValues)
+	opts := m.getAddonInstallOpts(ctx, license, rc)
 
 	logFn("installing addons")
 	if err := addOns.Install(ctx, opts); err != nil {
@@ -281,9 +278,7 @@ func (m *infraManager) installAddOns(ctx context.Context, kcli client.Client, mc
 	return nil
 }
 
-func (m *infraManager) getAddonInstallOpts(license *kotsv1beta1.License, rc runtimeconfig.RuntimeConfig, configValues kotsv1beta1.ConfigValues) addons.InstallOptions {
-	ecDomains := utils.GetDomains(m.releaseData)
-
+func (m *infraManager) getAddonInstallOpts(ctx context.Context, license *kotsv1beta1.License, rc runtimeconfig.RuntimeConfig) addons.InstallOptions {
 	opts := addons.InstallOptions{
 		ClusterID:               m.clusterID,
 		AdminConsolePwd:         m.password,
@@ -305,33 +300,8 @@ func (m *infraManager) getAddonInstallOpts(license *kotsv1beta1.License, rc runt
 		ServiceCIDR:             rc.ServiceCIDR(),
 	}
 
-	// TODO: move creation of the KotsInstaller to the AppConfigManager, rename to AppInstallManager
 	opts.KotsInstaller = func() error {
-		installOpts := kotscli.InstallOptions{
-			RuntimeConfig: rc,
-			AppSlug:       license.Spec.AppSlug,
-			License:       m.license,
-			Namespace:     constants.KotsadmNamespace,
-			ClusterID:     m.clusterID,
-			AirgapBundle:  m.airgapBundle,
-			// Skip running the KOTS app preflights in the Admin Console; they run in the manager experience installer when ENABLE_V3 is enabled
-			SkipPreflights:        os.Getenv("ENABLE_V3") == "1",
-			ReplicatedAppEndpoint: netutils.MaybeAddHTTPS(ecDomains.ReplicatedAppDomain),
-			// TODO (@salah): capture kots install logs
-			// Stdout:                stdout,
-		}
-
-		configValuesFile, err := m.createConfigValuesFile(configValues)
-		if err != nil {
-			return fmt.Errorf("creating config values file: %w", err)
-		}
-		installOpts.ConfigValuesFile = configValuesFile
-
-		if m.kotsCLI != nil {
-			return m.kotsCLI.Install(installOpts)
-		}
-
-		return kotscli.Install(installOpts)
+		return m.appInstaller(ctx)
 	}
 
 	return opts
@@ -367,23 +337,4 @@ func (m *infraManager) installExtensions(ctx context.Context, hcli helm.Client) 
 		return fmt.Errorf("install extensions: %w", err)
 	}
 	return nil
-}
-
-func (m *infraManager) createConfigValuesFile(configValues kotsv1beta1.ConfigValues) (string, error) {
-	// Use Kubernetes-specific YAML serialization to properly handle TypeMeta and ObjectMeta
-	data, err := kyaml.Marshal(configValues)
-	if err != nil {
-		return "", fmt.Errorf("marshaling config values: %w", err)
-	}
-
-	configValuesFile, err := os.CreateTemp("", "config-values*.yaml")
-	if err != nil {
-		return "", fmt.Errorf("unable to create temp file: %w", err)
-	}
-
-	if _, err := configValuesFile.Write(data); err != nil {
-		return "", fmt.Errorf("unable to write config values to temp file: %w", err)
-	}
-
-	return configValuesFile.Name(), nil
 }

--- a/api/internal/managers/linux/infra/install_test.go
+++ b/api/internal/managers/linux/infra/install_test.go
@@ -1,37 +1,23 @@
 package infra
 
 import (
-	"os"
 	"testing"
 
-	"github.com/replicatedhq/embedded-cluster/cmd/installer/kotscli"
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	kyaml "sigs.k8s.io/yaml"
 )
-
-// MockKotsCLIInstaller is a mock implementation of the KotsCLIInstaller interface
-type MockKotsCLIInstaller struct {
-	mock.Mock
-}
-
-func (m *MockKotsCLIInstaller) Install(opts kotscli.InstallOptions) error {
-	return m.Called(opts).Error(0)
-}
 
 func TestInfraManager_getAddonInstallOpts(t *testing.T) {
 	tests := []struct {
 		name              string
 		configValues      kotsv1beta1.ConfigValues
-		setupMock         func(m *MockKotsCLIInstaller)
 		verifyInstallOpts func(t *testing.T, opts addons.InstallOptions)
 	}{
 		{
-			name: "Config values should be passed to the installer",
+			name: "Config values should be passed correctly",
 			configValues: kotsv1beta1.ConfigValues{
 				Spec: kotsv1beta1.ConfigValuesSpec{
 					Values: map[string]kotsv1beta1.ConfigValue{
@@ -44,55 +30,17 @@ func TestInfraManager_getAddonInstallOpts(t *testing.T) {
 					},
 				},
 			},
-			setupMock: func(m *MockKotsCLIInstaller) {
-				m.On("Install", mock.MatchedBy(func(opts kotscli.InstallOptions) bool {
-					if opts.ConfigValuesFile == "" {
-						return false
-					}
-					b, err := os.ReadFile(opts.ConfigValuesFile)
-					if err != nil {
-						return false
-					}
-					var cv kotsv1beta1.ConfigValues
-					if err := kyaml.Unmarshal(b, &cv); err != nil {
-						return false
-					}
-					if cv.Spec.Values["key1"].Value != "value1" || cv.Spec.Values["key2"].Value != "value2" {
-						return false
-					}
-					return true
-				})).Return(nil)
-			},
 			verifyInstallOpts: func(t *testing.T, opts addons.InstallOptions) {
-				assert.NotNil(t, opts.KotsInstaller)
-				// Test that the KotsInstaller function works correctly
-				err := opts.KotsInstaller()
-				assert.NoError(t, err)
+				assert.Equal(t, "test-cluster", opts.ClusterID)
+				assert.NotNil(t, opts.License)
 			},
 		},
-
-		// Basic options tests
 		{
 			name:         "basic options should be set correctly",
 			configValues: kotsv1beta1.ConfigValues{},
-			setupMock: func(m *MockKotsCLIInstaller) {
-				m.On("Install", mock.MatchedBy(func(opts kotscli.InstallOptions) bool {
-					return opts.AppSlug == "test-app" &&
-						opts.License != nil &&
-						opts.Namespace == "kotsadm" &&
-						opts.ClusterID == "test-cluster" &&
-						opts.AirgapBundle == "" &&
-						opts.ConfigValuesFile != "" &&
-						opts.ReplicatedAppEndpoint == "https://replicated.app"
-				})).Return(nil)
-			},
 			verifyInstallOpts: func(t *testing.T, opts addons.InstallOptions) {
-				assert.NotNil(t, opts.KotsInstaller)
-				assert.NotNil(t, opts.ClusterID)
+				assert.Equal(t, "test-cluster", opts.ClusterID)
 				assert.NotNil(t, opts.License)
-				// Test that the KotsInstaller function works correctly
-				err := opts.KotsInstaller()
-				assert.NoError(t, err)
 			},
 		},
 	}
@@ -108,10 +56,6 @@ func TestInfraManager_getAddonInstallOpts(t *testing.T) {
 			}
 			rc := runtimeconfig.New(rcSpec)
 
-			// Create mock installer
-			mockInstaller := &MockKotsCLIInstaller{}
-			tt.setupMock(mockInstaller)
-
 			// Create test license
 			license := &kotsv1beta1.License{
 				Spec: kotsv1beta1.LicenseSpec{
@@ -119,27 +63,17 @@ func TestInfraManager_getAddonInstallOpts(t *testing.T) {
 				},
 			}
 
-			// Create infra manager with CLI config file - use mock installer to test the priority logic
+			// Create infra manager
 			manager := NewInfraManager(
 				WithClusterID("test-cluster"),
 				WithLicense([]byte("test-license")),
-				WithKotsCLIInstaller(mockInstaller),
 			)
 
 			// Test the getAddonInstallOpts method with configValues passed as parameter
-			opts := manager.getAddonInstallOpts(license, rc, tt.configValues)
+			opts := manager.getAddonInstallOpts(t.Context(), license, rc)
 
-			// Verify basic options are set correctly
-			assert.Equal(t, "test-cluster", opts.ClusterID)
-			assert.Equal(t, license, opts.License)
-
-			// Verify the installer function behavior
-			if tt.verifyInstallOpts != nil {
-				tt.verifyInstallOpts(t, opts)
-			}
-
-			// Verify mock expectations
-			mockInstaller.AssertExpectations(t)
+			// Verify the install options
+			tt.verifyInstallOpts(t, opts)
 		})
 	}
 }

--- a/api/internal/managers/linux/infra/manager_mock.go
+++ b/api/internal/managers/linux/infra/manager_mock.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/replicatedhq/embedded-cluster/api/types"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
-	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -16,8 +15,8 @@ type MockInfraManager struct {
 	mock.Mock
 }
 
-func (m *MockInfraManager) Install(ctx context.Context, rc runtimeconfig.RuntimeConfig, configValues kotsv1beta1.ConfigValues) error {
-	args := m.Called(ctx, rc, configValues)
+func (m *MockInfraManager) Install(ctx context.Context, rc runtimeconfig.RuntimeConfig) error {
+	args := m.Called(ctx, rc)
 	return args.Error(0)
 }
 

--- a/api/internal/states/install/states.go
+++ b/api/internal/states/install/states.go
@@ -37,6 +37,8 @@ const (
 	StateInfrastructureInstalling statemachine.State = "InfrastructureInstalling"
 	// StateInfrastructureInstallFailed is a final state of the install process when the infrastructure failed to isntall
 	StateInfrastructureInstallFailed statemachine.State = "InfrastructureInstallFailed"
+	// StateInfrastructureInstallSucceeded is the state of the install process when the infrastructure install has succeeded
+	StateInfrastructureInstallSucceeded statemachine.State = "InfrastructureInstallSucceeded"
 	// StateAppPreflightsRunning is the state of the install process when the preflights are running
 	StateAppPreflightsRunning statemachine.State = "AppPreflightsRunning"
 	// StateAppPreflightsExecutionFailed is the state of the install process when the preflights failed to execute due to an underlying system error
@@ -47,6 +49,10 @@ const (
 	StateAppPreflightsFailed statemachine.State = "AppPreflightsFailed"
 	// StateAppPreflightsFailedBypassed is the state of the install process when, despite preflights failing, the user has chosen to bypass the preflights and continue with the installation
 	StateAppPreflightsFailedBypassed statemachine.State = "AppPreflightsFailedBypassed"
+	// StateAppInstalling is the state of the install process when the app is being installed
+	StateAppInstalling statemachine.State = "AppInstalling"
+	// StateAppInstallFailed is a final state of the install process when the app failed to install
+	StateAppInstallFailed statemachine.State = "AppInstallFailed"
 	// StateSucceeded is the final state of the install process when the install has succeeded
 	StateSucceeded statemachine.State = "Succeeded"
 )

--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -842,7 +842,6 @@ func getAddonInstallOpts(flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig, 
 		ServiceCIDR:             rc.ServiceCIDR(),
 		KotsInstaller: func() error {
 			opts := kotscli.InstallOptions{
-				RuntimeConfig:         rc,
 				AppSlug:               flags.license.Spec.AppSlug,
 				License:               flags.licenseBytes,
 				Namespace:             constants.KotsadmNamespace,

--- a/cmd/installer/cli/restore.go
+++ b/cmd/installer/cli/restore.go
@@ -426,7 +426,6 @@ func runRestoreStepNew(ctx context.Context, appSlug, appTitle string, flags Inst
 
 	logrus.Debugf("configuring velero backup storage location")
 	if err := kotscli.VeleroConfigureOtherS3(kotscli.VeleroConfigureOtherS3Options{
-		RuntimeConfig:   rc,
 		Endpoint:        s3Store.endpoint,
 		Region:          s3Store.region,
 		Bucket:          s3Store.bucket,

--- a/cmd/installer/cli/update.go
+++ b/cmd/installer/cli/update.go
@@ -69,11 +69,10 @@ func UpdateCmd(ctx context.Context, appSlug, appTitle string) *cobra.Command {
 			}
 
 			if err := kotscli.AirgapUpdate(kotscli.AirgapUpdateOptions{
-				RuntimeConfig: rc,
-				AppSlug:       appSlug,
-				Namespace:     constants.KotsadmNamespace,
-				AirgapBundle:  airgapBundle,
-				ClusterID:     in.Spec.ClusterID,
+				AppSlug:      appSlug,
+				Namespace:    constants.KotsadmNamespace,
+				AirgapBundle: airgapBundle,
+				ClusterID:    in.Spec.ClusterID,
 			}); err != nil {
 				return err
 			}

--- a/cmd/installer/goods/materializer.go
+++ b/cmd/installer/goods/materializer.go
@@ -30,11 +30,15 @@ func NewMaterializer(rc runtimeconfig.RuntimeConfig) *Materializer {
 	}
 }
 
+func (m *Materializer) InternalBinary(name string) (string, error) {
+	return InternalBinary(name)
+}
+
 // InternalBinary materializes an internal binary from inside internal/bins directory
 // and writes it to a tmp file. It returns the path to the materialized binary.
 // The binary should be deleted after it is used.
 // This is used for binaries that are not meant to be exposed to the user.
-func (m *Materializer) InternalBinary(name string) (string, error) {
+func InternalBinary(name string) (string, error) {
 	srcpath := fmt.Sprintf("internal/bins/%s", name)
 	srcfile, err := internalBinfs.ReadFile(srcpath)
 	if err != nil {

--- a/cmd/installer/goods/materializer.go
+++ b/cmd/installer/goods/materializer.go
@@ -30,10 +30,6 @@ func NewMaterializer(rc runtimeconfig.RuntimeConfig) *Materializer {
 	}
 }
 
-func (m *Materializer) InternalBinary(name string) (string, error) {
-	return InternalBinary(name)
-}
-
 // InternalBinary materializes an internal binary from inside internal/bins directory
 // and writes it to a tmp file. It returns the path to the materialized binary.
 // The binary should be deleted after it is used.

--- a/cmd/installer/kotscli/kotscli.go
+++ b/cmd/installer/kotscli/kotscli.go
@@ -22,7 +22,6 @@ var (
 )
 
 type InstallOptions struct {
-	RuntimeConfig         runtimeconfig.RuntimeConfig
 	AppSlug               string
 	License               []byte
 	Namespace             string
@@ -35,8 +34,7 @@ type InstallOptions struct {
 }
 
 func Install(opts InstallOptions) error {
-	materializer := goods.NewMaterializer(opts.RuntimeConfig)
-	kotsBinPath, err := materializer.InternalBinary("kubectl-kots")
+	kotsBinPath, err := goods.InternalBinary("kubectl-kots")
 	if err != nil {
 		return fmt.Errorf("unable to materialize kubectl-kots binary: %w", err)
 	}
@@ -115,8 +113,7 @@ func Install(opts InstallOptions) error {
 }
 
 func ResetPassword(rc runtimeconfig.RuntimeConfig, password string) error {
-	materializer := goods.NewMaterializer(rc)
-	kotsBinPath, err := materializer.InternalBinary("kubectl-kots")
+	kotsBinPath, err := goods.InternalBinary("kubectl-kots")
 	if err != nil {
 		return fmt.Errorf("unable to materialize kubectl-kots binary: %w", err)
 	}
@@ -136,16 +133,14 @@ func ResetPassword(rc runtimeconfig.RuntimeConfig, password string) error {
 }
 
 type AirgapUpdateOptions struct {
-	RuntimeConfig runtimeconfig.RuntimeConfig
-	AppSlug       string
-	Namespace     string
-	AirgapBundle  string
-	ClusterID     string
+	AppSlug      string
+	Namespace    string
+	AirgapBundle string
+	ClusterID    string
 }
 
 func AirgapUpdate(opts AirgapUpdateOptions) error {
-	materializer := goods.NewMaterializer(opts.RuntimeConfig)
-	kotsBinPath, err := materializer.InternalBinary("kubectl-kots")
+	kotsBinPath, err := goods.InternalBinary("kubectl-kots")
 	if err != nil {
 		return fmt.Errorf("unable to materialize kubectl-kots binary: %w", err)
 	}
@@ -186,7 +181,6 @@ func AirgapUpdate(opts AirgapUpdateOptions) error {
 }
 
 type VeleroConfigureOtherS3Options struct {
-	RuntimeConfig   runtimeconfig.RuntimeConfig
 	Endpoint        string
 	Region          string
 	Bucket          string
@@ -197,8 +191,7 @@ type VeleroConfigureOtherS3Options struct {
 }
 
 func VeleroConfigureOtherS3(opts VeleroConfigureOtherS3Options) error {
-	materializer := goods.NewMaterializer(opts.RuntimeConfig)
-	kotsBinPath, err := materializer.InternalBinary("kubectl-kots")
+	kotsBinPath, err := goods.InternalBinary("kubectl-kots")
 	if err != nil {
 		return fmt.Errorf("unable to materialize kubectl-kots binary: %w", err)
 	}
@@ -270,8 +263,7 @@ func MaskKotsOutputForAirgap() spinner.MaskFn {
 }
 
 func GetJoinCommand(ctx context.Context, rc runtimeconfig.RuntimeConfig) (string, error) {
-	materializer := goods.NewMaterializer(rc)
-	kotsBinPath, err := materializer.InternalBinary("kubectl-kots")
+	kotsBinPath, err := goods.InternalBinary("kubectl-kots")
 	if err != nil {
 		return "", fmt.Errorf("unable to materialize kubectl-kots binary: %w", err)
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

- Moves app installation logic out of infrastructure setup but does not decouple the actual app installation from the infra installation yet. That will be done in a later PR.
- Moves app specific managers initialization to the app install controller.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-127428](https://app.shortcut.com/replicated/story/127428)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Yes

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE