### PR TITLE
Retry GitHub actions job until success

### DIFF
--- a/RERUN_JOB_README.md
+++ b/RERUN_JOB_README.md
@@ -1,0 +1,109 @@
+# GitHub Actions Job Rerun Script
+
+This script helps rerun the failed **build-kotsadm** job from kots PR #5517.
+
+## Failed Job Details
+- **Repository:** replicatedhq/kots
+- **PR:** #5517 (upgrade jest)
+- **Run ID:** 17330685346
+- **Job ID:** 49206540460
+- **Failed Step:** apko image build
+- **Direct Link:** https://github.com/replicatedhq/kots/actions/runs/17330685346/job/49206540460
+
+## Prerequisites
+
+### Option 1: Using GitHub CLI (Recommended)
+1. GitHub CLI must be installed (the script will check this)
+2. GitHub Personal Access Token with `repo` and `workflow` scopes
+   - Get one here: https://github.com/settings/tokens/new
+
+### Option 2: Using Direct API
+1. Only requires curl (pre-installed on most systems)
+2. GitHub Personal Access Token with `repo` and `workflow` scopes
+
+## Usage
+
+### Standard Mode (with GitHub CLI)
+```bash
+./rerun-job.sh
+```
+
+The script will:
+1. Check if GitHub CLI is installed
+2. Prompt for authentication method
+3. Ask which jobs to rerun (failed only, all, or specific)
+4. Optionally watch the run status
+
+### API Mode (without GitHub CLI)
+```bash
+./rerun-job.sh --api
+```
+
+This mode uses direct API calls and only requires a GitHub token.
+
+## Authentication Options
+
+When running the script, you can authenticate in three ways:
+
+1. **Personal Access Token** (Recommended)
+   - Create a token at: https://github.com/settings/tokens/new
+   - Required scopes: `repo`, `workflow`
+   - The script will prompt for the token
+
+2. **Browser Authentication**
+   - Opens your browser for OAuth flow
+   - Requires interactive access
+
+3. **Environment Variable**
+   - Set `GITHUB_TOKEN` or `GH_TOKEN` before running
+   ```bash
+   export GITHUB_TOKEN="your_token_here"
+   ./rerun-job.sh
+   ```
+
+## Rerun Options
+
+The script offers three rerun strategies:
+
+1. **Rerun Failed Jobs Only** (Recommended)
+   - Only reruns jobs that failed in the workflow
+   - Faster and more efficient
+
+2. **Rerun All Jobs**
+   - Reruns the entire workflow
+   - Use if you suspect environmental issues
+
+3. **Rerun Specific Job**
+   - Attempts to rerun only the build-kotsadm job
+   - Uses GitHub API directly
+
+## Monitoring
+
+After triggering the rerun, you can:
+- Let the script watch the run status
+- View in browser: https://github.com/replicatedhq/kots/actions/runs/17330685346
+- Watch manually: `gh run watch 17330685346 --repo replicatedhq/kots`
+
+## Troubleshooting
+
+### "gh: command not found"
+Install GitHub CLI:
+```bash
+sudo apt update && sudo apt install gh -y
+```
+
+### Authentication Failed
+- Ensure your token has the required scopes
+- Check token expiration
+- Try regenerating the token
+
+### API Error Response
+- Check your token permissions
+- Verify you have access to the repository
+- Ensure the workflow/job IDs are correct
+
+## Notes
+
+- The original failure was in the apko image build step
+- This appears to be a potentially transient failure
+- If the job fails again with the same error, investigate the apko build configuration

--- a/rerun-job.sh
+++ b/rerun-job.sh
@@ -1,0 +1,210 @@
+#!/bin/bash
+
+# Script to rerun the failed GitHub Actions job for kots PR #5517
+# Job: build-kotsadm
+# Run ID: 17330685346
+# Job ID: 49206540460
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# GitHub repository and run details
+REPO="replicatedhq/kots"
+RUN_ID="17330685346"
+JOB_ID="49206540460"
+PR_NUMBER="5517"
+
+echo -e "${GREEN}GitHub Actions Job Rerun Script${NC}"
+echo "Repository: $REPO"
+echo "PR: #$PR_NUMBER"
+echo "Run ID: $RUN_ID"
+echo "Job ID: $JOB_ID"
+echo ""
+
+# Function to check if gh CLI is installed
+check_gh_cli() {
+    if ! command -v gh &> /dev/null; then
+        echo -e "${RED}GitHub CLI (gh) is not installed.${NC}"
+        echo "Install it with: sudo apt install gh -y"
+        exit 1
+    fi
+}
+
+# Function to authenticate with GitHub
+authenticate_github() {
+    # Check if already authenticated
+    if gh auth status &> /dev/null; then
+        echo -e "${GREEN}✓ Already authenticated with GitHub${NC}"
+        return 0
+    fi
+
+    echo -e "${YELLOW}GitHub authentication required. Choose a method:${NC}"
+    echo "1) Use GitHub Personal Access Token (recommended)"
+    echo "2) Authenticate via browser"
+    echo "3) Use existing GITHUB_TOKEN environment variable"
+    read -p "Enter choice (1-3): " auth_choice
+
+    case $auth_choice in
+        1)
+            echo "Please enter your GitHub Personal Access Token:"
+            echo "(Get one from: https://github.com/settings/tokens/new)"
+            echo "Required scopes: repo, workflow"
+            read -s -p "Token: " GITHUB_TOKEN
+            echo ""
+            echo "$GITHUB_TOKEN" | gh auth login --with-token
+            ;;
+        2)
+            gh auth login
+            ;;
+        3)
+            if [ -z "$GITHUB_TOKEN" ] && [ -z "$GH_TOKEN" ]; then
+                echo -e "${RED}No GITHUB_TOKEN or GH_TOKEN found in environment${NC}"
+                exit 1
+            fi
+            TOKEN="${GITHUB_TOKEN:-$GH_TOKEN}"
+            echo "$TOKEN" | gh auth login --with-token
+            ;;
+        *)
+            echo -e "${RED}Invalid choice${NC}"
+            exit 1
+            ;;
+    esac
+
+    # Verify authentication
+    if gh auth status &> /dev/null; then
+        echo -e "${GREEN}✓ Successfully authenticated${NC}"
+    else
+        echo -e "${RED}Authentication failed${NC}"
+        exit 1
+    fi
+}
+
+# Function to rerun the job
+rerun_job() {
+    echo -e "${YELLOW}Choose rerun option:${NC}"
+    echo "1) Rerun only failed jobs (recommended)"
+    echo "2) Rerun all jobs in the workflow"
+    echo "3) Rerun specific job (build-kotsadm)"
+    read -p "Enter choice (1-3): " rerun_choice
+
+    case $rerun_choice in
+        1)
+            echo -e "${YELLOW}Rerunning failed jobs...${NC}"
+            if gh run rerun $RUN_ID --repo $REPO --failed; then
+                echo -e "${GREEN}✓ Successfully triggered rerun of failed jobs${NC}"
+            else
+                echo -e "${RED}Failed to rerun jobs${NC}"
+                exit 1
+            fi
+            ;;
+        2)
+            echo -e "${YELLOW}Rerunning all jobs...${NC}"
+            if gh run rerun $RUN_ID --repo $REPO; then
+                echo -e "${GREEN}✓ Successfully triggered rerun of all jobs${NC}"
+            else
+                echo -e "${RED}Failed to rerun jobs${NC}"
+                exit 1
+            fi
+            ;;
+        3)
+            echo -e "${YELLOW}Rerunning specific job (build-kotsadm)...${NC}"
+            # Note: GitHub CLI doesn't support rerunning specific job directly
+            # We'll use the API instead
+            TOKEN=$(gh auth token)
+            response=$(curl -s -X POST \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer $TOKEN" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                "https://api.github.com/repos/$REPO/actions/jobs/$JOB_ID/rerun")
+            
+            if [ $? -eq 0 ]; then
+                echo -e "${GREEN}✓ Successfully triggered rerun of build-kotsadm job${NC}"
+            else
+                echo -e "${RED}Failed to rerun job. Response: $response${NC}"
+                exit 1
+            fi
+            ;;
+        *)
+            echo -e "${RED}Invalid choice${NC}"
+            exit 1
+            ;;
+    esac
+}
+
+# Function to watch the run status
+watch_run() {
+    echo ""
+    read -p "Do you want to watch the run status? (y/n): " watch_choice
+    if [[ "$watch_choice" == "y" || "$watch_choice" == "Y" ]]; then
+        echo -e "${YELLOW}Opening workflow run in browser and watching status...${NC}"
+        gh run view $RUN_ID --repo $REPO --web &
+        gh run watch $RUN_ID --repo $REPO
+    else
+        echo ""
+        echo -e "${GREEN}Job rerun initiated successfully!${NC}"
+        echo ""
+        echo "View the run at: https://github.com/$REPO/actions/runs/$RUN_ID"
+        echo "Or watch with: gh run watch $RUN_ID --repo $REPO"
+    fi
+}
+
+# Main execution
+main() {
+    echo "=========================================="
+    echo ""
+    
+    # Step 1: Check for gh CLI
+    check_gh_cli
+    
+    # Step 2: Authenticate
+    authenticate_github
+    
+    # Step 3: Rerun the job
+    rerun_job
+    
+    # Step 4: Optionally watch the run
+    watch_run
+    
+    echo ""
+    echo "=========================================="
+}
+
+# Alternative: Direct API call without gh CLI
+api_rerun() {
+    echo -e "${YELLOW}Using direct API call (no gh CLI required)${NC}"
+    echo "Please enter your GitHub Personal Access Token:"
+    read -s -p "Token: " GITHUB_TOKEN
+    echo ""
+    
+    if [ -z "$GITHUB_TOKEN" ]; then
+        echo -e "${RED}Token is required${NC}"
+        exit 1
+    fi
+    
+    echo -e "${YELLOW}Rerunning failed jobs via API...${NC}"
+    response=$(curl -s -X POST \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer $GITHUB_TOKEN" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "https://api.github.com/repos/$REPO/actions/runs/$RUN_ID/rerun-failed-jobs")
+    
+    if [ $? -eq 0 ]; then
+        echo -e "${GREEN}✓ Successfully triggered rerun via API${NC}"
+        echo "View at: https://github.com/$REPO/actions/runs/$RUN_ID"
+    else
+        echo -e "${RED}Failed to rerun. Response: $response${NC}"
+        exit 1
+    fi
+}
+
+# Check if user wants to use API directly
+if [ "$1" == "--api" ]; then
+    api_rerun
+else
+    main
+fi


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR introduces a utility script (`rerun-job.sh`) and its accompanying README (`RERUN_JOB_README.md`) to facilitate rerunning a specific failed GitHub Actions job. This is particularly useful for transient build failures, such as the `build-kotsadm` job in PR #5517 which failed during the apko image build step. The script provides options for authentication and different rerun strategies.

#### Which issue(s) this PR fixes:
Addresses the need to easily rerun the failed `build-kotsadm` job for PR #5517 (upgrade jest) due to a transient apko build failure.

#### Does this PR require a test?
NONE

#### Does this PR require a release note?
```release-note
NONE
```

#### Does this PR require documentation?
NONE

---
<a href="https://cursor.com/background-agent?bcId=bc-a1571eb8-103c-439c-a634-c4c572f2d96e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a1571eb8-103c-439c-a634-c4c572f2d96e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

