### PR TITLE
feat(v3): rely on kots to process the app airgap bundle and create the image pull secrets

### DIFF
--- a/api/internal/managers/app/install/install.go
+++ b/api/internal/managers/app/install/install.go
@@ -86,11 +86,25 @@ func (m *appInstallManager) installKots(kotsConfigValues kotsv1beta1.ConfigValue
 	}
 	installOpts.ConfigValuesFile = configValuesFile
 
+	logFn := m.logFn("app")
+
+	logFn("preparing the app for installation")
+
 	if m.kotsCLI != nil {
-		return m.kotsCLI.Install(installOpts)
+		err := m.kotsCLI.Install(installOpts)
+		if err != nil {
+			return fmt.Errorf("install kots: %w", err)
+		}
+	} else {
+		err := kotscli.Install(installOpts)
+		if err != nil {
+			return fmt.Errorf("install kots: %w", err)
+		}
 	}
 
-	return kotscli.Install(installOpts)
+	logFn("successfully prepared the app for installation")
+
+	return nil
 }
 
 // createConfigValuesFile creates a temporary file with the config values
@@ -139,6 +153,8 @@ func (m *appInstallManager) installHelmCharts(ctx context.Context, installableCh
 
 		logFn("successfully installed %s chart", chartName)
 	}
+
+	logFn("successfully installed all %d helm charts", len(installableCharts))
 
 	return nil
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Call the kots install cli command before we install the app's helm charts to process the app airgap bundle and create the image pull secrets.

Tested end to end:

Using the test app the charts were deployed. The regular yaml files were not.

<img width="961" height="808" alt="Screenshot 2025-08-27 at 3 04 01 PM" src="https://github.com/user-attachments/assets/8ac4a50a-0db2-4a7e-99e2-a5e0fdc0964c" />

EC does not inject global replicated values so replicated-sdk is crashing.

```
root@node0:/replicatedhq/embedded-cluster# kubectl logs -n nginx-app          replicated-7fc8f67688-ndf42
Error: either license in the config file or integration license id must be specified
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
