### PR TITLE
fix(api): use correct helm client k8s version

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -95,6 +95,10 @@ func WithMetricsReporter(metricsReporter metrics.ReporterInterface) Option {
 
 // New creates a new API instance.
 func New(cfg types.APIConfig, opts ...Option) (*API, error) {
+	if cfg.InstallTarget == "" {
+		return nil, fmt.Errorf("target is required")
+	}
+
 	api := &API{
 		cfg: cfg,
 	}

--- a/api/controllers/app/install/controller.go
+++ b/api/controllers/app/install/controller.go
@@ -48,6 +48,7 @@ type InstallController struct {
 	clusterID                  string
 	airgapBundle               string
 	privateCACertConfigMapName string
+	k8sVersion                 string
 	restClientGetter           genericclioptions.RESTClientGetter
 	kubeConfigPath             string
 }
@@ -132,6 +133,12 @@ func WithPrivateCACertConfigMapName(configMapName string) InstallControllerOptio
 	}
 }
 
+func WithK8sVersion(k8sVersion string) InstallControllerOption {
+	return func(c *InstallController) {
+		c.k8sVersion = k8sVersion
+	}
+}
+
 func WithRESTClientGetter(restClientGetter genericclioptions.RESTClientGetter) InstallControllerOption {
 	return func(c *InstallController) {
 		c.restClientGetter = restClientGetter
@@ -205,6 +212,7 @@ func NewInstallController(opts ...InstallControllerOption) (*InstallController, 
 			appreleasemanager.WithReleaseData(controller.releaseData),
 			appreleasemanager.WithLicense(license),
 			appreleasemanager.WithPrivateCACertConfigMapName(controller.privateCACertConfigMapName),
+			appreleasemanager.WithK8sVersion(controller.k8sVersion),
 			appreleasemanager.WithRESTClientGetter(controller.restClientGetter),
 			appreleasemanager.WithKubeConfigPath(controller.kubeConfigPath),
 		)

--- a/api/controllers/app/install/controller.go
+++ b/api/controllers/app/install/controller.go
@@ -205,6 +205,8 @@ func NewInstallController(opts ...InstallControllerOption) (*InstallController, 
 			appreleasemanager.WithReleaseData(controller.releaseData),
 			appreleasemanager.WithLicense(license),
 			appreleasemanager.WithPrivateCACertConfigMapName(controller.privateCACertConfigMapName),
+			appreleasemanager.WithRESTClientGetter(controller.restClientGetter),
+			appreleasemanager.WithKubeConfigPath(controller.kubeConfigPath),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("create app release manager: %w", err)

--- a/api/controllers/app/install/controller.go
+++ b/api/controllers/app/install/controller.go
@@ -213,8 +213,6 @@ func NewInstallController(opts ...InstallControllerOption) (*InstallController, 
 			appreleasemanager.WithLicense(license),
 			appreleasemanager.WithPrivateCACertConfigMapName(controller.privateCACertConfigMapName),
 			appreleasemanager.WithK8sVersion(controller.k8sVersion),
-			appreleasemanager.WithRESTClientGetter(controller.restClientGetter),
-			appreleasemanager.WithKubeConfigPath(controller.kubeConfigPath),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("create app release manager: %w", err)

--- a/api/controllers/app/install/controller.go
+++ b/api/controllers/app/install/controller.go
@@ -230,6 +230,7 @@ func NewInstallController(opts ...InstallControllerOption) (*InstallController, 
 			appinstallmanager.WithClusterID(controller.clusterID),
 			appinstallmanager.WithAirgapBundle(controller.airgapBundle),
 			appinstallmanager.WithAppInstallStore(controller.store.AppInstallStore()),
+			appinstallmanager.WithK8sVersion(controller.k8sVersion),
 			appinstallmanager.WithRESTClientGetter(controller.restClientGetter),
 			appinstallmanager.WithKubeConfigPath(controller.kubeConfigPath),
 		)

--- a/api/controllers/app/install/test_suite.go
+++ b/api/controllers/app/install/test_suite.go
@@ -142,6 +142,7 @@ func (s *AppInstallControllerTestSuite) TestPatchAppConfigValues() {
 				WithAppInstallManager(appInstallManager),
 				WithStore(&store.MockStore{}),
 				WithReleaseData(&release.ReleaseData{}),
+				WithK8sVersion("v1.33.0"),
 			)
 			require.NoError(t, err, "failed to create install controller")
 
@@ -409,6 +410,7 @@ func (s *AppInstallControllerTestSuite) TestRunAppPreflights() {
 				WithAppReleaseManager(appReleaseManager),
 				WithStore(&store.MockStore{}),
 				WithReleaseData(&release.ReleaseData{}),
+				WithK8sVersion("v1.33.0"),
 			)
 			require.NoError(t, err, "failed to create install controller")
 
@@ -481,6 +483,7 @@ func (s *AppInstallControllerTestSuite) TestGetAppInstallStatus() {
 				WithAppInstallManager(appInstallManager),
 				WithStore(&store.MockStore{}),
 				WithReleaseData(&release.ReleaseData{}),
+				WithK8sVersion("v1.33.0"),
 			)
 			require.NoError(t, err, "failed to create install controller")
 
@@ -692,6 +695,7 @@ func (s *AppInstallControllerTestSuite) TestInstallApp() {
 				WithAppInstallManager(appInstallManager),
 				WithStore(&store.MockStore{}),
 				WithReleaseData(&release.ReleaseData{}),
+				WithK8sVersion("v1.33.0"),
 			)
 			require.NoError(t, err, "failed to create install controller")
 

--- a/api/controllers/kubernetes/install/controller.go
+++ b/api/controllers/kubernetes/install/controller.go
@@ -37,6 +37,7 @@ type InstallController struct {
 	installationManager installation.InstallationManager
 	infraManager        infra.InfraManager
 	metricsReporter     metrics.ReporterInterface
+	k8sVersion          string
 	restClientGetter    genericclioptions.RESTClientGetter
 	releaseData         *release.ReleaseData
 	password            string
@@ -70,6 +71,12 @@ func WithLogger(logger logrus.FieldLogger) InstallControllerOption {
 func WithMetricsReporter(metricsReporter metrics.ReporterInterface) InstallControllerOption {
 	return func(c *InstallController) {
 		c.metricsReporter = metricsReporter
+	}
+}
+
+func WithK8sVersion(k8sVersion string) InstallControllerOption {
+	return func(c *InstallController) {
+		c.k8sVersion = k8sVersion
 	}
 }
 
@@ -191,7 +198,8 @@ func NewInstallController(opts ...InstallControllerOption) (*InstallController, 
 			appcontroller.WithReleaseData(controller.releaseData),
 			appcontroller.WithConfigValues(controller.configValues),
 			appcontroller.WithAirgapBundle(controller.airgapBundle),
-			appcontroller.WithPrivateCACertConfigMapName(""), // Private CA ConfigMap functionality not yet implemented for Kubernetes installations
+			appcontroller.WithPrivateCACertConfigMapName(""),    // Private CA ConfigMap functionality not yet implemented for Kubernetes installations
+			appcontroller.WithK8sVersion(controller.k8sVersion), // Used to determine the kubernetes version for the helm client
 			appcontroller.WithRESTClientGetter(controller.restClientGetter),
 		)
 		if err != nil {

--- a/api/controllers/kubernetes/install/controller_test.go
+++ b/api/controllers/kubernetes/install/controller_test.go
@@ -102,6 +102,7 @@ func TestGetInstallationConfig(t *testing.T) {
 				WithInstallation(ki),
 				WithInstallationManager(mockManager),
 				WithReleaseData(getTestReleaseData(&kotsv1beta1.Config{})),
+				WithK8sVersion("v1.33.0"),
 			)
 			require.NoError(t, err)
 
@@ -219,6 +220,7 @@ func TestConfigureInstallation(t *testing.T) {
 				WithStore(mockStore),
 				WithMetricsReporter(metricsReporter),
 				WithReleaseData(getTestReleaseData(&kotsv1beta1.Config{})),
+				WithK8sVersion("v1.33.0"),
 			)
 			require.NoError(t, err)
 
@@ -282,6 +284,7 @@ func TestGetInstallationStatus(t *testing.T) {
 			controller, err := NewInstallController(
 				WithInstallationManager(mockManager),
 				WithReleaseData(getTestReleaseData(&kotsv1beta1.Config{})),
+				WithK8sVersion("v1.33.0"),
 			)
 			require.NoError(t, err)
 
@@ -408,6 +411,7 @@ func TestSetupInfra(t *testing.T) {
 				appcontroller.WithStore(mockStore),
 				appcontroller.WithReleaseData(getTestReleaseData(&appConfig)),
 				appcontroller.WithAppConfigManager(mockAppConfigManager),
+				appcontroller.WithK8sVersion("v1.33.0"),
 			)
 			require.NoError(t, err)
 
@@ -420,6 +424,7 @@ func TestSetupInfra(t *testing.T) {
 				WithMetricsReporter(mockMetricsReporter),
 				WithReleaseData(getTestReleaseData(&appConfig)),
 				WithStore(mockStore),
+				WithK8sVersion("v1.33.0"),
 			)
 			require.NoError(t, err)
 
@@ -514,6 +519,7 @@ func TestGetInfra(t *testing.T) {
 			controller, err := NewInstallController(
 				WithInfraManager(mockManager),
 				WithReleaseData(getTestReleaseData(&kotsv1beta1.Config{})),
+				WithK8sVersion("v1.33.0"),
 			)
 			require.NoError(t, err)
 

--- a/api/controllers/linux/install/controller.go
+++ b/api/controllers/linux/install/controller.go
@@ -21,6 +21,7 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/metrics"
 	"github.com/replicatedhq/embedded-cluster/pkg/release"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
+	"github.com/replicatedhq/embedded-cluster/pkg/versions"
 	"github.com/sirupsen/logrus"
 )
 
@@ -266,6 +267,7 @@ func NewInstallController(opts ...InstallControllerOption) (*InstallController, 
 			appcontroller.WithClusterID(controller.clusterID),
 			appcontroller.WithAirgapBundle(controller.airgapBundle),
 			appcontroller.WithPrivateCACertConfigMapName(adminconsole.PrivateCASConfigMapName), // Linux installations use the ConfigMap
+			appcontroller.WithK8sVersion(versions.K0sVersion),                                  // Used to determine the kubernetes version for the helm client
 			appcontroller.WithKubeConfigPath(controller.rc.PathToKubeConfig()),
 		)
 		if err != nil {

--- a/api/controllers/linux/install/controller_test.go
+++ b/api/controllers/linux/install/controller_test.go
@@ -1199,6 +1199,7 @@ func TestSetupInfra(t *testing.T) {
 				appcontroller.WithStateMachine(sm),
 				appcontroller.WithStore(mockStore),
 				appcontroller.WithReleaseData(getTestReleaseData(&appConfig)),
+				appcontroller.WithK8sVersion("v1.33.0"),
 				appcontroller.WithLicense([]byte("spec:\n  licenseID: test-license\n")),
 				appcontroller.WithAppConfigManager(mockAppConfigManager),
 				appcontroller.WithAppPreflightManager(mockAppPreflightManager),

--- a/api/integration/app/install/config_test.go
+++ b/api/integration/app/install/config_test.go
@@ -1051,7 +1051,7 @@ func TestAppInstallSuite(t *testing.T) {
 				)
 				require.NoError(t, err)
 				// Create the API with the install controller
-				return integration.NewAPIWithReleaseData(t,
+				return integration.NewTargetLinuxAPIWithReleaseData(t,
 					api.WithLinuxInstallController(controller),
 					api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 					api.WithLogger(logger.NewDiscardLogger()),
@@ -1068,10 +1068,11 @@ func TestAppInstallSuite(t *testing.T) {
 					kubernetesinstall.WithReleaseData(rd),
 					kubernetesinstall.WithLicense([]byte("spec:\n  licenseID: test-license\n")),
 					kubernetesinstall.WithConfigValues(configValues),
+					kubernetesinstall.WithK8sVersion("v1.33.0"),
 				)
 				require.NoError(t, err)
 				// Create the API with the install controller
-				return integration.NewAPIWithReleaseData(t,
+				return integration.NewTargetKubernetesAPIWithReleaseData(t,
 					api.WithKubernetesInstallController(controller),
 					api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 					api.WithLogger(logger.NewDiscardLogger()),

--- a/api/integration/auth/controller_test.go
+++ b/api/integration/auth/controller_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/replicatedhq/embedded-cluster/api/controllers/auth"
 	linuxinstall "github.com/replicatedhq/embedded-cluster/api/controllers/linux/install"
 	"github.com/replicatedhq/embedded-cluster/api/integration"
-	"github.com/replicatedhq/embedded-cluster/api/internal/managers/linux/installation"
+	linuxinstallation "github.com/replicatedhq/embedded-cluster/api/internal/managers/linux/installation"
 	"github.com/replicatedhq/embedded-cluster/api/internal/utils"
 	"github.com/replicatedhq/embedded-cluster/api/pkg/logger"
 	"github.com/replicatedhq/embedded-cluster/api/types"
@@ -28,15 +28,15 @@ func TestAuthLoginAndTokenValidation(t *testing.T) {
 
 	// Create an install controller
 	installController, err := linuxinstall.NewInstallController(
-		linuxinstall.WithInstallationManager(installation.NewInstallationManager(
-			installation.WithNetUtils(&utils.MockNetUtils{}),
+		linuxinstall.WithInstallationManager(linuxinstallation.NewInstallationManager(
+			linuxinstallation.WithNetUtils(&utils.MockNetUtils{}),
 		)),
 		linuxinstall.WithReleaseData(integration.DefaultReleaseData()),
 	)
 	require.NoError(t, err)
 
 	// Create the API with the auth controller
-	apiInstance := integration.NewAPIWithReleaseData(t,
+	apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 		api.WithAuthController(authController),
 		api.WithLinuxInstallController(installController),
 		api.WithLogger(logger.NewDiscardLogger()),
@@ -134,7 +134,7 @@ func TestAuthLoginAndTokenValidation(t *testing.T) {
 
 func TestAPIClientLogin(t *testing.T) {
 	// Create the API with the auth controller
-	apiInstance := integration.NewAPIWithReleaseData(t,
+	apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 		api.WithLogger(logger.NewDiscardLogger()),
 	)
 

--- a/api/integration/console/controller_test.go
+++ b/api/integration/console/controller_test.go
@@ -29,7 +29,7 @@ func TestConsoleListAvailableNetworkInterfaces(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create the API with the install controller
-	apiInstance := integration.NewAPIWithReleaseData(t,
+	apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 		api.WithConsoleController(consoleController),
 		api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 		api.WithLogger(logger.NewDiscardLogger()),
@@ -73,7 +73,7 @@ func TestConsoleListAvailableNetworkInterfacesUnauthorized(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create the API with the install controller
-	apiInstance := integration.NewAPIWithReleaseData(t,
+	apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 		api.WithConsoleController(consoleController),
 		api.WithAuthController(auth.NewStaticAuthController("VALID_TOKEN")),
 		api.WithLogger(logger.NewDiscardLogger()),
@@ -113,7 +113,7 @@ func TestConsoleListAvailableNetworkInterfacesError(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create the API with the install controller
-	apiInstance := integration.NewAPIWithReleaseData(t,
+	apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 		api.WithConsoleController(consoleController),
 		api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 		api.WithLogger(logger.NewDiscardLogger()),

--- a/api/integration/kubernetes/install/appconfig_test.go
+++ b/api/integration/kubernetes/install/appconfig_test.go
@@ -65,11 +65,12 @@ func TestInstallController_PatchAppConfigValuesWithAPIClient(t *testing.T) {
 		kubernetesinstall.WithReleaseData(&release.ReleaseData{
 			AppConfig: &appConfig,
 		}),
+		kubernetesinstall.WithK8sVersion("v1.33.0"),
 	)
 	require.NoError(t, err)
 
 	// Create the API with the install controller
-	apiInstance := integration.NewAPIWithReleaseData(t,
+	apiInstance := integration.NewTargetKubernetesAPIWithReleaseData(t,
 		api.WithKubernetesInstallController(installController),
 		api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 		api.WithLogger(logger.NewDiscardLogger()),
@@ -116,11 +117,12 @@ func TestInstallController_PatchAppConfigValuesWithAPIClient(t *testing.T) {
 			kubernetesinstall.WithReleaseData(&release.ReleaseData{
 				AppConfig: &appConfig,
 			}),
+			kubernetesinstall.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
 		// Create the API with the completed install controller
-		completedAPIInstance := integration.NewAPIWithReleaseData(t,
+		completedAPIInstance := integration.NewTargetKubernetesAPIWithReleaseData(t,
 			api.WithKubernetesInstallController(completedInstallController),
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),
@@ -219,11 +221,12 @@ func TestInstallController_GetAppConfigValuesWithAPIClient(t *testing.T) {
 		kubernetesinstall.WithReleaseData(&release.ReleaseData{
 			AppConfig: &appConfig,
 		}),
+		kubernetesinstall.WithK8sVersion("v1.33.0"),
 	)
 	require.NoError(t, err)
 
 	// Create the API with the install controller
-	apiInstance := integration.NewAPIWithReleaseData(t,
+	apiInstance := integration.NewTargetKubernetesAPIWithReleaseData(t,
 		api.WithKubernetesInstallController(installController),
 		api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 		api.WithLogger(logger.NewDiscardLogger()),

--- a/api/integration/kubernetes/install/appinstall_test.go
+++ b/api/integration/kubernetes/install/appinstall_test.go
@@ -69,6 +69,7 @@ func TestGetAppInstallStatus(t *testing.T) {
 			appinstallmanager.WithAppInstallStore(
 				appinstallstore.NewMemoryStore(appinstallstore.WithAppInstall(appInstallStatus)),
 			),
+			appinstallmanager.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
@@ -81,6 +82,7 @@ func TestGetAppInstallStatus(t *testing.T) {
 			appinstall.WithStateMachine(kubernetesinstall.NewStateMachine()),
 			appinstall.WithStore(mockStore),
 			appinstall.WithReleaseData(integration.DefaultReleaseData()),
+			appinstall.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
@@ -98,11 +100,12 @@ func TestGetAppInstallStatus(t *testing.T) {
 				},
 				AppConfig: &kotsv1beta1.Config{},
 			}),
+			kubernetesinstall.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
 		// Create the API
-		apiInstance := integration.NewAPIWithReleaseData(t,
+		apiInstance := integration.NewTargetKubernetesAPIWithReleaseData(t,
 			api.WithKubernetesInstallController(installController),
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),
@@ -154,11 +157,12 @@ func TestGetAppInstallStatus(t *testing.T) {
 		// Create simple Kubernetes install controller
 		installController, err := kubernetesinstall.NewInstallController(
 			kubernetesinstall.WithReleaseData(integration.DefaultReleaseData()),
+			kubernetesinstall.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
 		// Create the API
-		apiInstance := integration.NewAPIWithReleaseData(t,
+		apiInstance := integration.NewTargetKubernetesAPIWithReleaseData(t,
 			api.WithKubernetesInstallController(installController),
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),
@@ -185,7 +189,7 @@ func TestGetAppInstallStatus(t *testing.T) {
 		mockController.On("GetAppInstallStatus", mock.Anything).Return(types.AppInstall{}, assert.AnError)
 
 		// Create the API with mock controller
-		apiInstance := integration.NewAPIWithReleaseData(t,
+		apiInstance := integration.NewTargetKubernetesAPIWithReleaseData(t,
 			api.WithKubernetesInstallController(mockController),
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),
@@ -290,6 +294,7 @@ func TestPostInstallApp(t *testing.T) {
 			appinstall.WithStateMachine(stateMachine),
 			appinstall.WithStore(&store.MockStore{}),
 			appinstall.WithReleaseData(releaseData),
+			appinstall.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
@@ -298,13 +303,15 @@ func TestPostInstallApp(t *testing.T) {
 			kubernetesinstall.WithStateMachine(stateMachine),
 			kubernetesinstall.WithAppInstallController(appInstallController),
 			kubernetesinstall.WithReleaseData(releaseData),
+			kubernetesinstall.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
 		// Create the API
 		cfg := types.APIConfig{
-			Password:    "password",
-			ReleaseData: releaseData,
+			InstallTarget: types.InstallTargetKubernetes,
+			Password:      "password",
+			ReleaseData:   releaseData,
 			KubernetesConfig: types.KubernetesConfig{
 				Installation: kubernetesinstallation.New(nil),
 			},
@@ -354,6 +361,7 @@ func TestPostInstallApp(t *testing.T) {
 			appinstall.WithStateMachine(stateMachine),
 			appinstall.WithStore(mockStore),
 			appinstall.WithReleaseData(releaseData),
+			appinstall.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
@@ -362,13 +370,15 @@ func TestPostInstallApp(t *testing.T) {
 			kubernetesinstall.WithStateMachine(stateMachine),
 			kubernetesinstall.WithAppInstallController(appInstallController),
 			kubernetesinstall.WithReleaseData(releaseData),
+			kubernetesinstall.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
 		// Create the API
 		cfg := types.APIConfig{
-			Password:    "password",
-			ReleaseData: releaseData,
+			InstallTarget: types.InstallTargetKubernetes,
+			Password:      "password",
+			ReleaseData:   releaseData,
 			KubernetesConfig: types.KubernetesConfig{
 				Installation: kubernetesinstallation.New(nil),
 			},
@@ -423,6 +433,7 @@ func TestPostInstallApp(t *testing.T) {
 			appinstall.WithStateMachine(stateMachine),
 			appinstall.WithStore(mockStore),
 			appinstall.WithReleaseData(releaseData),
+			appinstall.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
@@ -431,13 +442,15 @@ func TestPostInstallApp(t *testing.T) {
 			kubernetesinstall.WithStateMachine(stateMachine),
 			kubernetesinstall.WithAppInstallController(appInstallController),
 			kubernetesinstall.WithReleaseData(releaseData),
+			kubernetesinstall.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
 		// Create the API
 		cfg := types.APIConfig{
-			Password:    "password",
-			ReleaseData: releaseData,
+			InstallTarget: types.InstallTargetKubernetes,
+			Password:      "password",
+			ReleaseData:   releaseData,
 			KubernetesConfig: types.KubernetesConfig{
 				Installation: kubernetesinstallation.New(nil),
 			},
@@ -477,11 +490,12 @@ func TestPostInstallApp(t *testing.T) {
 		// Create simple Kubernetes install controller
 		installController, err := kubernetesinstall.NewInstallController(
 			kubernetesinstall.WithReleaseData(releaseData),
+			kubernetesinstall.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
 		// Create the API
-		apiInstance := integration.NewAPIWithReleaseData(t,
+		apiInstance := integration.NewTargetKubernetesAPIWithReleaseData(t,
 			api.WithKubernetesInstallController(installController),
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),
@@ -530,6 +544,7 @@ func TestPostInstallApp(t *testing.T) {
 			appinstall.WithStateMachine(stateMachine),
 			appinstall.WithStore(mockStore),
 			appinstall.WithReleaseData(releaseData),
+			appinstall.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
@@ -538,13 +553,15 @@ func TestPostInstallApp(t *testing.T) {
 			kubernetesinstall.WithStateMachine(stateMachine),
 			kubernetesinstall.WithAppInstallController(appInstallController),
 			kubernetesinstall.WithReleaseData(releaseData),
+			kubernetesinstall.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
 		// Create the API
 		cfg := types.APIConfig{
-			Password:    "password",
-			ReleaseData: releaseData,
+			InstallTarget: types.InstallTargetKubernetes,
+			Password:      "password",
+			ReleaseData:   releaseData,
 			KubernetesConfig: types.KubernetesConfig{
 				Installation: kubernetesinstallation.New(nil),
 			},
@@ -601,6 +618,7 @@ func TestPostInstallApp(t *testing.T) {
 			appinstall.WithStateMachine(stateMachine),
 			appinstall.WithStore(mockStore),
 			appinstall.WithReleaseData(releaseData),
+			appinstall.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
@@ -609,13 +627,15 @@ func TestPostInstallApp(t *testing.T) {
 			kubernetesinstall.WithStateMachine(stateMachine),
 			kubernetesinstall.WithAppInstallController(appInstallController),
 			kubernetesinstall.WithReleaseData(releaseData),
+			kubernetesinstall.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
 		// Create the API
 		cfg := types.APIConfig{
-			Password:    "password",
-			ReleaseData: releaseData,
+			InstallTarget: types.InstallTargetKubernetes,
+			Password:      "password",
+			ReleaseData:   releaseData,
 			KubernetesConfig: types.KubernetesConfig{
 				Installation: kubernetesinstallation.New(nil),
 			},

--- a/api/integration/kubernetes/install/apppreflight_test.go
+++ b/api/integration/kubernetes/install/apppreflight_test.go
@@ -73,6 +73,7 @@ func TestGetAppPreflightsStatus(t *testing.T) {
 		appinstall.WithStateMachine(kubernetesinstall.NewStateMachine()),
 		appinstall.WithStore(mockStore),
 		appinstall.WithReleaseData(integration.DefaultReleaseData()),
+		appinstall.WithK8sVersion("v1.33.0"),
 	)
 	require.NoError(t, err)
 
@@ -80,11 +81,12 @@ func TestGetAppPreflightsStatus(t *testing.T) {
 	installController, err := kubernetesinstall.NewInstallController(
 		kubernetesinstall.WithAppInstallController(appInstallController),
 		kubernetesinstall.WithReleaseData(integration.DefaultReleaseData()),
+		kubernetesinstall.WithK8sVersion("v1.33.0"),
 	)
 	require.NoError(t, err)
 
 	// Create the API with the install controller
-	apiInstance := integration.NewAPIWithReleaseData(t,
+	apiInstance := integration.NewTargetKubernetesAPIWithReleaseData(t,
 		api.WithKubernetesInstallController(installController),
 		api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 		api.WithLogger(logger.NewDiscardLogger()),
@@ -139,7 +141,7 @@ func TestGetAppPreflightsStatus(t *testing.T) {
 		mockController.On("GetAppPreflightTitles", mock.Anything).Return([]string{}, assert.AnError)
 
 		// Create the API with the mock controller
-		apiInstance := integration.NewAPIWithReleaseData(t,
+		apiInstance := integration.NewTargetKubernetesAPIWithReleaseData(t,
 			api.WithKubernetesInstallController(mockController),
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),
@@ -226,6 +228,7 @@ func TestPostRunAppPreflights(t *testing.T) {
 			appinstall.WithStateMachine(stateMachine),
 			appinstall.WithStore(mockStore),
 			appinstall.WithReleaseData(integration.DefaultReleaseData()),
+			appinstall.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
@@ -234,12 +237,14 @@ func TestPostRunAppPreflights(t *testing.T) {
 			kubernetesinstall.WithStateMachine(stateMachine),
 			kubernetesinstall.WithAppInstallController(appInstallController),
 			kubernetesinstall.WithReleaseData(integration.DefaultReleaseData()),
+			kubernetesinstall.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
 		// Create the API with kubernetes config in the API config
 		apiInstance, err := api.New(types.APIConfig{
-			Password: "password",
+			InstallTarget: types.InstallTargetKubernetes,
+			Password:      "password",
 			KubernetesConfig: types.KubernetesConfig{
 				RESTClientGetter: &genericclioptions.ConfigFlags{},
 				Installation:     mockInstallation,
@@ -285,12 +290,14 @@ func TestPostRunAppPreflights(t *testing.T) {
 				kubernetesinstall.WithCurrentState(states.StateNew), // Wrong state
 			)),
 			kubernetesinstall.WithReleaseData(integration.DefaultReleaseData()),
+			kubernetesinstall.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
 		// Create the API with kubernetes config
 		apiInstance, err := api.New(types.APIConfig{
-			Password: "password",
+			InstallTarget: types.InstallTargetKubernetes,
+			Password:      "password",
 			KubernetesConfig: types.KubernetesConfig{
 				RESTClientGetter: &genericclioptions.ConfigFlags{},
 				Installation:     mockInstallation,
@@ -330,12 +337,14 @@ func TestPostRunAppPreflights(t *testing.T) {
 		// Create a basic install controller
 		installController, err := kubernetesinstall.NewInstallController(
 			kubernetesinstall.WithReleaseData(integration.DefaultReleaseData()),
+			kubernetesinstall.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
 		// Create the API with kubernetes config
 		apiInstance, err := api.New(types.APIConfig{
-			Password: "password",
+			InstallTarget: types.InstallTargetKubernetes,
+			Password:      "password",
 			KubernetesConfig: types.KubernetesConfig{
 				RESTClientGetter: &genericclioptions.ConfigFlags{},
 				Installation:     mockInstallation,

--- a/api/integration/kubernetes/install/infra_test.go
+++ b/api/integration/kubernetes/install/infra_test.go
@@ -133,11 +133,12 @@ func TestKubernetesPostSetupInfra(t *testing.T) {
 				},
 				AppConfig: &appConfig,
 			}),
+			kubernetesinstall.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
 		// Create the API with the install controller
-		apiInstance := integration.NewAPIWithReleaseData(t,
+		apiInstance := integration.NewTargetKubernetesAPIWithReleaseData(t,
 			api.WithKubernetesInstallController(installController),
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),
@@ -227,9 +228,25 @@ func TestKubernetesPostSetupInfra(t *testing.T) {
 
 	// Test authorization
 	t.Run("Authorization error", func(t *testing.T) {
+		installController, err := kubernetesinstall.NewInstallController(
+			kubernetesinstall.WithReleaseData(&release.ReleaseData{
+				EmbeddedClusterConfig: &ecv1beta1.Config{},
+				ChannelRelease: &release.ChannelRelease{
+					DefaultDomains: release.Domains{
+						ReplicatedAppDomain: "replicated.example.com",
+						ProxyRegistryDomain: "some-proxy.example.com",
+					},
+				},
+				AppConfig: &appConfig,
+			}),
+			kubernetesinstall.WithK8sVersion("v1.33.0"),
+		)
+		require.NoError(t, err)
+
 		// Create the API
-		apiInstance := integration.NewAPIWithReleaseData(t,
+		apiInstance := integration.NewTargetKubernetesAPIWithReleaseData(t,
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
+			api.WithKubernetesInstallController(installController),
 			api.WithLogger(logger.NewDiscardLogger()),
 		)
 
@@ -251,7 +268,7 @@ func TestKubernetesPostSetupInfra(t *testing.T) {
 
 		// Parse the response body
 		var apiError types.APIError
-		err := json.NewDecoder(rec.Body).Decode(&apiError)
+		err = json.NewDecoder(rec.Body).Decode(&apiError)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusUnauthorized, apiError.StatusCode)
 	})
@@ -312,11 +329,12 @@ func TestKubernetesPostSetupInfra(t *testing.T) {
 				},
 				AppConfig: &appConfig,
 			}),
+			kubernetesinstall.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
 		// Create the API with the install controller
-		apiInstance := integration.NewAPIWithReleaseData(t,
+		apiInstance := integration.NewTargetKubernetesAPIWithReleaseData(t,
 			api.WithKubernetesInstallController(installController),
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),

--- a/api/integration/kubernetes/install/installation_test.go
+++ b/api/integration/kubernetes/install/installation_test.go
@@ -137,11 +137,12 @@ func TestKubernetesConfigureInstallation(t *testing.T) {
 				kubernetesinstall.WithInstallation(ki),
 				kubernetesinstall.WithStateMachine(kubernetesinstall.NewStateMachine(kubernetesinstall.WithCurrentState(states.StateApplicationConfigured))),
 				kubernetesinstall.WithReleaseData(integration.DefaultReleaseData()),
+				kubernetesinstall.WithK8sVersion("v1.33.0"),
 			)
 			require.NoError(t, err)
 
 			// Create the API with the install controller
-			apiInstance := integration.NewAPIWithReleaseData(t,
+			apiInstance := integration.NewTargetKubernetesAPIWithReleaseData(t,
 				api.WithKubernetesInstallController(installController),
 				api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 				api.WithLogger(logger.NewDiscardLogger()),
@@ -228,11 +229,12 @@ func TestKubernetesConfigureInstallationValidation(t *testing.T) {
 		kubernetesinstall.WithInstallation(ki),
 		kubernetesinstall.WithStateMachine(kubernetesinstall.NewStateMachine(kubernetesinstall.WithCurrentState(states.StateApplicationConfigured))),
 		kubernetesinstall.WithReleaseData(integration.DefaultReleaseData()),
+		kubernetesinstall.WithK8sVersion("v1.33.0"),
 	)
 	require.NoError(t, err)
 
 	// Create the API with the install controller
-	apiInstance := integration.NewAPIWithReleaseData(t,
+	apiInstance := integration.NewTargetKubernetesAPIWithReleaseData(t,
 		api.WithKubernetesInstallController(installController),
 		api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 		api.WithLogger(logger.NewDiscardLogger()),
@@ -286,10 +288,11 @@ func TestKubernetesConfigureInstallationBadRequest(t *testing.T) {
 		kubernetesinstall.WithInstallation(ki),
 		kubernetesinstall.WithStateMachine(kubernetesinstall.NewStateMachine(kubernetesinstall.WithCurrentState(states.StateApplicationConfigured))),
 		kubernetesinstall.WithReleaseData(integration.DefaultReleaseData()),
+		kubernetesinstall.WithK8sVersion("v1.33.0"),
 	)
 	require.NoError(t, err)
 
-	apiInstance := integration.NewAPIWithReleaseData(t,
+	apiInstance := integration.NewTargetKubernetesAPIWithReleaseData(t,
 		api.WithKubernetesInstallController(installController),
 		api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 		api.WithLogger(logger.NewDiscardLogger()),
@@ -321,7 +324,7 @@ func TestKubernetesConfigureInstallationControllerError(t *testing.T) {
 	mockController.On("ConfigureInstallation", mock.Anything, mock.Anything).Return(assert.AnError)
 
 	// Create the API with the mock controller
-	apiInstance := integration.NewAPIWithReleaseData(t,
+	apiInstance := integration.NewTargetKubernetesAPIWithReleaseData(t,
 		api.WithKubernetesInstallController(mockController),
 		api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 		api.WithLogger(logger.NewDiscardLogger()),
@@ -370,6 +373,7 @@ func TestKubernetesGetInstallationConfig(t *testing.T) {
 		kubernetesinstall.WithInstallation(ki),
 		kubernetesinstall.WithInstallationManager(installationManager),
 		kubernetesinstall.WithReleaseData(integration.DefaultReleaseData()),
+		kubernetesinstall.WithK8sVersion("v1.33.0"),
 	)
 	require.NoError(t, err)
 
@@ -384,7 +388,7 @@ func TestKubernetesGetInstallationConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create the API with the install controller
-	apiInstance := integration.NewAPIWithReleaseData(t,
+	apiInstance := integration.NewTargetKubernetesAPIWithReleaseData(t,
 		api.WithKubernetesInstallController(installController),
 		api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 		api.WithLogger(logger.NewDiscardLogger()),
@@ -432,11 +436,12 @@ func TestKubernetesGetInstallationConfig(t *testing.T) {
 			kubernetesinstall.WithInstallation(ki),
 			kubernetesinstall.WithInstallationManager(emptyInstallationManager),
 			kubernetesinstall.WithReleaseData(integration.DefaultReleaseData()),
+			kubernetesinstall.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
 		// Create the API with the install controller
-		emptyAPI := integration.NewAPIWithReleaseData(t,
+		emptyAPI := integration.NewTargetKubernetesAPIWithReleaseData(t,
 			api.WithKubernetesInstallController(emptyInstallController),
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),
@@ -497,7 +502,7 @@ func TestKubernetesGetInstallationConfig(t *testing.T) {
 		mockController.On("GetInstallationConfig", mock.Anything).Return(types.KubernetesInstallationConfig{}, assert.AnError)
 
 		// Create the API with the mock controller
-		apiInstance := integration.NewAPIWithReleaseData(t,
+		apiInstance := integration.NewTargetKubernetesAPIWithReleaseData(t,
 			api.WithKubernetesInstallController(mockController),
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),

--- a/api/integration/linux/install/appconfig_test.go
+++ b/api/integration/linux/install/appconfig_test.go
@@ -69,7 +69,7 @@ func TestInstallController_PatchAppConfigValuesWithAPIClient(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create the API with the install controller
-	apiInstance := integration.NewAPIWithReleaseData(t,
+	apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 		api.WithLinuxInstallController(installController),
 		api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 		api.WithLogger(logger.NewDiscardLogger()),
@@ -120,7 +120,7 @@ func TestInstallController_PatchAppConfigValuesWithAPIClient(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create the API with the completed install controller
-		completedAPIInstance := integration.NewAPIWithReleaseData(t,
+		completedAPIInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 			api.WithLinuxInstallController(completedInstallController),
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),
@@ -223,7 +223,7 @@ func TestInstallController_GetAppConfigValuesWithAPIClient(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create the API with the install controller
-	apiInstance := integration.NewAPIWithReleaseData(t,
+	apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 		api.WithLinuxInstallController(installController),
 		api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 		api.WithLogger(logger.NewDiscardLogger()),

--- a/api/integration/linux/install/appinstall_test.go
+++ b/api/integration/linux/install/appinstall_test.go
@@ -86,6 +86,7 @@ func TestGetAppInstallStatus(t *testing.T) {
 			appinstallmanager.WithAppInstallStore(
 				appinstallstore.NewMemoryStore(appinstallstore.WithAppInstall(appInstallStatus)),
 			),
+			appinstallmanager.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
@@ -98,6 +99,7 @@ func TestGetAppInstallStatus(t *testing.T) {
 			appinstall.WithStateMachine(linuxinstall.NewStateMachine()),
 			appinstall.WithStore(mockStore),
 			appinstall.WithReleaseData(releaseData),
+			appinstall.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
@@ -111,7 +113,7 @@ func TestGetAppInstallStatus(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create the API
-		apiInstance := integration.NewAPIWithReleaseData(t,
+		apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 			api.WithLinuxInstallController(installController),
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),
@@ -167,7 +169,7 @@ func TestGetAppInstallStatus(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create the API
-		apiInstance := integration.NewAPIWithReleaseData(t,
+		apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 			api.WithLinuxInstallController(installController),
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),
@@ -194,7 +196,7 @@ func TestGetAppInstallStatus(t *testing.T) {
 		mockController.On("GetAppInstallStatus", mock.Anything).Return(types.AppInstall{}, assert.AnError)
 
 		// Create the API with mock controller
-		apiInstance := integration.NewAPIWithReleaseData(t,
+		apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 			api.WithLinuxInstallController(mockController),
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),
@@ -307,6 +309,7 @@ func TestPostInstallApp(t *testing.T) {
 			appinstall.WithStateMachine(stateMachine),
 			appinstall.WithStore(&store.MockStore{}),
 			appinstall.WithReleaseData(releaseData),
+			appinstall.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
@@ -322,8 +325,9 @@ func TestPostInstallApp(t *testing.T) {
 
 		// Create the API
 		cfg := types.APIConfig{
-			Password:    "password",
-			ReleaseData: releaseData,
+			InstallTarget: types.InstallTargetLinux,
+			Password:      "password",
+			ReleaseData:   releaseData,
 			LinuxConfig: types.LinuxConfig{
 				RuntimeConfig: rc,
 			},
@@ -378,6 +382,7 @@ func TestPostInstallApp(t *testing.T) {
 			appinstall.WithStateMachine(stateMachine),
 			appinstall.WithStore(mockStore),
 			appinstall.WithReleaseData(releaseData),
+			appinstall.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
@@ -391,8 +396,9 @@ func TestPostInstallApp(t *testing.T) {
 
 		// Create the API
 		cfg := types.APIConfig{
-			Password:    "password",
-			ReleaseData: releaseData,
+			InstallTarget: types.InstallTargetLinux,
+			Password:      "password",
+			ReleaseData:   releaseData,
 			LinuxConfig: types.LinuxConfig{
 				RuntimeConfig: rc,
 			},
@@ -461,6 +467,7 @@ func TestPostInstallApp(t *testing.T) {
 			appinstall.WithStateMachine(stateMachine),
 			appinstall.WithStore(mockStore),
 			appinstall.WithReleaseData(releaseData),
+			appinstall.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
@@ -477,8 +484,9 @@ func TestPostInstallApp(t *testing.T) {
 
 		// Create the API
 		cfg := types.APIConfig{
-			Password:    "password",
-			ReleaseData: releaseData,
+			InstallTarget: types.InstallTargetLinux,
+			Password:      "password",
+			ReleaseData:   releaseData,
 			LinuxConfig: types.LinuxConfig{
 				RuntimeConfig: rc,
 			},
@@ -529,8 +537,9 @@ func TestPostInstallApp(t *testing.T) {
 
 		// Create the API
 		cfg := types.APIConfig{
-			Password:    "password",
-			ReleaseData: releaseData,
+			InstallTarget: types.InstallTargetLinux,
+			Password:      "password",
+			ReleaseData:   releaseData,
 			LinuxConfig: types.LinuxConfig{
 				RuntimeConfig: rc,
 			},
@@ -589,6 +598,7 @@ func TestPostInstallApp(t *testing.T) {
 			appinstall.WithStateMachine(stateMachine),
 			appinstall.WithStore(mockStore),
 			appinstall.WithReleaseData(releaseData),
+			appinstall.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
@@ -602,8 +612,9 @@ func TestPostInstallApp(t *testing.T) {
 
 		// Create the API
 		cfg := types.APIConfig{
-			Password:    "password",
-			ReleaseData: releaseData,
+			InstallTarget: types.InstallTargetLinux,
+			Password:      "password",
+			ReleaseData:   releaseData,
 			LinuxConfig: types.LinuxConfig{
 				RuntimeConfig: rc,
 			},
@@ -664,6 +675,7 @@ func TestPostInstallApp(t *testing.T) {
 			appinstall.WithStateMachine(stateMachine),
 			appinstall.WithStore(mockStore),
 			appinstall.WithReleaseData(releaseData),
+			appinstall.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
@@ -677,8 +689,9 @@ func TestPostInstallApp(t *testing.T) {
 
 		// Create the API
 		cfg := types.APIConfig{
-			Password:    "password",
-			ReleaseData: releaseData,
+			InstallTarget: types.InstallTargetLinux,
+			Password:      "password",
+			ReleaseData:   releaseData,
 			LinuxConfig: types.LinuxConfig{
 				RuntimeConfig: rc,
 			},

--- a/api/integration/linux/install/apppreflight_test.go
+++ b/api/integration/linux/install/apppreflight_test.go
@@ -74,6 +74,7 @@ func TestGetAppPreflightsStatus(t *testing.T) {
 		appinstall.WithStateMachine(linuxinstall.NewStateMachine()),
 		appinstall.WithStore(mockStore),
 		appinstall.WithReleaseData(integration.DefaultReleaseData()),
+		appinstall.WithK8sVersion("v1.33.0"),
 	)
 	require.NoError(t, err)
 
@@ -85,7 +86,7 @@ func TestGetAppPreflightsStatus(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create the API with the install controller
-	apiInstance := integration.NewAPIWithReleaseData(t,
+	apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 		api.WithLinuxInstallController(installController),
 		api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 		api.WithLogger(logger.NewDiscardLogger()),
@@ -140,7 +141,7 @@ func TestGetAppPreflightsStatus(t *testing.T) {
 		mockController.On("GetAppPreflightTitles", mock.Anything).Return([]string{}, assert.AnError)
 
 		// Create the API with the mock controller
-		apiInstance := integration.NewAPIWithReleaseData(t,
+		apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 			api.WithLinuxInstallController(mockController),
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),
@@ -226,6 +227,7 @@ func TestPostRunAppPreflights(t *testing.T) {
 			appinstall.WithStateMachine(stateMachine),
 			appinstall.WithStore(mockStore),
 			appinstall.WithReleaseData(integration.DefaultReleaseData()),
+			appinstall.WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
@@ -249,7 +251,8 @@ func TestPostRunAppPreflights(t *testing.T) {
 
 		// Create the API with runtime config in the API config
 		apiInstance, err := api.New(types.APIConfig{
-			Password: "password",
+			InstallTarget: types.InstallTargetLinux,
+			Password:      "password",
 			LinuxConfig: types.LinuxConfig{
 				RuntimeConfig: rc,
 			},
@@ -299,7 +302,8 @@ func TestPostRunAppPreflights(t *testing.T) {
 
 		// Create the API with runtime config
 		apiInstance, err := api.New(types.APIConfig{
-			Password: "password",
+			InstallTarget: types.InstallTargetLinux,
+			Password:      "password",
 			LinuxConfig: types.LinuxConfig{
 				RuntimeConfig: rc,
 			},
@@ -343,7 +347,8 @@ func TestPostRunAppPreflights(t *testing.T) {
 
 		// Create the API with runtime config
 		apiInstance, err := api.New(types.APIConfig{
-			Password: "password",
+			InstallTarget: types.InstallTargetLinux,
+			Password:      "password",
 			LinuxConfig: types.LinuxConfig{
 				RuntimeConfig: rc,
 			},

--- a/api/integration/linux/install/hostpreflight_test.go
+++ b/api/integration/linux/install/hostpreflight_test.go
@@ -75,7 +75,7 @@ func TestGetHostPreflightsStatus(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create the API with the install controller
-	apiInstance := integration.NewAPIWithReleaseData(t,
+	apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 		api.WithLinuxInstallController(installController),
 		api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 		api.WithLogger(logger.NewDiscardLogger()),
@@ -140,7 +140,7 @@ func TestGetHostPreflightsStatus(t *testing.T) {
 		mockController.On("GetHostPreflightStatus", mock.Anything).Return(types.Status{}, assert.AnError)
 
 		// Create the API with the mock controller
-		apiInstance := integration.NewAPIWithReleaseData(t,
+		apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 			api.WithLinuxInstallController(mockController),
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),
@@ -224,7 +224,8 @@ func TestGetHostPreflightsStatusWithIgnoreFlag(t *testing.T) {
 			// Create the API with allow ignore host preflights flag
 			apiInstance, err := api.New(
 				types.APIConfig{
-					Password: "password",
+					InstallTarget: types.InstallTargetLinux,
+					Password:      "password",
 					LinuxConfig: types.LinuxConfig{
 						AllowIgnoreHostPreflights: tt.allowIgnoreHostPreflights,
 					},
@@ -339,7 +340,7 @@ func TestPostRunHostPreflights(t *testing.T) {
 		)
 
 		// Create the API with the install controller
-		apiInstance := integration.NewAPIWithReleaseData(t,
+		apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 			api.WithLinuxInstallController(installController),
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),
@@ -407,7 +408,7 @@ func TestPostRunHostPreflights(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create the API with the install controller
-		apiInstance := integration.NewAPIWithReleaseData(t,
+		apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 			api.WithLinuxInstallController(installController),
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),
@@ -464,7 +465,7 @@ func TestPostRunHostPreflights(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create the API with the install controller
-		apiInstance := integration.NewAPIWithReleaseData(t,
+		apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 			api.WithLinuxInstallController(installController),
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),
@@ -522,7 +523,7 @@ func TestPostRunHostPreflights(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create the API with the install controller
-		apiInstance := integration.NewAPIWithReleaseData(t,
+		apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 			api.WithLinuxInstallController(installController),
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),
@@ -593,7 +594,7 @@ func TestPostRunHostPreflights(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create the API with the install controller
-		apiInstance := integration.NewAPIWithReleaseData(t,
+		apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 			api.WithLinuxInstallController(installController),
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),

--- a/api/integration/linux/install/infra_test.go
+++ b/api/integration/linux/install/infra_test.go
@@ -182,7 +182,7 @@ func TestLinuxPostSetupInfra(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create the API with the install controller
-		apiInstance := integration.NewAPIWithReleaseData(t,
+		apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 			api.WithLinuxInstallController(installController),
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),
@@ -294,7 +294,7 @@ func TestLinuxPostSetupInfra(t *testing.T) {
 	// Test authorization
 	t.Run("Authorization error", func(t *testing.T) {
 		// Create the API
-		apiInstance := integration.NewAPIWithReleaseData(t,
+		apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),
 		)
@@ -357,7 +357,7 @@ func TestLinuxPostSetupInfra(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create the API with the install controller
-		apiInstance := integration.NewAPIWithReleaseData(t,
+		apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 			api.WithLinuxInstallController(installController),
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),
@@ -415,7 +415,7 @@ func TestLinuxPostSetupInfra(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create the API with the install controller
-		apiInstance := integration.NewAPIWithReleaseData(t,
+		apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 			api.WithLinuxInstallController(installController),
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),
@@ -480,7 +480,7 @@ func TestLinuxPostSetupInfra(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create the API with the install controller
-		apiInstance := integration.NewAPIWithReleaseData(t,
+		apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 			api.WithLinuxInstallController(installController),
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),
@@ -544,7 +544,7 @@ func TestLinuxPostSetupInfra(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create the API with the install controller
-		apiInstance := integration.NewAPIWithReleaseData(t,
+		apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 			api.WithLinuxInstallController(installController),
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),
@@ -608,7 +608,7 @@ func TestLinuxPostSetupInfra(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create the API with the install controller
-		apiInstance := integration.NewAPIWithReleaseData(t,
+		apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 			api.WithLinuxInstallController(installController),
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),
@@ -693,7 +693,7 @@ func TestLinuxPostSetupInfra(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create the API with the install controller
-		apiInstance := integration.NewAPIWithReleaseData(t,
+		apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 			api.WithLinuxInstallController(installController),
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),

--- a/api/integration/linux/install/installation_test.go
+++ b/api/integration/linux/install/installation_test.go
@@ -205,7 +205,7 @@ func TestLinuxConfigureInstallation(t *testing.T) {
 			require.NoError(t, err)
 
 			// Create the API with the install controller
-			apiInstance := integration.NewAPIWithReleaseData(t,
+			apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 				api.WithLinuxInstallController(installController),
 				api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 				api.WithLogger(logger.NewDiscardLogger()),
@@ -303,7 +303,7 @@ func TestLinuxConfigureInstallationValidation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create the API with the install controller
-	apiInstance := integration.NewAPIWithReleaseData(t,
+	apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 		api.WithLinuxInstallController(installController),
 		api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 		api.WithLogger(logger.NewDiscardLogger()),
@@ -362,7 +362,7 @@ func TestLinuxConfigureInstallationBadRequest(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	apiInstance := integration.NewAPIWithReleaseData(t,
+	apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 		api.WithLinuxInstallController(installController),
 		api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 		api.WithLogger(logger.NewDiscardLogger()),
@@ -394,7 +394,7 @@ func TestLinuxConfigureInstallationControllerError(t *testing.T) {
 	mockController.On("ConfigureInstallation", mock.Anything, mock.Anything).Return(assert.AnError)
 
 	// Create the API with the mock controller
-	apiInstance := integration.NewAPIWithReleaseData(t,
+	apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 		api.WithLinuxInstallController(mockController),
 		api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 		api.WithLogger(logger.NewDiscardLogger()),
@@ -458,7 +458,7 @@ func TestLinuxGetInstallationConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create the API with the install controller
-	apiInstance := integration.NewAPIWithReleaseData(t,
+	apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 		api.WithLinuxInstallController(installController),
 		api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 		api.WithLogger(logger.NewDiscardLogger()),
@@ -519,7 +519,7 @@ func TestLinuxGetInstallationConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create the API with the install controller
-		emptyAPI := integration.NewAPIWithReleaseData(t,
+		emptyAPI := integration.NewTargetLinuxAPIWithReleaseData(t,
 			api.WithLinuxInstallController(emptyInstallController),
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),
@@ -582,7 +582,7 @@ func TestLinuxGetInstallationConfig(t *testing.T) {
 		mockController.On("GetInstallationConfig", mock.Anything).Return(types.LinuxInstallationConfig{}, assert.AnError)
 
 		// Create the API with the mock controller
-		apiInstance := integration.NewAPIWithReleaseData(t,
+		apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 			api.WithLinuxInstallController(mockController),
 			api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 			api.WithLogger(logger.NewDiscardLogger()),
@@ -659,7 +659,7 @@ func TestLinuxInstallationConfigWithAPIClient(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create the API with controllers
-	apiInstance := integration.NewAPIWithReleaseData(t,
+	apiInstance := integration.NewTargetLinuxAPIWithReleaseData(t,
 		api.WithAuthController(auth.NewStaticAuthController("TOKEN")),
 		api.WithLinuxInstallController(installController),
 		api.WithLogger(logger.NewDiscardLogger()),

--- a/api/integration/util.go
+++ b/api/integration/util.go
@@ -57,10 +57,22 @@ func NewTestInterceptorFuncs() interceptor.Funcs {
 	}
 }
 
-func NewAPIWithReleaseData(t *testing.T, opts ...api.Option) *api.API {
+func NewTargetLinuxAPIWithReleaseData(t *testing.T, opts ...api.Option) *api.API {
 	cfg := types.APIConfig{
-		Password:    "password",
-		ReleaseData: DefaultReleaseData(),
+		InstallTarget: types.InstallTargetLinux,
+		Password:      "password",
+		ReleaseData:   DefaultReleaseData(),
+	}
+	a, err := api.New(cfg, opts...)
+	require.NoError(t, err)
+	return a
+}
+
+func NewTargetKubernetesAPIWithReleaseData(t *testing.T, opts ...api.Option) *api.API {
+	cfg := types.APIConfig{
+		InstallTarget: types.InstallTargetKubernetes,
+		Password:      "password",
+		ReleaseData:   DefaultReleaseData(),
 	}
 	a, err := api.New(cfg, opts...)
 	require.NoError(t, err)

--- a/api/internal/clients/kube.go
+++ b/api/internal/clients/kube.go
@@ -71,10 +71,10 @@ func NewDiscoveryClient(opts KubeClientOptions) (discovery.DiscoveryInterface, e
 }
 
 func getRESTConfig(opts KubeClientOptions) (*rest.Config, error) {
-	if opts.RESTClientGetter == nil {
-		conf, err := clientcmd.BuildConfigFromFlags("", opts.KubeConfigPath)
+	if opts.RESTClientGetter != nil {
+		conf, err := opts.RESTClientGetter.ToRESTConfig()
 		if err != nil {
-			return nil, fmt.Errorf("unable to process kubernetes config for kube client: %w", err)
+			return nil, fmt.Errorf("invalid rest client getter: %w", err)
 		}
 		return conf, nil
 	}
@@ -82,10 +82,10 @@ func getRESTConfig(opts KubeClientOptions) (*rest.Config, error) {
 	if opts.KubeConfigPath != "" {
 		conf, err := clientcmd.BuildConfigFromFlags("", opts.KubeConfigPath)
 		if err != nil {
-			return nil, fmt.Errorf("unable to process kubernetes config for kube client: %w", err)
+			return nil, fmt.Errorf("invalid kubeconfig path: %w", err)
 		}
 		return conf, nil
 	}
 
-	return nil, fmt.Errorf("no rest client getter or kube config path provided")
+	return nil, fmt.Errorf("a valid kube config is required to create a kube client")
 }

--- a/api/internal/clients/kube_test.go
+++ b/api/internal/clients/kube_test.go
@@ -117,7 +117,7 @@ func TestNewKubeClient(t *testing.T) {
 				}
 			},
 			expectedError: true,
-			errorContains: "unable to process kubernetes config for kube client",
+			errorContains: "invalid kubeconfig path",
 		},
 		{
 			name: "error with invalid kubeconfig content",
@@ -128,7 +128,7 @@ func TestNewKubeClient(t *testing.T) {
 				}
 			},
 			expectedError: true,
-			errorContains: "unable to process kubernetes config for kube client",
+			errorContains: "invalid kubeconfig path",
 		},
 		{
 			name: "error with RESTClientGetter returning error",
@@ -140,7 +140,7 @@ func TestNewKubeClient(t *testing.T) {
 				}
 			},
 			expectedError: true,
-			errorContains: "unable to process rest client config for kube client",
+			errorContains: "invalid rest client getter",
 		},
 	}
 
@@ -214,7 +214,7 @@ func TestNewMetadataClient(t *testing.T) {
 				}
 			},
 			expectedError: true,
-			errorContains: "unable to process kubernetes config for kube client",
+			errorContains: "invalid kubeconfig path",
 		},
 		{
 			name: "error with invalid kubeconfig content",
@@ -225,7 +225,7 @@ func TestNewMetadataClient(t *testing.T) {
 				}
 			},
 			expectedError: true,
-			errorContains: "unable to process kubernetes config for kube client",
+			errorContains: "invalid kubeconfig path",
 		},
 		{
 			name: "error with RESTClientGetter returning error",
@@ -237,7 +237,7 @@ func TestNewMetadataClient(t *testing.T) {
 				}
 			},
 			expectedError: true,
-			errorContains: "unable to process rest client config for kube client",
+			errorContains: "invalid rest client getter",
 		},
 	}
 

--- a/api/internal/handlers/kubernetes/kubernetes.go
+++ b/api/internal/handlers/kubernetes/kubernetes.go
@@ -52,9 +52,15 @@ func New(cfg types.APIConfig, opts ...Option) (*Handler, error) {
 
 	// TODO (@team): discuss which of these should / should not be pointers
 	if h.installController == nil {
+		k8sVersion, err := getK8sVersion(h.cfg.RESTClientGetter)
+		if err != nil {
+			return nil, fmt.Errorf("get k8s version: %w", err)
+		}
+
 		installController, err := install.NewInstallController(
 			install.WithLogger(h.logger),
 			install.WithMetricsReporter(h.metricsReporter),
+			install.WithK8sVersion(k8sVersion),
 			install.WithRESTClientGetter(h.cfg.RESTClientGetter),
 			install.WithReleaseData(h.cfg.ReleaseData),
 			install.WithConfigValues(h.cfg.ConfigValues),

--- a/api/internal/handlers/kubernetes/util.go
+++ b/api/internal/handlers/kubernetes/util.go
@@ -1,0 +1,23 @@
+package kubernetes
+
+import (
+	"fmt"
+
+	"github.com/replicatedhq/embedded-cluster/api/internal/clients"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+// getK8sVersion creates a kubernetes client and returns the kubernetes version
+func getK8sVersion(restClientGetter genericclioptions.RESTClientGetter) (string, error) {
+	kcli, err := clients.NewDiscoveryClient(clients.KubeClientOptions{
+		RESTClientGetter: restClientGetter,
+	})
+	if err != nil {
+		return "", fmt.Errorf("create discovery client: %w", err)
+	}
+	version, err := kcli.ServerVersion()
+	if err != nil {
+		return "", fmt.Errorf("get server version: %w", err)
+	}
+	return version.String(), nil
+}

--- a/api/internal/managers/app/install/install_test.go
+++ b/api/internal/managers/app/install/install_test.go
@@ -181,6 +181,7 @@ func TestAppInstallManager_Install(t *testing.T) {
 			WithClusterID("test-cluster"),
 			WithAirgapBundle("test-airgap.tar.gz"),
 			WithReleaseData(releaseData),
+			WithK8sVersion("v1.33.0"),
 			WithKotsCLI(mockInstaller),
 			WithHelmClient(mockHelmClient),
 			WithLogger(logger.NewDiscardLogger()),
@@ -218,6 +219,7 @@ func TestAppInstallManager_Install(t *testing.T) {
 			WithLicense(licenseBytes),
 			WithClusterID("test-cluster"),
 			WithReleaseData(releaseData),
+			WithK8sVersion("v1.33.0"),
 			WithKotsCLI(mockInstaller),
 			WithHelmClient(mockHelmClient),
 			WithLogger(logger.NewDiscardLogger()),
@@ -263,6 +265,7 @@ func TestAppInstallManager_Install(t *testing.T) {
 			WithLicense(licenseBytes),
 			WithClusterID("test-cluster"),
 			WithReleaseData(releaseData),
+			WithK8sVersion("v1.33.0"),
 			WithHelmClient(mockHelmClient),
 			WithLogger(logger.NewDiscardLogger()),
 			WithAppInstallStore(store),
@@ -297,6 +300,7 @@ func TestAppInstallManager_Install(t *testing.T) {
 		manager, err := NewAppInstallManager(
 			WithLogger(logger.NewDiscardLogger()),
 			WithAppInstallStore(store),
+			WithK8sVersion("v1.33.0"),
 		)
 		require.NoError(t, err)
 
@@ -441,6 +445,7 @@ func TestComponentStatusTracking(t *testing.T) {
 		manager, err := NewAppInstallManager(
 			WithAppInstallStore(appInstallStore),
 			WithReleaseData(&release.ReleaseData{}),
+			WithK8sVersion("v1.33.0"),
 			WithLicense([]byte(`{"spec":{"appSlug":"test-app"}}`)),
 			WithClusterID("test-cluster"),
 			WithKotsCLI(mockInstaller),
@@ -493,6 +498,7 @@ func TestComponentStatusTracking(t *testing.T) {
 		manager, err := NewAppInstallManager(
 			WithAppInstallStore(appInstallStore),
 			WithReleaseData(&release.ReleaseData{}),
+			WithK8sVersion("v1.33.0"),
 			WithLicense([]byte(`{"spec":{"appSlug":"test-app"}}`)),
 			WithClusterID("test-cluster"),
 			WithHelmClient(mockHelmClient),

--- a/api/internal/managers/app/install/manager.go
+++ b/api/internal/managers/app/install/manager.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"context"
+	"fmt"
 
 	appinstallstore "github.com/replicatedhq/embedded-cluster/api/internal/store/app/install"
 	"github.com/replicatedhq/embedded-cluster/api/pkg/logger"
@@ -119,6 +120,10 @@ func NewAppInstallManager(opts ...AppInstallManagerOption) (*appInstallManager, 
 
 	for _, opt := range opts {
 		opt(manager)
+	}
+
+	if manager.k8sVersion == "" {
+		return nil, fmt.Errorf("k8s version required")
 	}
 
 	if manager.logger == nil {

--- a/api/internal/managers/app/install/manager.go
+++ b/api/internal/managers/app/install/manager.go
@@ -39,6 +39,7 @@ type appInstallManager struct {
 	kotsCLI          KotsCLIInstaller
 	logger           logrus.FieldLogger
 	hcli             helm.Client
+	k8sVersion       string
 	kubeConfigPath   string
 	restClientGetter genericclioptions.RESTClientGetter
 }
@@ -91,6 +92,12 @@ func WithKotsCLI(kotsCLI KotsCLIInstaller) AppInstallManagerOption {
 func WithHelmClient(hcli helm.Client) AppInstallManagerOption {
 	return func(m *appInstallManager) {
 		m.hcli = hcli
+	}
+}
+
+func WithK8sVersion(k8sVersion string) AppInstallManagerOption {
+	return func(m *appInstallManager) {
+		m.k8sVersion = k8sVersion
 	}
 }
 

--- a/api/internal/managers/app/install/util.go
+++ b/api/internal/managers/app/install/util.go
@@ -32,9 +32,13 @@ func (m *appInstallManager) setupHelmClient() error {
 		return nil
 	}
 
-	k8sVersion, err := m.getK8sVersion()
-	if err != nil {
-		return fmt.Errorf("get k8s version: %w", err)
+	k8sVersion := m.k8sVersion
+	if k8sVersion == "" {
+		var err error
+		k8sVersion, err = m.getK8sVersion()
+		if err != nil {
+			return fmt.Errorf("get k8s version: %w", err)
+		}
 	}
 
 	hcli, err := helm.NewClient(helm.HelmOptions{

--- a/api/internal/managers/app/release/manager.go
+++ b/api/internal/managers/app/release/manager.go
@@ -13,7 +13,6 @@ import (
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"github.com/sirupsen/logrus"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 // AppReleaseManager provides methods for managing the release of an app
@@ -31,8 +30,6 @@ type appReleaseManager struct {
 	privateCACertConfigMapName string
 	hcli                       helm.Client
 	k8sVersion                 string
-	restClientGetter           genericclioptions.RESTClientGetter
-	kubeConfigPath             string
 }
 
 type AppReleaseManagerOption func(*appReleaseManager)
@@ -79,18 +76,6 @@ func WithK8sVersion(k8sVersion string) AppReleaseManagerOption {
 	}
 }
 
-func WithRESTClientGetter(restClientGetter genericclioptions.RESTClientGetter) AppReleaseManagerOption {
-	return func(m *appReleaseManager) {
-		m.restClientGetter = restClientGetter
-	}
-}
-
-func WithKubeConfigPath(kubeConfigPath string) AppReleaseManagerOption {
-	return func(m *appReleaseManager) {
-		m.kubeConfigPath = kubeConfigPath
-	}
-}
-
 // NewAppReleaseManager creates a new AppReleaseManager
 func NewAppReleaseManager(config kotsv1beta1.Config, opts ...AppReleaseManagerOption) (AppReleaseManager, error) {
 	manager := &appReleaseManager{
@@ -103,6 +88,9 @@ func NewAppReleaseManager(config kotsv1beta1.Config, opts ...AppReleaseManagerOp
 
 	if manager.releaseData == nil {
 		return nil, fmt.Errorf("release data not found")
+	}
+	if manager.k8sVersion == "" {
+		return nil, fmt.Errorf("k8s version required")
 	}
 
 	if manager.logger == nil {

--- a/api/internal/managers/app/release/manager.go
+++ b/api/internal/managers/app/release/manager.go
@@ -8,10 +8,12 @@ import (
 	"github.com/replicatedhq/embedded-cluster/api/pkg/template"
 	"github.com/replicatedhq/embedded-cluster/api/types"
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"github.com/replicatedhq/embedded-cluster/pkg/helm"
 	"github.com/replicatedhq/embedded-cluster/pkg/release"
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"github.com/sirupsen/logrus"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 // AppReleaseManager provides methods for managing the release of an app
@@ -27,6 +29,9 @@ type appReleaseManager struct {
 	license                    *kotsv1beta1.License
 	logger                     logrus.FieldLogger
 	privateCACertConfigMapName string
+	hcli                       helm.Client
+	restClientGetter           genericclioptions.RESTClientGetter
+	kubeConfigPath             string
 }
 
 type AppReleaseManagerOption func(*appReleaseManager)
@@ -58,6 +63,24 @@ func WithLicense(license *kotsv1beta1.License) AppReleaseManagerOption {
 func WithPrivateCACertConfigMapName(configMapName string) AppReleaseManagerOption {
 	return func(m *appReleaseManager) {
 		m.privateCACertConfigMapName = configMapName
+	}
+}
+
+func WithHelmClient(hcli helm.Client) AppReleaseManagerOption {
+	return func(m *appReleaseManager) {
+		m.hcli = hcli
+	}
+}
+
+func WithRESTClientGetter(restClientGetter genericclioptions.RESTClientGetter) AppReleaseManagerOption {
+	return func(m *appReleaseManager) {
+		m.restClientGetter = restClientGetter
+	}
+}
+
+func WithKubeConfigPath(kubeConfigPath string) AppReleaseManagerOption {
+	return func(m *appReleaseManager) {
+		m.kubeConfigPath = kubeConfigPath
 	}
 }
 

--- a/api/internal/managers/app/release/manager.go
+++ b/api/internal/managers/app/release/manager.go
@@ -30,6 +30,7 @@ type appReleaseManager struct {
 	logger                     logrus.FieldLogger
 	privateCACertConfigMapName string
 	hcli                       helm.Client
+	k8sVersion                 string
 	restClientGetter           genericclioptions.RESTClientGetter
 	kubeConfigPath             string
 }
@@ -69,6 +70,12 @@ func WithPrivateCACertConfigMapName(configMapName string) AppReleaseManagerOptio
 func WithHelmClient(hcli helm.Client) AppReleaseManagerOption {
 	return func(m *appReleaseManager) {
 		m.hcli = hcli
+	}
+}
+
+func WithK8sVersion(k8sVersion string) AppReleaseManagerOption {
+	return func(m *appReleaseManager) {
+		m.k8sVersion = k8sVersion
 	}
 }
 

--- a/api/internal/managers/app/release/template.go
+++ b/api/internal/managers/app/release/template.go
@@ -226,9 +226,13 @@ func (m *appReleaseManager) setupHelmClient() error {
 		return nil
 	}
 
-	k8sVersion, err := m.getK8sVersion()
-	if err != nil {
-		return fmt.Errorf("get k8s version: %w", err)
+	k8sVersion := m.k8sVersion
+	if k8sVersion == "" {
+		var err error
+		k8sVersion, err = m.getK8sVersion()
+		if err != nil {
+			return fmt.Errorf("get k8s version: %w", err)
+		}
 	}
 
 	hcli, err := helm.NewClient(helm.HelmOptions{

--- a/api/internal/managers/app/release/template.go
+++ b/api/internal/managers/app/release/template.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"strconv"
 
-	clients "github.com/replicatedhq/embedded-cluster/api/internal/clients"
 	"github.com/replicatedhq/embedded-cluster/api/pkg/template"
 	"github.com/replicatedhq/embedded-cluster/api/types"
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
@@ -219,47 +218,6 @@ func (m *appReleaseManager) dryRunHelmChart(ctx context.Context, templatedCR *ko
 	}
 
 	return manifests, nil
-}
-
-func (m *appReleaseManager) setupHelmClient() error {
-	if m.hcli != nil {
-		return nil
-	}
-
-	k8sVersion := m.k8sVersion
-	if k8sVersion == "" {
-		var err error
-		k8sVersion, err = m.getK8sVersion()
-		if err != nil {
-			return fmt.Errorf("get k8s version: %w", err)
-		}
-	}
-
-	hcli, err := helm.NewClient(helm.HelmOptions{
-		// hcli.Render doesn't need a kubeconfig as it is client only
-		K8sVersion: k8sVersion,
-	})
-	if err != nil {
-		return fmt.Errorf("create helm client: %w", err)
-	}
-	m.hcli = hcli
-	return nil
-}
-
-// getK8sVersion creates a kubernetes client and returns the kubernetes version
-func (m *appReleaseManager) getK8sVersion() (string, error) {
-	kcli, err := clients.NewDiscoveryClient(clients.KubeClientOptions{
-		RESTClientGetter: m.restClientGetter,
-		KubeConfigPath:   m.kubeConfigPath,
-	})
-	if err != nil {
-		return "", fmt.Errorf("create discovery client: %w", err)
-	}
-	version, err := kcli.ServerVersion()
-	if err != nil {
-		return "", fmt.Errorf("get server version: %w", err)
-	}
-	return version.String(), nil
 }
 
 // generateHelmValues generates Helm values for a single templated HelmChart custom resource

--- a/api/internal/managers/app/release/template_test.go
+++ b/api/internal/managers/app/release/template_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/replicatedhq/embedded-cluster/api/types"
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"github.com/replicatedhq/embedded-cluster/pkg/helm"
 	"github.com/replicatedhq/embedded-cluster/pkg/release"
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	kotsv1beta2 "github.com/replicatedhq/kotskinds/apis/kots/v1beta2"
@@ -322,6 +323,11 @@ spec:
 		},
 	}
 
+	hcli, err := helm.NewClient(helm.HelmOptions{
+		K8sVersion: "1.33.0",
+	})
+	require.NoError(t, err)
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create release data
@@ -335,6 +341,7 @@ spec:
 			manager, err := NewAppReleaseManager(
 				config,
 				WithReleaseData(releaseData),
+				WithHelmClient(hcli),
 			)
 			require.NoError(t, err)
 
@@ -843,6 +850,11 @@ spec:
 		},
 	}
 
+	hcli, err := helm.NewClient(helm.HelmOptions{
+		K8sVersion: "1.33.0",
+	})
+	require.NoError(t, err)
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a basic config for the template engine
@@ -857,6 +869,7 @@ spec:
 			manager, err := NewAppReleaseManager(
 				config,
 				WithReleaseData(releaseData),
+				WithHelmClient(hcli),
 			)
 			require.NoError(t, err)
 
@@ -1120,6 +1133,11 @@ spec:
 		},
 	}
 
+	hcli, err := helm.NewClient(helm.HelmOptions{
+		K8sVersion: "1.33.0",
+	})
+	require.NoError(t, err)
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a basic config for the template engine
@@ -1132,6 +1150,7 @@ spec:
 			manager, err := NewAppReleaseManager(
 				config,
 				WithReleaseData(releaseData),
+				WithHelmClient(hcli),
 			)
 			require.NoError(t, err)
 
@@ -2495,6 +2514,11 @@ spec:
 		},
 	}
 
+	hcli, err := helm.NewClient(helm.HelmOptions{
+		K8sVersion: "1.33.0",
+	})
+	require.NoError(t, err)
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create release data
@@ -2508,6 +2532,7 @@ spec:
 			manager, err := NewAppReleaseManager(
 				config,
 				WithReleaseData(releaseData),
+				WithHelmClient(hcli),
 			)
 			require.NoError(t, err)
 

--- a/api/internal/managers/app/release/template_test.go
+++ b/api/internal/managers/app/release/template_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/replicatedhq/embedded-cluster/api/types"
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
-	"github.com/replicatedhq/embedded-cluster/pkg/helm"
 	"github.com/replicatedhq/embedded-cluster/pkg/release"
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	kotsv1beta2 "github.com/replicatedhq/kotskinds/apis/kots/v1beta2"
@@ -323,11 +322,6 @@ spec:
 		},
 	}
 
-	hcli, err := helm.NewClient(helm.HelmOptions{
-		K8sVersion: "1.33.0",
-	})
-	require.NoError(t, err)
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create release data
@@ -341,7 +335,7 @@ spec:
 			manager, err := NewAppReleaseManager(
 				config,
 				WithReleaseData(releaseData),
-				WithHelmClient(hcli),
+				WithK8sVersion("v1.33.0"),
 			)
 			require.NoError(t, err)
 
@@ -850,11 +844,6 @@ spec:
 		},
 	}
 
-	hcli, err := helm.NewClient(helm.HelmOptions{
-		K8sVersion: "1.33.0",
-	})
-	require.NoError(t, err)
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a basic config for the template engine
@@ -869,7 +858,7 @@ spec:
 			manager, err := NewAppReleaseManager(
 				config,
 				WithReleaseData(releaseData),
-				WithHelmClient(hcli),
+				WithK8sVersion("1.33.0"),
 			)
 			require.NoError(t, err)
 
@@ -1133,11 +1122,6 @@ spec:
 		},
 	}
 
-	hcli, err := helm.NewClient(helm.HelmOptions{
-		K8sVersion: "1.33.0",
-	})
-	require.NoError(t, err)
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a basic config for the template engine
@@ -1150,7 +1134,7 @@ spec:
 			manager, err := NewAppReleaseManager(
 				config,
 				WithReleaseData(releaseData),
-				WithHelmClient(hcli),
+				WithK8sVersion("v1.33.0"),
 			)
 			require.NoError(t, err)
 
@@ -2514,11 +2498,6 @@ spec:
 		},
 	}
 
-	hcli, err := helm.NewClient(helm.HelmOptions{
-		K8sVersion: "1.33.0",
-	})
-	require.NoError(t, err)
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create release data
@@ -2532,7 +2511,7 @@ spec:
 			manager, err := NewAppReleaseManager(
 				config,
 				WithReleaseData(releaseData),
-				WithHelmClient(hcli),
+				WithK8sVersion("v1.33.0"),
 			)
 			require.NoError(t, err)
 

--- a/api/internal/managers/app/release/util.go
+++ b/api/internal/managers/app/release/util.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/replicatedhq/embedded-cluster/api/internal/clients"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
 	kotsv1beta2 "github.com/replicatedhq/kotskinds/apis/kots/v1beta2"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
@@ -17,40 +16,15 @@ func (m *appReleaseManager) setupHelmClient() error {
 		return nil
 	}
 
-	k8sVersion := m.k8sVersion
-	if k8sVersion == "" {
-		var err error
-		k8sVersion, err = m.getK8sVersion()
-		if err != nil {
-			return fmt.Errorf("get k8s version: %w", err)
-		}
-	}
-
 	hcli, err := helm.NewClient(helm.HelmOptions{
 		// hcli.Render doesn't need a kubeconfig as it is client only
-		K8sVersion: k8sVersion,
+		K8sVersion: m.k8sVersion,
 	})
 	if err != nil {
 		return fmt.Errorf("create helm client: %w", err)
 	}
 	m.hcli = hcli
 	return nil
-}
-
-// getK8sVersion creates a kubernetes client and returns the kubernetes version
-func (m *appReleaseManager) getK8sVersion() (string, error) {
-	kcli, err := clients.NewDiscoveryClient(clients.KubeClientOptions{
-		RESTClientGetter: m.restClientGetter,
-		KubeConfigPath:   m.kubeConfigPath,
-	})
-	if err != nil {
-		return "", fmt.Errorf("create discovery client: %w", err)
-	}
-	version, err := kcli.ServerVersion()
-	if err != nil {
-		return "", fmt.Errorf("get server version: %w", err)
-	}
-	return version.String(), nil
 }
 
 // findChartArchive finds the chart archive that corresponds to the given HelmChart CR

--- a/api/internal/managers/app/release/util.go
+++ b/api/internal/managers/app/release/util.go
@@ -5,10 +5,53 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/replicatedhq/embedded-cluster/api/internal/clients"
+	"github.com/replicatedhq/embedded-cluster/pkg/helm"
 	kotsv1beta2 "github.com/replicatedhq/kotskinds/apis/kots/v1beta2"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"helm.sh/helm/v3/pkg/chart/loader"
 )
+
+func (m *appReleaseManager) setupHelmClient() error {
+	if m.hcli != nil {
+		return nil
+	}
+
+	k8sVersion := m.k8sVersion
+	if k8sVersion == "" {
+		var err error
+		k8sVersion, err = m.getK8sVersion()
+		if err != nil {
+			return fmt.Errorf("get k8s version: %w", err)
+		}
+	}
+
+	hcli, err := helm.NewClient(helm.HelmOptions{
+		// hcli.Render doesn't need a kubeconfig as it is client only
+		K8sVersion: k8sVersion,
+	})
+	if err != nil {
+		return fmt.Errorf("create helm client: %w", err)
+	}
+	m.hcli = hcli
+	return nil
+}
+
+// getK8sVersion creates a kubernetes client and returns the kubernetes version
+func (m *appReleaseManager) getK8sVersion() (string, error) {
+	kcli, err := clients.NewDiscoveryClient(clients.KubeClientOptions{
+		RESTClientGetter: m.restClientGetter,
+		KubeConfigPath:   m.kubeConfigPath,
+	})
+	if err != nil {
+		return "", fmt.Errorf("create discovery client: %w", err)
+	}
+	version, err := kcli.ServerVersion()
+	if err != nil {
+		return "", fmt.Errorf("get server version: %w", err)
+	}
+	return version.String(), nil
+}
 
 // findChartArchive finds the chart archive that corresponds to the given HelmChart CR
 func findChartArchive(helmChartArchives [][]byte, templatedCR *kotsv1beta2.HelmChart) ([]byte, error) {

--- a/api/internal/managers/linux/infra/util.go
+++ b/api/internal/managers/linux/infra/util.go
@@ -52,7 +52,7 @@ func (m *infraManager) setupClients(kubeConfigPath string, airgapChartsPath stri
 		}
 		hcli, err := helm.NewClient(helm.HelmOptions{
 			KubeConfig: kubeConfigPath,
-			K0sVersion: versions.K0sVersion,
+			K8sVersion: versions.K0sVersion,
 			AirgapPath: airgapPath,
 			LogFn:      m.logFn("helm"),
 		})

--- a/api/types/api.go
+++ b/api/types/api.go
@@ -9,8 +9,14 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
+const (
+	InstallTargetLinux      InstallTarget = "linux"
+	InstallTargetKubernetes InstallTarget = "kubernetes"
+)
+
 // APIConfig holds the configuration for the API server
 type APIConfig struct {
+	InstallTarget      InstallTarget
 	Password           string
 	TLSConfig          TLSConfig
 	License            []byte
@@ -25,6 +31,8 @@ type APIConfig struct {
 	LinuxConfig
 	KubernetesConfig
 }
+
+type InstallTarget string
 
 type LinuxConfig struct {
 	RuntimeConfig             runtimeconfig.RuntimeConfig

--- a/cmd/buildtools/metadata.go
+++ b/cmd/buildtools/metadata.go
@@ -44,7 +44,7 @@ var metadataExtractHelmChartImagesCommand = &cli.Command{
 		charts := metadata.Configs.Charts
 
 		hcli, err := helm.NewClient(helm.HelmOptions{
-			K0sVersion: metadata.Versions["Kubernetes"],
+			K8sVersion: metadata.Versions["Kubernetes"],
 		})
 		if err != nil {
 			return fmt.Errorf("failed to create helm client: %w", err)

--- a/cmd/buildtools/utils.go
+++ b/cmd/buildtools/utils.go
@@ -522,7 +522,7 @@ func NewHelm() (helm.Client, error) {
 	}
 	return helm.NewClient(helm.HelmOptions{
 		Writer:     logrus.New().Writer(),
-		K0sVersion: sv.Original(),
+		K8sVersion: sv.Original(),
 	})
 }
 

--- a/cmd/installer/cli/api.go
+++ b/cmd/installer/cli/api.go
@@ -85,7 +85,7 @@ func serveAPI(ctx context.Context, listener net.Listener, cert tls.Certificate, 
 	webServer, err := web.New(web.InitialState{
 		Title:         opts.ReleaseData.Application.Spec.Title,
 		Icon:          opts.ReleaseData.Application.Spec.Icon,
-		InstallTarget: string(opts.APIConfig.InstallTarget),
+		InstallTarget: string(opts.InstallTarget),
 	}, web.WithLogger(logger), web.WithAssetsFS(opts.WebAssetsFS))
 	if err != nil {
 		return fmt.Errorf("new web server: %w", err)

--- a/cmd/installer/cli/api.go
+++ b/cmd/installer/cli/api.go
@@ -27,8 +27,7 @@ import (
 type apiOptions struct {
 	apitypes.APIConfig
 
-	ManagerPort   int
-	InstallTarget string
+	ManagerPort int
 
 	Logger          logrus.FieldLogger
 	MetricsReporter metrics.ReporterInterface
@@ -86,7 +85,7 @@ func serveAPI(ctx context.Context, listener net.Listener, cert tls.Certificate, 
 	webServer, err := web.New(web.InitialState{
 		Title:         opts.ReleaseData.Application.Spec.Title,
 		Icon:          opts.ReleaseData.Application.Spec.Icon,
-		InstallTarget: opts.InstallTarget,
+		InstallTarget: string(opts.APIConfig.InstallTarget),
 	}, web.WithLogger(logger), web.WithAssetsFS(opts.WebAssetsFS))
 	if err != nil {
 		return fmt.Errorf("new web server: %w", err)

--- a/cmd/installer/cli/api_test.go
+++ b/cmd/installer/cli/api_test.go
@@ -57,7 +57,8 @@ func Test_serveAPI(t *testing.T) {
 
 	config := apiOptions{
 		APIConfig: apitypes.APIConfig{
-			Password: "password",
+			InstallTarget: apitypes.InstallTargetLinux,
+			Password:      "password",
 			ReleaseData: &release.ReleaseData{
 				Application: &kotsv1beta1.Application{
 					Spec: kotsv1beta1.ApplicationSpec{},

--- a/cmd/installer/cli/enable_ha.go
+++ b/cmd/installer/cli/enable_ha.go
@@ -81,7 +81,7 @@ func runEnableHA(ctx context.Context, rc runtimeconfig.RuntimeConfig) error {
 
 	hcli, err := helm.NewClient(helm.HelmOptions{
 		KubeConfig: rc.PathToKubeConfig(),
-		K0sVersion: versions.K0sVersion,
+		K8sVersion: versions.K0sVersion,
 		AirgapPath: airgapChartsPath,
 	})
 	if err != nil {

--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -803,7 +803,7 @@ func runInstall(ctx context.Context, flags InstallCmdFlags, rc runtimeconfig.Run
 
 	hcli, err := helm.NewClient(helm.HelmOptions{
 		KubeConfig: rc.PathToKubeConfig(),
-		K0sVersion: versions.K0sVersion,
+		K8sVersion: versions.K0sVersion,
 		AirgapPath: airgapChartsPath,
 	})
 	if err != nil {

--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -696,7 +696,8 @@ func runManagerExperienceInstall(
 
 	apiConfig := apiOptions{
 		APIConfig: apitypes.APIConfig{
-			Password: flags.adminConsolePassword,
+			InstallTarget: apitypes.InstallTarget(flags.target),
+			Password:      flags.adminConsolePassword,
 			TLSConfig: apitypes.TLSConfig{
 				CertBytes: flags.tlsCertBytes,
 				KeyBytes:  flags.tlsKeyBytes,
@@ -722,7 +723,6 @@ func runManagerExperienceInstall(
 		},
 
 		ManagerPort:     flags.managerPort,
-		InstallTarget:   flags.target,
 		MetricsReporter: metricsReporter,
 	}
 

--- a/cmd/installer/cli/join.go
+++ b/cmd/installer/cli/join.go
@@ -611,7 +611,7 @@ func maybeEnableHA(ctx context.Context, kcli client.Client, mcli metadata.Interf
 	}
 	hcli, err := helm.NewClient(helm.HelmOptions{
 		KubeConfig: rc.PathToKubeConfig(),
-		K0sVersion: versions.K0sVersion,
+		K8sVersion: versions.K0sVersion,
 		AirgapPath: airgapChartsPath,
 	})
 	if err != nil {

--- a/cmd/installer/cli/restore.go
+++ b/cmd/installer/cli/restore.go
@@ -406,7 +406,7 @@ func runRestoreStepNew(ctx context.Context, appSlug, appTitle string, flags Inst
 
 	hcli, err := helm.NewClient(helm.HelmOptions{
 		KubeConfig: rc.PathToKubeConfig(),
-		K0sVersion: versions.K0sVersion,
+		K8sVersion: versions.K0sVersion,
 		AirgapPath: airgapChartsPath,
 	})
 	if err != nil {
@@ -613,7 +613,7 @@ func runRestoreEnableAdminConsoleHA(ctx context.Context, flags InstallCmdFlags, 
 
 	hcli, err := helm.NewClient(helm.HelmOptions{
 		KubeConfig: rc.PathToKubeConfig(),
-		K0sVersion: versions.K0sVersion,
+		K8sVersion: versions.K0sVersion,
 		AirgapPath: airgapChartsPath,
 	})
 	if err != nil {
@@ -711,7 +711,7 @@ func runRestoreExtensions(ctx context.Context, flags InstallCmdFlags, rc runtime
 
 	hcli, err := helm.NewClient(helm.HelmOptions{
 		KubeConfig: rc.PathToKubeConfig(),
-		K0sVersion: versions.K0sVersion,
+		K8sVersion: versions.K0sVersion,
 		AirgapPath: airgapChartsPath,
 	})
 	if err != nil {

--- a/operator/pkg/cli/upgrade_job.go
+++ b/operator/pkg/cli/upgrade_job.go
@@ -60,7 +60,7 @@ func UpgradeJobCmd() *cobra.Command {
 			}
 
 			hcli, err := helm.NewClient(helm.HelmOptions{
-				K0sVersion: versions.K0sVersion,
+				K8sVersion: versions.K0sVersion,
 				AirgapPath: airgapChartsPath,
 				LogFn: func(format string, v ...interface{}) {
 					slog.Info(fmt.Sprintf(format, v...), "component", "helm")

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -69,8 +69,8 @@ func newClient(opts HelmOptions) (*HelmClient, error) {
 		registryOpts = append(registryOpts, registry.ClientOptWriter(opts.Writer))
 	}
 	var kversion *semver.Version
-	if opts.K0sVersion != "" {
-		sv, err := semver.NewVersion(opts.K0sVersion)
+	if opts.K8sVersion != "" {
+		sv, err := semver.NewVersion(opts.K8sVersion)
 		if err != nil {
 			return nil, fmt.Errorf("parse k0s version: %w", err)
 		}
@@ -100,7 +100,7 @@ func newClient(opts HelmOptions) (*HelmClient, error) {
 type HelmOptions struct {
 	KubeConfig       string
 	RESTClientGetter genericclioptions.RESTClientGetter
-	K0sVersion       string
+	K8sVersion       string
 	AirgapPath       string
 	Writer           io.Writer
 	LogFn            action.DebugLog


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

App release manager needs to use a helm client with the k8s version so that it can properly render templates using KubeVersion helm built-in.

Additionally, app install manager is using the incorrect k8s version when instantiating the helm client for target=kubernetes. It is using the version from the build when it should be using the version discovered from the cluster. This makes it so the version is always retrieved from the cluster.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
