### PR TITLE
chore(ci): e2e lxd test preflight failure - wait for clock sync

### DIFF
--- a/e2e/cluster/lxd/cluster.go
+++ b/e2e/cluster/lxd/cluster.go
@@ -236,7 +236,7 @@ func NewCluster(in *ClusterInput) *Cluster {
 	wg := sync.WaitGroup{}
 	wg.Add(len(out.Nodes))
 	for i, node := range out.Nodes {
-		go func(node string) {
+		go func(i int, node string) {
 			defer wg.Done()
 			CopyFilesToNode(in, node)
 			CopyDirsToNode(in, node)
@@ -244,7 +244,7 @@ func NewCluster(in *ClusterInput) *Cluster {
 				CreateRegularUser(in, node)
 			}
 			out.waitForClockSync(i)
-		}(node)
+		}(i, node)
 	}
 	wg.Wait()
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Possibly fix

```
✗  1 host preflight failed
        
         • NTP is enabled but the system clock is not synchronized. Synchronize the system clock to continue. 
```

https://github.com/replicatedhq/embedded-cluster/actions/runs/16645336945/job/47105565227

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
