### PR TITLE
feat(v3): update the app installation page to show charts being installed with progress

### DIFF
--- a/api/internal/managers/app/install/install.go
+++ b/api/internal/managers/app/install/install.go
@@ -203,7 +203,7 @@ func (m *appInstallManager) installHelmChart(ctx context.Context, installableCha
 		Values:      installableChart.Values,
 	})
 	if err != nil {
-		return fmt.Errorf("helm install: %w", err)
+		return err // do not wrap as wrapping is repetitive, e.g. "helm install: helm install: context deadline exceeded"
 	}
 
 	return nil
@@ -213,7 +213,11 @@ func (m *appInstallManager) installHelmChart(ctx context.Context, installableCha
 func (m *appInstallManager) initializeComponents(charts []types.InstallableHelmChart) error {
 	chartNames := make([]string, 0, len(charts))
 	for _, chart := range charts {
-		chartNames = append(chartNames, chart.CR.GetChartName())
+		chartName := chart.CR.GetName()
+		if chartName == "" {
+			chartName = chart.CR.GetChartName()
+		}
+		chartNames = append(chartNames, chartName)
 	}
 
 	return m.appInstallStore.RegisterComponents(chartNames)

--- a/e2e/kots-release-install-v3/nginx-app-helm-v1beta2.yaml
+++ b/e2e/kots-release-install-v3/nginx-app-helm-v1beta2.yaml
@@ -1,7 +1,7 @@
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
-  name: nginx-app
+  name: Nginx App
 spec:
   chart:
     name: nginx-app

--- a/web/src/components/wizard/installation/tests/AppInstallationPhase.test.tsx
+++ b/web/src/components/wizard/installation/tests/AppInstallationPhase.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeAll, afterEach, afterAll } from 'vitest';
-import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
@@ -13,9 +12,9 @@ const createServer = (target: 'linux' | 'kubernetes') => setupServer(
   // Mock app installation status endpoint
   http.get(`*/api/${target}/install/app/status`, () => {
     return HttpResponse.json({
-      status: { 
-        state: 'Running', 
-        description: 'Installing application components...' 
+      status: {
+        state: 'Running',
+        description: 'Installing application components...'
       }
     });
   })
@@ -67,9 +66,9 @@ describe.each([
     server.use(
       http.get(`*/api/${target}/install/app/status`, () => {
         return HttpResponse.json({
-          status: { 
-            state: 'Running', 
-            description: 'Installing application components...' 
+          status: {
+            state: 'Running',
+            description: 'Installing application components...'
           }
         });
       })
@@ -88,10 +87,10 @@ describe.each([
       }
     );
 
-    // Should show loading state
+    // Should show installation in progress (log viewer should be present)
     await waitFor(() => {
-      expect(screen.getByTestId('app-installation-loading')).toBeInTheDocument();
-      expect(screen.getByTestId('app-installation-loading-description')).toBeInTheDocument();
+      expect(screen.getByTestId('log-viewer')).toBeInTheDocument();
+      expect(screen.getByText('Installing application components...')).toBeInTheDocument();
     });
 
     // Next button should be disabled during installation
@@ -105,9 +104,9 @@ describe.each([
     server.use(
       http.get(`*/api/${target}/install/app/status`, () => {
         return HttpResponse.json({
-          status: { 
-            state: 'Succeeded', 
-            description: 'Application installed successfully' 
+          status: {
+            state: 'Succeeded',
+            description: 'Application installed successfully'
           }
         });
       })
@@ -126,9 +125,9 @@ describe.each([
       }
     );
 
-    // Should show success state
+    // Should show success message in progress area
     await waitFor(() => {
-      expect(screen.getByTestId('app-installation-success')).toBeInTheDocument();
+      expect(screen.getByText('Application installed successfully')).toBeInTheDocument();
     });
 
     // Next button should be enabled after successful installation
@@ -137,7 +136,7 @@ describe.each([
       expect(nextButton).not.toBeDisabled();
     });
 
-    // Should call onStateChange with "Succeeded" 
+    // Should call onStateChange with "Succeeded"
     await waitFor(() => {
       const calls = mockOnStateChange.mock.calls.map(args => args[0]);
       expect(calls).toEqual(['Running', 'Succeeded']);
@@ -149,9 +148,9 @@ describe.each([
     server.use(
       http.get(`*/api/${target}/install/app/status`, () => {
         return HttpResponse.json({
-          status: { 
-            state: 'Failed', 
-            description: 'Installation failed due to insufficient resources' 
+          status: {
+            state: 'Failed',
+            description: 'Installation failed due to insufficient resources'
           }
         });
       })
@@ -170,10 +169,10 @@ describe.each([
       }
     );
 
-    // Should show error state
+    // Should show error message
     await waitFor(() => {
-      expect(screen.getByTestId('app-installation-error')).toBeInTheDocument();
-      expect(screen.getByTestId('app-installation-error-message')).toBeInTheDocument();
+      expect(screen.getByTestId('error-message')).toBeInTheDocument();
+      expect(screen.getAllByText('Installation failed due to insufficient resources')).toHaveLength(2);
     });
 
     // Next button should be disabled after failed installation
@@ -280,9 +279,9 @@ describe.each([
       }
     );
 
-    // Should show default loading state
+    // Should show log viewer (component is rendered)
     await waitFor(() => {
-      expect(screen.getByTestId('app-installation-loading')).toBeInTheDocument();
+      expect(screen.getByTestId('log-viewer')).toBeInTheDocument();
     });
 
     // Next button should be disabled
@@ -298,9 +297,9 @@ describe.each([
       http.get(`*/api/${target}/install/app/status`, () => {
         callCount++;
         return HttpResponse.json({
-          status: { 
-            state: 'Succeeded', 
-            description: 'Application installed successfully' 
+          status: {
+            state: 'Succeeded',
+            description: 'Application installed successfully'
           }
         });
       })
@@ -319,16 +318,16 @@ describe.each([
       }
     );
 
-    // Wait for success state
+    // Wait for success message to appear
     await waitFor(() => {
-      expect(screen.getByTestId('app-installation-success')).toBeInTheDocument();
+      expect(screen.getByText('Application installed successfully')).toBeInTheDocument();
     });
 
     const initialCallCount = callCount;
-    
+
     // Wait a bit more and ensure no additional calls are made
     await new Promise(resolve => setTimeout(resolve, 3000));
-    
+
     // Should not make additional API calls after success
     expect(callCount).toBeLessThanOrEqual(initialCallCount + 1); // Allow for one potential additional call due to timing
   });
@@ -339,9 +338,9 @@ describe.each([
       http.get(`*/api/${target}/install/app/status`, () => {
         callCount++;
         return HttpResponse.json({
-          status: { 
-            state: 'Failed', 
-            description: 'Installation failed' 
+          status: {
+            state: 'Failed',
+            description: 'Installation failed'
           }
         });
       })
@@ -360,29 +359,29 @@ describe.each([
       }
     );
 
-    // Wait for failure state
+    // Wait for error message to appear
     await waitFor(() => {
-      expect(screen.getByTestId('app-installation-error')).toBeInTheDocument();
+      expect(screen.getByTestId('error-message')).toBeInTheDocument();
     });
 
     const initialCallCount = callCount;
-    
+
     // Wait a bit more and ensure no additional calls are made
     await new Promise(resolve => setTimeout(resolve, 3000));
-    
+
     // Should not make additional API calls after failure
     expect(callCount).toBeLessThanOrEqual(initialCallCount + 1); // Allow for one potential additional call due to timing
   });
 
   it('displays custom status description when available', async () => {
     const customDescription = 'Configuring application settings and finalizing setup...';
-    
+
     server.use(
       http.get(`*/api/${target}/install/app/status`, () => {
         return HttpResponse.json({
-          status: { 
-            state: 'Running', 
-            description: customDescription 
+          status: {
+            state: 'Running',
+            description: customDescription
           }
         });
       })
@@ -401,9 +400,9 @@ describe.each([
       }
     );
 
-    // Should display custom description
+    // Should display custom description in the progress message
     await waitFor(() => {
-      expect(screen.getByTestId('app-installation-loading-description')).toBeInTheDocument();
+      expect(screen.getByText(customDescription)).toBeInTheDocument();
     });
   });
 
@@ -411,7 +410,7 @@ describe.each([
     server.use(
       http.get(`*/api/${target}/install/app/status`, () => {
         return HttpResponse.json({
-          status: { 
+          status: {
             state: 'Running'
           }
         });
@@ -431,9 +430,265 @@ describe.each([
       }
     );
 
-    // Should display fallback message
+    // Should display fallback message (Preparing installation...)
     await waitFor(() => {
-      expect(screen.getByTestId('app-installation-loading-description')).toBeInTheDocument();
+      expect(screen.getByText('Preparing installation...')).toBeInTheDocument();
+    });
+  });
+
+  it('displays individual component status indicators', async () => {
+    server.use(
+      http.get(`*/api/${target}/install/app/status`, () => {
+        return HttpResponse.json({
+          status: {
+            state: 'Running',
+            description: 'Installing application components...'
+          },
+          components: [
+            {
+              name: 'Nginx App',
+              status: { state: 'Running', description: 'Installing chart' }
+            },
+            {
+              name: 'Redis App',
+              status: { state: 'Succeeded', description: 'Installation complete' }
+            }
+          ]
+        });
+      })
+    );
+
+    renderWithProviders(
+      <TestAppInstallationPhase
+        onNext={mockOnNext}
+        onStateChange={mockOnStateChange}
+      />,
+      {
+        wrapperProps: {
+          target,
+          authenticated: true
+        }
+      }
+    );
+
+    // Should display component status indicators
+    await waitFor(() => {
+      expect(screen.getByText('Nginx App')).toBeInTheDocument();
+      expect(screen.getByText('Redis App')).toBeInTheDocument();
+    });
+  });
+
+  it('calculates progress correctly with multiple components', async () => {
+    server.use(
+      http.get(`*/api/${target}/install/app/status`, () => {
+        return HttpResponse.json({
+          status: {
+            state: 'Running',
+            description: 'Installing application components...'
+          },
+          components: [
+            {
+              name: 'Component 1',
+              status: { state: 'Succeeded', description: 'Complete' }
+            },
+            {
+              name: 'Component 2',
+              status: { state: 'Succeeded', description: 'Complete' }
+            },
+            {
+              name: 'Component 3',
+              status: { state: 'Running', description: 'Installing' }
+            },
+            {
+              name: 'Component 4',
+              status: { state: 'Pending', description: 'Waiting' }
+            }
+          ]
+        });
+      })
+    );
+
+    renderWithProviders(
+      <TestAppInstallationPhase
+        onNext={mockOnNext}
+        onStateChange={mockOnStateChange}
+      />,
+      {
+        wrapperProps: {
+          target,
+          authenticated: true
+        }
+      }
+    );
+
+    // Should show progress (2 out of 4 components completed = 50%)
+    await waitFor(() => {
+      const progressBar = document.querySelector('[style*="width: 50%"]');
+      expect(progressBar).toBeInTheDocument();
+    });
+  });
+
+  it('shows 0% progress when no components are provided', async () => {
+    server.use(
+      http.get(`*/api/${target}/install/app/status`, () => {
+        return HttpResponse.json({
+          status: {
+            state: 'Running',
+            description: 'Preparing installation...'
+          },
+          components: []
+        });
+      })
+    );
+
+    renderWithProviders(
+      <TestAppInstallationPhase
+        onNext={mockOnNext}
+        onStateChange={mockOnStateChange}
+      />,
+      {
+        wrapperProps: {
+          target,
+          authenticated: true
+        }
+      }
+    );
+
+    // Should show 0% progress when no components
+    await waitFor(() => {
+      const progressBar = document.querySelector('[style*="width: 0%"]');
+      expect(progressBar).toBeInTheDocument();
+    });
+  });
+
+  it('shows 100% progress when all components are succeeded', async () => {
+    server.use(
+      http.get(`*/api/${target}/install/app/status`, () => {
+        return HttpResponse.json({
+          status: {
+            state: 'Succeeded',
+            description: 'Installation complete'
+          },
+          components: [
+            {
+              name: 'Component 1',
+              status: { state: 'Succeeded', description: 'Complete' }
+            },
+            {
+              name: 'Component 2',
+              status: { state: 'Succeeded', description: 'Complete' }
+            }
+          ]
+        });
+      })
+    );
+
+    renderWithProviders(
+      <TestAppInstallationPhase
+        onNext={mockOnNext}
+        onStateChange={mockOnStateChange}
+      />,
+      {
+        wrapperProps: {
+          target,
+          authenticated: true
+        }
+      }
+    );
+
+    // Should show 100% progress when all components succeeded
+    await waitFor(() => {
+      const progressBar = document.querySelector('[style*="width: 100%"]');
+      expect(progressBar).toBeInTheDocument();
+    });
+  });
+
+  it('handles mixed component states correctly', async () => {
+    server.use(
+      http.get(`*/api/${target}/install/app/status`, () => {
+        return HttpResponse.json({
+          status: {
+            state: 'Running',
+            description: 'Installing application components...'
+          },
+          components: [
+            {
+              name: 'Database',
+              status: { state: 'Succeeded', description: 'Installation complete' }
+            },
+            {
+              name: 'API Server',
+              status: { state: 'Running', description: 'Installing...' }
+            },
+            {
+              name: 'Frontend',
+              status: { state: 'Failed', description: 'Installation failed' }
+            }
+          ]
+        });
+      })
+    );
+
+    renderWithProviders(
+      <TestAppInstallationPhase
+        onNext={mockOnNext}
+        onStateChange={mockOnStateChange}
+      />,
+      {
+        wrapperProps: {
+          target,
+          authenticated: true
+        }
+      }
+    );
+
+    // Should display all component names and states
+    await waitFor(() => {
+      expect(screen.getByText('Database')).toBeInTheDocument();
+      expect(screen.getByText('API Server')).toBeInTheDocument();
+      expect(screen.getByText('Frontend')).toBeInTheDocument();
+    });
+
+    // Progress should be 33% (1 out of 3 succeeded)
+    await waitFor(() => {
+      const progressBar = document.querySelector('[style*="width: 33%"]');
+      expect(progressBar).toBeInTheDocument();
+    });
+  });
+
+  it('displays logs from app installation', async () => {
+    const testLogs = '[app] Installing nginx chart\n[kots] Creating namespace\n[kots] Deploying application';
+
+    server.use(
+      http.get(`*/api/${target}/install/app/status`, () => {
+        return HttpResponse.json({
+          status: {
+            state: 'Running',
+            description: 'Installing application components...'
+          },
+          components: [],
+          logs: testLogs
+        });
+      })
+    );
+
+    renderWithProviders(
+      <TestAppInstallationPhase
+        onNext={mockOnNext}
+        onStateChange={mockOnStateChange}
+      />,
+      {
+        wrapperProps: {
+          target,
+          authenticated: true
+        }
+      }
+    );
+
+    // Should have log viewer available
+    await waitFor(() => {
+      expect(screen.getByTestId('log-viewer')).toBeInTheDocument();
+      expect(screen.getByTestId('log-viewer-toggle')).toBeInTheDocument();
     });
   });
 

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -8,21 +8,21 @@ export interface InitialState {
 
 export type State = 'Pending' | 'Running' | 'Succeeded' | 'Failed';
 
+export interface Status {
+  state: State;
+  description: string;
+  lastUpdated: string;
+}
+
 export interface InfraStatusResponse {
   components: InfraComponent[];
-  status: InfraStatus;
+  status: Status;
   logs: string;
 }
 
 export interface InfraComponent {
   name: string;
-  status: InfraStatus;
-}
-
-export interface InfraStatus {
-  state: State;
-  description: string;
-  lastUpdated: string;
+  status: Status;
 }
 
 export type WizardStep = 'welcome' | 'configuration' | 'linux-setup' | 'kubernetes-setup' | 'installation' | 'linux-completion' | 'kubernetes-completion';
@@ -77,37 +77,29 @@ export interface PreflightOutput {
   fail: PreflightResult[];
 }
 
-export interface PreflightStatus {
-  state: string;
-  description: string;
-  lastUpdated: string;
-}
-
 export interface HostPreflightResponse {
   titles: string[];
   output?: PreflightOutput;
-  status?: PreflightStatus;
+  status?: Status;
   allowIgnoreHostPreflights?: boolean;
 }
 
 export interface AppPreflightResponse {
   titles: string[];
   output?: PreflightOutput;
-  status?: PreflightStatus;
+  status?: Status;
   allowIgnoreAppPreflights?: boolean;
 }
 
-export interface AppInstallStatus {
-  status: {
-    state: State;
-    description: string;
-    lastUpdated: string;
-  };
+export interface AppInstallStatusResponse {
+  components: AppComponent[];
+  status: Status;
   logs: string;
 }
 
-export interface InstallationStatusResponse {
-  description: string;
-  lastUpdated: string;
-  state: State;
+export interface AppComponent {
+  name: string;
+  status: Status;
 }
+
+export type InstallationStatusResponse = Status;


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Adds charts as steps with progress and logs to the app installation page similar to the infra installation page.

<img width="1212" height="688" alt="Screenshot 2025-08-28 at 2 10 42 PM" src="https://github.com/user-attachments/assets/c28359cf-c641-4853-90a1-3030cedd1933" />

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
