### PR TITLE
Adds markdown support for config group description

### DIFF
--- a/web/src/components/wizard/config/ConfigurationStep.tsx
+++ b/web/src/components/wizard/config/ConfigurationStep.tsx
@@ -7,6 +7,7 @@ import Textarea from '../../common/Textarea';
 import Checkbox from '../../common/Checkbox';
 import Radio from '../../common/Radio';
 import Label from '../../common/Label';
+import Markdown from '../../common/Markdown';
 import FileInput from '../../common/file';
 import { useWizard } from '../../../contexts/WizardModeContext';
 import { useAuth } from '../../../contexts/AuthContext';
@@ -410,7 +411,11 @@ const ConfigurationStep: React.FC<ConfigurationStepProps> = ({ onNext }) => {
     return (
       <div className="space-y-6">
         {group.description && (
-          <p className="text-gray-600 mb-4">{group.description}</p>
+          <div className="text-gray-600 mb-4 prose max-w-none">
+            <Markdown>
+              {group.description}
+            </Markdown>
+          </div>
         )}
         {group.items.map(item => (
           <div key={item.name} data-testid={`config-item-${item.name}`}>


### PR DESCRIPTION
TL;DR
-----

Renders markdown in config group descriptions

Details
-------

Supporst markdown in the description field for configuration groups.
This was the primary blocker for running the V3 experience with
SlackerNews. It unlocks the potential for me to share the V3
experience with our customers.

 Now its
 
<img width="719" height="260" alt="image" src="https://github.com/user-attachments/assets/8bfa4b72-df6f-4030-803c-4d1e223b9921" />

instead of this

<img width="1196" height="287" alt="Screenshot 2025-09-12 at 4 50 55 PM" src="https://github.com/user-attachments/assets/12fff437-a376-4b40-bfd6-2f4852317cea" />