### PR TITLE
fix(openebs): delete leftover pre-upgrade hook resources before upgrade

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,7 +170,7 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: "**/*.sum"
       - name: Install kind
-        uses: helm/kind-action@v1.12.0
+        uses: helm/kind-action@50ea670a058121270d63a63b4f1e361d722932e4
         with:
           install_only: true
       - name: Run tests
@@ -194,7 +194,7 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: "**/*.sum"
       - name: Install kind
-        uses: helm/kind-action@v1.12.0
+        uses: helm/kind-action@50ea670a058121270d63a63b4f1e361d722932e4
         with:
           install_only: true
       - name: Run tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -169,8 +169,8 @@ jobs:
         with:
           go-version-file: go.mod
           cache-dependency-path: "**/*.sum"
-      - name: Install Kind
-        uses: helm/kind-action@v1
+      - name: Install kind
+        uses: helm/kind-action@v1.12.0
         with:
           install_only: true
       - name: Run tests
@@ -193,8 +193,8 @@ jobs:
         with:
           go-version-file: go.mod
           cache-dependency-path: "**/*.sum"
-      - name: Install Kind
-        uses: helm/kind-action@v1
+      - name: Install kind
+        uses: helm/kind-action@v1.12.0
         with:
           install_only: true
       - name: Run tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -158,6 +158,7 @@ jobs:
     name: Integration tests (kind)
     runs-on: ubuntu-latest
     needs:
+      - output-vars
       - should-run-int-tests-kind
     if: needs.should-run-int-tests-kind.outputs.run == 'true'
     steps:
@@ -175,6 +176,7 @@ jobs:
           sudo mv ./kind /usr/local/bin/kind
       - name: Run tests
         run: |
+          export VERSION=${{ needs.output-vars.outputs.ec_version }}
           make -C tests/integration test-kind SHORT=true
 
   int-tests-kind-ha-registry:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,7 +170,7 @@ jobs:
           cache-dependency-path: "**/*.sum"
       - name: Install kind
         run: |
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.29.0/kind-linux-amd64
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.30.0/kind-linux-amd64
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind
       - name: Run tests
@@ -193,7 +193,7 @@ jobs:
           cache-dependency-path: "**/*.sum"
       - name: Install kind
         run: |
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.29.0/kind-linux-amd64
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.30.0/kind-linux-amd64
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind
       - name: Run tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -176,7 +176,7 @@ jobs:
           sudo mv ./kind /usr/local/bin/kind
       - name: Run tests
         run: |
-          export VERSION=${{ needs.output-vars.outputs.ec_version }}
+          export PACKAGE_VERSION=${{ needs.output-vars.outputs.ec_version }}
           make -C tests/integration test-kind SHORT=true
 
   int-tests-kind-ha-registry:
@@ -201,7 +201,7 @@ jobs:
           sudo mv ./kind /usr/local/bin/kind
       - name: Run tests
         run: |
-          export VERSION=${{ needs.output-vars.outputs.ec_version }}
+          export PACKAGE_VERSION=${{ needs.output-vars.outputs.ec_version }}
           make -C tests/integration/kind test-registry RUN=TestRegistry_EnableHAAirgap
 
   dryrun-tests:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -181,6 +181,7 @@ jobs:
     name: Integration tests (kind) HA registry
     runs-on: ubuntu-latest
     needs:
+      - output-vars
       - should-run-int-tests-kind
     if: needs.should-run-int-tests-kind.outputs.run == 'true'
     steps:
@@ -198,6 +199,7 @@ jobs:
           sudo mv ./kind /usr/local/bin/kind
       - name: Run tests
         run: |
+          export VERSION=${{ needs.output-vars.outputs.ec_version }}
           make -C tests/integration/kind test-registry RUN=TestRegistry_EnableHAAirgap
 
   dryrun-tests:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -157,6 +157,8 @@ jobs:
   int-tests-kind:
     name: Integration tests (kind)
     runs-on: ubuntu-latest
+    needs:
+      - should-run-int-tests-kind
     if: needs.should-run-int-tests-kind.outputs.run == 'true'
     steps:
       - name: Checkout
@@ -178,6 +180,8 @@ jobs:
   int-tests-kind-ha-registry:
     name: Integration tests (kind) HA registry
     runs-on: ubuntu-latest
+    needs:
+      - should-run-int-tests-kind
     if: needs.should-run-int-tests-kind.outputs.run == 'true'
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -175,7 +175,7 @@ jobs:
           install_only: true
       - name: Run tests
         run: |
-          export PACKAGE_VERSION=${{ needs.output-vars.outputs.ec_version }}
+          export VERSION=${{ needs.output-vars.outputs.ec_version }}
           make -C tests/integration test-kind SHORT=true
 
   int-tests-kind-ha-registry:
@@ -199,7 +199,7 @@ jobs:
           install_only: true
       - name: Run tests
         run: |
-          export PACKAGE_VERSION=${{ needs.output-vars.outputs.ec_version }}
+          export VERSION=${{ needs.output-vars.outputs.ec_version }}
           make -C tests/integration/kind test-registry RUN=TestRegistry_EnableHAAirgap
 
   dryrun-tests:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -169,11 +169,10 @@ jobs:
         with:
           go-version-file: go.mod
           cache-dependency-path: "**/*.sum"
-      - name: Install kind
-        run: |
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.30.0/kind-linux-amd64
-          chmod +x ./kind
-          sudo mv ./kind /usr/local/bin/kind
+      - name: Install Kind
+        uses: helm/kind-action@v1
+        with:
+          install_only: true
       - name: Run tests
         run: |
           export PACKAGE_VERSION=${{ needs.output-vars.outputs.ec_version }}
@@ -194,11 +193,10 @@ jobs:
         with:
           go-version-file: go.mod
           cache-dependency-path: "**/*.sum"
-      - name: Install kind
-        run: |
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.30.0/kind-linux-amd64
-          chmod +x ./kind
-          sudo mv ./kind /usr/local/bin/kind
+      - name: Install Kind
+        uses: helm/kind-action@v1
+        with:
+          install_only: true
       - name: Run tests
         run: |
           export PACKAGE_VERSION=${{ needs.output-vars.outputs.ec_version }}

--- a/pkg/addons/openebs/upgrade.go
+++ b/pkg/addons/openebs/upgrade.go
@@ -2,6 +2,7 @@ package openebs
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
@@ -61,11 +62,11 @@ func (o *OpenEBS) Upgrade(
 // ensurePostUpgradeHooksDeleted will delete helm hooks if for some reason they fail. It is
 // necessary if the hook does not have the "before-hook-creation" delete policy and instead has the
 // policy "hook-succeeded".
-func (a *OpenEBS) ensurePreUpgradeHooksDeleted(ctx context.Context, kcli client.Client) error {
+func (o *OpenEBS) ensurePreUpgradeHooksDeleted(ctx context.Context, kcli client.Client) error {
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: a.Namespace(),
-			Name:      "openebs-pre-upgrade-hook",
+			Namespace: o.Namespace(),
+			Name:      fmt.Sprintf("%s-pre-upgrade-hook", o.ReleaseName()),
 		},
 	}
 	err := kcli.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationBackground))
@@ -75,7 +76,7 @@ func (a *OpenEBS) ensurePreUpgradeHooksDeleted(ctx context.Context, kcli client.
 
 	crb := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "openebs-pre-upgrade-hook",
+			Name: fmt.Sprintf("%s-pre-upgrade-hook", o.ReleaseName()),
 		},
 	}
 	err = kcli.Delete(ctx, crb)
@@ -85,7 +86,7 @@ func (a *OpenEBS) ensurePreUpgradeHooksDeleted(ctx context.Context, kcli client.
 
 	cr := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "openebs-pre-upgrade-hook",
+			Name: fmt.Sprintf("%s-pre-upgrade-hook", o.ReleaseName()),
 		},
 	}
 	err = kcli.Delete(ctx, cr)
@@ -95,8 +96,8 @@ func (a *OpenEBS) ensurePreUpgradeHooksDeleted(ctx context.Context, kcli client.
 
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: a.Namespace(),
-			Name:      "openebs-pre-upgrade-hook",
+			Namespace: o.Namespace(),
+			Name:      fmt.Sprintf("%s-pre-upgrade-hook", o.ReleaseName()),
 		},
 	}
 	err = kcli.Delete(ctx, sa)

