### PR TITLE
test: output if domain is in allowed domain list

### DIFF
--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -2100,6 +2100,12 @@ func TestSingleNodeNetworkReport(t *testing.T) {
 		t.Fatalf("failed to collect network report: %v", err)
 	}
 
+	allowedDomains := map[string]struct{}{
+		"proxy.replicated.com":    {},
+		"replicated.app":          {},
+		"registry.replicated.com": {},
+	}
+
 	domainsByIps := make(map[string]map[string]struct{})
 	for _, ne := range networkEvents {
 		// filter out local traffic
@@ -2123,7 +2129,12 @@ func TestSingleNodeNetworkReport(t *testing.T) {
 	for ip, domains := range domainsByIps {
 		domainOutput := ""
 		for domain := range domains {
-			domainOutput += fmt.Sprintf("\t- %v\n", domain)
+			_, allowed := allowedDomains[domain]
+			domainOutput += fmt.Sprintf("\t- %v - ALLOWED: %v\n", domain, allowed)
+		}
+
+		if len(ip) == 0 {
+			ip = "UNKNOWN"
 		}
 
 		t.Logf("IP: %v", ip)


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
This adds an allowed list of domains from EC's [docs](https://docs.replicated.com/enterprise/installing-embedded-requirements#firewall) and outputs whether the domain is allowed or not. Next step after we get this solidified would be to fail the test if unexpected domains are found.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/127479/setup-testing-for-network-reporting-in-ec

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
