### PR TITLE
fix: only unmarshal HelmChart custom resources after they are templated

### DIFF
--- a/api/internal/managers/app/release/template.go
+++ b/api/internal/managers/app/release/template.go
@@ -71,18 +71,12 @@ func (m *appReleaseManager) templateHelmChartCRs(configValues types.AppConfigVal
 	templatedCRs := make([]*kotsv1beta2.HelmChart, 0, len(helmChartCRs))
 
 	for _, helmChartCR := range helmChartCRs {
-		if helmChartCR == nil {
+		if len(helmChartCR) == 0 {
 			continue
 		}
 
-		// Marshal the HelmChart CR to YAML for templating
-		helmChartYAML, err := kyaml.Marshal(helmChartCR)
-		if err != nil {
-			return nil, fmt.Errorf("marshal helm chart CR: %w", err)
-		}
-
 		// Parse the YAML as a template
-		if err := m.templateEngine.Parse(string(helmChartYAML)); err != nil {
+		if err := m.templateEngine.Parse(string(helmChartCR)); err != nil {
 			return nil, fmt.Errorf("parse helm chart template: %w", err)
 		}
 

--- a/api/internal/managers/app/release/template_test.go
+++ b/api/internal/managers/app/release/template_test.go
@@ -22,7 +22,7 @@ func TestAppReleaseManager_ExtractAppPreflightSpec(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		helmChartCRs  []*kotsv1beta2.HelmChart
+		helmChartCRs  [][]byte
 		chartArchives [][]byte
 		configValues  types.AppConfigValues
 		proxySpec     *ecv1beta1.ProxySpec
@@ -32,7 +32,7 @@ func TestAppReleaseManager_ExtractAppPreflightSpec(t *testing.T) {
 	}{
 		{
 			name:         "no helm charts returns nil",
-			helmChartCRs: []*kotsv1beta2.HelmChart{},
+			helmChartCRs: [][]byte{},
 			configValues: types.AppConfigValues{},
 			proxySpec:    &ecv1beta1.ProxySpec{},
 			expectedSpec: nil,
@@ -40,9 +40,8 @@ func TestAppReleaseManager_ExtractAppPreflightSpec(t *testing.T) {
 		},
 		{
 			name: "single chart with preflight spec and templating",
-			helmChartCRs: []*kotsv1beta2.HelmChart{
-				createHelmChartCRFromYAML(`
-apiVersion: kots.io/v1beta2
+			helmChartCRs: [][]byte{
+				[]byte(`apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
   name: myapp-chart
@@ -114,9 +113,8 @@ spec:
 		},
 		{
 			name: "multiple charts with merged preflight specs and templating",
-			helmChartCRs: []*kotsv1beta2.HelmChart{
-				createHelmChartCRFromYAML(`
-apiVersion: kots.io/v1beta2
+			helmChartCRs: [][]byte{
+				[]byte(`apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
   name: frontend-chart
@@ -126,8 +124,7 @@ spec:
     chartVersion: "1.0.0"
   values:
     versionCheckName: '{{repl ConfigOption "version_check_name"}}'`),
-				createHelmChartCRFromYAML(`
-apiVersion: kots.io/v1beta2
+				[]byte(`apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
   name: backend-chart
@@ -224,9 +221,8 @@ spec:
 		},
 		{
 			name: "chart with no preflights returns empty spec",
-			helmChartCRs: []*kotsv1beta2.HelmChart{
-				createHelmChartCRFromYAML(`
-apiVersion: kots.io/v1beta2
+			helmChartCRs: [][]byte{
+				[]byte(`apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
   name: simple-chart
@@ -245,9 +241,8 @@ spec:
 		},
 		{
 			name: "chart with proxy template functions",
-			helmChartCRs: []*kotsv1beta2.HelmChart{
-				createHelmChartCRFromYAML(`
-apiVersion: kots.io/v1beta2
+			helmChartCRs: [][]byte{
+				[]byte(`apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
   name: proxy-chart
@@ -369,7 +364,7 @@ spec:
 func TestAppReleaseManager_templateHelmChartCRs(t *testing.T) {
 	tests := []struct {
 		name         string
-		helmChartCRs []*kotsv1beta2.HelmChart
+		helmChartCRs [][]byte
 		configValues types.AppConfigValues
 		proxySpec    *ecv1beta1.ProxySpec
 		expected     []*kotsv1beta2.HelmChart
@@ -377,7 +372,7 @@ func TestAppReleaseManager_templateHelmChartCRs(t *testing.T) {
 	}{
 		{
 			name:         "empty helm chart CRs",
-			helmChartCRs: []*kotsv1beta2.HelmChart{},
+			helmChartCRs: [][]byte{},
 			configValues: types.AppConfigValues{},
 			proxySpec:    &ecv1beta1.ProxySpec{},
 			expected:     []*kotsv1beta2.HelmChart{},
@@ -385,8 +380,8 @@ func TestAppReleaseManager_templateHelmChartCRs(t *testing.T) {
 		},
 		{
 			name: "single helm chart with repl templating",
-			helmChartCRs: []*kotsv1beta2.HelmChart{
-				createHelmChartCRFromYAML(`
+			helmChartCRs: [][]byte{
+				[]byte(`
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
@@ -451,8 +446,8 @@ spec:
 		},
 		{
 			name: "multiple helm charts with mixed templating",
-			helmChartCRs: []*kotsv1beta2.HelmChart{
-				createHelmChartCRFromYAML(`
+			helmChartCRs: [][]byte{
+				[]byte(`
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
@@ -471,7 +466,7 @@ spec:
         limits:
           memory: 128Mi
 `),
-				createHelmChartCRFromYAML(`
+				[]byte(`
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
@@ -552,9 +547,9 @@ spec:
 		},
 		{
 			name: "skip nil helm chart",
-			helmChartCRs: []*kotsv1beta2.HelmChart{
+			helmChartCRs: [][]byte{
 				nil,
-				createHelmChartCRFromYAML(`
+				[]byte(`
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
@@ -593,8 +588,8 @@ spec:
 		},
 		{
 			name: "helm chart with proxy template functions",
-			helmChartCRs: []*kotsv1beta2.HelmChart{
-				createHelmChartCRFromYAML(`
+			helmChartCRs: [][]byte{
+				[]byte(`
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
@@ -655,8 +650,8 @@ spec:
 		},
 		{
 			name: "helm chart with empty proxy spec",
-			helmChartCRs: []*kotsv1beta2.HelmChart{
-				createHelmChartCRFromYAML(`
+			helmChartCRs: [][]byte{
+				[]byte(`
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:

--- a/pkg/release/release_test.go
+++ b/pkg/release/release_test.go
@@ -141,7 +141,11 @@ metadata:
 spec:
   chart:
     chartVersion: "1.0.0"
-    name: test-chart`
+    name: test-chart
+  optionalValues:
+    - when: '{{repl not (empty (ConfigOption "test-option")) }}'
+      recursiveMerge: true
+      values: repl{{ ConfigOption "test-option" | nindent 8 }}`
 
 	chartArchive := []byte("fake-chart-archive-content")
 
@@ -178,6 +182,7 @@ spec:
 	// Verify HelmChart CRs
 	assert.Len(t, release.HelmChartCRs, 1)
 	assert.NotNil(t, release.HelmChartCRs[0])
+	assert.Greater(t, len(release.HelmChartCRs[0]), 0)
 
 	// Verify chart archives
 	assert.Len(t, release.HelmChartArchives, 1)


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Only unmarshals HelmChart custom resources after they are templated to avoid unmarshaling errors due to invalid schema that only becomes valid after templating.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-128089](https://app.shortcut.com/replicated/story/128089)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Yes

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes an issue where installations failed to parse release data if HelmChart custom resources contained template functions in non-string fields before being rendered.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE