### PR TITLE
fix(api): fix LicenseDockerCfg template function

### DIFF
--- a/api/controllers/linux/install/controller_test.go
+++ b/api/controllers/linux/install/controller_test.go
@@ -1199,7 +1199,7 @@ func TestSetupInfra(t *testing.T) {
 				appcontroller.WithStateMachine(sm),
 				appcontroller.WithStore(mockStore),
 				appcontroller.WithReleaseData(getTestReleaseData(&appConfig)),
-				appcontroller.WithLicense([]byte("test-license")),
+				appcontroller.WithLicense([]byte("spec:\n  licenseID: test-license\n")),
 				appcontroller.WithAppConfigManager(mockAppConfigManager),
 				appcontroller.WithAppPreflightManager(mockAppPreflightManager),
 				appcontroller.WithAppReleaseManager(mockAppReleaseManager),
@@ -1216,7 +1216,7 @@ func TestSetupInfra(t *testing.T) {
 				WithAllowIgnoreHostPreflights(tt.serverAllowIgnoreHostPreflights),
 				WithMetricsReporter(mockMetricsReporter),
 				WithReleaseData(getTestReleaseData(&appConfig)),
-				WithLicense([]byte("test-license")),
+				WithLicense([]byte("spec:\n  licenseID: test-license\n")),
 				WithStore(mockStore),
 			)
 			require.NoError(t, err)

--- a/api/integration/app/install/config_test.go
+++ b/api/integration/app/install/config_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/release"
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	"github.com/replicatedhq/kotskinds/multitype"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -1049,14 +1048,13 @@ func TestAppInstallSuite(t *testing.T) {
 					linuxinstall.WithReleaseData(rd),
 					linuxinstall.WithLicense([]byte("spec:\n  licenseID: test-license\n")),
 					linuxinstall.WithConfigValues(configValues),
-					linuxinstall.WithLogger(logrus.New()),
 				)
 				require.NoError(t, err)
 				// Create the API with the install controller
 				return integration.NewAPIWithReleaseData(t,
 					api.WithLinuxInstallController(controller),
 					api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
-					api.WithLogger(logrus.New()),
+					api.WithLogger(logger.NewDiscardLogger()),
 				)
 			},
 			baseURL: "/linux/install",
@@ -1070,7 +1068,6 @@ func TestAppInstallSuite(t *testing.T) {
 					kubernetesinstall.WithReleaseData(rd),
 					kubernetesinstall.WithLicense([]byte("spec:\n  licenseID: test-license\n")),
 					kubernetesinstall.WithConfigValues(configValues),
-					kubernetesinstall.WithLogger(logrus.New()),
 				)
 				require.NoError(t, err)
 				// Create the API with the install controller

--- a/api/internal/managers/linux/infra/install_test.go
+++ b/api/internal/managers/linux/infra/install_test.go
@@ -66,7 +66,7 @@ func TestInfraManager_getAddonInstallOpts(t *testing.T) {
 			// Create infra manager
 			manager := NewInfraManager(
 				WithClusterID("test-cluster"),
-				WithLicense([]byte("test-license")),
+				WithLicense([]byte("spec:\n  licenseID: test-license\n")),
 			)
 
 			// Test the getAddonInstallOpts method with configValues passed as parameter


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Config rendering fails with the following error when using the `LicenseDockerCfg` template function.

```
time="2025-08-12T13:45:19-07:00" level=error msg="failed to template app config" error="execute config template: template execution error: template config items: template value for license_docker_cfg: execute template: template: template:1:7: executing \"template\" at <LicenseDockerCfg>: error calling LicenseDockerCfg: license is nil" method=POST path=/linux/install/app/config/template
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
