### PR TITLE
chore(ci): clean up account, archive old channel releases and instances

### DIFF
--- a/.github/workflows/archive-instances.yaml
+++ b/.github/workflows/archive-instances.yaml
@@ -1,0 +1,32 @@
+name: Archive Instances
+
+on:
+  schedule:
+    # Run every 3 hours
+    - cron: '0 */3 * * *'
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  archive-instances:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up environment
+        run: |
+          # Set default values for the script
+          echo "COUNT=200" >> $GITHUB_ENV
+          echo "DRY_RUN=true" >> $GITHUB_ENV
+
+      - name: Run archive instances script
+        env:
+          REPLICATED_APP: "embedded-cluster-smoke-test-staging-app"
+          REPLICATED_API_TOKEN: ${{ secrets.STAGING_REPLICATED_API_TOKEN }}
+          REPLICATED_API_ORIGIN: "https://api.staging.replicated.com"
+          COUNT: ${{ env.COUNT }}
+          DRY_RUN: ${{ env.DRY_RUN }}
+        run: |
+          # Run the script
+          ./scripts/archive-instances.sh

--- a/.github/workflows/cleanup-resources.yaml
+++ b/.github/workflows/cleanup-resources.yaml
@@ -1,4 +1,4 @@
-name: Archive Instances
+name: Cleanup Resources
 
 on:
   schedule:
@@ -17,8 +17,8 @@ jobs:
       - name: Set up environment
         run: |
           # Set default values for the script
-          echo "COUNT=200" >> $GITHUB_ENV
-          echo "DRY_RUN=true" >> $GITHUB_ENV
+          echo "COUNT=500" >> $GITHUB_ENV
+          echo "DRY_RUN=false" >> $GITHUB_ENV
 
       - name: Run archive instances script
         env:

--- a/.github/workflows/cleanup-resources.yaml
+++ b/.github/workflows/cleanup-resources.yaml
@@ -27,5 +27,33 @@ jobs:
           COUNT: ${{ env.COUNT }}
           DRY_RUN: ${{ env.DRY_RUN }}
         run: |
-          # Run the script
+          # Make script executable and run it
+          chmod +x ./scripts/archive-instances.sh
           ./scripts/archive-instances.sh
+
+  demote-channel-releases:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up environment
+        run: |
+          # Set default values for the script
+          echo "DRY_RUN=false" >> $GITHUB_ENV
+          echo "START_PAGE=1" >> $GITHUB_ENV
+          echo "PAGE_SIZE=100" >> $GITHUB_ENV
+
+      - name: Run demote channel releases script
+        env:
+          REPLICATED_APP: "embedded-cluster-smoke-test-staging-app"
+          REPLICATED_API_TOKEN: ${{ secrets.STAGING_REPLICATED_API_TOKEN }}
+          REPLICATED_API_ORIGIN: "https://api.staging.replicated.com"
+          DRY_RUN: ${{ env.DRY_RUN }}
+          START_PAGE: ${{ env.START_PAGE }}
+          PAGE_SIZE: ${{ env.PAGE_SIZE }}
+        run: |
+          # Make script executable and run it
+          chmod +x ./scripts/demote-channel-releases.sh
+          ./scripts/demote-channel-releases.sh

--- a/.github/workflows/cleanup-resources.yaml
+++ b/.github/workflows/cleanup-resources.yaml
@@ -17,7 +17,6 @@ jobs:
       - name: Set up environment
         run: |
           # Set default values for the script
-          echo "COUNT=500" >> $GITHUB_ENV
           echo "DRY_RUN=false" >> $GITHUB_ENV
 
       - name: Run archive instances script

--- a/.github/workflows/cleanup-resources.yaml
+++ b/.github/workflows/cleanup-resources.yaml
@@ -2,8 +2,8 @@ name: Cleanup Resources
 
 on:
   schedule:
-    # Run every 3 hours
-    - cron: '0 */3 * * *'
+    # Run every 12 hours
+    - cron: '0 */12 * * *'
   workflow_dispatch: # Allow manual triggering
 
 jobs:
@@ -14,18 +14,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up environment
-        run: |
-          # Set default values for the script
-          echo "DRY_RUN=false" >> $GITHUB_ENV
-
       - name: Run archive instances script
         env:
           REPLICATED_APP: "embedded-cluster-smoke-test-staging-app"
           REPLICATED_API_TOKEN: ${{ secrets.STAGING_REPLICATED_API_TOKEN }}
           REPLICATED_API_ORIGIN: "https://api.staging.replicated.com"
