### PR TITLE
fix(ci): pipe grep exits with 141 no reader

### DIFF
--- a/e2e/scripts/check-postupgrade-state.sh
+++ b/e2e/scripts/check-postupgrade-state.sh
@@ -48,9 +48,9 @@ main() {
 
     # ensure that new app pods exist
     # wait for new app pods to be running
-    # NOTE: we cannot use grep -q here as a SIGPIPE will cause the script to exit with 141 if
-    # multiple lines are found, as grep -q will exit immediately and kubectl will still be writing
-    # to the pipe
+    # NOTE: We cannot use grep -q here because it exits immediately upon finding a match, which can
+    # cause the script to receive SIGPIPE (exit code 141) if kubectl is still writing to the pipe
+    # when grep terminates early.
     if ! retry 5 eval "kubectl get pods -n $APP_NAMESPACE -l app=second | grep Running >/dev/null" ; then
         echo "no pods found for second app version"
         kubectl get pods -n "$APP_NAMESPACE"


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Failing test is a bug as grep -q exits immediately after first match and kernel returns 141 error as the command is still writing to the pipe and there is no reader

https://stackoverflow.com/questions/19120263/why-exit-code-141-with-grep-q/19120674#19120674

https://github.com/replicatedhq/embedded-cluster/actions/runs/16650744879/job/47123777677#step:4:236

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
