### PR TITLE
fix(v3): names of uploaded files are not displayed correctly

### DIFF
--- a/api/pkg/template/config.go
+++ b/api/pkg/template/config.go
@@ -127,7 +127,12 @@ func (e *Engine) configOptionFilename(name string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolve config item: %w", err)
 	}
-	return resolved.Filename, nil
+
+	// Only return user filename, not config filename for KOTS parity
+	if resolved.UserFilename != nil {
+		return *resolved.UserFilename, nil
+	}
+	return "", nil
 }
 
 // resolveConfigItem processes a config item and returns its resolved values. It determines:

--- a/api/pkg/template/config.go
+++ b/api/pkg/template/config.go
@@ -55,6 +55,9 @@ func (e *Engine) templateConfigItems() (*kotsv1beta1.Config, error) {
 
 			cfg.Spec.Groups[i].Items[j].Value = multitype.FromString(value)
 			cfg.Spec.Groups[i].Items[j].Default = multitype.FromString(resolved.Default)
+			if resolved.Filename != "" {
+				cfg.Spec.Groups[i].Items[j].Filename = resolved.Filename
+			}
 		}
 	}
 	return cfg, nil

--- a/api/pkg/template/execute_test.go
+++ b/api/pkg/template/execute_test.go
@@ -1167,7 +1167,8 @@ func TestEngine_ConfigMode_BasicTemplating(t *testing.T) {
 
 	expectedYAML := `apiVersion: kots.io/v1beta1
 kind: Config
-metadata: {}
+metadata:
+  creationTimestamp: null
 spec:
   groups:
   - items:
@@ -1251,7 +1252,8 @@ func TestEngine_ConfigMode_ValuePriority(t *testing.T) {
 
 	expectedYAMLWithUserValues := `apiVersion: kots.io/v1beta1
 kind: Config
-metadata: {}
+metadata:
+  creationTimestamp: null
 spec:
   groups:
   - items:
@@ -1288,7 +1290,8 @@ status: {}
 
 	expectedYAMLWithoutUserValues := `apiVersion: kots.io/v1beta1
 kind: Config
-metadata: {}
+metadata:
+  creationTimestamp: null
 spec:
   groups:
   - items:
@@ -1420,7 +1423,8 @@ func TestEngine_ConfigMode_ComplexDependencyChain(t *testing.T) {
 
 	expectedYAML := `apiVersion: kots.io/v1beta1
 kind: Config
-metadata: {}
+metadata:
+  creationTimestamp: null
 spec:
   groups:
   - items:

--- a/api/pkg/template/execute_test.go
+++ b/api/pkg/template/execute_test.go
@@ -1076,8 +1076,8 @@ repl{{ toJson $tls }}`),
 	})
 
 	// Verify performance characteristics: non-cached should be in ms, cached much faster
-	assert.True(t, firstDuration > time.Millisecond*100, "First execution should take at least 100ms (cert generation)")
-	assert.True(t, firstCachedDuration < time.Millisecond*20, "First cached execution should be under 20ms")
+	assert.Greater(t, firstDuration, time.Millisecond*50, "First execution should take at least 50ms (cert generation)")
+	assert.Less(t, firstCachedDuration, time.Millisecond*20, "First cached execution should be under 20ms")
 
 	// Verify caching provides significant speedup
 	assert.True(t, firstCachedDuration < firstDuration/5,
@@ -1102,8 +1102,8 @@ repl{{ toJson $tls }}`),
 	})
 
 	// Verify performance characteristics for second hostname
-	assert.True(t, secondDuration > time.Millisecond*100, "Second execution should take at least 100ms (cert generation)")
-	assert.True(t, secondCachedDuration < time.Millisecond*20, "Second cached execution should be under 20ms")
+	assert.Greater(t, secondDuration, time.Millisecond*50, "Second execution should take at least 50ms (cert generation)")
+	assert.Less(t, secondCachedDuration, time.Millisecond*20, "Second cached execution should be under 20ms")
 
 	// Verify caching provides significant speedup
 	assert.True(t, secondCachedDuration < secondDuration/5,
@@ -1167,8 +1167,7 @@ func TestEngine_ConfigMode_BasicTemplating(t *testing.T) {
 
 	expectedYAML := `apiVersion: kots.io/v1beta1
 kind: Config
-metadata:
-  creationTimestamp: null
+metadata: {}
 spec:
   groups:
   - items:
@@ -1252,8 +1251,7 @@ func TestEngine_ConfigMode_ValuePriority(t *testing.T) {
 
 	expectedYAMLWithUserValues := `apiVersion: kots.io/v1beta1
 kind: Config
-metadata:
-  creationTimestamp: null
+metadata: {}
 spec:
   groups:
   - items:
@@ -1290,8 +1288,7 @@ status: {}
 
 	expectedYAMLWithoutUserValues := `apiVersion: kots.io/v1beta1
 kind: Config
-metadata:
-  creationTimestamp: null
+metadata: {}
 spec:
   groups:
   - items:
@@ -1423,8 +1420,7 @@ func TestEngine_ConfigMode_ComplexDependencyChain(t *testing.T) {
 
 	expectedYAML := `apiVersion: kots.io/v1beta1
 kind: Config
-metadata:
-  creationTimestamp: null
+metadata: {}
 spec:
   groups:
   - items:

--- a/e2e/kots-release-install-v3/config.yaml
+++ b/e2e/kots-release-install-v3/config.yaml
@@ -356,6 +356,7 @@ spec:
           type: file
           default: "default file"
           help_text: "Help text of a **_File_** config item type **_with default value_**"
+          filename: "default-file.txt"
 
         - name: file_required
           title: File marked required

--- a/e2e/kots-release-install-v3/config.yaml
+++ b/e2e/kots-release-install-v3/config.yaml
@@ -181,6 +181,12 @@ spec:
           type: text
           help_text: "Help text of a simple **_Text_** config item type"
 
+        - name: text_with_value
+          title: Text with value
+          type: text
+          value: "value text"
+          help_text: "Help text of a **_Text_** config item type **_with value_**"
+
         - name: text_with_default
           title: Text with default value
           type: text

--- a/web/src/components/wizard/config/ConfigurationStep.tsx
+++ b/web/src/components/wizard/config/ConfigurationStep.tsx
@@ -238,6 +238,12 @@ const ConfigurationStep: React.FC<ConfigurationStepProps> = ({ onNext }) => {
     return changedValues?.[item.name]?.value ?? (item.value || item.default || '');
   };
 
+  // Helper function to get the display filename for a config item (no defaults)
+  const getDisplayFilename = (item: AppConfigItem): string => {
+    // First check user value, then config item value (use ?? to allow empty strings from the user)
+    return changedValues?.[item.name]?.filename ?? (item.filename || '');
+  };
+
   // Helper function for password types to determine if the show password toggle should be enabled
   const allowShowPassword = (item: AppConfigItem): boolean => {
     // Only allow show password if the item is a password type and has a user value set
@@ -374,7 +380,7 @@ const ConfigurationStep: React.FC<ConfigurationStepProps> = ({ onNext }) => {
           <FileInput
             {...sharedProps}
             value={getDisplayValue(item)}
-            filename={changedValues[item.name]?.filename}
+            filename={getDisplayFilename(item)}
             defaultValue={item.default}
             defaultFilename={item.name}
             onChange={(value: string, filename: string) => handleFileChange(item.name, value, filename)}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -48,6 +48,7 @@ export interface AppConfigItem {
   type: string;
   value?: string;
   default?: string;
+  filename?: string;
   items?: AppConfigChildItem[];
 }
 

--- a/web/static.go
+++ b/web/static.go
@@ -72,7 +72,7 @@ func New(initialState InitialState, opts ...WebOption) (*Web, error) {
 	}
 
 	// TODO we might consider moving this env var evaluation to the CLI and make it an overarching property of the project
-	if os.Getenv("EC_DEV_ENV") == "true" {
+	if os.Getenv("EC_DEV_ENV") == "true" || os.Getenv("EC_DEV_ENV") == "1" {
 		web.isDev = true
 	}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Displays the correct filename when navigating back and forth through the installer
Fixes an issue where the user cannot clear the value (or file) if a value is set in the config

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
