### PR TITLE
tests: add test that reports network events while deploying an EC app

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -904,6 +904,7 @@ jobs:
   e2e:
     name: E2E # this name is used by .github/workflows/automated-prs-manager.yaml
     runs-on: ${{ matrix.runner || 'ubuntu-22.04' }}
+    continue-on-error: ${{ matrix.continue-on-error || false }}
     needs:
       - build-current
       - build-previous-k0s
@@ -926,7 +927,6 @@ jobs:
           - TestMultiNodeAirgapHAInstallation
           - TestSingleNodeAirgapDisasterRecovery
           - TestMultiNodeAirgapHADisasterRecovery
-          - TestSingleNodeNetworkReport
         include:
           - test: TestVersion
             is-lxd: true
@@ -940,6 +940,8 @@ jobs:
             is-lxd: true
           - test: TestInstallWithMITMProxy
             is-lxd: true
+          - test: TestSingleNodeNetworkReport
+            continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -926,6 +926,7 @@ jobs:
           - TestMultiNodeAirgapHAInstallation
           - TestSingleNodeAirgapDisasterRecovery
           - TestMultiNodeAirgapHADisasterRecovery
+          - TestSingleNodeNetworkReport
         include:
           - test: TestVersion
             is-lxd: true

--- a/e2e/cluster/cmx/cluster.go
+++ b/e2e/cluster/cmx/cluster.go
@@ -47,14 +47,6 @@ type Network struct {
 	ID string `json:"id"`
 }
 
