### PR TITLE
fix(web): styling issues for typography in v3

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,1 +1,6 @@
 @import 'tailwindcss';
+@plugin "@tailwindcss/typography";
+@plugin "@tailwindcss/forms";
+
+@variant is-enabled (&:not([disabled]));
+@variant is-disabled (&[disabled]);

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,6 +1,8 @@
 @import 'tailwindcss';
 @plugin "@tailwindcss/typography";
-@plugin "@tailwindcss/forms";
+@plugin "@tailwindcss/forms" {
+  strategy: class;
+};
 
 @variant is-enabled (&:not([disabled]));
 @variant is-disabled (&[disabled]);

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -1,18 +1,4 @@
-import plugin from "tailwindcss/plugin";
-
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ["./src/index.html", "./src/**/*.{js,jsx,ts,tsx}"],
-  corePlugins: {
-    preflight: true
-  },
-  plugins: [
-    plugin(function ({ addVariant }) {
-      addVariant("is-enabled", "&:not([disabled])");
-      addVariant("is-disabled", "&[disabled]");
-    }),
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    require("@tailwindcss/forms")({ strategy: "class" }),
-    require("@tailwindcss/typography")
-  ]
 };


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Fixes recent issues with typography styling introduced by #2851. Plugin setup is now different in v4, e.g. https://github.com/tailwindlabs/tailwindcss-forms?tab=readme-ov-file#installation

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/129289/it-seems-like-our-markdown-support-regressed-and-isn-t-working-well-now

<img width="2994" height="5218" alt="image" src="https://github.com/user-attachments/assets/fc5ee30a-17d5-4486-bf36-68f3f1d6ddc3" />

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
We need visual regression tests to pick up this kind of stuff.

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fix styling issues in markdown for the v3 installer
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
