### PR TITLE
fix(join): use local network interface and provided flag

### DIFF
--- a/cmd/installer/cli/join.go
+++ b/cmd/installer/cli/join.go
@@ -412,7 +412,7 @@ func installAndJoinCluster(ctx context.Context, rc runtimeconfig.RuntimeConfig, 
 	}
 
 	logrus.Debugf("overriding network configuration")
-	if err := applyNetworkConfiguration(rc, jcmd); err != nil {
+	if err := applyNetworkConfiguration(flags.networkInterface, rc, jcmd); err != nil {
 		return fmt.Errorf("unable to apply network configuration: %w", err)
 	}
 
@@ -460,11 +460,11 @@ func installK0sBinary(rc runtimeconfig.RuntimeConfig) error {
 	return nil
 }
 
-func applyNetworkConfiguration(rc runtimeconfig.RuntimeConfig, jcmd *join.JoinCommandResponse) error {
+func applyNetworkConfiguration(networkInterface string, rc runtimeconfig.RuntimeConfig, jcmd *join.JoinCommandResponse) error {
 	domains := domains.GetDomains(jcmd.InstallationSpec.Config, release.GetChannelRelease())
 	clusterSpec := config.RenderK0sConfig(domains.ProxyRegistryDomain)
 
-	address, err := netutils.FirstValidAddress(rc.NetworkInterface())
+	address, err := netutils.FirstValidAddress(networkInterface)
 	if err != nil {
 		return fmt.Errorf("unable to find first valid address: %w", err)
 	}

--- a/pkg-new/config/network_interface.go
+++ b/pkg-new/config/network_interface.go
@@ -10,8 +10,8 @@ import (
 
 // Dependency injection variables for testing
 var (
-	chooseHostInterface      = apimachinerynet.ChooseHostInterface
-	networkInterfaceProvider = netutils.DefaultNetworkInterfaceProvider
+	ChooseHostInterface      = apimachinerynet.ChooseHostInterface
+	NetworkInterfaceProvider = netutils.DefaultNetworkInterfaceProvider
 )
 
 var (
@@ -22,7 +22,7 @@ var (
 
 // DetermineBestNetworkInterface attempts to determine the best network interface to use for the cluster.
 func DetermineBestNetworkInterface() (string, error) {
-	iface, err := chooseHostInterface()
+	iface, err := ChooseHostInterface()
 
 	if err != nil || iface == nil {
 		return "", ErrNoAutoInterface
@@ -41,7 +41,7 @@ func DetermineBestNetworkInterface() (string, error) {
 }
 
 func findInterfaceNameByIP(ip net.IP) (string, error) {
-	interfaces, err := networkInterfaceProvider.Interfaces()
+	interfaces, err := NetworkInterfaceProvider.Interfaces()
 	if err != nil {
 		return "", fmt.Errorf("failed to list interfaces: %v", err)
 	}

--- a/pkg-new/config/network_interface_test.go
+++ b/pkg-new/config/network_interface_test.go
@@ -41,10 +41,10 @@ func (m *mockNetworkInterfaceProvider) Interfaces() ([]netutils.NetworkInterface
 func TestDetermineBestNetworkInterface(t *testing.T) {
 	// Save original variables
 	originalChooseHostInterface := chooseHostInterface
-	originalNetworkInterfaceProvider := networkInterfaceProvider
+	originalNetworkInterfaceProvider := NetworkInterfaceProvider
 	defer func() {
 		chooseHostInterface = originalChooseHostInterface
-		networkInterfaceProvider = originalNetworkInterfaceProvider
+		NetworkInterfaceProvider = originalNetworkInterfaceProvider
 	}()
 
 	tests := []struct {
@@ -128,7 +128,7 @@ func TestDetermineBestNetworkInterface(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			chooseHostInterface = tt.mockChooseHostInterface
-			networkInterfaceProvider = tt.mockNetworkInterfaceProvider
+			NetworkInterfaceProvider = tt.mockNetworkInterfaceProvider
 
 			result, err := DetermineBestNetworkInterface()
 
@@ -140,9 +140,9 @@ func TestDetermineBestNetworkInterface(t *testing.T) {
 
 func TestFindInterfaceNameByIP(t *testing.T) {
 	// Save original variable
-	originalNetworkInterfaceProvider := networkInterfaceProvider
+	originalNetworkInterfaceProvider := NetworkInterfaceProvider
 	defer func() {
-		networkInterfaceProvider = originalNetworkInterfaceProvider
+		NetworkInterfaceProvider = originalNetworkInterfaceProvider
 	}()
 
 	tests := []struct {
@@ -253,7 +253,7 @@ func TestFindInterfaceNameByIP(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			networkInterfaceProvider = tt.mockNetworkInterfaceProvider
+			NetworkInterfaceProvider = tt.mockNetworkInterfaceProvider
 
 			result, err := findInterfaceNameByIP(tt.ip)
 

--- a/pkg-new/config/network_interface_test.go
+++ b/pkg-new/config/network_interface_test.go
@@ -40,10 +40,10 @@ func (m *mockNetworkInterfaceProvider) Interfaces() ([]netutils.NetworkInterface
 
 func TestDetermineBestNetworkInterface(t *testing.T) {
 	// Save original variables
-	originalChooseHostInterface := chooseHostInterface
+	originalChooseHostInterface := ChooseHostInterface
 	originalNetworkInterfaceProvider := NetworkInterfaceProvider
 	defer func() {
-		chooseHostInterface = originalChooseHostInterface
+		ChooseHostInterface = originalChooseHostInterface
 		NetworkInterfaceProvider = originalNetworkInterfaceProvider
 	}()
 
@@ -127,7 +127,7 @@ func TestDetermineBestNetworkInterface(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			chooseHostInterface = tt.mockChooseHostInterface
+			ChooseHostInterface = tt.mockChooseHostInterface
 			NetworkInterfaceProvider = tt.mockNetworkInterfaceProvider
 
 			result, err := DetermineBestNetworkInterface()

--- a/pkg/dryrun/dryrun.go
+++ b/pkg/dryrun/dryrun.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/replicatedhq/embedded-cluster/pkg-new/config"
 	"github.com/replicatedhq/embedded-cluster/pkg-new/k0s"
 	"github.com/replicatedhq/embedded-cluster/pkg/dryrun/types"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
@@ -16,6 +17,7 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/kotsadm"
 	"github.com/replicatedhq/embedded-cluster/pkg/kubeutils"
 	"github.com/replicatedhq/embedded-cluster/pkg/metrics"
+	"github.com/replicatedhq/embedded-cluster/pkg/netutils"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
@@ -32,14 +34,16 @@ var (
 )
 
 type Client struct {
-	KubeUtils     *KubeUtils
-	Helpers       *Helpers
-	Systemd       *Systemd
-	FirewalldUtil *FirewalldUtil
-	Metrics       *Sender
-	K0sClient     *K0s
-	HelmClient    helm.Client
-	Kotsadm       *Kotsadm
+	KubeUtils                *KubeUtils
+	Helpers                  *Helpers
+	Systemd                  *Systemd
+	FirewalldUtil            *FirewalldUtil
+	Metrics                  *Sender
+	K0sClient                *K0s
+	HelmClient               helm.Client
+	Kotsadm                  *Kotsadm
+	NetworkInterfaceProvider netutils.NetworkInterfaceProvider
+	ChooseHostInterfaceImpl  *ChooseInterfaceImpl
 }
 
 func Init(outputFile string, client *Client) {
@@ -73,6 +77,10 @@ func Init(outputFile string, client *Client) {
 		helm.SetClientFactory(func(opts helm.HelmOptions) (helm.Client, error) {
 			return client.HelmClient, nil
 		})
+	}
+	if client.NetworkInterfaceProvider != nil {
+		config.NetworkInterfaceProvider = client.NetworkInterfaceProvider
+		config.ChooseHostInterface = client.ChooseHostInterfaceImpl.ChooseHostInterface
 	}
 	kubeutils.Set(client.KubeUtils)
 	helpers.Set(client.Helpers)

--- a/pkg/dryrun/dryrun.go
+++ b/pkg/dryrun/dryrun.go
@@ -80,6 +80,7 @@ func Init(outputFile string, client *Client) {
 	}
 	if client.NetworkInterfaceProvider != nil {
 		config.NetworkInterfaceProvider = client.NetworkInterfaceProvider
+		netutils.DefaultNetworkInterfaceProvider = client.NetworkInterfaceProvider
 		config.ChooseHostInterface = client.ChooseHostInterfaceImpl.ChooseHostInterface
 	}
 	kubeutils.Set(client.KubeUtils)

--- a/pkg/dryrun/network_interface.go
+++ b/pkg/dryrun/network_interface.go
@@ -1,0 +1,49 @@
+package dryrun
+
+import (
+	"net"
+
+	"github.com/replicatedhq/embedded-cluster/pkg/netutils"
+)
+
+var _ netutils.NetworkInterfaceProvider = (*NetworkInterfaceProvider)(nil)
+var _ netutils.NetworkInterface = (*NetworkInterface)(nil)
+
+// NetworkInterfaceProvider implementation for testing
+type NetworkInterfaceProvider struct {
+	Ifaces []netutils.NetworkInterface
+	Err    error
+}
+
+func (p *NetworkInterfaceProvider) Interfaces() ([]netutils.NetworkInterface, error) {
+	return p.Ifaces, p.Err
+}
+
+// NetworkInterface implementation for testing
+type NetworkInterface struct {
+	MockName  string
+	MockFlags net.Flags
+	MockAddrs []net.Addr
+	MockErr   error
+}
+
+func (i *NetworkInterface) Name() string {
+	return i.MockName
+}
+
+func (i *NetworkInterface) Flags() net.Flags {
+	return i.MockFlags
+}
+
+func (i *NetworkInterface) Addrs() ([]net.Addr, error) {
+	return i.MockAddrs, i.MockErr
+}
+
+// ChooseHostInterfaceImpl is a mock implementation that returns a fixed IP for testing
+type ChooseInterfaceImpl struct {
+	IP net.IP
+}
+
+func (c *ChooseInterfaceImpl) ChooseHostInterface() (net.IP, error) {
+	return c.IP, nil
+}

--- a/pkg/netutils/ips.go
+++ b/pkg/netutils/ips.go
@@ -8,11 +8,6 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg-new/cloudutils"
 )
 
-// Dependency injection variables for testing
-var (
-	networkInterfaceProvider = DefaultNetworkInterfaceProvider
-)
-
 // adapted from https://github.com/k0sproject/k0s/blob/v1.30.4%2Bk0s.0/internal/pkg/iface/iface.go#L61
 func FirstValidAddress(networkInterface string) (string, error) {
 	ipnet, err := FirstValidIPNet(networkInterface)
@@ -68,7 +63,7 @@ func ListValidNetworkInterfaces() ([]NetworkInterface, error) {
 
 // listValidInterfaces returns a list of valid network interfaces for the node.
 func listValidInterfaces() ([]NetworkInterface, error) {
-	ifs, err := networkInterfaceProvider.Interfaces()
+	ifs, err := DefaultNetworkInterfaceProvider.Interfaces()
 	if err != nil {
 		return nil, fmt.Errorf("list network interfaces: %w", err)
 	}

--- a/pkg/netutils/ips_test.go
+++ b/pkg/netutils/ips_test.go
@@ -41,9 +41,9 @@ func (m *mockNetworkInterfaceProvider) Interfaces() ([]NetworkInterface, error) 
 
 func TestFirstValidAddress(t *testing.T) {
 	// Save original provider
-	originalProvider := networkInterfaceProvider
+	originalProvider := DefaultNetworkInterfaceProvider
 	defer func() {
-		networkInterfaceProvider = originalProvider
+		DefaultNetworkInterfaceProvider = originalProvider
 	}()
 
 	tests := []struct {
@@ -155,7 +155,7 @@ func TestFirstValidAddress(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			networkInterfaceProvider = tt.mockProvider
+			DefaultNetworkInterfaceProvider = tt.mockProvider
 
 			result, err := FirstValidAddress(tt.networkInterface)
 
@@ -173,9 +173,9 @@ func TestFirstValidAddress(t *testing.T) {
 
 func TestFirstValidIPNet(t *testing.T) {
 	// Save original provider
-	originalProvider := networkInterfaceProvider
+	originalProvider := DefaultNetworkInterfaceProvider
 	defer func() {
-		networkInterfaceProvider = originalProvider
+		DefaultNetworkInterfaceProvider = originalProvider
 	}()
 
 	tests := []struct {
@@ -277,7 +277,7 @@ func TestFirstValidIPNet(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			networkInterfaceProvider = tt.mockProvider
+			DefaultNetworkInterfaceProvider = tt.mockProvider
 
 			result, err := FirstValidIPNet(tt.networkInterface)
 
@@ -297,9 +297,9 @@ func TestFirstValidIPNet(t *testing.T) {
 
 func TestListValidNetworkInterfaces(t *testing.T) {
 	// Save original provider
-	originalProvider := networkInterfaceProvider
+	originalProvider := DefaultNetworkInterfaceProvider
 	defer func() {
-		networkInterfaceProvider = originalProvider
+		DefaultNetworkInterfaceProvider = originalProvider
 	}()
 
 	tests := []struct {
@@ -444,7 +444,7 @@ func TestListValidNetworkInterfaces(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			networkInterfaceProvider = tt.mockProvider
+			DefaultNetworkInterfaceProvider = tt.mockProvider
 
 			result, err := ListValidNetworkInterfaces()
 
@@ -468,9 +468,9 @@ func TestListValidNetworkInterfaces(t *testing.T) {
 
 func TestListAllValidIPAddresses(t *testing.T) {
 	// Save original provider
-	originalProvider := networkInterfaceProvider
+	originalProvider := DefaultNetworkInterfaceProvider
 	defer func() {
-		networkInterfaceProvider = originalProvider
+		DefaultNetworkInterfaceProvider = originalProvider
 		cloudutils.Set(cloudutils.New())
 	}()
 
@@ -599,7 +599,7 @@ func TestListAllValidIPAddresses(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			networkInterfaceProvider = tt.mockProvider
+			DefaultNetworkInterfaceProvider = tt.mockProvider
 
 			mockCloudUtils := &cloudutils.MockCloudUtils{}
 			cloudutils.Set(mockCloudUtils)

--- a/tests/dryrun/join_test.go
+++ b/tests/dryrun/join_test.go
@@ -57,7 +57,7 @@ func testJoinControllerNodeImpl(t *testing.T, isAirgap bool, hasHAMigration bool
 			AirGap:         isAirgap,
 			RuntimeConfig: &ecv1beta1.RuntimeConfigSpec{
 				Network: ecv1beta1.NetworkSpec{
-					NetworkInterface: "eth0",
+					NetworkInterface: "ens1",
 					PodCIDR:          "10.2.0.0/17",
 					ServiceCIDR:      "10.2.128.0/17",
 				},
@@ -77,7 +77,7 @@ func testJoinControllerNodeImpl(t *testing.T, isAirgap bool, hasHAMigration bool
 	ifaceProvider := &dryrun.NetworkInterfaceProvider{
 		Ifaces: []netutils.NetworkInterface{
 			&dryrun.NetworkInterface{
-				MockName:  "ens1",
+				MockName:  "eth0",
 				MockFlags: net.FlagUp,
 				MockAddrs: []net.Addr{
 					&net.IPNet{IP: ip, Mask: net.CIDRMask(24, 32)},


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Fix for support issue - https://github.com/replicated-collab/cisco-replicated/issues/13

Had to make a couple of changes to the net* packages to be able to mock some behaviours to accurately test this using `dryrun`.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/127689/join-subcommand-doesn-t-rely-on-network-interface-flag

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Yes

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fix for `join` sub-command where the host interface name wasn't being used when joining a new node
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
