### PR TITLE
fix(ci): e2e snapshot test flake

### DIFF
--- a/e2e/playwright/tests/create-backup/test.spec.ts
+++ b/e2e/playwright/tests/create-backup/test.spec.ts
@@ -18,13 +18,17 @@ test('create backup', async ({ page }) => {
   await page.getByPlaceholder('http[s]://hostname[:port]').fill(process.env.DR_S3_ENDPOINT);
   await page.getByPlaceholder('us-east-1').click();
   await page.getByPlaceholder('us-east-1').fill(process.env.DR_S3_REGION);
-  await page.getByRole('button', { name: 'Update storage settings' }).click();
-  await expect(page.locator('.Loader')).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Updating', exact: true })).toBeDisabled();
-  await expect(page.getByRole('button', { name: 'Update storage settings' })).not.toBeVisible();
-  await expect(page.locator('form')).toContainText('Settings updated', { timeout: 90000 });
-  await expect(page.locator('.Loader')).not.toBeVisible();
-  await expect(page.getByRole('button', { name: 'Update storage settings' })).toBeEnabled();
+
+  const storageCard = page.locator('[data-testid="snapshots-storage-settings-card"]');
+  await expect(storageCard.getByRole('button', { name: 'Update storage settings' })).toBeVisible();
+  await storageCard.getByRole('button', { name: 'Update storage settings' }).click();
+  await expect(storageCard.locator('.Loader')).toBeVisible();
+  await expect(storageCard.getByRole('button', { name: 'Updating', exact: true })).toBeDisabled();
+  await expect(storageCard.getByRole('button', { name: 'Update storage settings' })).not.toBeVisible();
+  await expect(storageCard.locator('form')).toContainText('Settings updated', { timeout: 90000 });
+  await expect(storageCard.locator('.Loader')).not.toBeVisible();
+  await expect(storageCard.getByRole('button', { name: 'Update storage settings' })).toBeEnabled();
+
   await page.locator('.subnav-item').getByText('Backups', { exact: true }).click();
   await expect(page.locator('#app')).toContainText('No backups yet');
   await page.getByRole('button', { name: 'Start a backup' }).click();


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

the test is failing because there are two loaders on the page

```
Error: expect.toBeVisible: Error: strict mode violation: locator('.Loader') resolved to 2 elements:
    1) <div class="Loader u-marginLeft--10 u-display--inlineBlock">…</div> aka locator('div').filter({ hasText: /^Updating$/ }).locator('div')
    2) <div class="Loader u-display--inlineBlock">…</div> aka locator('.flex-column > .Loader')
Call log:
  - Expect "toBeVisible" with timeout 5000ms
waiting for locator('.Loader')
```

<img width="899" height="695" alt="Screenshot 2025-08-27 at 1 50 36 PM" src="https://github.com/user-attachments/assets/737d77a8-505b-4e1c-9ef0-5b6494db8f99" />

https://github.com/replicatedhq/embedded-cluster/actions/runs/17257008089/job/49028266947#step:4:307

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