-type NetworkReport struct {
-	Events []EventWrapper `json:"events"`
-}
-
-type EventWrapper struct {
-	EventData string `json:"event_data"`
-}
-
 type NetworkEvent struct {
 	Timestamp     time.Time `json:"timestamp"`
 	PID           int       `json:"pid"`
@@ -583,18 +575,21 @@ func (c *Cluster) CollectNetworkReport() ([]NetworkEvent, error) {
 	}
 
 	// TODO: investigate CLI changes to make event_data a json object instead of a string
+	type eventWrapper struct {
+		EventData string `json:"event_data"`
+	}
 
 	type networkReport struct {
 		Events []eventWrapper `json:"events"`
 	}
 
-	events := []eventWrapper{}
-	if err := json.Unmarshal(output, &events); err != nil {
+	report := networkReport{}
+	if err := json.Unmarshal(output, &report); err != nil {
 		return nil, fmt.Errorf("unmarshal network events: %v", err)
 	}
 
-	networkEvents := make([]NetworkEvent, 0, len(events))
-	for _, e := range events {
+	networkEvents := make([]NetworkEvent, 0, len(report.Events))
+	for _, e := range report.Events {
 		ne := NetworkEvent{}
 		if err := json.Unmarshal([]byte(e.EventData), &ne); err != nil {
 			return nil, fmt.Errorf("unmarshal network event data: %v", err)

--- a/e2e/cluster/cmx/cluster.go
+++ b/e2e/cluster/cmx/cluster.go
@@ -527,7 +527,7 @@ func (c *Cluster) SetNetworkReport(enabled bool) error {
 
 	// Wait until the nodes are all back in running
 	for nodeNum, node := range c.Nodes {
-		if err := c.waitUntilRunning(node, 30*time.Second); err != nil {
+		if err := c.waitUntilRunning(node, nodeNum, 30*time.Second); err != nil {
 			return fmt.Errorf("wait until node %d is airgapped: %v", nodeNum, err)
 		}
 	}
@@ -535,7 +535,7 @@ func (c *Cluster) SetNetworkReport(enabled bool) error {
 	return nil
 }
 
-func (c *Cluster) waitUntilRunning(node Node, timeoutDuration time.Duration) error {
+func (c *Cluster) waitUntilRunning(node Node, nodeNum int, timeoutDuration time.Duration) error {
 	timeout := time.After(timeoutDuration)
 	tick := time.Tick(2 * time.Second)
 	for {
@@ -553,7 +553,7 @@ func (c *Cluster) waitUntilRunning(node Node, timeoutDuration time.Duration) err
 				return fmt.Errorf("unmarshal node info: %v", err)
 			}
 
-			for nodeNum, checkNode := range nodes {
+			for _, checkNode := range nodes {
 				if checkNode.ID != node.ID {
 					continue
 				}

--- a/e2e/cluster/cmx/cluster.go
+++ b/e2e/cluster/cmx/cluster.go
@@ -36,6 +36,7 @@ type Node struct {
 	ID        string `json:"id"`
 	Name      string `json:"name"`
 	NetworkID string `json:"network_id"`
+	Status    string `json:"status"`
 
 	privateIP       string `json:"-"`
 	sshEndpoint     string `json:"-"`
@@ -44,6 +45,18 @@ type Node struct {
 
 type Network struct {
 	ID string `json:"id"`
+}
+
+type NetworkEvent struct {
+	Timestamp     time.Time `json:"timestamp"`
+	PID           int       `json:"pid"`
+	SrcIP         string    `json:"srcIp"`
+	SrcPort       int       `json:"srcPort"`
+	DstIP         int       `json:"dstIp"`
+	DstPort       int       `json:"dstPort"`
+	DNSQueryName  string    `json:"dnsQueryName"`
+	LikelyService string    `json:"likelyService"`
+	Command       string    `json:"comm"`
 }
 
 func NewCluster(in *ClusterInput) *Cluster {
@@ -503,4 +516,83 @@ func sshArgs() []string {
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "BatchMode=yes",
 	}
+}
+
+func (c *Cluster) SetNetworkReport(enabled bool) error {
+	// Update network reporting
+	output, err := exec.Command("replicated", "network", "update", c.network.ID, fmt.Sprintf("--collect-report=%v", enabled)).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("update network collect-report: %v: %s", err, string(output))
+	}
+
+	// Wait until the nodes are all back in running
+	for nodeNum, node := range c.Nodes {
+		if err := c.waitUntilRunning(node, 30*time.Second); err != nil {
+			return fmt.Errorf("wait until node %d is airgapped: %v", nodeNum, err)
+		}
+	}
+
+	return nil
+}
+
+func (c *Cluster) waitUntilRunning(node Node, timeoutDuration time.Duration) error {
+	timeout := time.After(timeoutDuration)
+	tick := time.Tick(2 * time.Second)
+	for {
+		select {
+		case <-timeout:
+			return fmt.Errorf("timed out after waiting %s for node to be in running state", timeoutDuration)
+		case <-tick:
+			output, err := exec.Command("replicated", "vm", "ls", "-ojson").Output()
+			if err != nil {
+				return fmt.Errorf("check node status: %v", err)
+			}
+
+			nodes := []Node{}
+			if err := json.Unmarshal(output, &nodes); err != nil {
+				return fmt.Errorf("unmarshal node info: %v", err)
+			}
+
+			for nodeNum, checkNode := range nodes {
+				if checkNode.ID != node.ID {
+					continue
+				}
+
+				if checkNode.Status == "running" {
+					return nil
+				}
+
+				c.t.Logf("node %v is not running yet, %v", nodeNum, checkNode.Status)
+			}
+		}
+	}
+}
+
+func (c *Cluster) CollectNetworkReport() ([]NetworkEvent, error) {
+	output, err := exec.Command("replicated", "network", "report", fmt.Sprintf("--id=%v", c.network.ID), "-ojson").Output()
+	if err != nil {
+		return nil, fmt.Errorf("collect network report: %v", err)
+	}
+
+	// TODO: investigate CLI changes to make event_data a json object instead of a string
+	type eventWrapper struct {
+		EventData string `json:"event_data"`
+	}
+
+	events := []eventWrapper{}
+	if err := json.Unmarshal(output, &events); err != nil {
+		return nil, fmt.Errorf("unmarshal network events: %v", err)
+	}
+
+	networkEvents := make([]NetworkEvent, 0, len(events))
+	for _, e := range events {
+		ne := NetworkEvent{}
+		if err := json.Unmarshal([]byte(e.EventData), &ne); err != nil {
+			return nil, fmt.Errorf("unmarshal network event data: %v", err)
+		}
+
+		networkEvents = append(networkEvents, ne)
+	}
+
+	return networkEvents, nil
 }

--- a/e2e/cluster/cmx/cluster.go
+++ b/e2e/cluster/cmx/cluster.go
@@ -52,7 +52,7 @@ type NetworkEvent struct {
 	PID           int       `json:"pid"`
 	SrcIP         string    `json:"srcIp"`
 	SrcPort       int       `json:"srcPort"`
-	DstIP         int       `json:"dstIp"`
+	DstIP         string    `json:"dstIp"`
 	DstPort       int       `json:"dstPort"`
 	DNSQueryName  string    `json:"dnsQueryName"`
 	LikelyService string    `json:"likelyService"`

--- a/e2e/cluster/cmx/cluster.go
+++ b/e2e/cluster/cmx/cluster.go
@@ -47,6 +47,14 @@ type Network struct {
 	ID string `json:"id"`
 }
 
+type NetworkReport struct {
+	Events []EventWrapper `json:"events"`
+}
+
+type EventWrapper struct {
+	EventData string `json:"event_data"`
+}
+
 type NetworkEvent struct {
 	Timestamp     time.Time `json:"timestamp"`
 	PID           int       `json:"pid"`
@@ -575,8 +583,9 @@ func (c *Cluster) CollectNetworkReport() ([]NetworkEvent, error) {
 	}
 
 	// TODO: investigate CLI changes to make event_data a json object instead of a string
-	type eventWrapper struct {
-		EventData string `json:"event_data"`
+
+	type networkReport struct {
+		Events []eventWrapper `json:"events"`
 	}
 
 	events := []eventWrapper{}

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -3,9 +3,7 @@ package e2e
 import (
 	"encoding/base64"
 	"fmt"
-	"net"
 	"os"
-	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -2034,41 +2032,7 @@ func TestSingleNodeNetworkReport(t *testing.T) {
 		t.Fatalf("failed to collect network report: %v", err)
 	}
 
-	// TODO: these are the production domains, need to be environment specific
-	allowedDestinations := map[string]struct{}{
-		"proxy.replicated.com":    {},
-		"replicated.app":          {},
-		"registry.replicated.com": {},
-	}
-
-	// TODO once we CMX network reporting can catch domains from k8s pods, we should not check against ips
-	allowedDstIps := []net.IP{}
-	for destDomain := range allowedDestinations {
-		ips, err := net.LookupIP(destDomain)
-		if err != nil {
-			t.Fatalf("could not get allowed ips for domain %v: %v", destDomain, err)
-		}
-
-		allowedDstIps = append(allowedDstIps, ips...)
-	}
-
 	for _, ne := range networkEvents {
-		if ne.DstIP == "" {
-			continue
-		}
-
-		dstIP := net.ParseIP(ne.DstIP)
-		if dstIP == nil {
-			t.Errorf("could not parse destination ip (%v) from network events", ne.DstIP)
-		}
-
-		if dstIP.IsPrivate() {
-			continue
-		}
-
-		inAllowList := slices.ContainsFunc(allowedDstIps, dstIP.Equal)
-		if !inAllowList {
-			t.Errorf("network violation found: %+v", ne)
-		}
+		t.Logf("network event: %+v", ne)
 	}
 }

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -2005,6 +2005,7 @@ func TestSingleNodeNetworkReport(t *testing.T) {
 		Nodes:        1,
 		Distribution: "ubuntu",
 		Version:      "22.04",
+		InstanceType: "r1.medium",
 	})
 	defer tc.Cleanup()
 

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -2012,6 +2012,7 @@ func TestSingleNodeNetworkReport(t *testing.T) {
 		t.Fatalf("failed to enable network reporting: %v", err)
 	}
 
+	downloadECRelease(t, tc, 0)
 	installSingleNode(t, tc)
 	isMultiNodeEnabled := "false"
 	testArgs := []string{isMultiNodeEnabled}

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -1998,6 +1998,7 @@ spec:
 
 func TestSingleNodeNetworkReport(t *testing.T) {
 	t.Parallel()
+	RequireEnvVars(t, []string{"SHORT_SHA"})
 	tc := cmx.NewCluster(&cmx.ClusterInput{
 		T:            t,
 		Nodes:        1,

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -2015,10 +2015,7 @@ func TestSingleNodeNetworkReport(t *testing.T) {
 
 	downloadECRelease(t, tc, 0)
 	installSingleNode(t, tc)
-	isMultiNodeEnabled := "false"
-	testArgs := []string{isMultiNodeEnabled}
-
-	if stdout, stderr, err := tc.SetupPlaywrightAndRunTest("deploy-app", testArgs...); err != nil {
+	if stdout, stderr, err := tc.SetupPlaywrightAndRunTest("deploy-app"); err != nil {
 		t.Fatalf("fail to run playwright test deploy-app: %v: %s: %s", err, stdout, stderr)
 	}
 
@@ -2034,7 +2031,7 @@ func TestSingleNodeNetworkReport(t *testing.T) {
 
 	networkEvents, err := tc.CollectNetworkReport()
 	if err != nil {
-		t.Fatalf("failed to collect network report")
+		t.Fatalf("failed to collect network report: %v", err)
 	}
 
 	// TODO: these are the production domains, need to be environment specific


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Adds a test that uses CMX network reports to verify that all requests go to expected destinations during an app install.

The first iteration of this just prints out the IPs reached and any domains used in the connection if available. Follow ups will assert that the connections made are limited to the expected destinations for the EC install process.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/127479/setup-testing-for-network-reporting-in-ec

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE
#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE