### PR TITLE
chore(ci): move away from bitnami charts

### DIFF
--- a/e2e/kots-release-upgrade/cluster-config.yaml
+++ b/e2e/kots-release-upgrade/cluster-config.yaml
@@ -87,14 +87,11 @@ spec:
           values: |
             image:
               repository: ec-e2e-proxy.testcluster.net/anonymous/bloomberg/goldpinger
-        - chartname: oci://ec-e2e-proxy.testcluster.net/anonymous/giteacharts/gitea
-          name: gitea
-          namespace: gitea
+        - chartname: oci://ec-e2e-proxy.testcluster.net/anonymous/ghcr.io/prometheus-community/charts/kube-state-metrics
+          name: kube-state-metrics
+          namespace: kube-state-metrics
+          version: 6.1.4
+          order: 4
           values: |
             global:
-              imageRegistry: ec-e2e-proxy.testcluster.net/anonymous
-            gitea:
-              config:
-                APP_NAME: "Custom Gitea: With a cup of tea."
-          order: 4
-          version: 12.1.3
+              imageRegistry: ec-e2e-proxy.testcluster.net/anonymous/registry.k8s.io

--- a/e2e/kots-release-upgrade/cluster-config.yaml
+++ b/e2e/kots-release-upgrade/cluster-config.yaml
@@ -87,19 +87,14 @@ spec:
           values: |
             image:
               repository: ec-e2e-proxy.testcluster.net/anonymous/bloomberg/goldpinger
-        - chartname: oci://ec-e2e-proxy.testcluster.net/anonymous/bitnamicharts/memcached
-          name: memcached
-          namespace: memcached
+        - chartname: oci://ec-e2e-proxy.testcluster.net/anonymous/gitea/gitea
+          name: gitea
+          namespace: gitea
           values: |
             global:
               imageRegistry: ec-e2e-proxy.testcluster.net/anonymous
-            volumePermissions:
-             resources:
-               requests:
-                 cpu: 25m
-                 memory: 128Mi
-               limits:
-                 cpu: 25m
-                 memory: 256Mi
+            gitea:
+              config:
+                APP_NAME: "Custom Gitea: With a cup of tea."
           order: 4
-          version: 6.6.4
+          version: 12.1.3

--- a/e2e/kots-release-upgrade/cluster-config.yaml
+++ b/e2e/kots-release-upgrade/cluster-config.yaml
@@ -87,7 +87,7 @@ spec:
           values: |
             image:
               repository: ec-e2e-proxy.testcluster.net/anonymous/bloomberg/goldpinger
-        - chartname: oci://ec-e2e-proxy.testcluster.net/anonymous/gitea/gitea
+        - chartname: oci://ec-e2e-proxy.testcluster.net/anonymous/giteacharts/gitea
           name: gitea
           namespace: gitea
           values: |

--- a/e2e/scripts/check-postupgrade-state.sh
+++ b/e2e/scripts/check-postupgrade-state.sh
@@ -32,17 +32,17 @@ main() {
     echo "installations"
     kubectl get installations
 
-    # ensure that memcached exists
-    if ! kubectl get ns memcached; then
-        echo "no memcached ns found"
+    # ensure that gitea exists
+    if ! kubectl get ns gitea; then
+        echo "no gitea ns found"
         kubectl get ns
         exit 1
     fi
 
-    # ensure that memcached pods exist
-    if ! kubectl get pods -n memcached | grep -q Running ; then
-        echo "no pods found for memcached deployment"
-        kubectl get pods -n memcached
+    # ensure that gitea pods exist
+    if ! kubectl get pods -n gitea | grep -q Running ; then
+        echo "no pods found for gitea deployment"
+        kubectl get pods -n gitea
         exit 1
     fi
 

--- a/e2e/scripts/check-postupgrade-state.sh
+++ b/e2e/scripts/check-postupgrade-state.sh
@@ -32,17 +32,17 @@ main() {
     echo "installations"
     kubectl get installations
 
-    # ensure that gitea exists
-    if ! kubectl get ns gitea; then
-        echo "no gitea ns found"
+    # ensure that kube-state-metrics exists
+    if ! kubectl get ns kube-state-metrics; then
+        echo "no kube-state-metrics ns found"
         kubectl get ns
         exit 1
     fi
 
-    # ensure that gitea pods exist
-    if ! kubectl get pods -n gitea | grep -q Running ; then
-        echo "no pods found for gitea deployment"
-        kubectl get pods -n gitea
+    # ensure that kube-state-metrics pods exist
+    if ! kubectl get pods -n kube-state-metrics | grep -q Running ; then
+        echo "no pods found for kube-state-metrics deployment"
+        kubectl get pods -n kube-state-metrics
         exit 1
     fi
 

--- a/e2e/scripts/common.sh
+++ b/e2e/scripts/common.sh
@@ -203,8 +203,8 @@ ensure_app_deployed_airgap() {
 }
 
 ensure_app_not_upgraded() {
-    if kubectl get ns | grep -q gitea ; then
-        echo "found gitea ns"
+    if kubectl get ns | grep -q kube-state-metrics ; then
+        echo "found kube-state-metrics ns"
         return 1
     fi
     if kubectl get pods -n "$APP_NAMESPACE" -l app=second | grep -q second ; then

--- a/e2e/scripts/common.sh
+++ b/e2e/scripts/common.sh
@@ -111,22 +111,6 @@ wait_for_nginx_pods() {
     done
 }
 
-wait_for_memcached_pods() {
-    ready=$(kubectl get pods -n embedded-cluster | grep -c memcached || true)
-    counter=0
-    while [ "$ready" -lt "1" ]; do
-        if [ "$counter" -gt 36 ]; then
-            return 1
-        fi
-        sleep 5
-        counter=$((counter+1))
-        echo "Waiting for memcached pods"
-        ready=$(kubectl get pods -n embedded-cluster | grep -c memcached || true)
-        kubectl get pods -n embedded-cluster 2>&1 || true
-        echo "$ready"
-    done
-}
-
 wait_for_pods_running() {
     local timeout="$1"
     local start_time
@@ -219,8 +203,8 @@ ensure_app_deployed_airgap() {
 }
 
 ensure_app_not_upgraded() {
-    if kubectl get ns | grep -q memcached ; then
-        echo "found memcached ns"
+    if kubectl get ns | grep -q gitea ; then
+        echo "found gitea ns"
         return 1
     fi
     if kubectl get pods -n "$APP_NAMESPACE" -l app=second | grep -q second ; then

--- a/hack/test-installation.yaml
+++ b/hack/test-installation.yaml
@@ -41,17 +41,14 @@ spec:
             image:
               repository: proxy.replicated.com/anonymous/bloomberg/goldpinger
           version: 6.1.2
-        - chartname: oci://ec-e2e-proxy.testcluster.net/anonymous/giteacharts/gitea
-          name: gitea
-          namespace: gitea
+        - chartname: oci://ec-e2e-proxy.testcluster.net/anonymous/ghcr.io/prometheus-community/charts/kube-state-metrics
+          name: kube-state-metrics
+          namespace: kube-state-metrics
           order: 4
           values: |
             global:
-              imageRegistry: ec-e2e-proxy.testcluster.net/anonymous
-            gitea:
-              config:
-                APP_NAME: "Custom Gitea: With a cup of tea."
-          version: 12.1.3
+              imageRegistry: ec-e2e-proxy.testcluster.net/anonymous/registry.k8s.io
+          version: 6.1.4
         concurrencyLevel: 0
         repositories:
         - name: ingress-nginx

--- a/hack/test-installation.yaml
+++ b/hack/test-installation.yaml
@@ -41,22 +41,17 @@ spec:
             image:
               repository: proxy.replicated.com/anonymous/bloomberg/goldpinger
           version: 6.1.2
-        - chartname: oci://proxy.replicated.com/anonymous/bitnamicharts/memcached
-          name: memcached
-          namespace: memcached
+        - chartname: oci://ec-e2e-proxy.testcluster.net/anonymous/gitea/gitea
+          name: gitea
+          namespace: gitea
           order: 4
           values: |
             global:
-              imageRegistry: proxy.replicated.com/anonymous
-            volumePermissions:
-              resources:
-                requests:
-                  cpu: 25m
-                  memory: 128Mi
-                limits:
-                  cpu: 25m
-                  memory: 256Mi
-          version: 6.6.4
+              imageRegistry: ec-e2e-proxy.testcluster.net/anonymous
+            gitea:
+              config:
+                APP_NAME: "Custom Gitea: With a cup of tea."
+          version: 12.1.3
         concurrencyLevel: 0
         repositories:
         - name: ingress-nginx

--- a/hack/test-installation.yaml
+++ b/hack/test-installation.yaml
@@ -41,7 +41,7 @@ spec:
             image:
               repository: proxy.replicated.com/anonymous/bloomberg/goldpinger
           version: 6.1.2
-        - chartname: oci://ec-e2e-proxy.testcluster.net/anonymous/gitea/gitea
+        - chartname: oci://ec-e2e-proxy.testcluster.net/anonymous/giteacharts/gitea
           name: gitea
           namespace: gitea
           order: 4


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Moves off of bitnami hosted chart to free one for test.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