-          COUNT: ${{ env.COUNT }}
-          DRY_RUN: ${{ env.DRY_RUN }}
+          DRY_RUN: "false"
         run: |
           # Make script executable and run it
           chmod +x ./scripts/archive-instances.sh
@@ -38,21 +32,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up environment
-        run: |
-          # Set default values for the script
-          echo "DRY_RUN=false" >> $GITHUB_ENV
-          echo "START_PAGE=1" >> $GITHUB_ENV
-          echo "PAGE_SIZE=100" >> $GITHUB_ENV
-
       - name: Run demote channel releases script
         env:
           REPLICATED_APP: "embedded-cluster-smoke-test-staging-app"
           REPLICATED_API_TOKEN: ${{ secrets.STAGING_REPLICATED_API_TOKEN }}
           REPLICATED_API_ORIGIN: "https://api.staging.replicated.com"
-          DRY_RUN: ${{ env.DRY_RUN }}
-          START_PAGE: ${{ env.START_PAGE }}
-          PAGE_SIZE: ${{ env.PAGE_SIZE }}
+          DRY_RUN: "false"
         run: |
           # Make script executable and run it
           chmod +x ./scripts/demote-channel-releases.sh

--- a/scripts/archive-instances.sh
+++ b/scripts/archive-instances.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+set -euo pipefail
+
+COUNT=${COUNT:-200}
+DRY_RUN=${DRY_RUN:-true}
+REPLICATED_API_ORIGIN=${REPLICATED_API_ORIGIN:-"https://api.staging.replicated.com"}
+REPLICATED_APP=${REPLICATED_APP:-"embedded-cluster-smoke-test-staging-app"}
+
+# Trim /vendor suffix if present
+REPLICATED_API_ORIGIN="${REPLICATED_API_ORIGIN%/vendor}"
+
+function archive_instances() {
+    # Calculate timestamp for 1 hour ago (in seconds since epoch) - macOS compatible
+    ONE_HOUR_AGO=$(date -v-1H +%s)
+
+    echo "Fetching instances with lastCheckinAt greater than 1 hour ago..."
+    echo "Timestamp for 1 hour ago: $(date -v-1H)"
+    echo "---"
+
+    # Get the JSON response and extract instances
+    RESPONSE=$(curl -fsSL -H "Authorization: $REPLICATED_API_TOKEN" "$REPLICATED_API_ORIGIN/v1/instances?appSelector=$REPLICATED_APP&pageSize=$COUNT&currentPage=1")
+
+    # Loop through each instance using jq to extract the array
+    echo "$RESPONSE" | jq -c '.instances[]' | while read -r instance; do
+        # Extract fields from each instance
+        ID=$(echo "$instance" | jq -r '.id')
+        LAST_CHECKIN=$(echo "$instance" | jq -r '.lastCheckinAt // empty')
+        VERSION=$(echo "$instance" | jq -r '.versionLabel // "N/A"')
+        CHANNEL=$(echo "$instance" | jq -r '._embedded.channel.name // "N/A"')
+        
+        # Skip if lastCheckinAt is null
+        if [[ -z "$LAST_CHECKIN" ]]; then
+            continue
+        fi
+        
+        maybe_archive_instance "$ID" "$LAST_CHECKIN" "$VERSION" "$CHANNEL"
+    done
+}
+
+function maybe_archive_instance() {
+    local ID="$1"
+    local LAST_CHECKIN="$2"
+    local VERSION="$3"
+    local CHANNEL="$4"
+
+    # Parse the timestamp and compare
+    TIMESTAMP="${LAST_CHECKIN%%.*}Z"
+    INSTANCE_TIME=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$TIMESTAMP" +%s 2>/dev/null || echo "0")
+    
+    # Check if instance hasn't checked in for more than 1 hour
+    if [[ "$INSTANCE_TIME" -lt "$ONE_HOUR_AGO" ]]; then
+        # Convert UTC timestamp to local time
+        LOCAL_TIME=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$TIMESTAMP" 2>/dev/null || echo "$LAST_CHECKIN")
+        echo "Archiving instance: ID: $ID, LastCheckin: $LOCAL_TIME, Version: $VERSION, Channel: $CHANNEL"
+
+        if [[ "$DRY_RUN" == "true" ]]; then
+        echo "  ✓ DRY RUN"
+        else
+        # Archive the instance
+        ARCHIVE_RESPONSE=$(curl -sSL -w "%{http_code}" -X POST -H "Authorization: $REPLICATED_API_TOKEN" -H "Content-Type: application/json" "$REPLICATED_API_ORIGIN/vendor/v3/instance/$ID/archive" -d '{}')
+        HTTP_CODE="${ARCHIVE_RESPONSE: -3}"
+        RESPONSE_BODY="${ARCHIVE_RESPONSE%???}"
+        
+        if [[ "$HTTP_CODE" -eq 200 ]]; then
+            echo "  ✓ Successfully archived instance $ID"
+        else
+            echo "  ✗ Failed to archive instance $ID (HTTP $HTTP_CODE): $RESPONSE_BODY"
+        fi
+        fi
+    fi
+}
+
+function main() {
+    archive_instances
+}
+
+main "$@"

