### PR TITLE
feat(v3): install Helm charts directly without KOTS CLI

### DIFF
--- a/api/controllers/kubernetes/install/controller.go
+++ b/api/controllers/kubernetes/install/controller.go
@@ -192,6 +192,7 @@ func NewInstallController(opts ...InstallControllerOption) (*InstallController, 
 			appcontroller.WithConfigValues(controller.configValues),
 			appcontroller.WithAirgapBundle(controller.airgapBundle),
 			appcontroller.WithPrivateCACertConfigMapName(""), // Private CA ConfigMap functionality not yet implemented for Kubernetes installations
+			appcontroller.WithRESTClientGetter(controller.restClientGetter),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("create app install controller: %w", err)

--- a/api/controllers/linux/install/controller.go
+++ b/api/controllers/linux/install/controller.go
@@ -264,6 +264,7 @@ func NewInstallController(opts ...InstallControllerOption) (*InstallController, 
 			appcontroller.WithClusterID(controller.clusterID),
 			appcontroller.WithAirgapBundle(controller.airgapBundle),
 			appcontroller.WithPrivateCACertConfigMapName(adminconsole.PrivateCASConfigMapName), // Linux installations use the ConfigMap
+			appcontroller.WithKubeConfigPath(controller.rc.PathToKubeConfig()),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("create app install controller: %w", err)

--- a/api/integration/kubernetes/install/appinstall_test.go
+++ b/api/integration/kubernetes/install/appinstall_test.go
@@ -175,6 +175,22 @@ func TestGetAppInstallStatus(t *testing.T) {
 
 // TestPostInstallApp tests the POST /kubernetes/install/app/install endpoint
 func TestPostInstallApp(t *testing.T) {
+	// Create mock helm chart archive
+	mockChartArchive := []byte("mock-helm-chart-archive-data")
+
+	// Create test release data with helm chart archives
+	releaseData := &release.ReleaseData{
+		HelmChartArchives:     [][]byte{mockChartArchive},
+		EmbeddedClusterConfig: &ecv1beta1.Config{},
+		ChannelRelease: &release.ChannelRelease{
+			DefaultDomains: release.Domains{
+				ReplicatedAppDomain: "replicated.example.com",
+				ProxyRegistryDomain: "some-proxy.example.com",
+			},
+		},
+		AppConfig: &kotsv1beta1.Config{},
+	}
+
 	t.Run("Success", func(t *testing.T) {
 
 		// Create mock app install manager that succeeds
@@ -202,7 +218,7 @@ func TestPostInstallApp(t *testing.T) {
 			appinstall.WithAppInstallManager(mockAppInstallManager),
 			appinstall.WithStateMachine(stateMachine),
 			appinstall.WithStore(mockStore),
-			appinstall.WithReleaseData(integration.DefaultReleaseData()),
+			appinstall.WithReleaseData(releaseData),
 		)
 		require.NoError(t, err)
 
@@ -210,16 +226,7 @@ func TestPostInstallApp(t *testing.T) {
 		installController, err := kubernetesinstall.NewInstallController(
 			kubernetesinstall.WithStateMachine(stateMachine),
 			kubernetesinstall.WithAppInstallController(appInstallController),
-			kubernetesinstall.WithReleaseData(&release.ReleaseData{
-				EmbeddedClusterConfig: &ecv1beta1.Config{},
-				ChannelRelease: &release.ChannelRelease{
-					DefaultDomains: release.Domains{
-						ReplicatedAppDomain: "replicated.example.com",
-						ProxyRegistryDomain: "some-proxy.example.com",
-					},
-				},
-				AppConfig: &kotsv1beta1.Config{},
-			}),
+			kubernetesinstall.WithReleaseData(releaseData),
 		)
 		require.NoError(t, err)
 
@@ -265,7 +272,7 @@ func TestPostInstallApp(t *testing.T) {
 		appInstallController, err := appinstall.NewInstallController(
 			appinstall.WithStateMachine(stateMachine),
 			appinstall.WithStore(mockStore),
-			appinstall.WithReleaseData(integration.DefaultReleaseData()),
+			appinstall.WithReleaseData(releaseData),
 		)
 		require.NoError(t, err)
 
@@ -273,7 +280,7 @@ func TestPostInstallApp(t *testing.T) {
 		installController, err := kubernetesinstall.NewInstallController(
 			kubernetesinstall.WithStateMachine(stateMachine),
 			kubernetesinstall.WithAppInstallController(appInstallController),
-			kubernetesinstall.WithReleaseData(integration.DefaultReleaseData()),
+			kubernetesinstall.WithReleaseData(releaseData),
 		)
 		require.NoError(t, err)
 
@@ -326,7 +333,7 @@ func TestPostInstallApp(t *testing.T) {
 			appinstall.WithAppInstallManager(mockAppInstallManager),
 			appinstall.WithStateMachine(stateMachine),
 			appinstall.WithStore(mockStore),
-			appinstall.WithReleaseData(integration.DefaultReleaseData()),
+			appinstall.WithReleaseData(releaseData),
 		)
 		require.NoError(t, err)
 
@@ -334,7 +341,7 @@ func TestPostInstallApp(t *testing.T) {
 		installController, err := kubernetesinstall.NewInstallController(
 			kubernetesinstall.WithStateMachine(stateMachine),
 			kubernetesinstall.WithAppInstallController(appInstallController),
-			kubernetesinstall.WithReleaseData(integration.DefaultReleaseData()),
+			kubernetesinstall.WithReleaseData(releaseData),
 		)
 		require.NoError(t, err)
 
@@ -372,7 +379,7 @@ func TestPostInstallApp(t *testing.T) {
 	t.Run("Authorization error", func(t *testing.T) {
 		// Create simple Kubernetes install controller
 		installController, err := kubernetesinstall.NewInstallController(
-			kubernetesinstall.WithReleaseData(integration.DefaultReleaseData()),
+			kubernetesinstall.WithReleaseData(releaseData),
 		)
 		require.NoError(t, err)
 
@@ -425,7 +432,7 @@ func TestPostInstallApp(t *testing.T) {
 			appinstall.WithAppInstallManager(mockAppInstallManager),
 			appinstall.WithStateMachine(stateMachine),
 			appinstall.WithStore(mockStore),
-			appinstall.WithReleaseData(integration.DefaultReleaseData()),
+			appinstall.WithReleaseData(releaseData),
 		)
 		require.NoError(t, err)
 
@@ -433,7 +440,7 @@ func TestPostInstallApp(t *testing.T) {
 		installController, err := kubernetesinstall.NewInstallController(
 			kubernetesinstall.WithStateMachine(stateMachine),
 			kubernetesinstall.WithAppInstallController(appInstallController),
-			kubernetesinstall.WithReleaseData(integration.DefaultReleaseData()),
+			kubernetesinstall.WithReleaseData(releaseData),
 		)
 		require.NoError(t, err)
 
@@ -488,7 +495,7 @@ func TestPostInstallApp(t *testing.T) {
 		appInstallController, err := appinstall.NewInstallController(
 			appinstall.WithStateMachine(stateMachine),
 			appinstall.WithStore(mockStore),
-			appinstall.WithReleaseData(integration.DefaultReleaseData()),
+			appinstall.WithReleaseData(releaseData),
 		)
 		require.NoError(t, err)
 
@@ -496,7 +503,7 @@ func TestPostInstallApp(t *testing.T) {
 		installController, err := kubernetesinstall.NewInstallController(
 			kubernetesinstall.WithStateMachine(stateMachine),
 			kubernetesinstall.WithAppInstallController(appInstallController),
-			kubernetesinstall.WithReleaseData(integration.DefaultReleaseData()),
+			kubernetesinstall.WithReleaseData(releaseData),
 		)
 		require.NoError(t, err)
 

--- a/api/integration/linux/install/appinstall_test.go
+++ b/api/integration/linux/install/appinstall_test.go
@@ -33,6 +33,22 @@ import (
 
 // TestGetAppInstallStatus tests the GET /linux/install/app/status endpoint
 func TestGetAppInstallStatus(t *testing.T) {
+	// Create mock helm chart archive
+	mockChartArchive := []byte("mock-helm-chart-archive-data")
+
+	// Create test release data with helm chart archives
+	releaseData := &release.ReleaseData{
+		HelmChartArchives:     [][]byte{mockChartArchive},
+		EmbeddedClusterConfig: &ecv1beta1.Config{},
+		ChannelRelease: &release.ChannelRelease{
+			DefaultDomains: release.Domains{
+				ReplicatedAppDomain: "replicated.example.com",
+				ProxyRegistryDomain: "some-proxy.example.com",
+			},
+		},
+		AppConfig: &kotsv1beta1.Config{},
+	}
+
 	t.Run("Success", func(t *testing.T) {
 		// Create app install status
 		appInstallStatus := types.AppInstall{
@@ -59,7 +75,7 @@ func TestGetAppInstallStatus(t *testing.T) {
 			appinstall.WithAppInstallManager(appInstallManager),
 			appinstall.WithStateMachine(linuxinstall.NewStateMachine()),
 			appinstall.WithStore(mockStore),
-			appinstall.WithReleaseData(integration.DefaultReleaseData()),
+			appinstall.WithReleaseData(releaseData),
 		)
 		require.NoError(t, err)
 
@@ -67,16 +83,7 @@ func TestGetAppInstallStatus(t *testing.T) {
 		installController, err := linuxinstall.NewInstallController(
 			linuxinstall.WithStateMachine(linuxinstall.NewStateMachine()),
 			linuxinstall.WithAppInstallController(appInstallController),
-			linuxinstall.WithReleaseData(&release.ReleaseData{
-				EmbeddedClusterConfig: &ecv1beta1.Config{},
-				ChannelRelease: &release.ChannelRelease{
-					DefaultDomains: release.Domains{
-						ReplicatedAppDomain: "replicated.example.com",
-						ProxyRegistryDomain: "some-proxy.example.com",
-					},
-				},
-				AppConfig: &kotsv1beta1.Config{},
-			}),
+			linuxinstall.WithReleaseData(releaseData),
 			linuxinstall.WithRuntimeConfig(runtimeconfig.New(nil)),
 		)
 		require.NoError(t, err)
@@ -118,7 +125,7 @@ func TestGetAppInstallStatus(t *testing.T) {
 	t.Run("Authorization error", func(t *testing.T) {
 		// Create simple Linux install controller
 		installController, err := linuxinstall.NewInstallController(
-			linuxinstall.WithReleaseData(integration.DefaultReleaseData()),
+			linuxinstall.WithReleaseData(releaseData),
 		)
 		require.NoError(t, err)
 
@@ -178,6 +185,22 @@ func TestGetAppInstallStatus(t *testing.T) {
 
 // TestPostInstallApp tests the POST /linux/install/app/install endpoint
 func TestPostInstallApp(t *testing.T) {
+	// Create mock helm chart archive
+	mockChartArchive := []byte("mock-helm-chart-archive-data")
+
+	// Create test release data with helm chart archives
+	releaseData := &release.ReleaseData{
+		HelmChartArchives:     [][]byte{mockChartArchive},
+		EmbeddedClusterConfig: &ecv1beta1.Config{},
+		ChannelRelease: &release.ChannelRelease{
+			DefaultDomains: release.Domains{
+				ReplicatedAppDomain: "replicated.example.com",
+				ProxyRegistryDomain: "some-proxy.example.com",
+			},
+		},
+		AppConfig: &kotsv1beta1.Config{},
+	}
+
 	t.Run("Success", func(t *testing.T) {
 		// Create a real runtime config with temp directory
 		rc := runtimeconfig.New(nil)
@@ -212,7 +235,7 @@ func TestPostInstallApp(t *testing.T) {
 			appinstall.WithAppInstallManager(mockAppInstallManager),
 			appinstall.WithStateMachine(stateMachine),
 			appinstall.WithStore(mockStore),
-			appinstall.WithReleaseData(integration.DefaultReleaseData()),
+			appinstall.WithReleaseData(releaseData),
 		)
 		require.NoError(t, err)
 
@@ -221,16 +244,7 @@ func TestPostInstallApp(t *testing.T) {
 			linuxinstall.WithStateMachine(stateMachine),
 			linuxinstall.WithAppInstallController(appInstallController),
 			linuxinstall.WithMetricsReporter(mockReporter),
-			linuxinstall.WithReleaseData(&release.ReleaseData{
-				EmbeddedClusterConfig: &ecv1beta1.Config{},
-				ChannelRelease: &release.ChannelRelease{
-					DefaultDomains: release.Domains{
-						ReplicatedAppDomain: "replicated.example.com",
-						ProxyRegistryDomain: "some-proxy.example.com",
-					},
-				},
-				AppConfig: &kotsv1beta1.Config{},
-			}),
+			linuxinstall.WithReleaseData(releaseData),
 			linuxinstall.WithRuntimeConfig(rc),
 		)
 		require.NoError(t, err)
@@ -278,7 +292,7 @@ func TestPostInstallApp(t *testing.T) {
 		appInstallController, err := appinstall.NewInstallController(
 			appinstall.WithStateMachine(stateMachine),
 			appinstall.WithStore(mockStore),
-			appinstall.WithReleaseData(integration.DefaultReleaseData()),
+			appinstall.WithReleaseData(releaseData),
 		)
 		require.NoError(t, err)
 
@@ -286,7 +300,7 @@ func TestPostInstallApp(t *testing.T) {
 		installController, err := linuxinstall.NewInstallController(
 			linuxinstall.WithStateMachine(stateMachine),
 			linuxinstall.WithAppInstallController(appInstallController),
-			linuxinstall.WithReleaseData(integration.DefaultReleaseData()),
+			linuxinstall.WithReleaseData(releaseData),
 		)
 		require.NoError(t, err)
 
@@ -353,7 +367,7 @@ func TestPostInstallApp(t *testing.T) {
 			appinstall.WithAppInstallManager(mockAppInstallManager),
 			appinstall.WithStateMachine(stateMachine),
 			appinstall.WithStore(mockStore),
-			appinstall.WithReleaseData(integration.DefaultReleaseData()),
+			appinstall.WithReleaseData(releaseData),
 		)
 		require.NoError(t, err)
 
@@ -363,7 +377,7 @@ func TestPostInstallApp(t *testing.T) {
 			linuxinstall.WithAppInstallController(appInstallController),
 			linuxinstall.WithMetricsReporter(mockReporter),
 			linuxinstall.WithStore(mockStore),
-			linuxinstall.WithReleaseData(integration.DefaultReleaseData()),
+			linuxinstall.WithReleaseData(releaseData),
 			linuxinstall.WithRuntimeConfig(rc),
 		)
 		require.NoError(t, err)
@@ -404,7 +418,7 @@ func TestPostInstallApp(t *testing.T) {
 	t.Run("Authorization error", func(t *testing.T) {
 		// Create simple Linux install controller
 		installController, err := linuxinstall.NewInstallController(
-			linuxinstall.WithReleaseData(integration.DefaultReleaseData()),
+			linuxinstall.WithReleaseData(releaseData),
 		)
 		require.NoError(t, err)
 
@@ -457,7 +471,7 @@ func TestPostInstallApp(t *testing.T) {
 			appinstall.WithAppInstallManager(mockAppInstallManager),
 			appinstall.WithStateMachine(stateMachine),
 			appinstall.WithStore(mockStore),
-			appinstall.WithReleaseData(integration.DefaultReleaseData()),
+			appinstall.WithReleaseData(releaseData),
 		)
 		require.NoError(t, err)
 
@@ -465,7 +479,7 @@ func TestPostInstallApp(t *testing.T) {
 		installController, err := linuxinstall.NewInstallController(
 			linuxinstall.WithStateMachine(stateMachine),
 			linuxinstall.WithAppInstallController(appInstallController),
-			linuxinstall.WithReleaseData(integration.DefaultReleaseData()),
+			linuxinstall.WithReleaseData(releaseData),
 		)
 		require.NoError(t, err)
 
@@ -520,7 +534,7 @@ func TestPostInstallApp(t *testing.T) {
 		appInstallController, err := appinstall.NewInstallController(
 			appinstall.WithStateMachine(stateMachine),
 			appinstall.WithStore(mockStore),
-			appinstall.WithReleaseData(integration.DefaultReleaseData()),
+			appinstall.WithReleaseData(releaseData),
 		)
 		require.NoError(t, err)
 
@@ -528,7 +542,7 @@ func TestPostInstallApp(t *testing.T) {
 		installController, err := linuxinstall.NewInstallController(
 			linuxinstall.WithStateMachine(stateMachine),
 			linuxinstall.WithAppInstallController(appInstallController),
-			linuxinstall.WithReleaseData(integration.DefaultReleaseData()),
+			linuxinstall.WithReleaseData(releaseData),
 		)
 		require.NoError(t, err)
 

--- a/api/internal/managers/app/install/install.go
+++ b/api/internal/managers/app/install/install.go
@@ -61,6 +61,7 @@ func (m *appInstallManager) install(ctx context.Context, configValues kotsv1beta
 	if err := m.installHelmCharts(ctx); err != nil {
 		return fmt.Errorf("install helm charts: %w", err)
 	}
+
 	ecDomains := utils.GetDomains(m.releaseData)
 
 	installOpts := kotscli.InstallOptions{

--- a/api/internal/managers/app/install/install.go
+++ b/api/internal/managers/app/install/install.go
@@ -1,6 +1,7 @@
 package install
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -10,8 +11,10 @@ import (
 	"github.com/replicatedhq/embedded-cluster/api/types"
 	kotscli "github.com/replicatedhq/embedded-cluster/cmd/installer/kotscli"
 	"github.com/replicatedhq/embedded-cluster/pkg-new/constants"
+	"github.com/replicatedhq/embedded-cluster/pkg/helm"
 	"github.com/replicatedhq/embedded-cluster/pkg/netutils"
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
+	"helm.sh/helm/v3/pkg/chart/loader"
 	kyaml "sigs.k8s.io/yaml"
 )
 
@@ -49,16 +52,24 @@ func (m *appInstallManager) install(ctx context.Context, configValues kotsv1beta
 		return fmt.Errorf("parse license: %w", err)
 	}
 
+	// Setup Helm client
+	if err := m.setupHelmClient(); err != nil {
+		return fmt.Errorf("setup helm client: %w", err)
+	}
+
+	// Install Helm charts
+	if err := m.installHelmCharts(ctx); err != nil {
+		return fmt.Errorf("install helm charts: %w", err)
+	}
 	ecDomains := utils.GetDomains(m.releaseData)
 
 	installOpts := kotscli.InstallOptions{
-		AppSlug:      license.Spec.AppSlug,
-		License:      m.license,
-		Namespace:    constants.KotsadmNamespace,
-		ClusterID:    m.clusterID,
-		AirgapBundle: m.airgapBundle,
-		// Skip running the KOTS app preflights in the Admin Console; they run in the manager experience installer when ENABLE_V3 is enabled
-		SkipPreflights:        os.Getenv("ENABLE_V3") == "1",
+		AppSlug:               license.Spec.AppSlug,
+		License:               m.license,
+		Namespace:             constants.KotsadmNamespace,
+		ClusterID:             m.clusterID,
+		AirgapBundle:          m.airgapBundle,
+		SkipPreflights:        true,
 		ReplicatedAppEndpoint: netutils.MaybeAddHTTPS(ecDomains.ReplicatedAppDomain),
 		Stdout:                m.newLogWriter(),
 	}
@@ -96,4 +107,48 @@ func (m *appInstallManager) createConfigValuesFile(configValues kotsv1beta1.Conf
 	}
 
 	return configValuesFile.Name(), nil
+}
+
+func (m *appInstallManager) installHelmCharts(ctx context.Context) error {
+	logFn := m.logFn("app-helm")
+
+	if m.releaseData == nil || len(m.releaseData.HelmChartArchives) == 0 {
+		logFn("no helm charts found in release data")
+		return nil
+	}
+
+	logFn("installing %d helm charts from release data", len(m.releaseData.HelmChartArchives))
+
+	for i, chartArchive := range m.releaseData.HelmChartArchives {
+		logFn("installing chart %d/%d", i+1, len(m.releaseData.HelmChartArchives))
+
+		// Write chart archive to temp file
+		chartPath, err := m.writeChartArchiveToTemp(chartArchive)
+		if err != nil {
+			return fmt.Errorf("write chart archive %d to temp: %w", i, err)
+		}
+		defer os.Remove(chartPath)
+
+		// Get chart name to use as release name
+		ch, err := loader.LoadArchive(bytes.NewReader(chartArchive))
+		if err != nil {
+			return fmt.Errorf("load archive: %w", err)
+		}
+
+		// Install chart using Helm client
+		_, err = m.hcli.Install(ctx, helm.InstallOptions{
+			ChartPath: chartPath,
+			// TODO: namespace should come from HelmChart custom resource instead of constants.KotsadmNamespace
+			Namespace: constants.KotsadmNamespace,
+			// TODO: release name should come from HelmChart custom resource instead of chart name
+			ReleaseName: ch.Metadata.Name,
+		})
+		if err != nil {
+			return fmt.Errorf("install chart %d: %w", i, err)
+		}
+
+		logFn("successfully installed chart %d/%d", i+1, len(m.releaseData.HelmChartArchives))
+	}
+
+	return nil
 }

--- a/api/internal/managers/app/install/install_test.go
+++ b/api/internal/managers/app/install/install_test.go
@@ -24,7 +24,6 @@ import (
 	kyaml "sigs.k8s.io/yaml"
 )
 
-
 func TestAppInstallManager_Install(t *testing.T) {
 	// Create test license
 	license := &kotsv1beta1.License{

--- a/api/internal/managers/app/install/manager.go
+++ b/api/internal/managers/app/install/manager.go
@@ -7,6 +7,7 @@ import (
 	"github.com/replicatedhq/embedded-cluster/api/pkg/logger"
 	"github.com/replicatedhq/embedded-cluster/api/types"
 	kotscli "github.com/replicatedhq/embedded-cluster/cmd/installer/kotscli"
+	"github.com/replicatedhq/embedded-cluster/pkg/helm"
 	"github.com/replicatedhq/embedded-cluster/pkg/release"
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	"github.com/sirupsen/logrus"
@@ -36,6 +37,8 @@ type appInstallManager struct {
 	airgapBundle    string
 	kotsCLI         KotsCLIInstaller
 	logger          logrus.FieldLogger
+	hcli            helm.Client
+	kubeConfigPath  string
 }
 
 type AppInstallManagerOption func(*appInstallManager)
@@ -79,6 +82,19 @@ func WithAirgapBundle(airgapBundle string) AppInstallManagerOption {
 func WithKotsCLI(kotsCLI KotsCLIInstaller) AppInstallManagerOption {
 	return func(m *appInstallManager) {
 		m.kotsCLI = kotsCLI
+	}
+}
+
+// Add constructor options following infra manager pattern
+func WithHelmClient(hcli helm.Client) AppInstallManagerOption {
+	return func(m *appInstallManager) {
+		m.hcli = hcli
+	}
+}
+
+func WithKubeConfigPath(path string) AppInstallManagerOption {
+	return func(m *appInstallManager) {
+		m.kubeConfigPath = path
 	}
 }
 

--- a/api/internal/managers/app/install/manager.go
+++ b/api/internal/managers/app/install/manager.go
@@ -11,6 +11,7 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/release"
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	"github.com/sirupsen/logrus"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 var _ AppInstallManager = &appInstallManager{}
@@ -30,15 +31,16 @@ type AppInstallManager interface {
 
 // appInstallManager is an implementation of the AppInstallManager interface
 type appInstallManager struct {
-	appInstallStore appinstallstore.Store
-	releaseData     *release.ReleaseData
-	license         []byte
-	clusterID       string
-	airgapBundle    string
-	kotsCLI         KotsCLIInstaller
-	logger          logrus.FieldLogger
-	hcli            helm.Client
-	kubeConfigPath  string
+	appInstallStore  appinstallstore.Store
+	releaseData      *release.ReleaseData
+	license          []byte
+	clusterID        string
+	airgapBundle     string
+	kotsCLI          KotsCLIInstaller
+	logger           logrus.FieldLogger
+	hcli             helm.Client
+	kubeConfigPath   string
+	restClientGetter genericclioptions.RESTClientGetter
 }
 
 type AppInstallManagerOption func(*appInstallManager)
@@ -95,6 +97,12 @@ func WithHelmClient(hcli helm.Client) AppInstallManagerOption {
 func WithKubeConfigPath(path string) AppInstallManagerOption {
 	return func(m *appInstallManager) {
 		m.kubeConfigPath = path
+	}
+}
+
+func WithRESTClientGetter(restClientGetter genericclioptions.RESTClientGetter) AppInstallManagerOption {
+	return func(m *appInstallManager) {
+		m.restClientGetter = restClientGetter
 	}
 }
 

--- a/api/internal/managers/app/install/status.go
+++ b/api/internal/managers/app/install/status.go
@@ -1,7 +1,6 @@
 package install
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/replicatedhq/embedded-cluster/api/types"
@@ -17,11 +16,4 @@ func (m *appInstallManager) setStatus(state types.State, description string) err
 		Description: description,
 		LastUpdated: time.Now(),
 	})
-}
-
-func (m *appInstallManager) addLogs(format string, v ...interface{}) {
-	msg := fmt.Sprintf(format, v...)
-	if err := m.appInstallStore.AddLogs(msg); err != nil {
-		m.logger.WithError(err).Error("add log")
-	}
 }

--- a/api/internal/managers/app/install/util.go
+++ b/api/internal/managers/app/install/util.go
@@ -33,9 +33,10 @@ func (m *appInstallManager) setupHelmClient() error {
 	}
 
 	hcli, err := helm.NewClient(helm.HelmOptions{
-		KubeConfig: m.kubeConfigPath,
-		K0sVersion: versions.K0sVersion,
-		LogFn:      m.logFn("app-helm"),
+		KubeConfig:       m.kubeConfigPath,
+		RESTClientGetter: m.restClientGetter,
+		K0sVersion:       versions.K0sVersion,
+		LogFn:            m.logFn("app-helm"),
 	})
 	if err != nil {
 		return fmt.Errorf("create helm client: %w", err)
@@ -66,7 +67,7 @@ func (m *appInstallManager) writeChartArchiveToTemp(chartArchive []byte) (string
 	defer tmpFile.Close()
 
 	if _, err := tmpFile.Write(chartArchive); err != nil {
-		os.Remove(tmpFile.Name())
+		_ = os.Remove(tmpFile.Name())
 		return "", fmt.Errorf("write chart archive: %w", err)
 	}
 

--- a/api/internal/managers/app/install/util.go
+++ b/api/internal/managers/app/install/util.go
@@ -1,8 +1,13 @@
 package install
 
 import (
+	"fmt"
 	"io"
+	"os"
 	"strings"
+
+	"github.com/replicatedhq/embedded-cluster/pkg/helm"
+	"github.com/replicatedhq/embedded-cluster/pkg/versions"
 )
 
 // logWriter is an io.Writer that captures output and feeds it to the logs
@@ -17,7 +22,53 @@ func (m *appInstallManager) newLogWriter() io.Writer {
 func (lw *logWriter) Write(p []byte) (n int, err error) {
 	output := strings.TrimSpace(string(p))
 	if output != "" {
-		lw.manager.addLogs("[kots] %s", output)
+		lw.manager.addLogs("kots", "%s", output)
 	}
 	return len(p), nil
+}
+
+func (m *appInstallManager) setupHelmClient() error {
+	if m.hcli != nil {
+		return nil
+	}
+
+	hcli, err := helm.NewClient(helm.HelmOptions{
+		KubeConfig: m.kubeConfigPath,
+		K0sVersion: versions.K0sVersion,
+		LogFn:      m.logFn("app-helm"),
+	})
+	if err != nil {
+		return fmt.Errorf("create helm client: %w", err)
+	}
+	m.hcli = hcli
+	return nil
+}
+
+func (m *appInstallManager) logFn(component string) func(format string, v ...interface{}) {
+	return func(format string, v ...interface{}) {
+		m.logger.WithField("component", component).Debugf(format, v...)
+		m.addLogs(component, format, v...)
+	}
+}
+
+func (m *appInstallManager) addLogs(component string, format string, v ...interface{}) {
+	msg := fmt.Sprintf("[%s] %s", component, fmt.Sprintf(format, v...))
+	if err := m.appInstallStore.AddLogs(msg); err != nil {
+		m.logger.WithError(err).Error("add log")
+	}
+}
+
+func (m *appInstallManager) writeChartArchiveToTemp(chartArchive []byte) (string, error) {
+	tmpFile, err := os.CreateTemp("", "helm-chart-*.tgz")
+	if err != nil {
+		return "", fmt.Errorf("create temp file: %w", err)
+	}
+	defer tmpFile.Close()
+
+	if _, err := tmpFile.Write(chartArchive); err != nil {
+		os.Remove(tmpFile.Name())
+		return "", fmt.Errorf("write chart archive: %w", err)
+	}
+
+	return tmpFile.Name(), nil
 }

--- a/api/internal/managers/app/release/template.go
+++ b/api/internal/managers/app/release/template.go
@@ -128,7 +128,7 @@ func (m *appReleaseManager) dryRunHelmChart(ctx context.Context, templatedCR *ko
 	}
 
 	// Create a Helm client for dry run templating
-	helmClient, err := helm.NewClient(helm.HelmOptions{})
+	helmClient, err := helm.NewClient(helm.HelmOptions{}) // TODO: pass K0sVersion (maybe rename to kubernetesVersion)
 	if err != nil {
 		return nil, fmt.Errorf("create helm client: %w", err)
 	}

--- a/api/internal/managers/app/release/util.go
+++ b/api/internal/managers/app/release/util.go
@@ -62,7 +62,7 @@ func writeChartArchiveToTemp(chartArchive []byte) (string, error) {
 
 	// Write the chart archive to the temporary file
 	if _, err := tmpFile.Write(chartArchive); err != nil {
-		os.Remove(tmpFile.Name())
+		_ = os.Remove(tmpFile.Name())
 		return "", fmt.Errorf("write chart archive: %w", err)
 	}
 

--- a/proposals/helm_direct_install.md
+++ b/proposals/helm_direct_install.md
@@ -1,203 +1,55 @@
 # Proposal: Direct Helm Chart Installation for V3 API
 
-**Status**: Proposed  
-**Related**: Works in conjunction with KOTS skip deployment proposal (sc-128049)
+**Status:** Proposed
+**Epic Proposal:** [V3 App Deployment Transition](./v3_app_deployment_transition.md)
+**Story:** [sc-128045](https://app.shortcut.com/replicated/story/128045)
+**Iteration:** 1 (Foundation)
 
 ## TL;DR
-Enhance the V3 API app installation manager to deploy Helm charts directly from `releaseData.HelmChartArchives` before calling KOTS CLI, enabling the V3 installer to handle application deployment while maintaining KOTS functionality for upgrades and management.
 
-## The Problem
+Enhance the V3 API app installation manager to deploy Helm charts directly from releaseData.HelmChartArchives before calling KOTS CLI. This is the foundational story for transitioning application
+deployment ownership from KOTS to the V3 embedded-cluster binary.
 
-This proposal is an iterative step toward the larger architectural goal of controlling application lifecycle management outside the cluster through the embedded-cluster binary, while ensuring KOTS continues to function end-to-end during the transition.
+## Scope
 
-**Long-term vision**: Move application deployment and lifecycle management from in-cluster KOTS to the external embedded-cluster binary for better control, reliability, and user experience.
+This proposal covers only the basic Helm chart installation functionality needed for Iteration 1:
+- Add Helm client to V3 API installation manager
+- Install charts from releaseData.HelmChartArchives using default configuration
+- Coordinate with KOTS CLI for metadata management
 
-**Current iteration goal**: Enable the V3 embedded-cluster API to handle initial application deployment while allowing KOTS to seamlessly take over lifecycle management post-install. This iteration uses basic default configuration for all charts and does not yet integrate with HelmChart custom resources for chart-specific deployment configuration. This approach:
+**Out of scope for this story:**
+- HelmChart custom resource field support (covered in Iteration 2)
+- Airgap image handling (covered in Iteration 3)
+- Progress reporting UI (covered in Iteration 4)
 
-- **Maintains KOTS functionality**: Admin console, upgrades, configuration management remain intact
-- **Enables iterative development**: Allows V3 API development to proceed without breaking existing KOTS workflows  
-- **Preserves upgrade path**: KOTS can manage subsequent deployments after initial install
-- **Reduces scope**: Smaller, manageable change that keeps the system working end-to-end
-- **Establishes foundation**: Core deployment mechanism can be enhanced with HelmChart custom resource integration in future iterations
+See the [epic proposal](./v3_app_deployment_transition.md) for the complete implementation plan and architectural vision.
 
-**Current technical problem**: The V3 API installation manager delegates entirely to KOTS CLI for application deployment, preventing direct control over Helm chart installation. We need the V3 API to deploy charts directly using existing `releaseData.HelmChartArchives` data while maintaining coordination with KOTS CLI.
+## Implementation
 
-**Evidence**: V3 API development requires this separation to proceed with external lifecycle management while keeping KOTS operational for existing features. The complementary KOTS skip deployment proposal (sc-128049) will prevent double deployment conflicts.
+**Core Changes:**
+- `api/internal/managers/app/install/manager.go` - Add Helm client field and constructor options
+- `api/internal/managers/app/install/install.go` - Add `installHelmCharts()` method before KOTS CLI call
+- `api/internal/managers/app/install/util.go` - Add Helm client setup utilities
 
-## Prototype / Design
-
-The solution introduces direct Helm chart deployment in the V3 API installation flow:
-
-```
-┌─────────────────┐
-│  V3 Install API │
-└────────┬────────┘
-         │
-         ▼
-┌─────────────────┐     ┌──────────────────┐
-│ Setup Helm      │────▶│ Install Charts   │
-│ Client          │     │ from ReleaseData │
-└─────────────────┘     └──────────┬───────┘
-                                   │
-                                   ▼
-                        ┌──────────────────┐
-                        │ Call KOTS CLI    │
-                        │ SkipPreflights   │
-                        └──────────────────┘
-```
-
-**Flow Details**:
-1. **Setup Helm client** following infra manager patterns
-2. **Install charts** directly from `releaseData.HelmChartArchives` 
-3. **Call KOTS CLI** with `SkipPreflights: true` for metadata management
-4. **Fail fast** on errors without complex rollback logic
-
-**Coordination with KOTS**: The complementary KOTS skip deployment proposal (sc-128049) ensures KOTS doesn't attempt chart deployment when called by V3 API, preventing resource conflicts.
-
-## Key Technical Decisions
-
-### 1. No Complex Rollback Logic
-- **Decision**: Return errors immediately on Helm failures
-- **Rationale**: Simplicity, reliability, aligns with existing error handling patterns
-- **Risk**: Partial installations possible, but consistent with current behavior
-
-### 2. V3 API Isolation
-- **Decision**: Only apply changes to V3 API installations  
-- **Rationale**: Zero risk to existing production installations
-- **Benefit**: Can iterate and improve without backward compatibility concerns
-
-### 3. Leverage Existing Infrastructure
-- **Decision**: Reuse infra manager patterns for Helm client setup
-- **Rationale**: Proven patterns, consistent codebase, reduced development time
-- **Benefit**: Familiar debugging and monitoring approaches
-
-## Implementation Plan
-
-### Files to Modify
-
-**Core Changes**:
-- `api/internal/managers/app/install/manager.go` - Add Helm client fields and constructor options
-- `api/internal/managers/app/install/install.go` - Update install() method to call Helm before KOTS CLI  
-- `api/internal/managers/app/install/util.go` - Move utility functions following code organization patterns
-
-**Test Updates**:
-- `api/internal/managers/app/install/install_test.go` - Enhance unit tests with Helm client mocks
-- `api/integration/kubernetes/install/appinstall_test.go` - Update integration tests with unified releaseData
-- `api/integration/linux/install/appinstall_test.go` - Update integration tests with unified releaseData
-
-### Toggle Strategy
-
-**V3 API Only**: Change only applies to V3 API installations
-- No feature flags or environment variables required
-- Clear architectural boundary with existing installations
-- Zero impact on current production deployments
-
-### External Contracts
-
-No changes to external APIs or events:
-- Same request/response structure for `/install/app` endpoint
-- Version record format unchanged  
-- API contracts preserved
-
-## Risk Assessment
-
-### Technical Risks
-| Risk | Probability | Impact | Mitigation |
-|------|-------------|--------|------------|
-| Helm client integration issues | Low | Medium | Leverage proven infra manager patterns |
-| Chart installation failures | Medium | Medium | Fail fast, clear error messages |
-| KOTS CLI coordination issues | Low | High | Maintain existing KOTS CLI integration |
-
-### Business Risks
-| Risk | Probability | Impact | Mitigation |
-|------|-------------|--------|------------|
-| V3 API deployment regressions | Low | High | Comprehensive testing, V3-only scope |
-| Increased complexity | Low | Medium | Follow existing patterns, minimal changes |
-| Support burden | Low | Low | Component-specific logging, familiar patterns |
+**Key Technical Decisions:**
+1. **Basic Chart Installation Only:** Use chart name as release name, install to kotsadm namespace
+2. **Sequential Processing:** Install charts one at a time for reliability
+3. **No Rollback Logic:** Fail fast on errors, consistent with existing patterns
 
 ## Testing
 
-### Unit Tests
-- Enhance `TestAppInstallManager_Install` test cases to include Helm client mocks
-- Add test coverage for Helm chart installation and error handling  
-- Update test data to use unified `releaseData` structure with `HelmChartArchives`
-- Verify both successful installation and error scenarios
+- Unit tests with Helm client mocks in `install_test.go`
+- Integration tests using unified releaseData structure
+- Compatibility verification that non-V3 installations remain unchanged
 
-### Integration Tests  
-- Modify `TestPostInstallApp` tests to use `releaseData` with Helm chart archives
-- Ensure all test cases use consistent release data structure
-- Validate V3 API installation flow with direct Helm charts
+## Dependencies
 
-### Compatibility Tests
-- Non-V3 installations will continue to work unchanged
-- Existing V3 API functionality will be preserved
-- KOTS CLI integration will be maintained
+- Requires KOTS skip deployment changes (sc-128049) to prevent conflicts
+- Foundation for HelmChart custom resource support in Iteration 2
 
-## Backward Compatibility
-
-**Fully backward compatible**:
-- Only affects V3 API installations 
-- All existing installation types unchanged
-- KOTS CLI integration preserved for metadata management
-- API contracts preserved
-
-**Forward compatibility**:
-- V3 installations can upgrade to future versions normally
-- Foundation for additional V3 API enhancements
-- Maintains KOTS functionality for long-term management
-
-## Trade-offs
-
-**Optimizing for**: Clean separation of concerns between KOTS and V3 installer while maintaining end-to-end functionality
-
-**Trade-offs made**:
-
-1. **Complexity**: Adding Helm deployment logic to V3 API installation flow
-   - **Mitigation**: Will leverage proven infra manager patterns, well-isolated changes
-   
-2. **Testing surface**: Need to test both V3 API Helm deployment and KOTS CLI coordination  
-   - **Mitigation**: Will implement comprehensive test coverage for both integration points
-   
-3. **Sequential processing**: Charts will be installed one at a time vs parallel installation
-   - **Mitigation**: Simpler, more reliable approach; can optimize later if needed
-   
-4. **No rollback logic**: Helm failures will result in partial installations
-   - **Mitigation**: Fail fast approach aligns with existing error handling patterns
-
-## Alternative Solutions Considered
-
-### 1. Remove KOTS from V3 Entirely
-- **Rejected**: Need admin console for upgrades and management for now
-- Would require significant changes and is out of scope for this iteration
-
-### 2. New Installation Interface
-- **Rejected**: User noted no new methods needed, just update existing Install method
-- Would increase API surface area unnecessarily  
-
-### 3. Parallel Chart Installation  
-- **Deferred**: Sequential approach simpler and more reliable initially
-- Can optimize for parallel installation in future iterations
-
-## Checkpoints (PR Plan)
-
-### Single PR: Complete Implementation
-**Scope**: 
-- Add Helm client to appInstallManager struct with constructor options
-- Update install() method to call Helm installation before KOTS CLI
-- Move utility functions to util.go following code organization patterns  
-- Enhance unit tests with Helm client mocks and error scenarios
-- Update integration tests to use unified releaseData structure
-- Document component logging approach
-
-The change is isolated enough that breaking it into multiple PRs would add unnecessary overhead without improving reviewability.
-
-## Research
-
-### Prior Art in Codebase
-- **Helm Client Setup**: `api/internal/managers/linux/infra/util.go` patterns for Helm client initialization
-- **Component Logging**: `api/internal/managers/linux/infra/util.go` patterns for structured logging
-- **Release Data**: Using existing `releaseData.HelmChartArchives` data structure
-
-### External References  
-- [Helm Go SDK Documentation](https://helm.sh/docs/topics/advanced/#go-sdk)
-- [KOTS CLI Architecture](https://docs.replicated.com/reference/kots-cli-install)
+The key changes:
+1. Reduced scope - Focus only on the basic Helm installation for this specific story
+2. Clear references - Point to the epic proposal for the bigger picture
+3. Iteration context - Explicitly state this is Iteration 1 foundation work
+4. Dependencies - Clear about what this depends on and enables
+5. Removed duplicate content - Architecture, risk assessment, etc. are in the epic proposal

--- a/proposals/helm_direct_install.md
+++ b/proposals/helm_direct_install.md
@@ -1,0 +1,203 @@
+# Proposal: Direct Helm Chart Installation for V3 API
+
+**Status**: Proposed  
+**Related**: Works in conjunction with KOTS skip deployment proposal (sc-128049)
+
+## TL;DR
+Enhance the V3 API app installation manager to deploy Helm charts directly from `releaseData.HelmChartArchives` before calling KOTS CLI, enabling the V3 installer to handle application deployment while maintaining KOTS functionality for upgrades and management.
+
+## The Problem
+
+This proposal is an iterative step toward the larger architectural goal of controlling application lifecycle management outside the cluster through the embedded-cluster binary, while ensuring KOTS continues to function end-to-end during the transition.
+
+**Long-term vision**: Move application deployment and lifecycle management from in-cluster KOTS to the external embedded-cluster binary for better control, reliability, and user experience.
+
+**Current iteration goal**: Enable the V3 embedded-cluster API to handle initial application deployment while allowing KOTS to seamlessly take over lifecycle management post-install. This iteration uses basic default configuration for all charts and does not yet integrate with HelmChart custom resources for chart-specific deployment configuration. This approach:
+
+- **Maintains KOTS functionality**: Admin console, upgrades, configuration management remain intact
+- **Enables iterative development**: Allows V3 API development to proceed without breaking existing KOTS workflows  
+- **Preserves upgrade path**: KOTS can manage subsequent deployments after initial install
+- **Reduces scope**: Smaller, manageable change that keeps the system working end-to-end
+- **Establishes foundation**: Core deployment mechanism can be enhanced with HelmChart custom resource integration in future iterations
+
+**Current technical problem**: The V3 API installation manager delegates entirely to KOTS CLI for application deployment, preventing direct control over Helm chart installation. We need the V3 API to deploy charts directly using existing `releaseData.HelmChartArchives` data while maintaining coordination with KOTS CLI.
+
+**Evidence**: V3 API development requires this separation to proceed with external lifecycle management while keeping KOTS operational for existing features. The complementary KOTS skip deployment proposal (sc-128049) will prevent double deployment conflicts.
+
+## Prototype / Design
+
+The solution introduces direct Helm chart deployment in the V3 API installation flow:
+
+```
+┌─────────────────┐
+│  V3 Install API │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐     ┌──────────────────┐
+│ Setup Helm      │────▶│ Install Charts   │
+│ Client          │     │ from ReleaseData │
+└─────────────────┘     └──────────┬───────┘
+                                   │
+                                   ▼
+                        ┌──────────────────┐
+                        │ Call KOTS CLI    │
+                        │ SkipPreflights   │
+                        └──────────────────┘
+```
+
+**Flow Details**:
+1. **Setup Helm client** following infra manager patterns
+2. **Install charts** directly from `releaseData.HelmChartArchives` 
+3. **Call KOTS CLI** with `SkipPreflights: true` for metadata management
+4. **Fail fast** on errors without complex rollback logic
+
+**Coordination with KOTS**: The complementary KOTS skip deployment proposal (sc-128049) ensures KOTS doesn't attempt chart deployment when called by V3 API, preventing resource conflicts.
+
+## Key Technical Decisions
+
+### 1. No Complex Rollback Logic
+- **Decision**: Return errors immediately on Helm failures
+- **Rationale**: Simplicity, reliability, aligns with existing error handling patterns
+- **Risk**: Partial installations possible, but consistent with current behavior
+
+### 2. V3 API Isolation
+- **Decision**: Only apply changes to V3 API installations  
+- **Rationale**: Zero risk to existing production installations
+- **Benefit**: Can iterate and improve without backward compatibility concerns
+
+### 3. Leverage Existing Infrastructure
+- **Decision**: Reuse infra manager patterns for Helm client setup
+- **Rationale**: Proven patterns, consistent codebase, reduced development time
+- **Benefit**: Familiar debugging and monitoring approaches
+
+## Implementation Plan
+
+### Files to Modify
+
+**Core Changes**:
+- `api/internal/managers/app/install/manager.go` - Add Helm client fields and constructor options
+- `api/internal/managers/app/install/install.go` - Update install() method to call Helm before KOTS CLI  
+- `api/internal/managers/app/install/util.go` - Move utility functions following code organization patterns
+
+**Test Updates**:
+- `api/internal/managers/app/install/install_test.go` - Enhance unit tests with Helm client mocks
+- `api/integration/kubernetes/install/appinstall_test.go` - Update integration tests with unified releaseData
+- `api/integration/linux/install/appinstall_test.go` - Update integration tests with unified releaseData
+
+### Toggle Strategy
+
+**V3 API Only**: Change only applies to V3 API installations
+- No feature flags or environment variables required
+- Clear architectural boundary with existing installations
+- Zero impact on current production deployments
+
+### External Contracts
+
+No changes to external APIs or events:
+- Same request/response structure for `/install/app` endpoint
+- Version record format unchanged  
+- API contracts preserved
+
+## Risk Assessment
+
+### Technical Risks
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|------------|
+| Helm client integration issues | Low | Medium | Leverage proven infra manager patterns |
+| Chart installation failures | Medium | Medium | Fail fast, clear error messages |
+| KOTS CLI coordination issues | Low | High | Maintain existing KOTS CLI integration |
+
+### Business Risks
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|------------|
+| V3 API deployment regressions | Low | High | Comprehensive testing, V3-only scope |
+| Increased complexity | Low | Medium | Follow existing patterns, minimal changes |
+| Support burden | Low | Low | Component-specific logging, familiar patterns |
+
+## Testing
+
+### Unit Tests
+- Enhance `TestAppInstallManager_Install` test cases to include Helm client mocks
+- Add test coverage for Helm chart installation and error handling  
+- Update test data to use unified `releaseData` structure with `HelmChartArchives`
+- Verify both successful installation and error scenarios
+
+### Integration Tests  
+- Modify `TestPostInstallApp` tests to use `releaseData` with Helm chart archives
+- Ensure all test cases use consistent release data structure
+- Validate V3 API installation flow with direct Helm charts
+
+### Compatibility Tests
+- Non-V3 installations will continue to work unchanged
+- Existing V3 API functionality will be preserved
+- KOTS CLI integration will be maintained
+
+## Backward Compatibility
+
+**Fully backward compatible**:
+- Only affects V3 API installations 
+- All existing installation types unchanged
+- KOTS CLI integration preserved for metadata management
+- API contracts preserved
+
+**Forward compatibility**:
+- V3 installations can upgrade to future versions normally
+- Foundation for additional V3 API enhancements
+- Maintains KOTS functionality for long-term management
+
+## Trade-offs
+
+**Optimizing for**: Clean separation of concerns between KOTS and V3 installer while maintaining end-to-end functionality
+
+**Trade-offs made**:
+
+1. **Complexity**: Adding Helm deployment logic to V3 API installation flow
+   - **Mitigation**: Will leverage proven infra manager patterns, well-isolated changes
+   
+2. **Testing surface**: Need to test both V3 API Helm deployment and KOTS CLI coordination  
+   - **Mitigation**: Will implement comprehensive test coverage for both integration points
+   
+3. **Sequential processing**: Charts will be installed one at a time vs parallel installation
+   - **Mitigation**: Simpler, more reliable approach; can optimize later if needed
+   
+4. **No rollback logic**: Helm failures will result in partial installations
+   - **Mitigation**: Fail fast approach aligns with existing error handling patterns
+
+## Alternative Solutions Considered
+
+### 1. Remove KOTS from V3 Entirely
+- **Rejected**: Need admin console for upgrades and management for now
+- Would require significant changes and is out of scope for this iteration
+
+### 2. New Installation Interface
+- **Rejected**: User noted no new methods needed, just update existing Install method
+- Would increase API surface area unnecessarily  
+
+### 3. Parallel Chart Installation  
+- **Deferred**: Sequential approach simpler and more reliable initially
+- Can optimize for parallel installation in future iterations
+
+## Checkpoints (PR Plan)
+
+### Single PR: Complete Implementation
+**Scope**: 
+- Add Helm client to appInstallManager struct with constructor options
+- Update install() method to call Helm installation before KOTS CLI
+- Move utility functions to util.go following code organization patterns  
+- Enhance unit tests with Helm client mocks and error scenarios
+- Update integration tests to use unified releaseData structure
+- Document component logging approach
+
+The change is isolated enough that breaking it into multiple PRs would add unnecessary overhead without improving reviewability.
+
+## Research
+
+### Prior Art in Codebase
+- **Helm Client Setup**: `api/internal/managers/linux/infra/util.go` patterns for Helm client initialization
+- **Component Logging**: `api/internal/managers/linux/infra/util.go` patterns for structured logging
+- **Release Data**: Using existing `releaseData.HelmChartArchives` data structure
+
+### External References  
+- [Helm Go SDK Documentation](https://helm.sh/docs/topics/advanced/#go-sdk)
+- [KOTS CLI Architecture](https://docs.replicated.com/reference/kots-cli-install)

--- a/proposals/helm_direct_install_research.md
+++ b/proposals/helm_direct_install_research.md
@@ -1,0 +1,160 @@
+# Research: Direct Helm Chart Installation Without KOTS CLI
+
+## Executive Summary
+This research document analyzes the current implementation and identifies key areas for modifying the app install endpoint to install Helm charts directly while maintaining KOTS CLI for version record creation.
+
+## Current Architecture
+
+### 1. Installation Flow
+The current installation flow follows this sequence:
+1. `/kubernetes/install/app/install` endpoint receives request
+2. `InstallController.InstallApp()` validates state transitions
+3. `AppInstallManager.Install()` invokes KOTS CLI
+4. KOTS CLI handles entire installation including:
+   - Creating version records
+   - Installing Helm charts
+   - Managing application state
+
+### 2. Key Components
+
+#### AppInstallManager (`api/internal/managers/app/install/`)
+- Primary interface for app installation
+- Current implementation delegates entirely to KOTS CLI via `kotscli.Install()`
+- Manages installation status and logging
+
+#### KOTS CLI Integration (`cmd/installer/kotscli/kotscli.go`)
+- `Install()` function executes kubectl-kots binary
+- Passes configuration via command-line arguments
+- Handles both online and airgap installations
+
+#### Release Data (`pkg/release/release.go`)
+- Contains `ReleaseData` struct with `HelmChartArchives [][]byte`
+- Helm charts are already extracted and available in memory
+- Also contains `HelmChartCRs [][]byte` for Helm chart custom resources
+
+#### Helm Client (`pkg/helm/client.go`)
+- Existing robust Helm client implementation
+- Supports install, upgrade, uninstall operations
+- Already used throughout the codebase for addon installation
+
+## Technical Analysis
+
+### 1. Available Helm Chart Data
+The `ReleaseData` structure already contains:
+```go
+type ReleaseData struct {
+    // ... other fields
+    HelmChartCRs      [][]byte  // Helm chart custom resources
+    HelmChartArchives [][]byte  // Actual Helm chart archives
+}
+```
+
+### 2. Existing Helm Infrastructure
+The codebase has a complete Helm client implementation that:
+- Supports chart installation from archives
+- Handles namespace creation
+- Manages releases
+- Provides timeout and retry logic
+
+### 3. KOTS CLI Invocation Pattern
+Current KOTS CLI invocation uses these key parameters:
+- `--exclude-admin-console`: Already excludes admin console deployment
+- `--app-version-label`: Version tracking
+- `--config-values`: Application configuration
+- `--skip-preflights`: Conditionally skip preflight checks
+
+## Implementation Considerations
+
+### 1. Dual Path Architecture
+Need to implement:
+- KOTS CLI path: Version record creation only (coordinated with sc-128049)
+- Direct Helm path: Actual chart deployment
+
+### 2. Chart Installation Requirements
+- Extract charts from `HelmChartArchives`
+- Apply configuration values
+- Maintain proper installation order
+- Handle dependencies
+
+### 3. State Management
+- Coordinate state transitions between KOTS and Helm operations
+- Handle partial failures
+- Implement rollback capabilities
+
+### 4. Configuration Mapping
+- Transform KOTS config values to Helm values
+- Handle templating requirements
+- Manage secrets and sensitive data
+
+## Identified Challenges
+
+### 1. Coordination with sc-128049
+- Need to ensure KOTS CLI changes are compatible
+- Timing of deployment between stories
+- Feature flag or version detection strategy
+
+### 2. Error Handling Complexity
+- Dual-path failures (KOTS success, Helm failure)
+- Partial installation states
+- Recovery mechanisms
+
+### 3. Backward Compatibility
+- Support for existing installations
+- Migration path for current deployments
+- Feature detection and gradual rollout
+
+### 4. Observability
+- Logging across two systems
+- Metrics collection
+- Debugging capabilities
+
+## Key Files to Modify
+
+### Primary Changes
+1. `api/internal/managers/app/install/install.go` - Core installation logic
+2. `api/internal/managers/app/install/manager.go` - Manager interface updates
+3. `cmd/installer/kotscli/kotscli.go` - KOTS CLI invocation modifications
+
+### Supporting Changes
+1. `api/internal/handlers/kubernetes/install.go` - Endpoint handlers
+2. `api/controllers/app/install/install.go` - Controller logic
+3. Configuration and test files
+
+## Dependencies and Risks
+
+### Dependencies
+- Story sc-128049 (KOTS CLI modification)
+- Existing Helm client functionality
+- Release data structure
+
+### Risks
+1. **High Risk**: Dual deployment path complexity
+2. **Medium Risk**: State synchronization issues
+3. **Medium Risk**: Rollback complexity
+4. **Low Risk**: Performance impact
+
+## Recommendations
+
+### 1. Phased Implementation
+- Phase 1: Add Helm installation capability alongside KOTS
+- Phase 2: Modify KOTS CLI invocation (with sc-128049)
+- Phase 3: Full integration and testing
+
+### 2. Feature Flag Strategy
+- Implement feature flag for gradual rollout
+- Allow fallback to original behavior
+- Enable A/B testing in production
+
+### 3. Comprehensive Testing
+- Unit tests for new Helm installation logic
+- Integration tests for dual-path scenario
+- E2E tests for complete workflow
+- Rollback scenario testing
+
+### 4. Monitoring Strategy
+- Add detailed logging at each step
+- Implement metrics for success/failure rates
+- Create dashboards for deployment monitoring
+
+## Conclusion
+The architecture supports this change with existing Helm infrastructure and available chart data. The primary complexity lies in coordinating the dual deployment paths and ensuring proper state management. A phased approach with feature flags and comprehensive testing will minimize risk.

--- a/proposals/v3_app_deployment_transition.md
+++ b/proposals/v3_app_deployment_transition.md
@@ -1,0 +1,204 @@
+# Proposal: Transition Application Deployment to V3 Embedded-Cluster
+
+**Status:** Proposed
+**Epic:** [Installer Experience v2 - Milestone 7](https://app.shortcut.com/replicated/epic/126565)
+**Related Stories:** sc-128045, sc-128049
+
+## TL;DR
+
+Transition application deployment from KOTS to the V3 embedded-cluster binary to deliver Helm charts directly through our installer instead of KOTS. This enables better control, reliability, and
+user experience while maintaining KOTS functionality for upgrades and management, delivered through iterative milestones.
+
+## The Problem
+
+This proposal addresses the larger architectural goal of controlling application lifecycle management outside the cluster through the embedded-cluster binary, while ensuring KOTS continues to
+function end-to-end during the transition.
+
+**Long-term vision:** Move entire application deployment and lifecycle management from in-cluster KOTS to the external embedded-cluster binary for better control, reliability, and user experience.
+
+**Current iteration goal:** Enable the V3 embedded-cluster binary to handle initial application deployment with full HelmChart resource support while allowing KOTS to seamlessly take over lifecycle
+management post-install.
+
+**Current technical problem:** The V3 API installation manager delegates entirely to KOTS CLI for application deployment, preventing direct control over Helm chart installation and HelmChart custom
+resource configuration. Both KOTS and the V3 installer attempt to deploy applications during initial install, creating resource conflicts and unclear ownership.
+
+## Prototype / Design
+
+The solution transitions application deployment from KOTS to the V3 embedded-cluster binary:
+
+┌─────────────────┐
+│  V3 Install API │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐     ┌──────────────────┐
+│ Setup Helm      │────▶│ Install Charts   │
+│ Client          │     │ (V3 Binary)      │
+└─────────────────┘     └──────────┬───────┘
+                                    │
+                                    ▼
+                        ┌──────────────────┐
+                        │ Call KOTS CLI    │
+                        │ (Skip Deploy)    │
+                        └──────────────────┘
+
+**Flow Details:**
+1. V3 binary takes ownership of application deployment
+2. Setup Helm client following infra manager patterns
+3. Install charts directly from releaseData.HelmChartArchives with full HelmChart custom resource support
+4. Call KOTS CLI with SkipDeploy: true for metadata management only
+5. Fail fast on errors without complex rollback logic
+
+**KOTS Coordination:** KOTS skips application deployment during V3 initial installs when `EMBEDDED_CLUSTER_V3=true` environment variable is set, preventing resource conflicts while maintaining
+version records and metadata.
+
+## Implementation Plan
+
+### Iteration 1: Core Deployment Transition (Stories sc-128045, sc-128049)
+- **V3 Binary Takes Ownership**
+   - Add Helm client to appInstallManager with constructor options
+   - Update install() method to deploy charts before KOTS CLI
+   - Implement chart installation from releaseData.HelmChartArchives
+
+- **KOTS Delegates to V3**
+   - Modify KOTS DeployApp() to skip deployment for V3 EC initial installs
+   - Maintain version records and metadata creation
+   - Add V3 detection via EMBEDDED_CLUSTER_V3 environment variable
+
+### Iteration 2: Full HelmChart Resource Implementation
+- **HelmChart Fields**
+   - Support namespace field configuration (sc-128055)
+   - Support exclude field for conditional chart deployment (sc-128056)
+   - Support chart weight ordering for installation sequence (sc-128057)
+   - Support helmUpgradeFlags for deployment customization (sc-128058)
+   - Support releaseName field customization (sc-128062)
+   - Support values and optionalValues field configuration (sc-128065)
+
+### Iteration 3: Complete Airgap Transition
+- **V3 Binary Handles Airgap**
+   - Push airgap images from bundle to EC registry without KOTS (sc-128061)
+   - Create image pull secrets for applications (sc-128059)
+   - Add support for image pull secret template functions (sc-128060)
+
+### Iteration 4: Enhanced User Experience
+- **V3 Binary Progress Reporting**
+   - Update app install status endpoint to return chart installation progress (sc-128046)
+   - Update installation page UI to show charts being installed with progress (sc-128047)
+
+## Key Technical Decisions
+
+1. **V3 Binary Ownership**
+   - **Decision:** V3 embedded-cluster binary takes full ownership of application deployment
+   - **Rationale:** Enables better control, reliability, and iterative improvement outside KOTS
+
+2. **KOTS Delegation Model**
+   - **Decision:** KOTS delegates deployment to V3 binary but maintains metadata management
+   - **Rationale:** Preserves KOTS functionality for upgrades while transitioning deployment control
+
+3. **V3 API Isolation**
+   - **Decision:** Only apply changes to V3 API installations
+   - **Rationale:** Zero risk to existing production installations
+   - **Benefit:** Can iterate and improve without backward compatibility concerns
+
+4. **Environment Variable Toggle**
+   - **Decision:** Use EMBEDDED_CLUSTER_V3 environment variable for detection
+   - **Rationale:** Clear delegation mechanism, no feature flags required
+
+## Files to Modify
+
+**Core Changes:**
+- `api/internal/managers/app/install/manager.go` - Add Helm client fields and constructor options
+- `api/internal/managers/app/install/install.go` - Update install() method to call Helm before KOTS CLI
+- `api/internal/managers/app/install/util.go` - Move utility functions following code organization patterns
+- `pkg/operator/operator.go` - Modify DeployApp() function to skip deployment for V3 EC initial installs
+- `pkg/util/util.go` - Add V3 detection utilities
+
+**Test Updates:**
+- `api/internal/managers/app/install/install_test.go` - Enhance unit tests with Helm client mocks
+- `api/integration/kubernetes/install/appinstall_test.go` - Update integration tests with unified releaseData
+- `api/integration/linux/install/appinstall_test.go` - Update integration tests with unified releaseData
+- `pkg/operator/operator_test.go` - Add unit tests for V3 detection logic
+
+## External Contracts
+
+No changes to external APIs or events:
+- Same request/response structure for `/install/app` endpoint
+- Version record format unchanged
+- API contracts preserved
+
+## Risk Assessment
+
+**Technical Risks:**
+- V3 binary deployment integration issues (Low probability, Medium impact)
+- Chart installation failures (Medium probability, Medium impact)
+- KOTS delegation coordination issues (Low probability, High impact)
+
+**Business Risks:**
+- V3 deployment regressions (Low probability, High impact)
+- Increased complexity during transition (Low probability, Medium impact)
+- Support burden during dual-mode operation (Low probability, Low impact)
+
+## Testing
+
+**Unit Tests:**
+- Enhance TestAppInstallManager_Install with Helm client mocks
+- Test coverage for V3 binary chart installation and error handling
+- V3 detection logic and initial install vs upgrade scenarios
+
+**Integration Tests:**
+- Modify TestPostInstallApp tests to validate V3 binary deployment
+- Validate V3 API installation flow with direct Helm charts
+- Ensure HelmChart custom resource fields are respected by V3 binary
+
+**Compatibility Tests:**
+- Non-V3 installations continue to work unchanged (KOTS deployment)
+- Existing V3 API functionality preserved
+- KOTS CLI integration maintained for metadata management
+
+## Backward Compatibility
+
+Fully backward compatible:
+- Only affects V3 API installations when EMBEDDED_CLUSTER_V3=true
+- All existing installation types unchanged (continue using KOTS deployment)
+- KOTS CLI integration preserved for metadata management
+- API contracts preserved
+
+## Trade-offs
+
+**Optimizing for:** Complete transition of application deployment ownership from KOTS to V3 embedded-cluster binary while maintaining end-to-end functionality
+
+**Trade-offs made:**
+- **Deployment Ownership Split:** V3 binary handles deployment, KOTS handles metadata
+   - *Mitigation:* Clear delegation model with environment variable detection
+- **Testing surface:** Need to test both V3 binary deployment and KOTS delegation
+   - *Mitigation:* Comprehensive test coverage for both integration points
+- **Sequential processing:** Charts installed one at a time vs parallel installation
+   - *Mitigation:* Simpler, more reliable approach; can optimize later if needed
+- **Transition complexity:** Dual-mode operation during migration period
+   - *Mitigation:* Clear boundaries and comprehensive testing
+
+## Alternative Solutions Considered
+
+1. **Remove KOTS from V3 Entirely**
+   - *Rejected:* Need admin console for upgrades and management
+   - Would require significant changes beyond epic scope
+
+2. **Gradual Feature Migration**
+   - *Rejected:* Creates more complexity than clean delegation model
+   - Would increase API surface area unnecessarily
+
+3. **New Installation Interface**
+   - *Rejected:* User noted no new methods needed, just update existing Install method
+   - Clean delegation model achieves the same goal
+
+## Research
+
+**Prior Art in Codebase:**
+- Helm Client Setup: `api/internal/managers/linux/infra/util.go` patterns for Helm client initialization
+- Component Logging: `api/internal/managers/linux/infra/util.go` patterns for structured logging
+- Release Data: Using existing `releaseData.HelmChartArchives` data structure
+
+**External References:**
+- Helm Go SDK Documentation
+- KOTS CLI Architecture
+- Kubernetes operator deployment strategies


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Installs Helm charts directly without relying on the KOTS CLI

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-128045](https://app.shortcut.com/replicated/story/128045)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Yes

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE