### PR TITLE
Autorelabel is no longer required

### DIFF
--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -770,7 +770,7 @@ func TestSingleNodeAirgapUpgradeSelinux(t *testing.T) {
 		T:            t,
 		Nodes:        1,
 		Distribution: "almalinux",
-		Version:      "10",
+		Version:      "8",
 	})
 	defer tc.Cleanup()
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
When using selinux within CMX, it is no longer needed to `autorelabel`.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/127391/support-selinux-on-almalinux

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE