### PR TITLE
chore(ci): allow for specifying alternative image repo for dev env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ go.work.sum
 *.tmp
 .envrc
 .DS_Store
+.vscode
 
 # Ignore preflight bundles generated during local dev
 preflightbundle*

--- a/Makefile
+++ b/Makefile
@@ -177,10 +177,10 @@ output/bins/kubectl-kots-%:
 output/bins/kubectl-kots-override:
 	mkdir -p output/bins
 	mkdir -p output/tmp
-	if [[ "$(KOTS_BINARY_URL_OVERRIDE)" == ttl.sh* ]]; then \
-		oras pull "$(KOTS_BINARY_URL_OVERRIDE)" --output output/tmp ; \
-	else \
+	if [[ "$(KOTS_BINARY_URL_OVERRIDE)" == http://* ]] || [[ "$(KOTS_BINARY_URL_OVERRIDE)" == https://* ]]; then \
 		curl --retry 5 --retry-all-errors -fL -o output/tmp/kots.tar.gz "$(KOTS_BINARY_URL_OVERRIDE)" ; \
+	else \
+		oras pull "$(KOTS_BINARY_URL_OVERRIDE)" --output output/tmp ; \
 	fi
 	tar -xzf output/tmp/kots.tar.gz -C output/tmp
 	mv output/tmp/kots $@

--- a/local-artifact-mirror/Makefile
+++ b/local-artifact-mirror/Makefile
@@ -88,9 +88,8 @@ build-and-push-local-artifact-mirror-image-dockerfile: build-local-artifact-mirr
 	docker push "$(IMAGE_NAME):$(call image-tag,$(PACKAGE_VERSION))"
 
 .PHONY: build-ttl.sh
-build-ttl.sh:
-	@$(MAKE) build-and-push-local-artifact-mirror-image \
-		IMAGE_NAME=ttl.sh/$(CURRENT_USER)/embedded-cluster-local-artifact-mirror
+build-ttl.sh: IMAGE_NAME = ttl.sh/$(CURRENT_USER)/embedded-cluster-local-artifact-mirror
+build-ttl.sh: build-and-push-local-artifact-mirror-image
 
 .PHONY: clean
 clean:

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -227,15 +227,13 @@ build-chart:
 	echo "$(CHART_REMOTE)/embedded-cluster-operator:$(CHART_VERSION)" > build/chart
 
 .PHONY: build-ttl.sh
-build-ttl.sh:
-	@$(MAKE) build-and-push-operator-image \
-		IMAGE_NAME=ttl.sh/$(CURRENT_USER)/embedded-cluster-operator-image
+build-ttl.sh: IMAGE_NAME = ttl.sh/$(CURRENT_USER)/embedded-cluster-operator-image
+build-ttl.sh: build-and-push-operator-image
 
 .PHONY: build-chart-ttl.sh
-build-chart-ttl.sh:
-	@$(MAKE) build-chart \
-		IMAGE_NAME=ttl.sh/$(CURRENT_USER)/embedded-cluster-operator-image \
-		CHART_REMOTE=oci://ttl.sh/$(CURRENT_USER)
+build-chart-ttl.sh: IMAGE_NAME = ttl.sh/$(CURRENT_USER)/embedded-cluster-operator-image
+build-chart-ttl.sh: CHART_REMOTE = oci://ttl.sh/$(CURRENT_USER)
+build-chart-ttl.sh: build-chart
 
 .PHONY: clean
 clean:

--- a/scripts/ci-build-deps.sh
+++ b/scripts/ci-build-deps.sh
@@ -7,6 +7,8 @@ set -euo pipefail
 
 EC_VERSION=${EC_VERSION:-}
 USE_CHAINGUARD=${USE_CHAINGUARD:-1}
+OPERATOR_IMAGE_NAME=${OPERATOR_IMAGE_NAME:-}
+LOCAL_ARTIFACT_MIRROR_IMAGE_NAME=${LOCAL_ARTIFACT_MIRROR_IMAGE_NAME:-}
 
 function init_vars() {
     if [ -z "${EC_VERSION:-}" ]; then
@@ -17,14 +19,28 @@ function init_vars() {
 }
 
 function local_artifact_mirror() {
-    make -C local-artifact-mirror build-ttl.sh 2>&1 | prefix_output "LAM"
+    if [ -n "$LOCAL_ARTIFACT_MIRROR_IMAGE_NAME" ]; then
+        make -C local-artifact-mirror build-ttl.sh \
+            IMAGE_NAME="$LOCAL_ARTIFACT_MIRROR_IMAGE_NAME" \
+            | prefix_output "LAM"
+    else
+        make -C local-artifact-mirror build-ttl.sh \
+            | prefix_output "LAM"
+    fi
     cp local-artifact-mirror/build/image "local-artifact-mirror/build/image-$EC_VERSION"
 }
 
 function operator() {
-    make -C operator build-ttl.sh build-chart-ttl.sh \
-        PACKAGE_VERSION="$EC_VERSION" \
-        VERSION="$EC_VERSION" 2>&1 | prefix_output "OPERATOR"
+    if [ -n "$OPERATOR_IMAGE_NAME" ]; then
+        make -C operator build-ttl.sh build-chart-ttl.sh \
+            IMAGE_NAME="$OPERATOR_IMAGE_NAME" \
+            PACKAGE_VERSION="$EC_VERSION" \
+            VERSION="$EC_VERSION" 2>&1 | prefix_output "OPERATOR"
+    else
+        make -C operator build-ttl.sh build-chart-ttl.sh \
+            PACKAGE_VERSION="$EC_VERSION" \
+            VERSION="$EC_VERSION" 2>&1 | prefix_output "OPERATOR"
+    fi
     cp operator/build/image "operator/build/image-$EC_VERSION"
     cp operator/build/chart "operator/build/chart-$EC_VERSION"
 }

--- a/scripts/ci-upload-binaries.sh
+++ b/scripts/ci-upload-binaries.sh
@@ -114,11 +114,11 @@ function kotsbin() {
 
     if [ -n "${kots_url_override}" ]; then
         echo "KOTS_BINARY_URL_OVERRIDE is set to '${kots_url_override}', using that source"
-        if [[ "${kots_url_override}" == ttl.sh/* ]]; then
+        if [[ "${kots_url_override}" == http://* ]] || [[ "${kots_url_override}" == https://* ]]; then
+            curl --retry 5 --retry-all-errors -fL -o "build/kots_linux_${ARCH}.tar.gz" "${kots_url_override}"
+        else
             oras pull "${kots_url_override}" --output "build"
             mv build/kots.tar.gz "build/kots_linux_${ARCH}.tar.gz"
-        else
-            curl --retry 5 --retry-all-errors -fL -o "build/kots_linux_${ARCH}.tar.gz" "${kots_url_override}"
         fi
     elif [ -n "${kots_file_override}" ]; then
         echo "KOTS_BINARY_FILE_OVERRIDE is set to '${kots_file_override}', using that source"


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

i was having issues with ttl.sh. this allows for the following:

```
export OPERATOR_IMAGE_NAME=docker.io/emosbaugh/operator
export LOCAL_ARTIFACT_MIRROR_IMAGE_NAME=docker.io/emosbaugh/lam                    
make initial-release
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
