### PR TITLE
Shows which security tools are detected in host support bundle spec

### DIFF
--- a/cmd/installer/goods/support/host-support-bundle.tmpl.yaml
+++ b/cmd/installer/goods/support/host-support-bundle.tmpl.yaml
@@ -394,7 +394,28 @@ spec:
   - run:
       collectorName: "ps-detect-antivirus-and-security-tools"
       command: "sh"
-      args: ["-c", "pat='(clamav|sophos|esets_daemon|fsav|symantec|mfend|ds_agent|kav|bdagent|s1agent|falcon|illumio|xagt|wdavdaemon|mdatp)'; if command -v pgrep >/dev/null 2>&1; then pgrep -afi \"$pat\"; else ps -eo args=; fi | awk -v pat=\"$pat\" 'BEGIN{ IGNORECASE=1 } /(awk|grep|pgrep|ps|sh -c)/{ next } { line=$0; while (match(line, pat)) { print tolower(substr(line, RSTART, RLENGTH)); line=substr(line, RSTART+RLENGTH) } }' | sort -u"]
+      args:
+        - -c
+        - |
+          pat='(clamav|sophos|esets_daemon|fsav|symantec|mfend|ds_agent|kav|bdagent|s1agent|falcon|illumio|xagt|wdavdaemon|mdatp)'
+      
+          if command -v pgrep >/dev/null 2>&1; then
+            pgrep -afi "$pat"
+          else
+            ps -eo args=
+          fi \
+          | awk -v pat="$pat" '
+              BEGIN { IGNORECASE=1 }
+              /(awk|grep|pgrep|ps|sh -c)/ { next }
+              {
+                line=$0
+                while (match(line, pat)) {
+                  print tolower(substr(line, RSTART, RLENGTH))
+                  line=substr(line, RSTART+RLENGTH)
+                }
+              }
+            ' \
+          | sort -u
   - systemPackages:
       collectorName: security-tools-packages
       ubuntu:


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR changes host preflight checks to show which security tools are detected, instead of just saying some were found, and changes wording to not make it seem like the security tools have to be permanently disabled

#### Which issue(s) this PR fixes:
https://app.shortcut.com/replicated/story/129209/host-preflights-improve-messaging-around-security-tools-detected

#### Does this PR require a test?
NONE

#### Does this PR require a release note?
```release-note
NONE
```

#### Does this PR require documentation?
NONE
