### PR TITLE
chore(ci): fix update addons openebs and velero new kubectl image

### DIFF
--- a/cmd/buildtools/openebs.go
+++ b/cmd/buildtools/openebs.go
@@ -39,6 +39,13 @@ var openebsImageComponents = map[string]addonComponent{
 		},
 		upstreamVersionInputOverride: "INPUT_KUBECTL_VERSION",
 	},
+	"docker.io/bitnamilegacy/kubectl": {
+		name: "kubectl",
+		getWolfiPackageName: func(opts addonComponentOptions) string {
+			return "kubectl"
+		},
+		upstreamVersionInputOverride: "INPUT_KUBECTL_VERSION",
+	},
 	"docker.io/openebs/kubectl": {
 		name: "kubectl",
 		getWolfiPackageName: func(opts addonComponentOptions) string {

--- a/cmd/buildtools/openebs.go
+++ b/cmd/buildtools/openebs.go
@@ -39,6 +39,13 @@ var openebsImageComponents = map[string]addonComponent{
 		},
 		upstreamVersionInputOverride: "INPUT_KUBECTL_VERSION",
 	},
+	"docker.io/openebs/kubectl": {
+		name: "kubectl",
+		getWolfiPackageName: func(opts addonComponentOptions) string {
+			return "kubectl"
+		},
+		upstreamVersionInputOverride: "INPUT_KUBECTL_VERSION",
+	},
 }
 
 var updateOpenEBSAddonCommand = &cli.Command{

--- a/cmd/buildtools/velero.go
+++ b/cmd/buildtools/velero.go
@@ -52,6 +52,13 @@ var veleroImageComponents = map[string]addonComponent{
 		},
 		upstreamVersionInputOverride: "INPUT_KUBECTL_VERSION",
 	},
+	"docker.io/bitnamilegacy/kubectl": {
+		name: "kubectl",
+		getWolfiPackageName: func(opts addonComponentOptions) string {
+			return "kubectl"
+		},
+		upstreamVersionInputOverride: "INPUT_KUBECTL_VERSION",
+	},
 }
 
 var veleroRepo = &repo.Entry{


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

https://github.com/replicatedhq/embedded-cluster/actions/runs/17600356736/job/50001228715

```
failed to update openebs images: failed to update images: no component found for image docker.io/openebs/kubectl:1.25.15
```

https://github.com/replicatedhq/embedded-cluster/actions/runs/17614698156/job/50044981255

```
failed to update velero images: failed to update images: no component found for image docker.io/bitnamilegacy/kubectl:1.33
```

Fix:

https://github.com/replicatedhq/embedded-cluster/actions/runs/17614860986/job/50045527043

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
