### PR TITLE
chore(ci): install kots cli before enabling network report

### DIFF
--- a/e2e/cluster/cmx/cluster.go
+++ b/e2e/cluster/cmx/cluster.go
@@ -548,6 +548,15 @@ func (c *Cluster) SetNetworkReport(enabled bool) error {
 	return nil
 }
 
+func (c *Cluster) InstallKotsCLI(node int, envs ...map[string]string) error {
+	c.t.Logf("%s: installing kots cli on node %d", time.Now().Format(time.RFC3339), node)
+	line := []string{"install-kots-cli.sh"}
+	if stdout, stderr, err := c.RunCommandOnNode(node, line, envs...); err != nil {
+		return fmt.Errorf("run command: %v: %s: %s", err, stdout, stderr)
+	}
+	return nil
+}
+
 func (c *Cluster) waitUntilRunning(node Node, nodeNum int, timeoutDuration time.Duration) error {
 	timeout := time.After(timeoutDuration)
 	tick := time.Tick(2 * time.Second)

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -2077,6 +2077,11 @@ func TestSingleNodeNetworkReport(t *testing.T) {
 		t.Fatalf("fail to setup playwright: %v", err)
 	}
 
+	// install kots cli before starting the network report.
+	if err := tc.InstallKotsCLI(0); err != nil {
+		t.Fatalf("fail to install kots cli on node 0: %v", err)
+	}
+
 	if err := tc.SetNetworkReport(true); err != nil {
 		t.Fatalf("failed to enable network reporting: %v", err)
 	}
@@ -2110,10 +2115,6 @@ func TestSingleNodeNetworkReport(t *testing.T) {
 	allowedDomains := map[string]struct{}{
 		"ec-e2e-proxy.testcluster.net":          {},
 		"ec-e2e-replicated-app.testcluster.net": {},
-
-		// these two appear due to the install_cots_cli function in single-node-install.sh
-		"kots.io":                              {},
-		"release-assets.githubusercontent.com": {},
 	}
 
 	seenAllowedDomains := map[string]struct{}{}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Install KOTS CLI before starting the network report to ensure that there is no outbound connections to any domains other than the custom domain.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
