### PR TITLE
chore(ci): fix web unit test

### DIFF
--- a/web/src/components/wizard/tests/LinuxValidationStep.test.tsx
+++ b/web/src/components/wizard/tests/LinuxValidationStep.test.tsx
@@ -16,10 +16,15 @@ const server = setupServer(
     });
   }),
 
+  // Mock preflight run endpoint
+  http.post('*/api/linux/install/host-preflights/run', () => {
+    return HttpResponse.json({ success: true });
+  }),
+
   // Mock start installation endpoint
   http.post('*/api/linux/install/infra/setup', () => {
     return HttpResponse.json({ success: true });
-  })
+  }),
 );
 
 describe('LinuxValidationStep', () => {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

web unit tests are failing

```
 FAIL  src/components/wizard/tests/LinuxValidationStep.test.tsx > LinuxValidationStep > enables Start Installation button when allowIgnoreHostPreflights is true and preflights fail
TestingLibraryElementError: Unable to find an element with the text: Host Requirements Not Met. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.
```

```
              <div
                class="ml-3"
              >
                <h4
                  class="text-sm font-medium text-gray-900"
                >
                  Unable to complete system requirement checks
                </h4>
                <p
                  class="mt-1 text-sm text-red-600"
                >
                  fetch failed
                </p>
              </div>
```

from cursor:

The Problem
The test was failing because it was looking for the text "Host Requirements Not Met" but the component was showing "Unable to complete system requirement checks" instead. This was a race condition caused by missing API mocks.

Root Cause
The LinuxValidationStep component uses LinuxPreflightCheck, which follows this flow:
1. First: Calls /api/linux/install/host-preflights/run to start preflight checks
2. Then: Polls /api/linux/install/host-preflights/status to get results
The test was only mocking the status endpoint but not the run endpoint. When the component tried to call the run endpoint, it failed, which triggered the error message "Unable to complete system requirement checks" instead of the expected "Host Requirements Not Met" message.

The Fix
I added the missing mock for the preflight run endpoint in the test setup:

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