--- a/pkg/addons/openebs/upgrade.go
+++ b/pkg/addons/openebs/upgrade.go
@@ -8,6 +8,10 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/types"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
 	"github.com/sirupsen/logrus"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/metadata"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -17,6 +21,11 @@ func (o *OpenEBS) Upgrade(
 	kcli client.Client, mcli metadata.Interface, hcli helm.Client,
 	domains ecv1beta1.Domains, overrides []string,
 ) error {
+	err := o.ensurePreUpgradeHooksDeleted(ctx, kcli)
+	if err != nil {
+		return errors.Wrap(err, "ensure pre-upgrade hooks deleted")
+	}
+
 	exists, err := hcli.ReleaseExists(ctx, o.Namespace(), o.ReleaseName())
 	if err != nil {
 		return errors.Wrap(err, "check if release exists")
@@ -44,6 +53,54 @@ func (o *OpenEBS) Upgrade(
 	})
 	if err != nil {
 		return errors.Wrap(err, "helm upgrade")
+	}
+
+	return nil
+}
+
+// ensurePostUpgradeHooksDeleted will delete helm hooks if for some reason they fail. It is
+// necessary if the hook does not have the "before-hook-creation" delete policy and instead has the
+// policy "hook-succeeded".
+func (a *OpenEBS) ensurePreUpgradeHooksDeleted(ctx context.Context, kcli client.Client) error {
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "openebs-pre-upgrade-hook",
+		},
+	}
+	err := kcli.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationBackground))
+	if client.IgnoreNotFound(err) != nil {
+		return errors.Wrap(err, "delete openebs-pre-upgrade-hook job")
+	}
+
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "openebs-pre-upgrade-hook",
+		},
+	}
+	err = kcli.Delete(ctx, crb)
+	if client.IgnoreNotFound(err) != nil {
+		return errors.Wrap(err, "delete openebs-pre-upgrade-hook cluster role binding")
+	}
+
+	cr := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "openebs-pre-upgrade-hook",
+		},
+	}
+	err = kcli.Delete(ctx, cr)
+	if client.IgnoreNotFound(err) != nil {
+		return errors.Wrap(err, "delete openebs-pre-upgrade-hook cluster role")
+	}
+
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: a.Namespace(),
+			Name:      "openebs-pre-upgrade-hook",
+		},
+	}
+	err = kcli.Delete(ctx, sa)
+	if client.IgnoreNotFound(err) != nil {
+		return errors.Wrap(err, "delete openebs-pre-upgrade-hook service account")
 	}
 
 	return nil

--- a/pkg/addons/openebs/upgrade.go
+++ b/pkg/addons/openebs/upgrade.go
@@ -64,7 +64,8 @@ func (o *OpenEBS) Upgrade(
 func (a *OpenEBS) ensurePreUpgradeHooksDeleted(ctx context.Context, kcli client.Client) error {
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "openebs-pre-upgrade-hook",
+			Namespace: a.Namespace(),
+			Name:      "openebs-pre-upgrade-hook",
 		},
 	}
 	err := kcli.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationBackground))

--- a/pkg/addons/openebs/upgrade_test.go
+++ b/pkg/addons/openebs/upgrade_test.go
@@ -1,0 +1,90 @@
+package openebs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestOpenEBS_ensurePreUpgradeHooksDeleted(t *testing.T) {
+	tests := []struct {
+		name       string
+		objects    []client.Object
+		wantErr    bool
+		wantErrMsg string
+	}{
+		{
+			name: "successful deletion of all resources",
+			objects: []client.Object{
+				&batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "openebs-pre-upgrade-hook",
+						Namespace: "openebs",
+					},
+				},
+				&rbacv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "openebs-pre-upgrade-hook",
+					},
+				},
+				&rbacv1.ClusterRole{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "openebs-pre-upgrade-hook",
+					},
+				},
+				&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "openebs-pre-upgrade-hook",
+						Namespace: "openebs",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "all resources not found - should succeed",
+			objects: []client.Object{},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create fake client with objects
+			fakeClient := fake.NewClientBuilder().
+				WithObjects(tt.objects...).
+				Build()
+
+			// Create OpenEBS instance
+			openebs := &OpenEBS{}
+
+			// Call the function
+			err := openebs.ensurePreUpgradeHooksDeleted(context.Background(), fakeClient)
+
+			// Verify results
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMsg)
+			} else {
+				require.NoError(t, err)
+			}
+
+			// Verify that objects were deleted (for successful deletion test)
+			if len(tt.objects) > 0 {
+				for _, obj := range tt.objects {
+					err := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(obj), obj)
+					assert.True(t, apierrors.IsNotFound(err), "Object should be deleted: %v", obj)
+				}
+			}
+		})
+	}
+}

--- a/tests/integration/kind/openebs/upgrade_hook_cleanup_test.go
+++ b/tests/integration/kind/openebs/upgrade_hook_cleanup_test.go
@@ -1,0 +1,186 @@
+package openebs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"github.com/replicatedhq/embedded-cluster/pkg/addons/openebs"
+	"github.com/replicatedhq/embedded-cluster/tests/integration/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestOpenEBS_UpgradeHookCleanup(t *testing.T) {
+	util.SetupCtrlLogging(t)
+
+	clusterName := util.GenerateClusterName(t)
+	kubeconfig := util.SetupKindCluster(t, clusterName, nil)
+
+	kcli := util.CtrlClient(t, kubeconfig)
+	mcli := util.MetadataClient(t, kubeconfig)
+	hcli := util.HelmClient(t, kubeconfig)
+
+	domains := ecv1beta1.Domains{
+		ProxyRegistryDomain: "proxy.replicated.com",
+	}
+
+	addon := &openebs.OpenEBS{}
+
+	t.Log("installing openebs")
+	err := addon.Install(context.Background(), t.Logf, kcli, mcli, hcli, domains, nil)
+	require.NoError(t, err, "failed to install openebs")
+
+	t.Log("creating pre-upgrade hook resources that simulate failed helm hooks")
+	hookResources := createPreUpgradeHookResources(t, kcli, addon)
+
+	t.Log("verifying hook resources exist before upgrade")
+	verifyHookResourcesExist(t, kcli, hookResources)
+
+	t.Log("performing openebs upgrade")
+	err = addon.Upgrade(context.Background(), t.Logf, kcli, mcli, hcli, domains, nil)
+	require.NoError(t, err, "failed to upgrade openebs")
+
+	// Validate that the helm upgrade occurred (a new release should be created)
+	err = kcli.Get(context.Background(), client.ObjectKey{Namespace: addon.Namespace(), Name: "sh.helm.release.v1.openebs.v2"}, &corev1.Secret{})
+	require.NoError(t, err, "failed to get secret")
+
+	t.Log("verifying hook resources are cleaned up after upgrade")
+	verifyHookResourcesDeleted(t, kcli, hookResources)
+}
+
+func createPreUpgradeHookResources(t *testing.T, kcli client.Client, addon *openebs.OpenEBS) []client.Object {
+	namespace := addon.Namespace()
+	releaseName := addon.ReleaseName()
+	hookName := releaseName + "-pre-upgrade-hook"
+
+	// Create ServiceAccount
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      hookName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":      "openebs",
+				"app.kubernetes.io/instance":  releaseName,
+				"app.kubernetes.io/component": "pre-upgrade-hook",
+			},
+		},
+	}
+	err := kcli.Create(context.Background(), sa)
+	require.NoError(t, err, "failed to create service account")
+
+	// Create ClusterRole
+	cr := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: hookName,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":      "openebs",
+				"app.kubernetes.io/instance":  releaseName,
+				"app.kubernetes.io/component": "pre-upgrade-hook",
+			},
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"persistentvolumes"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+		},
+	}
+	err = kcli.Create(context.Background(), cr)
+	require.NoError(t, err, "failed to create cluster role")
+
+	// Create ClusterRoleBinding
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: hookName,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":      "openebs",
+				"app.kubernetes.io/instance":  releaseName,
+				"app.kubernetes.io/component": "pre-upgrade-hook",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     hookName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      hookName,
+				Namespace: namespace,
+			},
+		},
+	}
+	err = kcli.Create(context.Background(), crb)
+	require.NoError(t, err, "failed to create cluster role binding")
+
+	// Create Job (simulating a failed helm hook)
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      hookName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":      "openebs",
+				"app.kubernetes.io/instance":  releaseName,
+				"app.kubernetes.io/component": "pre-upgrade-hook",
+				"helm.sh/hook":                "pre-upgrade",
+				"helm.sh/hook-weight":         "1",
+			},
+			Annotations: map[string]string{
+				"helm.sh/hook-delete-policy": "hook-succeeded",
+			},
+		},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app.kubernetes.io/name":      "openebs",
+						"app.kubernetes.io/instance":  releaseName,
+						"app.kubernetes.io/component": "pre-upgrade-hook",
+					},
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: hookName,
+					RestartPolicy:      corev1.RestartPolicyNever,
+					Containers: []corev1.Container{
+						{
+							Name:    "pre-upgrade-hook",
+							Image:   "busybox:1.35",
+							Command: []string{"sh", "-c", "echo 'Pre-upgrade hook completed' && sleep 5"},
+						},
+					},
+				},
+			},
+		},
+	}
+	err = kcli.Create(context.Background(), job)
+	require.NoError(t, err, "failed to create job")
+
+	return []client.Object{sa, cr, crb, job}
+}
+
+func verifyHookResourcesExist(t *testing.T, kcli client.Client, resources []client.Object) {
+	for _, obj := range resources {
+		err := kcli.Get(context.Background(), client.ObjectKeyFromObject(obj), obj)
+		assert.NoError(t, err, "resource should exist before upgrade: %v", obj)
+	}
+}
+
+func verifyHookResourcesDeleted(t *testing.T, kcli client.Client, resources []client.Object) {
+	// Wait a bit for the deletion to complete
+	time.Sleep(2 * time.Second)
+
+	for _, obj := range resources {
+		err := kcli.Get(context.Background(), client.ObjectKeyFromObject(obj), obj)
+		assert.True(t, apierrors.IsNotFound(err), "resource should be deleted after upgrade: %v", obj)
+	}
+}

