### PR TITLE
Add flag to ignore app preflights for V2 installs and update success message

### DIFF
--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -75,6 +75,7 @@ type InstallCmdFlags struct {
 	localArtifactMirrorPort int
 	skipHostPreflights      bool
 	ignoreHostPreflights    bool
+	ignoreAppPreflights     bool
 	networkInterface        string
 
 	// kubernetes flags
@@ -276,8 +277,9 @@ func newLinuxInstallFlags(flags *InstallCmdFlags, enableV3 bool) *pflag.FlagSet 
 	defaultDataDir := ecv1beta1.DefaultDataDir
 	if enableV3 {
 		defaultDataDir = filepath.Join("/var/lib", runtimeconfig.AppSlug())
+	} else {
+		flagSet.BoolVar(&flags.ignoreAppPreflights, "ignore-app-preflights", false, "Allow bypassing app preflight failures")
 	}
-
 	flagSet.StringVar(&flags.dataDir, "data-dir", defaultDataDir, "Path to the data directory")
 	flagSet.IntVar(&flags.localArtifactMirrorPort, "local-artifact-mirror-port", ecv1beta1.DefaultLocalArtifactMirrorPort, "Port on which the Local Artifact Mirror will be served")
 	flagSet.StringVar(&flags.networkInterface, "network-interface", "", "The network interface to use for the cluster")
@@ -847,6 +849,7 @@ func getAddonInstallOpts(flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig, 
 		euCfgSpec = &euCfg.Spec
 	}
 
+
 	opts := &addons.InstallOptions{
 		ClusterID:               flags.clusterID,
 		AdminConsolePwd:         flags.adminConsolePassword,
@@ -875,6 +878,7 @@ func getAddonInstallOpts(flags InstallCmdFlags, rc runtimeconfig.RuntimeConfig, 
 				AirgapBundle:          flags.airgapBundle,
 				ConfigValuesFile:      flags.configValues,
 				ReplicatedAppEndpoint: replicatedAppURL(),
+				SkipPreflights:        flags.ignoreAppPreflights,
 				Stdout:                *loading,
 			}
 			return kotscli.Install(opts)


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Add a new `--ignore-app-preflights` flag to ignore app preflights with failures and warning for V2 EC installations
Changes the wording of the success message for headless installations

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/127100/add-support-for-skipping-app-preflights-on-warning-failure
https://app.shortcut.com/replicated/story/128033/change-visit-the-admin-console-wording-if-a-headless-install-is-done

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Tests for the new ignore-app-preflights flag were added

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE