### PR TITLE
chore(ci): fix previous stable version e2e tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -467,7 +467,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          k0s_majmin_version="$(make print-PREVIOUS_K0S_VERSION | sed 's/v\([0-9]*\.[0-9]*\).*/\1/')"
+          k0s_minor_version=$(make print-K0S_MINOR_VERSION)
+          previous_k0s_minor_version=$(($k0s_minor_version - 1))
+          k0s_majmin_version="1.${previous_k0s_minor_version}"
           if [ "$k0s_majmin_version" == "1.28" ]; then
             k0s_majmin_version="1.29"
           fi


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

fixes TestMultiNodeAirgapUpgradePreviousStable and TestSingleNodeUpgradePreviousStable use the wrong previous version with k0s version n-2 resulting in error "Before you can update to this version, you need to update to an earlier version that includes the required infrastructure update."

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
