### PR TITLE
chore: Collect more columns with `top` command

### DIFF
--- a/cmd/installer/goods/support/host-support-bundle.tmpl.yaml
+++ b/cmd/installer/goods/support/host-support-bundle.tmpl.yaml
@@ -72,7 +72,8 @@ spec:
   - run:
       collectorName: top
       command: top
-      args: ['-b', '-n', '1']
+      env: ['COLUMNS=512']
+      args: ['-b', '-n', '1', '-c']
   - run:
       collectorName: uname
       command: uname


### PR DESCRIPTION




#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

by default, `top` only emits ~80 columns of output, making the process list look a little truncated:

```
top - 18:57:58 up  4:59,  3 users,  load average: 0.57, 1.06, 1.24
Tasks: 302 total,   1 running, 301 sleeping,   0 stopped,   0 zombie
%Cpu(s):  2.8 us,  4.9 sy,  0.0 ni, 88.8 id,  0.0 wa,  0.0 hi,  0.7 si,  2.8 st
MiB Mem :  31714.2 total,  22289.4 free,   3603.9 used,   5820.9 buff/cache
MiB Swap:      0.0 total,      0.0 free,      0.0 used.  27632.2 avail Mem

    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND
   2374 etcd      20   0   11.5g 464956  99024 S   5.9   1.4   9:07.66 etcd
   2386 kube-ap+  20   0 2121636 762116  69956 S   5.9   2.3  26:06.39 kube-ap+
   2465 kube-ap+  20   0 1375060 169348  59980 S   5.9   0.5  11:40.30 kube-co+
   2575 root      20   0 1302324 117292  54948 S   5.9   0.4  13:16.67 kubelet
   9232 1001      20   0  148492  12800   8432 S   5.9   0.0   1:19.66 redis-s+
 717909 root      20   0 1234328   8736   7100 S   5.9   0.0   0:00.01 runc
      1 root      20   0  174536  19192  10676 S   0.0   0.1   0:33.83 systemd
```


Expand this to 512 columns (maximum supported by `top`)

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
collect more columns of output from the `top` command in host support bundles
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
