### PR TITLE
chore(web): standardise styling for code blocks across components

### DIFF
--- a/web/src/components/common/Markdown.tsx
+++ b/web/src/components/common/Markdown.tsx
@@ -22,11 +22,17 @@ const Markdown: React.FC<MarkdownProps> = ({ children, rehypePlugins = [] }) => 
             className="text-blue-600 hover:text-blue-800 underline"
           />
         ),
-        // We use:
-        // - pre selectors to style code blocks and inline code blocks differently. This is because code blocks are rendered with a <pre><code>...</code></pre> structure
-        // - before:content-none and after:content-none to remove the default backticks that are added by the Label component through the prose class
+        // We need to use not-prose here to prevent Tailwind Typography from styling the code block differently within a prose parent (e.g. Label)
+        pre: ({ children }) => (
+          <pre className="not-prose bg-gray-100 p-4 rounded overflow-x-auto">
+            {children}
+          </pre>
+        ),
+        // We need to use not-prose here to prevent Tailwind Typography from styling the code block differently within a prose parent (e.g. Label)
+        // Specific selectors used for `pre` to make sure inline code styling does not conflict with code block styling since code blocks are rendered
+        // within a pre element
         code: ({ children }) => (
-          <code className="font-mono text-xs bg-gray-100 px-1 py-0.5 rounded [pre_&]:text-sm [pre_&]:bg-transparent [pre_&]:px-0 [pre_&]:py-0 before:content-none after:content-none">
+          <code className="not-prose font-mono font-semibold text-xs text-gray-700 bg-gray-100 px-1 py-0.5 rounded [pre_&]:bg-transparent [pre_&]:px-0 [pre_&]:py-0">
             {children}
           </code>
         ),


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Differences in styling for code blocks in markdown. Prints below are for Labels and Help text respectively.

<img width="1374" height="408" alt="image" src="https://github.com/user-attachments/assets/f8c386a0-cc02-4fa3-b426-099db789c20f" />


<img width="1070" height="587" alt="image" src="https://github.com/user-attachments/assets/1f75e222-376d-4e18-a9b4-78bc6975dcc3" />


#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

https://app.shortcut.com/replicated/story/126837/markdown-code-blocks-have-the-wrong-background-color

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Differences in markdown styling of code blocks for config items on V3.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
