### PR TITLE
Add support for strict app preflights (frontend)

### DIFF
--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -132,6 +132,7 @@ export type AppConfigValues = Record<string, AppConfigValue>;
 export interface PreflightResult {
   title: string;
   message: string;
+  strict?: boolean;
 }
 
 export interface PreflightOutput {
@@ -158,6 +159,7 @@ export interface AppPreflightResponse {
   output?: PreflightOutput;
   status?: PreflightStatus;
   allowIgnoreAppPreflights?: boolean;
+  hasStrictAppPreflightFailures?: boolean;
 }
 
 export interface AppInstallStatus {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Add frontend logic to enforce blocking installation progress on strict app preflight failures

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/126717/block-install-from-proceeding-if-a-strict-preflight-check-fails

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Tests were added per the proposal

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