--- a/tests/integration/util/kind.go
+++ b/tests/integration/util/kind.go
@@ -3,6 +3,7 @@ package util
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,8 +12,8 @@ import (
 	"time"
 
 	"github.com/replicatedhq/embedded-cluster/tests/integration/util/kind"
-	"go.yaml.in/yaml/v3"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/yaml"
 )
 
 type KindClusterOptions struct {
@@ -190,6 +191,7 @@ func writeKindClusterConfig(t *testing.T, config kind.Cluster) string {
 	if err != nil {
 		t.Fatalf("failed to marshal kind cluster config: %s", err)
 	}
+	fmt.Println(string(data))
 	return WriteTempFile(t, "kind-config-*.yaml", data, 0644)
 }
 

--- a/tests/integration/util/kind.go
+++ b/tests/integration/util/kind.go
@@ -3,7 +3,6 @@ package util
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -191,7 +190,6 @@ func writeKindClusterConfig(t *testing.T, config kind.Cluster) string {
 	if err != nil {
 		t.Fatalf("failed to marshal kind cluster config: %s", err)
 	}
-	fmt.Println(string(data))
 	return WriteTempFile(t, "kind-config-*.yaml", data, 0644)
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Openebs pre-upgrade hook has delete policy "hook-succeeded". Subsequent upgrade attempts after a failure can fail with the following error:

```
2025/09/17 10:20:02 INFO updating status for rolled back release for openebs component=helm
Error: upgrade addons: upgrade addons: addon Storage: upgrade addon: helm upgrade: helm upgrade: release openebs failed, and has been rolled back due to atomic being set: pre-upgrade hooks failed: warning: Hook pre-upgrade openebs/templates/pre-upgrade-hook.yaml failed: 1 error occurred:
        * serviceaccounts "openebs-pre-upgrade-hook" already exists
```

This change deletes the hook resources if they exist before performing the upgrade.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue that can cause upgrades to fail when upgrading the OpenEBS add-on with error 'serviceaccounts "openebs-pre-upgrade-hook" already exists'
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
