### PR TITLE
fix(web): code block rendering in markdown

### DIFF
--- a/web/src/components/common/HelpText.tsx
+++ b/web/src/components/common/HelpText.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
 import { truncate } from '../../utils/textUtils';
+import Markdown from './Markdown';
 
 interface HelpTextProps {
   dataTestId?: string;
@@ -33,27 +32,11 @@ const HelpText: React.FC<HelpTextProps> = ({ dataTestId, helpText, defaultValue,
 
   return (
     <div data-testid={dataTestId ? `help-text-${dataTestId}` : "help-text"} className="mt-1 text-sm text-gray-500 [&_p]:inline [&_p]:mb-0">
-      <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
+      <Markdown
         rehypePlugins={shouldTruncate && !showFullText ? [[truncate, maxTextLength]] : []}
-        components={{
-          a: ({ ...props }) => (
-            <a
-              {...props}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-blue-600 hover:text-blue-800 underline"
-            />
-          ),
-          code: ({ children }) => (
-            <code className="font-mono text-xs bg-gray-100 px-1 py-0.5 rounded">
-              {children}
-            </code>
-          ),
-        }}
       >
         {combinedText}
-      </ReactMarkdown>
+      </Markdown>
       {shouldTruncate && (
         <button
           onClick={() => setShowFullText(!showFullText)}

--- a/web/src/components/common/Label.tsx
+++ b/web/src/components/common/Label.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import Markdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
+import Markdown from './Markdown';
 
 interface LabelProps {
   content: string;
@@ -16,24 +15,7 @@ const Label: React.FC<LabelProps> = ({
   return (
     <div className={`mb-4 ${className}`} data-testid={dataTestId}>
       <div className="prose prose-sm prose-gray max-w-none">
-        <Markdown
-          remarkPlugins={[remarkGfm]}
-          components={{
-            a: ({ ...props }) => (
-              <a
-                {...props}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:text-blue-800 underline"
-              />
-            ),
-            code: ({ children }) => (
-              <code className="font-mono text-xs bg-gray-100 px-1 py-0.5 rounded">
-                {children}
-              </code>
-            ),
-          }}
-        >
+        <Markdown>
           {content}
         </Markdown>
       </div>

--- a/web/src/components/common/Markdown.tsx
+++ b/web/src/components/common/Markdown.tsx
@@ -23,7 +23,7 @@ const Markdown: React.FC<MarkdownProps> = ({ children, rehypePlugins = [] }) => 
           />
         ),
         // We use:
-        // - pre selectors to style code blocks and inline code blocks differently. This is becasuse code blocks are rendered with a <pre><code>...</code></pre> structure
+        // - pre selectors to style code blocks and inline code blocks differently. This is because code blocks are rendered with a <pre><code>...</code></pre> structure
         // - before:content-none and after:content-none to remove the default backticks that are added by the Label component through the prose class
         code: ({ children }) => (
           <code className="font-mono text-xs bg-gray-100 px-1 py-0.5 rounded [pre_&]:text-sm [pre_&]:bg-transparent [pre_&]:px-0 [pre_&]:py-0 before:content-none after:content-none">

--- a/web/src/components/common/Markdown.tsx
+++ b/web/src/components/common/Markdown.tsx
@@ -5,7 +5,6 @@ import type { PluggableList } from 'react-markdown/lib/react-markdown';
 
 interface MarkdownProps {
   children: string;
-  className?: string;
   rehypePlugins?: PluggableList;
 }
 

--- a/web/src/components/common/Markdown.tsx
+++ b/web/src/components/common/Markdown.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+interface MarkdownProps {
+  children: string;
+  className?: string;
+  rehypePlugins?: any[];
+}
+
+const Markdown: React.FC<MarkdownProps> = ({ children, rehypePlugins = [] }) => {
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm]}
+      rehypePlugins={rehypePlugins}
+      components={{
+        a: ({ ...props }) => (
+          <a
+            {...props}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 hover:text-blue-800 underline"
+          />
+        ),
+        // We use:
+        // - pre selectors to style code blocks and inline code blocks differently. This is becasuse code blocks are rendered with a <pre><code>...</code></pre> structure
+        // - before:content-none and after:content-none to remove the default backticks that are added by the Label component through the prose class
+        code: ({ children }) => (
+          <code className="font-mono text-xs bg-gray-100 px-1 py-0.5 rounded [pre_&]:text-sm [pre_&]:bg-transparent [pre_&]:px-0 [pre_&]:py-0 before:content-none after:content-none">
+            {children}
+          </code>
+        ),
+      }}
+    >
+      {children}
+    </ReactMarkdown>
+  );
+};
+
+export default Markdown;

--- a/web/src/components/common/Markdown.tsx
+++ b/web/src/components/common/Markdown.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import type { PluggableList } from 'react-markdown/lib/react-markdown';
 
 interface MarkdownProps {
   children: string;
   className?: string;
-  rehypePlugins?: any[];
+  rehypePlugins?: PluggableList;
 }
 
 const Markdown: React.FC<MarkdownProps> = ({ children, rehypePlugins = [] }) => {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Fix rendering issues with the code blocks in markdown.


Printscreen fix:
<img width="1281" height="426" alt="image" src="https://github.com/user-attachments/assets/e81f4d2f-2065-4a81-a5e9-a69ebed672c3" />


Before:
<img width="1308" height="398" alt="image" src="https://github.com/user-attachments/assets/60013ca8-9031-4b7e-be2f-908df4ce641c" />


#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/126837/markdown-code-blocks-have-the-wrong-background-color

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
It's a visual change only unfortunately, hard to test IMO and doing so through CSS classes can be messy.

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fix markdown rendering issues for code blocks for V3
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