--- a/scripts/archive-instances.sh
+++ b/scripts/archive-instances.sh
@@ -73,6 +73,12 @@ function archive_instances() {
 
             instance_time=$(parse_date "$timestamp" +%s)
 
+            # Skip if parsing failed (returns -1)
+            if [[ "$instance_time" -eq -1 ]]; then
+                echo "Warning: Failed to parse timestamp $timestamp for instance $id: $last_checkin"
+                continue
+            fi
+
             # Check if instance hasn't checked in for more than 1 day
             if [[ "$instance_time" -lt "$ONE_DAY_AGO" ]]; then
                 # Extract fields from each instance
@@ -138,7 +144,7 @@ function parse_date() {
             fi
         else
             # Specific format - treat as UTC
-            date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$date_string" "$format" 2>/dev/null || echo "0"
+            date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$date_string" "$format" 2>/dev/null || echo "-1"
         fi
     else
         # Linux syntax
@@ -147,7 +153,7 @@ function parse_date() {
             date -d "$date_string" 2>/dev/null || echo "$date_string"
         else
             # Specific format
-            date -d "$date_string" "$format" 2>/dev/null || echo "0"
+            date -d "$date_string" "$format" 2>/dev/null || echo "-1"
         fi
     fi
 }

--- a/scripts/archive-instances.sh
+++ b/scripts/archive-instances.sh
@@ -56,6 +56,7 @@ function archive_instances() {
 
             # Skip if lastCheckinAt is null
             if [[ -z "$last_checkin" ]]; then
+                echo "Warning: lastCheckinAt is empty for instance"
                 continue
             fi
 

--- a/scripts/archive-instances.sh
+++ b/scripts/archive-instances.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-COUNT=${COUNT:-200}
+COUNT=${COUNT:-500}
 DRY_RUN=${DRY_RUN:-true}
 REPLICATED_API_ORIGIN=${REPLICATED_API_ORIGIN:-"https://api.staging.replicated.com"}
 REPLICATED_APP=${REPLICATED_APP:-"embedded-cluster-smoke-test-staging-app"}
@@ -10,12 +10,22 @@ REPLICATED_APP=${REPLICATED_APP:-"embedded-cluster-smoke-test-staging-app"}
 # Trim /vendor suffix if present
 REPLICATED_API_ORIGIN="${REPLICATED_API_ORIGIN%/vendor}"
 
-function archive_instances() {
-    # Calculate timestamp for 1 hour ago (in seconds since epoch) - macOS compatible
+# Calculate timestamp for 1 hour ago (in seconds since epoch)
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS (darwin) syntax
     ONE_HOUR_AGO=$(date -v-1H +%s)
+else
+    # Linux syntax
+    ONE_HOUR_AGO=$(date -d '1 hour ago' +%s)
+fi
 
+function archive_instances() {
     echo "Fetching instances with lastCheckinAt greater than 1 hour ago..."
-    echo "Timestamp for 1 hour ago: $(date -v-1H)"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        echo "Timestamp for 1 hour ago: $(date -v-1H)"
+    else
+        echo "Timestamp for 1 hour ago: $(date -d '1 hour ago')"
+    fi
     echo "---"
 
     # Get the JSON response and extract instances
@@ -28,12 +38,12 @@ function archive_instances() {
         LAST_CHECKIN=$(echo "$instance" | jq -r '.lastCheckinAt // empty')
         VERSION=$(echo "$instance" | jq -r '.versionLabel // "N/A"')
         CHANNEL=$(echo "$instance" | jq -r '._embedded.channel.name // "N/A"')
-        
+
         # Skip if lastCheckinAt is null
         if [[ -z "$LAST_CHECKIN" ]]; then
             continue
         fi
-        
+
         maybe_archive_instance "$ID" "$LAST_CHECKIN" "$VERSION" "$CHANNEL"
     done
 }
@@ -45,28 +55,70 @@ function maybe_archive_instance() {
     local CHANNEL="$4"
 
     # Parse the timestamp and compare
-    TIMESTAMP="${LAST_CHECKIN%%.*}Z"
-    INSTANCE_TIME=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$TIMESTAMP" +%s 2>/dev/null || echo "0")
-    
+    # Remove milliseconds and ensure proper UTC format
+    TIMESTAMP=$(echo "$LAST_CHECKIN" | sed 's/\.[0-9]*//' | sed 's/Z$//' | sed 's/$/Z/')
+
+    # Validate timestamp format before parsing
+    if [[ ! "$TIMESTAMP" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then
+        echo "Warning: Invalid timestamp format for instance $ID: $LAST_CHECKIN"
+        return
+    fi
+
+    INSTANCE_TIME=$(parse_date "$TIMESTAMP" +%s)
+    # Convert UTC timestamp to local time
+    LOCAL_TIME=$(parse_date "$TIMESTAMP")
+
     # Check if instance hasn't checked in for more than 1 hour
     if [[ "$INSTANCE_TIME" -lt "$ONE_HOUR_AGO" ]]; then
-        # Convert UTC timestamp to local time
-        LOCAL_TIME=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$TIMESTAMP" 2>/dev/null || echo "$LAST_CHECKIN")
         echo "Archiving instance: ID: $ID, LastCheckin: $LOCAL_TIME, Version: $VERSION, Channel: $CHANNEL"
 
         if [[ "$DRY_RUN" == "true" ]]; then
-        echo "  ✓ DRY RUN"
+            echo "  ✓ DRY RUN"
         else
-        # Archive the instance
-        ARCHIVE_RESPONSE=$(curl -sSL -w "%{http_code}" -X POST -H "Authorization: $REPLICATED_API_TOKEN" -H "Content-Type: application/json" "$REPLICATED_API_ORIGIN/vendor/v3/instance/$ID/archive" -d '{}')
-        HTTP_CODE="${ARCHIVE_RESPONSE: -3}"
-        RESPONSE_BODY="${ARCHIVE_RESPONSE%???}"
-        
-        if [[ "$HTTP_CODE" -eq 200 ]]; then
-            echo "  ✓ Successfully archived instance $ID"
-        else
-            echo "  ✗ Failed to archive instance $ID (HTTP $HTTP_CODE): $RESPONSE_BODY"
+            # Archive the instance
+            ARCHIVE_RESPONSE=$(curl -sSL -w "%{http_code}" -X POST -H "Authorization: $REPLICATED_API_TOKEN" -H "Content-Type: application/json" "$REPLICATED_API_ORIGIN/vendor/v3/instance/$ID/archive" -d '{}')
+            HTTP_CODE="${ARCHIVE_RESPONSE: -3}"
+            RESPONSE_BODY="${ARCHIVE_RESPONSE%???}"
+
+            if [[ "$HTTP_CODE" -eq 200 ]]; then
+                echo "  ✓ Successfully archived instance $ID"
+            else
+                echo "  ✗ Failed to archive instance $ID (HTTP $HTTP_CODE): $RESPONSE_BODY"
+            fi
         fi
+    else
+        echo "Instance $ID has checked in within the last hour ($LOCAL_TIME), skipping..."
+    fi
+}
+
+# Cross-platform date parsing function
+function parse_date() {
+    local date_string="$1"
+    local format="${2:-}"
+
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        # macOS (darwin) syntax
+        if [[ -z "$format" ]]; then
+            # Human readable format - treat as UTC and convert to local
+            # First convert UTC to epoch, then epoch to local time
+            epoch=$(date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$date_string" +%s 2>/dev/null)
+            if [[ -n "$epoch" && "$epoch" != "0" ]]; then
+                date -r "$epoch" 2>/dev/null || echo "$date_string"
+            else
+                echo "$date_string"
+            fi
+        else
+            # Specific format - treat as UTC
+            date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$date_string" "$format" 2>/dev/null || echo "0"
+        fi
+    else
+        # Linux syntax
+        if [[ -z "$format" ]]; then
+            # Human readable format
+            date -d "$date_string" 2>/dev/null || echo "$date_string"
+        else
+            # Specific format
+            date -d "$date_string" "$format" 2>/dev/null || echo "0"
         fi
     fi
 }

--- a/scripts/demote-channel-releases.sh
+++ b/scripts/demote-channel-releases.sh
@@ -93,11 +93,12 @@ function process_channel_releases() {
         while IFS= read -r release; do
             local created_at timestamp release_time sequence version
 
+            version=$(echo "$release" | jq -r '.semver // "N/A"')
             created_at=$(echo "$release" | jq -r '.created // empty')
 
             # Skip if createdAt is null
             if [[ -z "$created_at" ]]; then
-                echo "  Warning: created is empty for release"
+                echo "  Warning: created is empty for release $version"
                 continue
             fi
 
@@ -107,7 +108,7 @@ function process_channel_releases() {
 
             # Validate timestamp format before parsing
             if [[ ! "$timestamp" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then
-                echo "  Warning: Invalid timestamp format for release: $created_at"
+                echo "  Warning: Invalid timestamp format for release $version: $created_at"
                 continue
             fi
 
@@ -117,7 +118,6 @@ function process_channel_releases() {
             if [[ "$release_time" -lt "$SEVEN_DAYS_AGO" ]]; then
                 # Extract fields from each release
                 sequence=$(echo "$release" | jq -r '.channelSequence')
-                version=$(echo "$release" | jq -r '.semver // "N/A"')
 
                 demote_release "$channel_id" "$channel_name" "$sequence" "$timestamp" "$version" "$app_id"
             fi

--- a/scripts/demote-channel-releases.sh
+++ b/scripts/demote-channel-releases.sh
@@ -114,6 +114,12 @@ function process_channel_releases() {
 
             release_time=$(parse_date "$timestamp" +%s)
 
+            # Skip if parsing failed (returns -1)
+            if [[ "$release_time" -eq -1 ]]; then
+                echo "  Warning: Failed to parse timestamp $timestamp for release $version: $created_at"
+                continue
+            fi
+
             # Check if release is older than 7 days
             if [[ "$release_time" -lt "$SEVEN_DAYS_AGO" ]]; then
                 # Extract fields from each release
@@ -178,7 +184,7 @@ function parse_date() {
             fi
         else
             # Specific format - treat as UTC
-            date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$date_string" "$format" 2>/dev/null || echo "0"
+            date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$date_string" "$format" 2>/dev/null || echo "-1"
         fi
     else
         # Linux syntax
@@ -187,7 +193,7 @@ function parse_date() {
             date -d "$date_string" 2>/dev/null || echo "$date_string"
         else
             # Specific format
-            date -d "$date_string" "$format" 2>/dev/null || echo "0"
+            date -d "$date_string" "$format" 2>/dev/null || echo "-1"
         fi
     fi
 }

--- a/scripts/demote-channel-releases.sh
+++ b/scripts/demote-channel-releases.sh
@@ -91,10 +91,16 @@ function process_channel_releases() {
 
         # Loop through each release
         while IFS= read -r release; do
-            local created_at timestamp release_time sequence version
+            local created_at timestamp release_time sequence version is_demoted
 
             version=$(echo "$release" | jq -r '.semver // "N/A"')
             created_at=$(echo "$release" | jq -r '.created // empty')
+            is_demoted=$(echo "$release" | jq -r '.isDemoted // false')
+
+            # Skip if release is already demoted
+            if [[ "$is_demoted" == "true" ]]; then
+                continue
+            fi
 
             # Skip if createdAt is null
             if [[ -z "$created_at" ]]; then

--- a/scripts/demote-channel-releases.sh
+++ b/scripts/demote-channel-releases.sh
@@ -28,7 +28,7 @@ function get_app_id() {
     app_id=$(echo "$apps_response" | jq -r --arg slug "$REPLICATED_APP" '.apps[] | select(.slug == $slug) | .id')
 
     if [[ -z "$app_id" || "$app_id" == "null" ]]; then
-        echo "Error: Could not find app with slug '$REPLICATED_APP'"
+        echo "Error: Could not find app with slug '$REPLICATED_APP'" >&2
         exit 1
     fi
 

--- a/scripts/demote-channel-releases.sh
+++ b/scripts/demote-channel-releases.sh
@@ -2,7 +2,8 @@
 
 set -euo pipefail
 
-START_PAGE=${START_PAGE:-1}
+# Start on page 2, allow 100+ releases to stay promoted
+START_PAGE=${START_PAGE:-2}
 PAGE_SIZE=${PAGE_SIZE:-100}
 DRY_RUN=${DRY_RUN:-true}
 REPLICATED_API_ORIGIN=${REPLICATED_API_ORIGIN:-"https://api.staging.replicated.com"}

--- a/scripts/demote-channel-releases.sh
+++ b/scripts/demote-channel-releases.sh
@@ -196,4 +196,4 @@ function main() {
     demote_old_releases
 }
 
-main "$@" 
+main "$@"

--- a/scripts/demote-channel-releases.sh
+++ b/scripts/demote-channel-releases.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+
+set -euo pipefail
+
+START_PAGE=${START_PAGE:-1}
+PAGE_SIZE=${PAGE_SIZE:-100}
+DRY_RUN=${DRY_RUN:-true}
+REPLICATED_API_ORIGIN=${REPLICATED_API_ORIGIN:-"https://api.staging.replicated.com"}
+REPLICATED_APP=${REPLICATED_APP:-"embedded-cluster-smoke-test-staging-app"}
+
+# Trim /vendor suffix if present
+REPLICATED_API_ORIGIN="${REPLICATED_API_ORIGIN%/vendor}"
+
+# Calculate timestamp for 7 days ago (in seconds since epoch)
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS (darwin) syntax
+    SEVEN_DAYS_AGO=$(date -v-7d +%s)
+else
+    # Linux syntax
+    SEVEN_DAYS_AGO=$(date -d '7 days ago' +%s)
+fi
+
+function get_app_id() {
+    local apps_response
+    apps_response=$(curl -fsSL -H "Authorization: $REPLICATED_API_TOKEN" "$REPLICATED_API_ORIGIN/vendor/v3/apps")
+
+    local app_id
+    app_id=$(echo "$apps_response" | jq -r --arg slug "$REPLICATED_APP" '.apps[] | select(.slug == $slug) | .id')
+
+    if [[ -z "$app_id" || "$app_id" == "null" ]]; then
+        echo "Error: Could not find app with slug '$REPLICATED_APP'"
+        exit 1
+    fi
+
+    echo "$app_id"
+}
+
+function demote_old_releases() {
+    echo "Fetching channels and releases older than 7 days..."
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        echo "Timestamp for 7 days ago: $(date -v-7d)"
+    else
+        echo "Timestamp for 7 days ago: $(date -d '7 days ago')"
+    fi
+    echo "---"
+
+    # Get app ID first
+    local app_id
+    app_id=$(get_app_id)
+
+    # Get all channels
+    echo "Fetching channels..."
+    local channels_response
+    channels_response=$(curl -fsSL -H "Authorization: $REPLICATED_API_TOKEN" "$REPLICATED_API_ORIGIN/vendor/v3/app/$app_id/channels?excludeDetail=true&excludeAdoption=true")
+
+    # Process each channel
+    echo "$channels_response" | jq -c '.channels[]' | while read -r channel; do
+        local channel_id channel_name
+        channel_id=$(echo "$channel" | jq -r '.id')
+        channel_name=$(echo "$channel" | jq -r '.name')
+
+        echo "Processing channel: $channel_name (ID: $channel_id)"
+        process_channel_releases "$channel_id" "$channel_name" "$app_id"
+    done
+
+    echo "Finished processing all channels."
+}
+
+function process_channel_releases() {
+    local channel_id="$1"
+    local channel_name="$2"
+    local app_id="$3"
+    local current_page=$START_PAGE
+
+    while true; do
+        echo "  Processing page $current_page for channel $channel_name..."
+
+        local response
+
+        # Get releases for this channel (excluding already demoted ones)
+        response=$(curl -fsSL -H "Authorization: $REPLICATED_API_TOKEN" "$REPLICATED_API_ORIGIN/vendor/v3/app/$app_id/channel/$channel_id/releases?excludeDemoted=true&pageSize=$PAGE_SIZE&currentPage=$current_page")
+
+        # Check if we have releases on this page
+        release_count=$(echo "$response" | jq -r '.releases | length')
+        if [[ "$release_count" -eq 0 ]]; then
+            echo "  No releases found on page $current_page for channel $channel_name, stopping."
+            break
+        fi
+
+        echo "  Found $release_count releases on page $current_page for channel $channel_name"
+
+        # Loop through each release
+        while IFS= read -r release; do
+            local created_at timestamp release_time sequence version
+
+            created_at=$(echo "$release" | jq -r '.created // empty')
+
+            # Skip if createdAt is null
+            if [[ -z "$created_at" ]]; then
+                echo "  Warning: created is empty for release"
+                continue
+            fi
+
+            # Parse the timestamp and compare
+            # Remove milliseconds and ensure proper UTC format
+            timestamp=$(echo "$created_at" | sed 's/\.[0-9]*//' | sed 's/Z$//' | sed 's/$/Z/')
+
+            # Validate timestamp format before parsing
+            if [[ ! "$timestamp" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then
+                echo "  Warning: Invalid timestamp format for release: $created_at"
+                continue
+            fi
+
+            release_time=$(parse_date "$timestamp" +%s)
+
+            # Check if release is older than 7 days
+            if [[ "$release_time" -lt "$SEVEN_DAYS_AGO" ]]; then
+                # Extract fields from each release
+                sequence=$(echo "$release" | jq -r '.channelSequence')
+                version=$(echo "$release" | jq -r '.semver // "N/A"')
+
+                demote_release "$channel_id" "$channel_name" "$sequence" "$timestamp" "$version" "$app_id"
+            fi
+        done < <(echo "$response" | jq -c '.releases[]')
+
+        current_page=$((current_page + 1))
+    done
+}
+
+function demote_release() {
+    local channel_id="$1"
+    local channel_name="$2"
+    local sequence="$3"
+    local timestamp="$4"
+    local version="$5"
+    local app_id="$6"
+
+    local local_time
+
+    # Convert UTC timestamp to local time
+    local_time=$(parse_date "$timestamp")
+
+    echo "  Demoting release: Channel: $channel_name, Sequence: $sequence, Created: $local_time, Version: $version"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "    ✓ DRY RUN"
+    else
+        local demote_response http_code response_body
+
+        # Demote the release
+        demote_response=$(curl -sSL -w "%{http_code}" -X POST -H "Authorization: $REPLICATED_API_TOKEN" -H "Content-Type: application/json" "$REPLICATED_API_ORIGIN/vendor/v3/app/$app_id/channel/$channel_id/release/$sequence/demote" -d '{}')
+        http_code="${demote_response: -3}"
+        response_body="${demote_response%???}"
+
+        if [[ "$http_code" -eq 200 ]]; then
+            echo "    ✓ Successfully demoted release $sequence in channel $channel_name"
+        else
+            echo "    ✗ Failed to demote release $sequence in channel $channel_name (HTTP $http_code): $response_body"
+        fi
+    fi
+}
+
+# Cross-platform date parsing function
+function parse_date() {
+    local date_string="$1"
+    local format="${2:-}"
+
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        # macOS (darwin) syntax
+        if [[ -z "$format" ]]; then
+            # Human readable format - treat as UTC and convert to local
+            # First convert UTC to epoch, then epoch to local time
+            epoch=$(date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$date_string" +%s 2>/dev/null)
+            if [[ -n "$epoch" && "$epoch" != "0" ]]; then
+                date -r "$epoch" 2>/dev/null || echo "$date_string"
+            else
+                echo "$date_string"
+            fi
+        else
+            # Specific format - treat as UTC
+            date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$date_string" "$format" 2>/dev/null || echo "0"
+        fi
+    else
+        # Linux syntax
+        if [[ -z "$format" ]]; then
+            # Human readable format
+            date -d "$date_string" 2>/dev/null || echo "$date_string"
+        else
+            # Specific format
+            date -d "$date_string" "$format" 2>/dev/null || echo "0"
+        fi
+    fi
+}
+
+function main() {
+    demote_old_releases
+}
+
+main "$@" 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

The replicated-sdk is timing out when starting due to api load. this is likely because of all the channel releases and instances in the e2e test account. This change adds a scheduled job that runs every 12 hours and cleans up resources in the api.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
