### PR TITLE
bug: Fix label config item duplication

### DIFF
--- a/e2e/kots-release-install-v3/config.yaml
+++ b/e2e/kots-release-install-v3/config.yaml
@@ -274,9 +274,9 @@ spec:
           type: dropdown
           help_text: "Help text of a simple **_Dropdown_** config item type"
           items:
-            - name: opt1
+            - name: dropdown_simple_opt1
               title: Option 1
-            - name: opt2
+            - name: dropdown_simple_opt2
               title: Option 2
 
         - name: dropdown_with_default
@@ -284,11 +284,11 @@ spec:
           type: dropdown
           help_text: "Help text of a **_Dropdown_** config item type **_with default value_**"
           items:
-            - name: opt1
+            - name: dropdown_with_default_opt1
               title: Option 1
-            - name: opt2
+            - name: dropdown_with_default_opt2
               title: Option 2
-          default: opt1
+          default: dropdown_with_default_opt1
 
         - name: dropdown_required
           title: Dropdown marked required
@@ -296,11 +296,11 @@ spec:
           required: true
           help_text: "Help text of a **_Dropdown_** config item type **_marked required_**"
           items:
-            - name: opt1
+            - name: dropdown_required_opt1
               title: Option 1
-            - name: opt2
+            - name: dropdown_required_opt2
               title: Option 2
-          default: opt1 # temporarily set a default to get past the required validation until we support dropdowns in the UI
+          default: dropdown_required_opt1 # temporarily set a default to get past the required validation until we support dropdowns in the UI
 
         - name: label_radio
           type: label
@@ -313,9 +313,9 @@ spec:
           type: radio
           help_text: "Help text of a simple **_Radio_** config item type"
           items:
-            - name: opt1
+            - name: radio_simple_opt1
               title: Option 1
-            - name: opt2
+            - name: radio_simple_opt2
               title: Option 2
 
         - name: radio_with_default
@@ -323,11 +323,11 @@ spec:
           type: radio
           help_text: "Help text of a **_Radio_** config item type **_with default value_**"
           items:
-            - name: opt1
+            - name: radio_with_default_opt1
               title: Option 1
-            - name: opt2
+            - name: radio_with_default_opt2
               title: Option 2
-          default: opt1
+          default: radio_with_default_opt1
 
         - name: radio_required
           title: Radio marked required
@@ -335,9 +335,9 @@ spec:
           required: true
           help_text: "Help text of a **_Radio_** config item type **_marked required_**"
           items:
-            - name: opt1
+            - name: radio_required_opt1
               title: Option 1
-            - name: opt2
+            - name: radio_required_opt2
               title: Option 2
 
         - name: label_file

--- a/e2e/kots-release-install-v3/config.yaml
+++ b/e2e/kots-release-install-v3/config.yaml
@@ -165,12 +165,12 @@ spec:
     - name: config-items
       title: Config Items
       items:
-        - name: label
+        - name: label_intro
           type: label
           title: |
             The values set in the config items below will populate the `configitems` ConfigMap in the app (nginx-app).
 
-        - name: label
+        - name: label_text
           type: label
           title: |
             ## Text Items
@@ -193,7 +193,7 @@ spec:
           required: true
           help_text: "Help text of a **_Text_** config item type **_marked required_**"
 
-        - name: label
+        - name: label_password
           type: label
           title: |
             ## Password Items
@@ -216,7 +216,7 @@ spec:
           required: true
           help_text: "Help text of a **_Password_** config item type **_marked required_**"
 
-        - name: label
+        - name: label_textarea
           type: label
           title: |
             ## Textarea Items
@@ -239,7 +239,7 @@ spec:
           required: true
           help_text: "Help text of a **_Textarea_** config item type **_marked required_**"
 
-        - name: label
+        - name: label_checkbox
           type: label
           title: |
             ## Checkbox/Bool Items
@@ -263,7 +263,7 @@ spec:
           help_text: "Help text of a **_Checkbox_** config item type **_marked required_**"
 
         # TODO: uncomment when we support dropdowns in the UI
-        # - name: label
+        # - name: label_dropdown
         #   type: label
         #   title: |
         #     ## Dropdown Items
@@ -302,7 +302,7 @@ spec:
               title: Option 2
           default: opt1 # temporarily set a default to get past the required validation until we support dropdowns in the UI
 
-        - name: label
+        - name: label_radio
           type: label
           title: |
             ## Radio Items
@@ -340,7 +340,7 @@ spec:
             - name: opt2
               title: Option 2
 
-        - name: label
+        - name: label_file
           type: label
           title: |
             ## File Items
@@ -379,7 +379,7 @@ spec:
           help_text: "Help text of a **_Checkbox_** config item type"
           default: "1"
 
-        - name: label
+        - name: label_markdown
           type: label
           when: '{{repl ConfigOptionEquals "markdown_toggle" "1" }}'
           title: |


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Fix duplication of Label type config items when switching between groups in the configuration step UI caused by Label config items sharing the same name.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/127414/label-config-items-duplicate-when-switching-tabs

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE