### PR TITLE
feat(web): add initial upgrade flow

### DIFF
--- a/web/src/components/wizard/InstallWizard.tsx
+++ b/web/src/components/wizard/InstallWizard.tsx
@@ -28,9 +28,6 @@ const InstallWizard: React.FC = () => {
     steps = ["welcome", "configuration", `${target}-setup`, "installation", `${target}-completion`]
   }
 
-  console.log(mode)
-  console.log(steps)
-
   const goToNextStep = () => {
     const currentIndex = steps.indexOf(currentStep);
     if (currentIndex < steps.length - 1) {

--- a/web/src/components/wizard/StepNavigation.tsx
+++ b/web/src/components/wizard/StepNavigation.tsx
@@ -39,8 +39,6 @@ const StepNavigation: React.FC<StepNavigationProps> = ({ currentStep: currentSte
   // configured to use
   const steps = getNavigationSteps(mode)
     .filter(({ id: navId }) => enabledSteps.includes(navId));
-  console.log(steps)
-  console.log(enabledSteps)
 
   const currentStep = steps.find(step => step.id === currentStepId);
 

--- a/web/src/components/wizard/StepNavigation.tsx
+++ b/web/src/components/wizard/StepNavigation.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { WizardStep } from '../../types';
+import { WizardMode } from '../../types/wizard-mode.ts';
 import { ClipboardList, Settings, Download, CheckCircle, Server } from 'lucide-react';
 import { useWizard } from '../../contexts/WizardModeContext';
 import { useSettings } from '../../contexts/SettingsContext';
 
 interface StepNavigationProps {
   currentStep: WizardStep;
+  enabledSteps: WizardStep[];
 }
 
 interface NavigationStep {
@@ -16,32 +18,30 @@ interface NavigationStep {
   parentId?: WizardStep;
 }
 
-const StepNavigation: React.FC<StepNavigationProps> = ({ currentStep: currentStepId }) => {
-  const { mode, target } = useWizard();
+const getNavigationSteps = (mode: WizardMode): NavigationStep[] => {
+  return [
+    { id: 'welcome', name: 'Welcome', icon: ClipboardList },
+    { id: 'configuration', name: 'Configuration', icon: Server },
+    { id: 'linux-setup', name: 'Setup', icon: Settings },
+    { id: 'kubernetes-setup', name: 'Setup', icon: Settings },
+    { id: 'installation', name: mode === 'upgrade' ? 'Upgrade' : 'Installation', icon: Download },
+    { id: 'kubernetes-completion', name: 'Completion', icon: CheckCircle },
+    { id: 'linux-completion', name: 'Completion', icon: CheckCircle },
+  ]
+}
+
+const StepNavigation: React.FC<StepNavigationProps> = ({ currentStep: currentStepId, enabledSteps }) => {
+  const { mode } = useWizard();
   const { settings } = useSettings();
   const themeColor = settings.themeColor;
 
-  const getSteps = (): NavigationStep[] => {
-    if (target === 'kubernetes') {
-      return [
-        { id: 'welcome', name: 'Welcome', icon: ClipboardList },
-        { id: 'configuration', name: 'Configuration', icon: Server },
-        { id: 'kubernetes-setup', name: 'Setup', icon: Settings },
-        { id: 'installation', name: mode === 'upgrade' ? 'Upgrade' : 'Installation', icon: Download },
-        { id: 'kubernetes-completion', name: 'Completion', icon: CheckCircle },
-      ];
-    } else {
-      return [
-        { id: 'welcome', name: 'Welcome', icon: ClipboardList },
-        { id: 'configuration', name: 'Configuration', icon: Server },
-        { id: 'linux-setup', name: 'Setup', icon: Settings },
-        { id: 'installation', name: mode === 'upgrade' ? 'Upgrade' : 'Installation', icon: Download },
-        { id: 'linux-completion', name: 'Completion', icon: CheckCircle },
-      ];
-    }
-  }
+  // Get the navigation steps for this wizard mode and then filter them, removing steps the wizard isn't
+  // configured to use
+  const steps = getNavigationSteps(mode)
+    .filter(({ id: navId }) => enabledSteps.includes(navId));
+  console.log(steps)
+  console.log(enabledSteps)
 
-  const steps = getSteps();
   const currentStep = steps.find(step => step.id === currentStepId);
 
   const getStepStatus = (step: NavigationStep) => {

--- a/web/src/components/wizard/config/ConfigurationStep.tsx
+++ b/web/src/components/wizard/config/ConfigurationStep.tsx
@@ -16,6 +16,7 @@ import { ChevronRight, Loader2 } from 'lucide-react';
 import { handleUnauthorized } from '../../../utils/auth';
 import { useDebouncedFetch } from '../../../utils/debouncedFetch';
 import { AppConfig, AppConfigGroup, AppConfigItem, AppConfigValues } from '../../../types';
+import { getApiBase } from '../../../utils/api-base';
 
 
 interface ConfigurationStepProps {
@@ -27,7 +28,7 @@ interface ConfigError extends Error {
 }
 
 const ConfigurationStep: React.FC<ConfigurationStepProps> = ({ onNext }) => {
-  const { text, target } = useWizard();
+  const { text, target, mode } = useWizard();
   const { token } = useAuth();
   const { settings } = useSettings();
   const [activeTab, setActiveTab] = useState<string>('');
@@ -157,7 +158,8 @@ const ConfigurationStep: React.FC<ConfigurationStepProps> = ({ onNext }) => {
   // Mutation to save config values
   const { mutate: submitConfigValues } = useMutation<void, ConfigError>({
     mutationFn: async () => {
-      const response = await fetch(`/api/${target}/install/app/config/values`, {
+      const apiBase = getApiBase(target, mode);
+      const response = await fetch(`${apiBase}/app/config/values`, {
         method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',

--- a/web/src/components/wizard/installation/InstallationTimeline.tsx
+++ b/web/src/components/wizard/installation/InstallationTimeline.tsx
@@ -44,7 +44,7 @@ const InstallationTimeline: React.FC<InstallationTimelineProps> = ({
   return (
     <div className="w-80 bg-gray-50 border-r border-gray-200 p-6">
       <h3 className="text-lg font-medium text-gray-900 mb-6" data-testid="timeline-title">Installation Progress</h3>
-      
+
       <div className="space-y-6">
         {phaseOrder.map((phaseKey) => {
           const phase = phases[phaseKey];
@@ -52,13 +52,12 @@ const InstallationTimeline: React.FC<InstallationTimelineProps> = ({
           const isSelected = selectedPhase === phaseKey;
           const isFailed = phase.status === 'Failed';
           const isClickable = phase.status !== 'Pending';
-          
+
           return (
             <div key={phaseKey} className="relative">
               <button
-                className={`flex items-start space-x-3 text-left w-full p-2 rounded-md transition-colors ${
-                  isClickable ? 'hover:bg-gray-100 cursor-pointer' : 'cursor-default'
-                } ${isSelected ? 'bg-blue-50 border border-blue-200' : ''}`}
+                className={`flex items-start space-x-3 text-left w-full p-2 rounded-md transition-colors ${isClickable ? 'hover:bg-gray-100 cursor-pointer' : 'cursor-default'
+                  } ${isSelected ? 'bg-blue-50 border border-blue-200' : ''}`}
                 onClick={() => isClickable && onPhaseClick(phaseKey)}
                 disabled={!isClickable}
                 data-testid={`timeline-${phaseKey}`}
@@ -66,19 +65,17 @@ const InstallationTimeline: React.FC<InstallationTimelineProps> = ({
                 <div className="shrink-0 mt-0.5">
                   {getStatusIcon(phase.status)}
                 </div>
-                
+
                 <div className="grow min-w-0">
-                  <h4 className={`text-sm font-medium ${
-                    isSelected ? 'text-gray-900' : isActive ? 'text-gray-900' : phase.status === 'Succeeded' ? 'text-gray-700' : 'text-gray-600'
-                  }`}>
+                  <h4 className={`text-sm font-medium ${isSelected ? 'text-gray-900' : isActive ? 'text-gray-900' : phase.status === 'Succeeded' ? 'text-gray-700' : 'text-gray-600'
+                    }`}>
                     {phase.title}
                   </h4>
-                  <p className={`text-xs mt-1 ${
-                    isSelected ? 'text-gray-600' : isActive ? 'text-gray-600' : 'text-gray-500'
-                  }`}>
+                  <p className={`text-xs mt-1 ${isSelected ? 'text-gray-600' : isActive ? 'text-gray-600' : 'text-gray-500'
+                    }`}>
                     {phase.description}
                   </p>
-                  
+
                   {isFailed && phase.error && (
                     <p className="text-xs text-red-600 mt-1">{phase.error}</p>
                   )}

--- a/web/src/components/wizard/installation/UpgradeStep.tsx
+++ b/web/src/components/wizard/installation/UpgradeStep.tsx
@@ -1,0 +1,212 @@
+import React, { useState, useCallback, useRef } from 'react';
+import Card from '../../common/Card';
+import Button from '../../common/Button';
+import { useWizard } from '../../../contexts/WizardModeContext';
+import { useSettings } from '../../../contexts/SettingsContext';
+import { State } from '../../../types';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import InstallationTimeline, { InstallationPhaseId as InstallationPhase, PhaseStatus } from './InstallationTimeline';
+import AppInstallationPhase from './phases/AppInstallationPhase';
+import UpgradeConfirmationPhase from './phases/UpgradeConfirmationPhase';
+import { NextButtonConfig, BackButtonConfig } from './types';
+
+interface InstallationStepProps {
+  onNext: () => void;
+  onBack: () => void;
+}
+
+const UpgradeStep: React.FC<InstallationStepProps> = ({ onNext, onBack }) => {
+  const { text } = useWizard();
+  const { settings } = useSettings();
+  const themeColor = settings.themeColor;
+
+  const getPhaseOrder = (): InstallationPhase[] => {
+    return ["app-preflight", "app-installation"];
+  };
+
+  const phaseOrder = getPhaseOrder();
+  const [currentPhase, setCurrentPhase] = useState<InstallationPhase>(phaseOrder[0]);
+  const [selectedPhase, setSelectedPhase] = useState<InstallationPhase>(phaseOrder[0]);
+  const [completedPhases, setCompletedPhases] = useState<Set<InstallationPhase>>(new Set());
+  const [nextButtonConfig, setNextButtonConfig] = useState<NextButtonConfig | null>(null);
+  const [backButtonConfig, setBackButtonConfig] = useState<BackButtonConfig | null>(null);
+  const nextButtonRef = useRef<HTMLButtonElement>(null);
+
+  const [phases, setPhases] = useState<Record<InstallationPhase, PhaseStatus>>(() => ({
+    'linux-preflight': {
+      status: 'Pending' as State,
+      title: text.linuxValidationTitle,
+      description: text.linuxValidationDescription,
+    },
+    'linux-installation': {
+      status: 'Pending' as State,
+      title: text.linuxInstallationTitle,
+      description: text.linuxInstallationDescription,
+    },
+    'kubernetes-installation': {
+      status: 'Pending' as State,
+      title: text.kubernetesInstallationTitle,
+      description: text.kubernetesInstallationDescription,
+    },
+    'app-preflight': {
+      status: 'Pending' as State,
+      title: "Confirm Upgrade",
+      description: "Execute app upgrade",
+    },
+    'app-installation': {
+      status: 'Pending' as State,
+      title: text.appInstallationTitle,
+      description: text.appInstallationDescription,
+    },
+  }));
+
+  const handleStateChange = useCallback((phase: InstallationPhase) => (status: State) => {
+    setPhases(prev => ({
+      ...prev,
+      [phase]: { ...prev[phase], status }
+    }));
+
+    // Auto-advance to next phase when current phase succeeds
+    if (phase === currentPhase && status === 'Succeeded') {
+      setTimeout(() => {
+        nextButtonRef.current?.click();
+      }, 500);
+    }
+  }, [currentPhase]);
+
+  const goToNextPhase = () => {
+    // Mark current phase as completed
+    setCompletedPhases(prev => new Set([...prev, currentPhase]));
+
+    // Move to next phase
+    const currentIndex = phaseOrder.indexOf(currentPhase);
+    if (currentIndex < phaseOrder.length - 1) {
+      const nextPhase = phaseOrder[currentIndex + 1];
+      setCurrentPhase(nextPhase);
+      setSelectedPhase(nextPhase);
+    } else {
+      // All phases complete, go to next wizard step
+      onNext();
+    }
+  };
+
+  const getNextButtonText = () => {
+    const currentIndex = phaseOrder.indexOf(currentPhase);
+    if (currentIndex < phaseOrder.length - 1) {
+      const nextPhase = phaseOrder[currentIndex + 1];
+      return `Next: ${phases[nextPhase]?.title}`;
+    } else {
+      return 'Next: Finish';
+    }
+  };
+
+  const canSelectPhase = (phase: InstallationPhase) => {
+    // Only allow clicking on completed phases or current phase
+    return completedPhases.has(phase) || phase === currentPhase;
+  };
+
+  const handlePhaseClick = (phase: InstallationPhase) => {
+    if (canSelectPhase(phase)) {
+      setSelectedPhase(phase);
+    }
+  };
+
+  // No-op function for non-current steps
+  const noOp = useCallback(() => { }, []);
+
+  const renderPhase = (phase: InstallationPhase) => {
+    const commonProps = {
+      onNext: goToNextPhase,
+      onBack,
+      // Only pass the real setNextButtonConfig to the current phase
+      setNextButtonConfig: phase === currentPhase ? setNextButtonConfig : noOp,
+      // Only pass the real setBackButtonConfig to the current phase
+      setBackButtonConfig: phase === currentPhase ? setBackButtonConfig : noOp,
+      onStateChange: handleStateChange(phase)
+    };
+
+    switch (phase) {
+      case 'app-preflight':
+        return <UpgradeConfirmationPhase {...commonProps} />
+      case 'app-installation':
+        return <AppInstallationPhase {...commonProps} />;
+      default:
+        return (
+          <div className="text-gray-600">
+            Loading {phase} content...
+          </div>
+        );
+    }
+  };
+
+  const renderPhases = () => {
+    // Render all completed and current phases to preserve component state and polling logic.
+    // This prevents unmounting when users switch between phases, which would stop React Query
+    // polling intervals and lose component state. Non-selected phases are simply hidden.
+    // Future phases are excluded to avoid triggering mutations on mount for phases that haven't started yet.
+    return phaseOrder.map(phase => {
+      if (!canSelectPhase(phase)) {
+        return null;
+      };
+
+      return (
+        <div
+          key={phase}
+          data-testid={`${phase}-container`}
+          className={`h-full flex flex-col ${phase === selectedPhase ? 'block' : 'hidden'}`}
+        >
+          {renderPhase(phase)}
+        </div>
+      );
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card className="p-0 overflow-hidden">
+        <div className="flex min-h-[600px]">
+          <InstallationTimeline
+            phases={phases}
+            currentPhase={currentPhase}
+            selectedPhase={selectedPhase}
+            onPhaseClick={handlePhaseClick}
+            phaseOrder={phaseOrder}
+            themeColor={themeColor}
+          />
+
+          <div className="flex-1 p-8">
+            {renderPhases()}
+          </div>
+        </div>
+      </Card>
+
+      <div className="flex justify-between">
+        {backButtonConfig && !backButtonConfig.hidden && (
+          <Button
+            onClick={backButtonConfig.onClick}
+            variant="outline"
+            disabled={backButtonConfig.disabled ?? false}
+            icon={<ChevronLeft className="w-5 h-5" />}
+            dataTestId="installation-back-button"
+          >
+            Back
+          </Button>
+        )}
+        {nextButtonConfig && (
+          <Button
+            ref={nextButtonRef}
+            onClick={nextButtonConfig.onClick}
+            disabled={nextButtonConfig.disabled}
+            icon={<ChevronRight className="w-5 h-5" />}
+            dataTestId="installation-next-button"
+            className={(!backButtonConfig || backButtonConfig.hidden) ? 'ml-auto' : ''}
+          >
+            {getNextButtonText()}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default UpgradeStep;

--- a/web/src/components/wizard/installation/phases/AppInstallationPhase.tsx
+++ b/web/src/components/wizard/installation/phases/AppInstallationPhase.tsx
@@ -6,6 +6,7 @@ import { useQuery } from "@tanstack/react-query";
 import { XCircle, CheckCircle, Loader2 } from "lucide-react";
 import { NextButtonConfig } from "../types";
 import { State, AppInstallStatus } from "../../../../types";
+import { getApiBase } from '../../../../utils/api-base';
 import ErrorMessage from "../shared/ErrorMessage";
 
 interface AppInstallationPhaseProps {
@@ -15,7 +16,7 @@ interface AppInstallationPhaseProps {
 }
 
 const AppInstallationPhase: React.FC<AppInstallationPhaseProps> = ({ onNext, setNextButtonConfig, onStateChange }) => {
-  const { text, target } = useWizard();
+  const { text, target, mode } = useWizard();
   const { settings } = useSettings();
   const { token } = useAuth();
   const [isPolling, setIsPolling] = useState(true);
@@ -27,7 +28,8 @@ const AppInstallationPhase: React.FC<AppInstallationPhaseProps> = ({ onNext, set
   const { data: appInstallStatus, error: appStatusError } = useQuery<AppInstallStatus, Error>({
     queryKey: ["appInstallationStatus"],
     queryFn: async () => {
-      const response = await fetch(`/api/${target}/install/app/status`, {
+      const apiBase = getApiBase(target, mode);
+      const response = await fetch(`${apiBase}/app/status`, {
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${token}`,

--- a/web/src/components/wizard/installation/phases/AppPreflightCheck.tsx
+++ b/web/src/components/wizard/installation/phases/AppPreflightCheck.tsx
@@ -6,6 +6,7 @@ import { useQuery, useMutation } from "@tanstack/react-query";
 import Button from "../../../common/Button";
 import { useAuth } from "../../../../contexts/AuthContext";
 import { PreflightOutput, AppPreflightResponse } from "../../../../types";
+import { getApiBase } from '../../../../utils/api-base';
 
 interface AppPreflightCheckProps {
   onRun: () => void;
@@ -15,7 +16,7 @@ interface AppPreflightCheckProps {
 const AppPreflightCheck: React.FC<AppPreflightCheckProps> = ({ onRun, onComplete }) => {
   const [isPreflightsPolling, setIsPreflightsPolling] = useState(false);
   const { settings } = useSettings();
-  const { target } = useWizard();
+  const { target, mode } = useWizard();
   const themeColor = settings.themeColor;
   const { token } = useAuth();
 
@@ -34,10 +35,11 @@ const AppPreflightCheck: React.FC<AppPreflightCheckProps> = ({ onRun, onComplete
     return "";
   };
 
+  const apiBase = getApiBase(target, mode);
   // Mutation to run preflight checks
   const { mutate: runPreflights, error: preflightsRunError } = useMutation({
     mutationFn: async () => {
-      const response = await fetch(`/api/${target}/install/app-preflights/run`, {
+      const response = await fetch(`${apiBase}/app-preflights/run`, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -63,7 +65,7 @@ const AppPreflightCheck: React.FC<AppPreflightCheckProps> = ({ onRun, onComplete
   const { data: preflightResponse } = useQuery<AppPreflightResponse, Error>({
     queryKey: ["appPreflightStatus"],
     queryFn: async () => {
-      const response = await fetch(`/api/${target}/install/app-preflights/status`, {
+      const response = await fetch(`${apiBase}/app-preflights/status`, {
         headers: {
           ...(localStorage.getItem("auth") && {
             Authorization: `Bearer ${localStorage.getItem("auth")}`,

--- a/web/src/components/wizard/installation/phases/AppPreflightPhase.tsx
+++ b/web/src/components/wizard/installation/phases/AppPreflightPhase.tsx
@@ -8,6 +8,7 @@ import { useMutation } from "@tanstack/react-query";
 import { useAuth } from "../../../../contexts/AuthContext";
 import { NextButtonConfig } from "../types";
 import { State } from "../../../../types";
+import { getApiBase } from '../../../../utils/api-base';
 
 interface AppPreflightPhaseProps {
   onNext: () => void;
@@ -16,7 +17,7 @@ interface AppPreflightPhaseProps {
 }
 
 const AppPreflightPhase: React.FC<AppPreflightPhaseProps> = ({ onNext, setNextButtonConfig, onStateChange }) => {
-  const { text, target } = useWizard();
+  const { text, target, mode } = useWizard();
   const [preflightComplete, setPreflightComplete] = React.useState(false);
   const [preflightSuccess, setPreflightSuccess] = React.useState(false);
   const [allowIgnoreAppPreflights, setAllowIgnoreAppPreflights] = React.useState(false);
@@ -43,7 +44,8 @@ const AppPreflightPhase: React.FC<AppPreflightPhaseProps> = ({ onNext, setNextBu
 
   const { mutate: startAppInstallation } = useMutation({
     mutationFn: async ({ ignoreAppPreflights }: { ignoreAppPreflights: boolean }) => {
-      const response = await fetch(`/api/${target}/install/app/install`, {
+      const apiBase = getApiBase(target, mode);
+      const response = await fetch(`${apiBase}/app/${mode}`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/web/src/components/wizard/installation/phases/KubernetesInstallationPhase.tsx
+++ b/web/src/components/wizard/installation/phases/KubernetesInstallationPhase.tsx
@@ -2,12 +2,14 @@ import React, { useState, useEffect } from 'react';
 import { useQuery } from "@tanstack/react-query";
 import { useSettings } from '../../../../contexts/SettingsContext';
 import { useAuth } from "../../../../contexts/AuthContext";
+import { useWizard } from '../../../../contexts/WizardModeContext';
 import { InfraStatusResponse, State } from '../../../../types';
 import InstallationProgress from '../shared/InstallationProgress';
 import LogViewer from '../shared/LogViewer';
 import StatusIndicator from '../shared/StatusIndicator';
 import ErrorMessage from '../shared/ErrorMessage';
 import { NextButtonConfig, BackButtonConfig } from '../types';
+import { getApiBase } from '../../../../utils/api-base';
 
 interface KubernetesInstallationPhaseProps {
   onNext: () => void;
@@ -20,6 +22,7 @@ interface KubernetesInstallationPhaseProps {
 const KubernetesInstallationPhase: React.FC<KubernetesInstallationPhaseProps> = ({ onNext, onBack, setNextButtonConfig, setBackButtonConfig, onStateChange }) => {
   const { token } = useAuth();
   const { settings } = useSettings();
+  const { mode } = useWizard();
   const [isInfraPolling, setIsInfraPolling] = useState(true);
   const [installComplete, setInstallComplete] = useState(false);
   const [showLogs, setShowLogs] = useState(false);
@@ -27,9 +30,10 @@ const KubernetesInstallationPhase: React.FC<KubernetesInstallationPhaseProps> = 
 
   // Query to poll infra status
   const { data: infraStatusResponse, error: infraStatusError } = useQuery<InfraStatusResponse, Error>({
-    queryKey: ["infraStatus"],
+    queryKey: ["infraStatus", mode],
     queryFn: async () => {
-      const response = await fetch("/api/kubernetes/install/infra/status", {
+      const apiBase = getApiBase("kubernetes", mode);
+      const response = await fetch(`${apiBase}/infra/status`, {
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${token}`,

--- a/web/src/components/wizard/installation/phases/LinuxInstallationPhase.tsx
+++ b/web/src/components/wizard/installation/phases/LinuxInstallationPhase.tsx
@@ -2,12 +2,14 @@ import React, { useState, useEffect } from 'react';
 import { useQuery } from "@tanstack/react-query";
 import { useSettings } from '../../../../contexts/SettingsContext';
 import { useAuth } from "../../../../contexts/AuthContext";
+import { useWizard } from '../../../../contexts/WizardModeContext';
 import { InfraStatusResponse, State } from '../../../../types';
 import InstallationProgress from '../shared/InstallationProgress';
 import LogViewer from '../shared/LogViewer';
 import StatusIndicator from '../shared/StatusIndicator';
 import ErrorMessage from '../shared/ErrorMessage';
 import { NextButtonConfig, BackButtonConfig } from '../types';
+import { getApiBase } from '../../../../utils/api-base';
 
 interface LinuxInstallationPhaseProps {
   onNext: () => void;
@@ -20,6 +22,7 @@ interface LinuxInstallationPhaseProps {
 const LinuxInstallationPhase: React.FC<LinuxInstallationPhaseProps> = ({ onNext, onBack, setNextButtonConfig, setBackButtonConfig, onStateChange }) => {
   const { token } = useAuth();
   const { settings } = useSettings();
+  const { mode } = useWizard();
   const [isInfraPolling, setIsInfraPolling] = useState(true);
   const [installComplete, setInstallComplete] = useState(false);
   const [showLogs, setShowLogs] = useState(false);
@@ -27,9 +30,10 @@ const LinuxInstallationPhase: React.FC<LinuxInstallationPhaseProps> = ({ onNext,
 
   // Query to poll infra status
   const { data: infraStatusResponse, error: infraStatusError } = useQuery<InfraStatusResponse, Error>({
-    queryKey: ["infraStatus"],
+    queryKey: ["infraStatus", mode],
     queryFn: async () => {
-      const response = await fetch("/api/linux/install/infra/status", {
+      const apiBase = getApiBase("linux", mode);
+      const response = await fetch(`${apiBase}/infra/status`, {
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${token}`,

--- a/web/src/components/wizard/installation/phases/LinuxPreflightCheck.tsx
+++ b/web/src/components/wizard/installation/phases/LinuxPreflightCheck.tsx
@@ -1,10 +1,12 @@
 import React, { useState, useEffect } from "react";
-import { useSettings } from "../../../../contexts/SettingsContext";
 import { XCircle, CheckCircle, Loader2, AlertTriangle, RefreshCw } from "lucide-react";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import Button from "../../../common/Button";
-import { useAuth } from "../../../../contexts/AuthContext";
 import { PreflightOutput, HostPreflightResponse, State } from "../../../../types";
+import { useWizard } from "../../../../contexts/WizardModeContext";
+import { useAuth } from "../../../../contexts/AuthContext";
+import { useSettings } from "../../../../contexts/SettingsContext";
+import { getApiBase } from '../../../../utils/api-base';
 
 interface LinuxPreflightCheckProps {
   onRun: () => void;
@@ -18,6 +20,7 @@ interface InstallationStatusResponse {
 }
 
 const LinuxPreflightCheck: React.FC<LinuxPreflightCheckProps> = ({ onRun, onComplete }) => {
+  const { target, mode } = useWizard();
   const [isPreflightsPolling, setIsPreflightsPolling] = useState(false);
   const [isInstallationStatusPolling, setIsInstallationStatusPolling] = useState(true);
   const { settings } = useSettings();
@@ -41,10 +44,11 @@ const LinuxPreflightCheck: React.FC<LinuxPreflightCheckProps> = ({ onRun, onComp
     return "";
   };
 
+  const apiBase = getApiBase(target, mode);
   // Mutation to run preflight checks
   const { mutate: runPreflights, error: preflightsRunError } = useMutation({
     mutationFn: async () => {
-      const response = await fetch("/api/linux/install/host-preflights/run", {
+      const response = await fetch(`${apiBase}/host-preflights/run`, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -70,7 +74,7 @@ const LinuxPreflightCheck: React.FC<LinuxPreflightCheckProps> = ({ onRun, onComp
   const { data: installationStatus } = useQuery<InstallationStatusResponse, Error>({
     queryKey: ["installationStatus"],
     queryFn: async () => {
-      const response = await fetch("/api/linux/install/installation/status", {
+      const response = await fetch(`${apiBase}/installation/status`, {
         headers: {
           ...(localStorage.getItem("auth") && {
             Authorization: `Bearer ${localStorage.getItem("auth")}`,
@@ -92,7 +96,7 @@ const LinuxPreflightCheck: React.FC<LinuxPreflightCheckProps> = ({ onRun, onComp
   const { data: preflightResponse } = useQuery<HostPreflightResponse, Error>({
     queryKey: ["preflightStatus"],
     queryFn: async () => {
-      const response = await fetch("/api/linux/install/host-preflights/status", {
+      const response = await fetch(`${apiBase}/host-preflights/status`, {
         headers: {
           ...(localStorage.getItem("auth") && {
             Authorization: `Bearer ${localStorage.getItem("auth")}`,

--- a/web/src/components/wizard/installation/phases/LinuxPreflightPhase.tsx
+++ b/web/src/components/wizard/installation/phases/LinuxPreflightPhase.tsx
@@ -8,6 +8,7 @@ import { useMutation } from "@tanstack/react-query";
 import { useAuth } from "../../../../contexts/AuthContext";
 import { NextButtonConfig, BackButtonConfig } from "../types";
 import { State } from "../../../../types";
+import { getApiBase } from '../../../../utils/api-base';
 
 interface LinuxPreflightPhaseProps {
   onNext: () => void;
@@ -18,7 +19,7 @@ interface LinuxPreflightPhaseProps {
 }
 
 const LinuxPreflightPhase: React.FC<LinuxPreflightPhaseProps> = ({ onNext, onBack, setNextButtonConfig, setBackButtonConfig, onStateChange }) => {
-  const { text } = useWizard();
+  const { text, target, mode } = useWizard();
   const [preflightComplete, setPreflightComplete] = React.useState(false);
   const [preflightSuccess, setPreflightSuccess] = React.useState(false);
   const [allowIgnoreHostPreflights, setAllowIgnoreHostPreflights] = React.useState(false);
@@ -42,7 +43,8 @@ const LinuxPreflightPhase: React.FC<LinuxPreflightPhaseProps> = ({ onNext, onBac
 
   const { mutate: startInstallation } = useMutation({
     mutationFn: async ({ ignoreHostPreflights }: { ignoreHostPreflights: boolean }) => {
-      const response = await fetch("/api/linux/install/infra/setup", {
+      const apiBase = getApiBase(target, mode);
+      const response = await fetch(`${apiBase}/infra/setup`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/web/src/components/wizard/installation/phases/UpgradeConfirmationPhase.tsx
+++ b/web/src/components/wizard/installation/phases/UpgradeConfirmationPhase.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect } from "react";
+import { useWizard } from "../../../../contexts/WizardModeContext";
+import { useMutation } from "@tanstack/react-query";
+import { useAuth } from "../../../../contexts/AuthContext";
+import { NextButtonConfig } from "../types";
+import { State } from "../../../../types";
+import { getApiBase } from '../../../../utils/api-base';
+
+interface AppPreflightPhaseProps {
+  onNext: () => void;
+  setNextButtonConfig: (config: NextButtonConfig) => void;
+  onStateChange: (status: State) => void;
+}
+
+// TODO Upgrade this component sole purpose is to trigger the installation. Once we add more phases it can be removed.
+const UpgradeConfirmationPhase: React.FC<AppPreflightPhaseProps> = ({ onNext, setNextButtonConfig }) => {
+  const { text, target, mode } = useWizard();
+  const [error, setError] = React.useState<string | null>(null);
+  const { token } = useAuth();
+
+  const { mutate: startAppInstallation } = useMutation({
+    mutationFn: async ({ ignoreAppPreflights }: { ignoreAppPreflights: boolean }) => {
+      const apiBase = getApiBase(target, mode);
+      const response = await fetch(`${apiBase}/app/${mode}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          ignoreAppPreflights: ignoreAppPreflights
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData.message || "Failed to start application installation");
+      }
+      return response.json();
+    },
+    onSuccess: () => {
+      setError(null); // Clear any previous errors
+      onNext();
+    },
+    onError: (err: Error) => {
+      setError(err.message || "Failed to start application installation");
+    },
+  });
+
+  const handleNextClick = () => {
+    startAppInstallation({ ignoreAppPreflights: false }); // No need to ignore preflights
+  };
+
+
+
+  // Update next button configuration
+  useEffect(() => {
+    setNextButtonConfig({
+      disabled: false,
+      onClick: handleNextClick,
+    });
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      <div className="mb-6">
+        <h2 className="text-2xl font-bold text-gray-900">{text.appValidationTitle}</h2>
+        <p className="text-gray-600 mt-1">{text.appValidationDescription}</p>
+      </div>
+      {error && <div className="mt-4 p-3 bg-red-50 text-red-500 rounded-md">{error}</div>}
+    </div>
+  );
+};
+
+export default UpgradeConfirmationPhase;

--- a/web/src/components/wizard/installation/tests/UpgradeConfirmationPhase.test.tsx
+++ b/web/src/components/wizard/installation/tests/UpgradeConfirmationPhase.test.tsx
@@ -271,11 +271,12 @@ describe.each([
   });
 
   it('sends correct upgrade request payload', async () => {
-    let receivedPayload: any = null;
+    type Payload = { ignoreAppPreflights: boolean } | null;
+    let receivedPayload: Payload = null;
 
     server.use(
       http.post(`*/api/${target}/upgrade/app/upgrade`, async ({ request }) => {
-        receivedPayload = await request.json();
+        receivedPayload = await request.json() as Payload;
         return HttpResponse.json({ success: true });
       })
     );

--- a/web/src/components/wizard/installation/tests/UpgradeConfirmationPhase.test.tsx
+++ b/web/src/components/wizard/installation/tests/UpgradeConfirmationPhase.test.tsx
@@ -1,0 +1,313 @@
+import { describe, it, expect, vi, beforeAll, afterEach, afterAll } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { renderWithProviders } from '../../../../test/setup.tsx';
+import UpgradeConfirmationPhase from '../phases/UpgradeConfirmationPhase';
+
+const createServer = (target: 'linux' | 'kubernetes') => setupServer(
+  // Mock app upgrade endpoint
+  http.post(`*/api/${target}/upgrade/app/upgrade`, () => {
+    return HttpResponse.json({ success: true });
+  })
+);
+
+describe.each([
+  { target: "kubernetes" as const, displayName: "Kubernetes" },
+  { target: "linux" as const, displayName: "Linux" }
+])('UpgradeConfirmationPhase - $displayName', ({ target }) => {
+  const mockOnNext = vi.fn();
+  const mockSetNextButtonConfig = vi.fn();
+  const mockOnStateChange = vi.fn();
+  let server: ReturnType<typeof createServer>;
+
+  beforeAll(() => {
+    server = createServer(target);
+    server.listen();
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('renders upgrade confirmation content', async () => {
+    renderWithProviders(
+      <UpgradeConfirmationPhase
+        onNext={mockOnNext}
+        setNextButtonConfig={mockSetNextButtonConfig}
+        onStateChange={mockOnStateChange}
+      />,
+      {
+        wrapperProps: {
+          target,
+          mode: 'upgrade',
+          authenticated: true
+        }
+      }
+    );
+
+    // Should show upgrade confirmation title and description
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 2 })).toBeInTheDocument();
+    });
+  });
+
+  it('configures next button on mount', async () => {
+    renderWithProviders(
+      <UpgradeConfirmationPhase
+        onNext={mockOnNext}
+        setNextButtonConfig={mockSetNextButtonConfig}
+        onStateChange={mockOnStateChange}
+      />,
+      {
+        wrapperProps: {
+          target,
+          mode: 'upgrade',
+          authenticated: true
+        }
+      }
+    );
+
+    // Should configure the next button
+    await waitFor(() => {
+      expect(mockSetNextButtonConfig).toHaveBeenCalledWith({
+        disabled: false,
+        onClick: expect.any(Function)
+      });
+    });
+  });
+
+  it('starts upgrade when next button is clicked', async () => {
+    let upgradeCalled = false;
+
+    server.use(
+      http.post(`*/api/${target}/upgrade/app/upgrade`, () => {
+        upgradeCalled = true;
+        return HttpResponse.json({ success: true });
+      })
+    );
+
+    renderWithProviders(
+      <UpgradeConfirmationPhase
+        onNext={mockOnNext}
+        setNextButtonConfig={mockSetNextButtonConfig}
+        onStateChange={mockOnStateChange}
+      />,
+      {
+        wrapperProps: {
+          target,
+          mode: 'upgrade',
+          authenticated: true
+        }
+      }
+    );
+
+    // Wait for component to mount and configure next button
+    await waitFor(() => {
+      expect(mockSetNextButtonConfig).toHaveBeenCalled();
+    });
+
+    // Get the onClick handler that was passed to setNextButtonConfig
+    const nextButtonConfig = mockSetNextButtonConfig.mock.calls[0][0];
+    const handleNextClick = nextButtonConfig.onClick;
+
+    // Simulate clicking the next button
+    handleNextClick();
+
+    // Should call the upgrade API
+    await waitFor(() => {
+      expect(upgradeCalled).toBe(true);
+    });
+
+    // Should call onNext after successful upgrade start
+    await waitFor(() => {
+      expect(mockOnNext).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('shows error message when upgrade fails to start', async () => {
+    const errorMessage = 'Failed to start upgrade due to insufficient resources';
+
+    server.use(
+      http.post(`*/api/${target}/upgrade/app/upgrade`, () => {
+        return HttpResponse.json(
+          { message: errorMessage },
+          { status: 500 }
+        );
+      })
+    );
+
+    renderWithProviders(
+      <UpgradeConfirmationPhase
+        onNext={mockOnNext}
+        setNextButtonConfig={mockSetNextButtonConfig}
+        onStateChange={mockOnStateChange}
+      />,
+      {
+        wrapperProps: {
+          target,
+          mode: 'upgrade',
+          authenticated: true
+        }
+      }
+    );
+
+    // Wait for component to mount
+    await waitFor(() => {
+      expect(mockSetNextButtonConfig).toHaveBeenCalled();
+    });
+
+    // Get the onClick handler and simulate clicking
+    const nextButtonConfig = mockSetNextButtonConfig.mock.calls[0][0];
+    nextButtonConfig.onClick();
+
+    // Should show error message
+    await waitFor(() => {
+      expect(screen.getByText(errorMessage)).toBeInTheDocument();
+    });
+
+    // Should not call onNext when there's an error
+    expect(mockOnNext).not.toHaveBeenCalled();
+  });
+
+  it('handles network error gracefully', async () => {
+    server.use(
+      http.post(`*/api/${target}/upgrade/app/upgrade`, () => {
+        return HttpResponse.error();
+      })
+    );
+
+    renderWithProviders(
+      <UpgradeConfirmationPhase
+        onNext={mockOnNext}
+        setNextButtonConfig={mockSetNextButtonConfig}
+        onStateChange={mockOnStateChange}
+      />,
+      {
+        wrapperProps: {
+          target,
+          mode: 'upgrade',
+          authenticated: true
+        }
+      }
+    );
+
+    // Wait for component to mount
+    await waitFor(() => {
+      expect(mockSetNextButtonConfig).toHaveBeenCalled();
+    });
+
+    // Get the onClick handler and simulate clicking
+    const nextButtonConfig = mockSetNextButtonConfig.mock.calls[0][0];
+    nextButtonConfig.onClick();
+
+    // Should show error message for network error (actual message is "Failed to fetch" for network errors)
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to fetch/)).toBeInTheDocument();
+    });
+
+    // Should not call onNext when there's an error
+    expect(mockOnNext).not.toHaveBeenCalled();
+  });
+
+  it('clears previous error on successful upgrade start', async () => {
+    let shouldFail = true;
+
+    server.use(
+      http.post(`*/api/${target}/upgrade/app/upgrade`, () => {
+        if (shouldFail) {
+          return HttpResponse.json(
+            { message: 'First attempt failed' },
+            { status: 500 }
+          );
+        }
+        return HttpResponse.json({ success: true });
+      })
+    );
+
+    renderWithProviders(
+      <UpgradeConfirmationPhase
+        onNext={mockOnNext}
+        setNextButtonConfig={mockSetNextButtonConfig}
+        onStateChange={mockOnStateChange}
+      />,
+      {
+        wrapperProps: {
+          target,
+          mode: 'upgrade',
+          authenticated: true
+        }
+      }
+    );
+
+    // Wait for component to mount
+    await waitFor(() => {
+      expect(mockSetNextButtonConfig).toHaveBeenCalled();
+    });
+
+    const nextButtonConfig = mockSetNextButtonConfig.mock.calls[0][0];
+
+    // First attempt - should fail
+    nextButtonConfig.onClick();
+
+    await waitFor(() => {
+      expect(screen.getByText('First attempt failed')).toBeInTheDocument();
+    });
+
+    // Second attempt - should succeed
+    shouldFail = false;
+    nextButtonConfig.onClick();
+
+    await waitFor(() => {
+      expect(mockOnNext).toHaveBeenCalledTimes(1);
+      // Error message should be cleared
+      expect(screen.queryByText('First attempt failed')).not.toBeInTheDocument();
+    });
+  });
+
+  it('sends correct upgrade request payload', async () => {
+    let receivedPayload: any = null;
+
+    server.use(
+      http.post(`*/api/${target}/upgrade/app/upgrade`, async ({ request }) => {
+        receivedPayload = await request.json();
+        return HttpResponse.json({ success: true });
+      })
+    );
+
+    renderWithProviders(
+      <UpgradeConfirmationPhase
+        onNext={mockOnNext}
+        setNextButtonConfig={mockSetNextButtonConfig}
+        onStateChange={mockOnStateChange}
+      />,
+      {
+        wrapperProps: {
+          target,
+          mode: 'upgrade',
+          authenticated: true
+        }
+      }
+    );
+
+    // Wait for component to mount
+    await waitFor(() => {
+      expect(mockSetNextButtonConfig).toHaveBeenCalled();
+    });
+
+    // Trigger upgrade
+    const nextButtonConfig = mockSetNextButtonConfig.mock.calls[0][0];
+    nextButtonConfig.onClick();
+
+    await waitFor(() => {
+      expect(receivedPayload).toEqual({
+        ignoreAppPreflights: false
+      });
+    });
+  });
+});

--- a/web/src/components/wizard/installation/tests/UpgradeStep.test.tsx
+++ b/web/src/components/wizard/installation/tests/UpgradeStep.test.tsx
@@ -1,0 +1,319 @@
+import { describe, it, expect, vi, beforeAll, afterEach, afterAll } from 'vitest';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { renderWithProviders } from '../../../../test/setup.tsx';
+import UpgradeStep from '../UpgradeStep';
+
+const createServer = (target: 'linux' | 'kubernetes') => setupServer(
+  // Mock app upgrade status endpoint
+  http.get(`*/api/${target}/upgrade/app/status`, () => {
+    return HttpResponse.json({
+      status: {
+        state: 'Pending',
+        description: 'Waiting to start upgrade...'
+      }
+    });
+  })
+);
+
+describe.each([
+  { target: "kubernetes" as const, displayName: "Kubernetes" },
+  { target: "linux" as const, displayName: "Linux" }
+])('UpgradeStep - $displayName', ({ target }) => {
+  const mockOnNext = vi.fn();
+  const mockOnBack = vi.fn();
+  let server: ReturnType<typeof createServer>;
+
+  beforeAll(() => {
+    server = createServer(target);
+    server.listen();
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('renders upgrade timeline with correct phases', async () => {
+    renderWithProviders(
+      <UpgradeStep onNext={mockOnNext} onBack={mockOnBack} />,
+      {
+        wrapperProps: {
+          target,
+          mode: 'upgrade',
+          authenticated: true
+        }
+      }
+    );
+
+    // Should show timeline with upgrade phases
+    await waitFor(() => {
+      expect(screen.getByTestId('timeline-title')).toBeInTheDocument();
+    });
+
+    // Should show confirm upgrade phase
+    await waitFor(() => {
+      expect(screen.getByTestId('timeline-app-preflight')).toBeInTheDocument();
+    });
+
+    // Should show app installation phase
+    await waitFor(() => {
+      expect(screen.getByTestId('timeline-app-installation')).toBeInTheDocument();
+    });
+
+    // Should not show linux/kubernetes preflight or installation phases
+    expect(screen.queryByTestId('timeline-linux-preflight')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('timeline-linux-installation')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('timeline-kubernetes-installation')).not.toBeInTheDocument();
+  });
+
+  it('starts at upgrade confirmation phase', async () => {
+    renderWithProviders(
+      <UpgradeStep onNext={mockOnNext} onBack={mockOnBack} />,
+      {
+        wrapperProps: {
+          target,
+          mode: 'upgrade',
+          authenticated: true
+        }
+      }
+    );
+
+    // Should show upgrade confirmation phase first
+    await waitFor(() => {
+      expect(screen.getByTestId('app-preflight-container')).toBeInTheDocument();
+      expect(screen.getByTestId('app-preflight-container')).not.toHaveClass('hidden');
+    });
+
+    // App installation phase should be hidden initially
+    expect(screen.queryByTestId('app-installation-container')).not.toBeInTheDocument();
+  });
+
+  it('shows correct phase titles for upgrade', async () => {
+    renderWithProviders(
+      <UpgradeStep onNext={mockOnNext} onBack={mockOnBack} />,
+      {
+        wrapperProps: {
+          target,
+          mode: 'upgrade',
+          authenticated: true
+        }
+      }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Confirm Upgrade')).toBeInTheDocument();
+    });
+  });
+
+  it('advances to next phase when current phase succeeds', async () => {
+    let upgradeStarted = false;
+
+    server.use(
+      // Mock upgrade confirmation endpoint
+      http.post(`*/api/${target}/upgrade/app/upgrade`, () => {
+        upgradeStarted = true;
+        return HttpResponse.json({ success: true });
+      }),
+
+      // Mock app status to return success after upgrade starts
+      http.get(`*/api/${target}/upgrade/app/status`, () => {
+        if (upgradeStarted) {
+          return HttpResponse.json({
+            status: {
+              state: 'Succeeded',
+              description: 'Application upgraded successfully'
+            }
+          });
+        }
+        return HttpResponse.json({
+          status: {
+            state: 'Pending',
+            description: 'Waiting to start upgrade...'
+          }
+        });
+      })
+    );
+
+    renderWithProviders(
+      <UpgradeStep onNext={mockOnNext} onBack={mockOnBack} />,
+      {
+        wrapperProps: {
+          target,
+          mode: 'upgrade',
+          authenticated: true
+        }
+      }
+    );
+
+    // Wait for confirmation phase to load
+    await waitFor(() => {
+      expect(screen.getByTestId('app-preflight-container')).toBeInTheDocument();
+    });
+
+    // Click the next button to trigger upgrade
+    const nextButton = screen.getByTestId('installation-next-button');
+    fireEvent.click(nextButton);
+
+    // Should advance to app installation phase automatically after success
+    await waitFor(() => {
+      expect(screen.getByTestId('app-installation-container')).toBeInTheDocument();
+    }, { timeout: 1000 });
+  });
+
+  it('completes upgrade flow and calls onNext when all phases succeed', async () => {
+    server.use(
+      // Mock successful upgrade status
+      http.get(`*/api/${target}/upgrade/app/status`, () => {
+        return HttpResponse.json({
+          status: {
+            state: 'Succeeded',
+            description: 'Application upgraded successfully'
+          }
+        });
+      })
+    );
+
+    renderWithProviders(
+      <UpgradeStep onNext={mockOnNext} onBack={mockOnBack} />,
+      {
+        wrapperProps: {
+          target,
+          mode: 'upgrade',
+          authenticated: true
+        }
+      }
+    );
+
+    // Skip to app installation phase by completing confirmation
+    // In a real scenario, this would happen after user confirms the upgrade
+    await waitFor(() => {
+      expect(screen.getByTestId('app-preflight-container')).toBeInTheDocument();
+    });
+
+    // Simulate completing all phases - the auto-advance should eventually call onNext
+    await waitFor(() => {
+      // The component should call onNext when all phases are complete
+      // This might take some time due to the setTimeout in the component
+    }, { timeout: 3000 });
+  });
+
+  it('does not show back button in first phase by default', async () => {
+    renderWithProviders(
+      <UpgradeStep onNext={mockOnNext} onBack={mockOnBack} />,
+      {
+        wrapperProps: {
+          target,
+          mode: 'upgrade',
+          authenticated: true
+        }
+      }
+    );
+
+    await waitFor(() => {
+      // Back button should not be visible in the first phase unless configured by the phase component
+      expect(screen.queryByTestId('installation-back-button')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows next button with correct text for different phases', async () => {
+    renderWithProviders(
+      <UpgradeStep onNext={mockOnNext} onBack={mockOnBack} />,
+      {
+        wrapperProps: {
+          target,
+          mode: 'upgrade',
+          authenticated: true
+        }
+      }
+    );
+
+    // At first phase, should show next phase name
+    await waitFor(() => {
+      const nextButton = screen.getByTestId('installation-next-button');
+      expect(nextButton).toBeInTheDocument();
+      // Should reference the app installation phase title
+      expect(nextButton).toHaveTextContent(/next:/i);
+    });
+  });
+
+  it('allows clicking on completed phases to view them', async () => {
+    renderWithProviders(
+      <UpgradeStep onNext={mockOnNext} onBack={mockOnBack} />,
+      {
+        wrapperProps: {
+          target,
+          mode: 'upgrade',
+          authenticated: true
+        }
+      }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('timeline-app-preflight')).toBeInTheDocument();
+    });
+
+    // Initially, current phase should be clickable and selected
+    const confirmPhaseButton = screen.getByTestId('timeline-app-preflight');
+    expect(confirmPhaseButton).toBeInTheDocument();
+
+    // App installation phase should exist but not be the current phase
+    const appInstallPhaseButton = screen.getByTestId('timeline-app-installation');
+    expect(appInstallPhaseButton).toBeInTheDocument();
+  });
+
+  it('handles phase state changes correctly', async () => {
+    let phaseStatus = 'Running';
+
+    server.use(
+      http.get(`*/api/${target}/upgrade/app/status`, () => {
+        return HttpResponse.json({
+          status: {
+            state: phaseStatus,
+            description: 'Upgrade in progress...'
+          }
+        });
+      })
+    );
+
+    renderWithProviders(
+      <UpgradeStep onNext={mockOnNext} onBack={mockOnBack} />,
+      {
+        wrapperProps: {
+          target,
+          mode: 'upgrade',
+          authenticated: true
+        }
+      }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('app-preflight-container')).toBeInTheDocument();
+    });
+
+    // Change phase status to succeeded
+    phaseStatus = 'Succeeded';
+    server.resetHandlers();
+    server.use(
+      http.get(`*/api/${target}/upgrade/app/status`, () => {
+        return HttpResponse.json({
+          status: {
+            state: phaseStatus,
+            description: 'Upgrade completed successfully'
+          }
+        });
+      })
+    );
+
+    // The phase should update its status
+    await waitFor(() => {
+      // Check if the timeline reflects the success state
+      // This would be indicated by the phase having a success icon or status
+    });
+  });
+});

--- a/web/src/components/wizard/setup/KubernetesSetupStep.tsx
+++ b/web/src/components/wizard/setup/KubernetesSetupStep.tsx
@@ -10,6 +10,7 @@ import { handleUnauthorized } from "../../../utils/auth";
 import { formatErrorMessage } from "../../../utils/errorMessage";
 import { ChevronRight, ChevronLeft } from "lucide-react";
 import { KubernetesConfig } from "../../../types";
+import { getApiBase } from '../../../utils/api-base';
 
 /**
  * Maps internal field names to user-friendly display names.
@@ -47,17 +48,18 @@ interface KubernetesConfigResponse {
 
 const KubernetesSetupStep: React.FC<KubernetesSetupStepProps> = ({ onNext, onBack }) => {
   const { updateConfig } = useKubernetesConfig(); // We need to make sure to update the global config
-  const { text } = useWizard();
+  const { text, target, mode } = useWizard();
   const [error, setError] = useState<string | null>(null);
   const [defaults, setDefaults] = useState<KubernetesConfig>({});
   const [configValues, setConfigValues] = useState<KubernetesConfig>({});
   const { token } = useAuth();
+  const apiBase = getApiBase(target, mode);
 
   // Query for fetching install configuration
   const { isLoading: isConfigLoading } = useQuery<KubernetesConfigResponse, Error>({
     queryKey: ["installConfig"],
     queryFn: async () => {
-      const response = await fetch("/api/kubernetes/install/installation/config", {
+      const response = await fetch(`${apiBase}/installation/config`, {
         headers: {
           Authorization: `Bearer ${token}`,
         },
@@ -84,7 +86,7 @@ const KubernetesSetupStep: React.FC<KubernetesSetupStepProps> = ({ onNext, onBac
   // Mutation for submitting the configuration
   const { mutate: submitConfig, error: submitError } = useMutation<Status, ConfigError, KubernetesConfig>({
     mutationFn: async (configData) => {
-      const response = await fetch("/api/kubernetes/install/installation/configure", {
+      const response = await fetch(`${apiBase}/installation/configure`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -119,7 +121,7 @@ const KubernetesSetupStep: React.FC<KubernetesSetupStepProps> = ({ onNext, onBac
   // Mutation for starting the installation
   const { mutate: startInstallation } = useMutation({
     mutationFn: async () => {
-      const response = await fetch("/api/kubernetes/install/infra/setup", {
+      const response = await fetch(`${apiBase}/infra/setup`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/web/src/components/wizard/setup/LinuxSetupStep.tsx
+++ b/web/src/components/wizard/setup/LinuxSetupStep.tsx
@@ -12,6 +12,7 @@ import { handleUnauthorized } from "../../../utils/auth";
 import { formatErrorMessage } from "../../../utils/errorMessage";
 import { ChevronDown, ChevronLeft, ChevronRight } from "lucide-react";
 import { LinuxConfig } from "../../../types";
+import { getApiBase } from '../../../utils/api-base';
 
 /**
  * Maps internal field names to user-friendly display names.
@@ -60,19 +61,20 @@ interface NetworkInterfacesResponse {
 
 const LinuxSetupStep: React.FC<LinuxSetupStepProps> = ({ onNext, onBack }) => {
   const { updateConfig } = useLinuxConfig(); // We need to make sure to update the global config
-  const { text } = useWizard();
+  const { text, target, mode } = useWizard();
   const { title } = useInitialState();
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [defaults, setDefaults] = useState<LinuxConfig>({ dataDirectory: "" });
   const [configValues, setConfigValues] = useState<LinuxConfig>({ dataDirectory: "" });
   const { token } = useAuth();
+  const apiBase = getApiBase(target, mode);
 
   // Query for fetching install configuration
   const { isLoading: isConfigLoading } = useQuery<LinuxConfigResponse, Error>({
     queryKey: ["installConfig"],
     queryFn: async () => {
-      const response = await fetch("/api/linux/install/installation/config", {
+      const response = await fetch(`${apiBase}/installation/config`, {
         headers: {
           Authorization: `Bearer ${token}`,
         },
@@ -120,7 +122,7 @@ const LinuxSetupStep: React.FC<LinuxSetupStepProps> = ({ onNext, onBack }) => {
   // Mutation for submitting the configuration
   const { mutate: submitConfig, error: submitError } = useMutation<Status, ConfigError, LinuxConfig>({
     mutationFn: async (configData) => {
-      const response = await fetch("/api/linux/install/installation/configure", {
+      const response = await fetch(`${apiBase}/installation/configure`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/web/src/components/wizard/tests/StepNavigation.test.tsx
+++ b/web/src/components/wizard/tests/StepNavigation.test.tsx
@@ -15,8 +15,10 @@ describe("StepNavigation", () => {
   };
 
   describe("Linux Target", () => {
+    const linuxInstallSteps: WizardStep[] = ["welcome", "configuration", "linux-setup", "installation", "linux-completion"];
+
     it("shows 'current' status for the current step", () => {
-      renderWithProviders(<StepNavigation currentStep="linux-setup" />, {
+      renderWithProviders(<StepNavigation currentStep="linux-setup" enabledSteps={linuxInstallSteps} />, {
         wrapperProps: {
           authenticated: true,
           contextValues: defaultContextValues,
@@ -30,7 +32,7 @@ describe("StepNavigation", () => {
     });
 
     it("shows upcoming steps with default styling", () => {
-      renderWithProviders(<StepNavigation currentStep="welcome" />, {
+      renderWithProviders(<StepNavigation currentStep="welcome" enabledSteps={linuxInstallSteps} />, {
         wrapperProps: {
           authenticated: true,
           contextValues: defaultContextValues,
@@ -52,7 +54,7 @@ describe("StepNavigation", () => {
     });
 
     it("renders correct icons for each step", () => {
-      renderWithProviders(<StepNavigation currentStep="welcome" />, {
+      renderWithProviders(<StepNavigation currentStep="welcome" enabledSteps={linuxInstallSteps} />, {
         wrapperProps: {
           authenticated: true,
           contextValues: defaultContextValues,
@@ -81,7 +83,7 @@ describe("StepNavigation", () => {
 
       testCases.forEach(({ currentStep, setupStatus, installStatus }) => {
         const { unmount } = renderWithProviders(
-          <StepNavigation currentStep={currentStep as WizardStep} />,
+          <StepNavigation currentStep={currentStep as WizardStep} enabledSteps={linuxInstallSteps} />,
           {
             wrapperProps: {
               authenticated: true,
@@ -117,8 +119,10 @@ describe("StepNavigation", () => {
   });
 
   describe("Kubernetes Target", () => {
+    const kubernetesInstallSteps: WizardStep[] = ["welcome", "configuration", "kubernetes-setup", "installation", "kubernetes-completion"];
+
     it("renders all navigation steps", () => {
-      renderWithProviders(<StepNavigation currentStep="welcome" />, {
+      renderWithProviders(<StepNavigation currentStep="welcome" enabledSteps={kubernetesInstallSteps} />, {
         wrapperProps: {
           authenticated: true,
           contextValues: defaultContextValues,
@@ -134,7 +138,7 @@ describe("StepNavigation", () => {
     });
 
     it("shows 'current' status for the current step", () => {
-      renderWithProviders(<StepNavigation currentStep="kubernetes-setup" />, {
+      renderWithProviders(<StepNavigation currentStep="kubernetes-setup" enabledSteps={kubernetesInstallSteps} />, {
         wrapperProps: {
           authenticated: true,
           contextValues: defaultContextValues,
@@ -149,7 +153,7 @@ describe("StepNavigation", () => {
     });
 
     it("shows upcoming steps with default styling", () => {
-      renderWithProviders(<StepNavigation currentStep="welcome" />, {
+      renderWithProviders(<StepNavigation currentStep="welcome" enabledSteps={kubernetesInstallSteps} />, {
         wrapperProps: {
           authenticated: true,
           contextValues: defaultContextValues,
@@ -172,7 +176,7 @@ describe("StepNavigation", () => {
     });
 
     it("renders correct icons for each step", () => {
-      renderWithProviders(<StepNavigation currentStep="welcome" />, {
+      renderWithProviders(<StepNavigation currentStep="welcome" enabledSteps={kubernetesInstallSteps} />, {
         wrapperProps: {
           authenticated: true,
           contextValues: defaultContextValues,
@@ -202,7 +206,7 @@ describe("StepNavigation", () => {
 
       testCases.forEach(({ currentStep, setupStatus, installStatus }) => {
         const { unmount } = renderWithProviders(
-          <StepNavigation currentStep={currentStep as WizardStep} />,
+          <StepNavigation currentStep={currentStep as WizardStep} enabledSteps={kubernetesInstallSteps} />,
           {
             wrapperProps: {
               authenticated: true,
@@ -234,6 +238,78 @@ describe("StepNavigation", () => {
         }
 
         unmount(); // Clean up for next iteration
+      });
+    });
+  });
+
+  describe("Upgrade Mode", () => {
+    describe("Linux Upgrade", () => {
+      const linuxUpgradeSteps: WizardStep[] = ["welcome", "installation", "linux-completion"];
+
+      it("shows only enabled steps for upgrade", () => {
+        renderWithProviders(<StepNavigation currentStep="welcome" enabledSteps={linuxUpgradeSteps} />, {
+          wrapperProps: {
+            authenticated: true,
+            contextValues: defaultContextValues,
+            target: "linux",
+            mode: "upgrade"
+          },
+        });
+
+        // Should show welcome, installation (as upgrade), and completion
+        expect(screen.getByText("Welcome")).toBeInTheDocument();
+        expect(screen.getByText("Upgrade")).toBeInTheDocument(); // Installation step shows as "Upgrade"
+        expect(screen.getByText("Completion")).toBeInTheDocument();
+
+        // Should not show configuration or setup steps
+        expect(screen.queryByText("Configuration")).not.toBeInTheDocument();
+        expect(screen.queryByText("Setup")).not.toBeInTheDocument();
+
+        // Should show 3 steps total
+        const stepElements = screen.getAllByRole("listitem");
+        expect(stepElements).toHaveLength(3);
+      });
+
+      it("shows 'Upgrade' text instead of 'Installation' in upgrade mode", () => {
+        renderWithProviders(<StepNavigation currentStep="installation" enabledSteps={linuxUpgradeSteps} />, {
+          wrapperProps: {
+            authenticated: true,
+            contextValues: defaultContextValues,
+            target: "linux",
+            mode: "upgrade"
+          },
+        });
+
+        expect(screen.getByText("Upgrade")).toBeInTheDocument();
+        expect(screen.queryByText("Installation")).not.toBeInTheDocument();
+      });
+    });
+
+    describe("Kubernetes Upgrade", () => {
+      const kubernetesUpgradeSteps: WizardStep[] = ["welcome", "installation", "kubernetes-completion"];
+
+      it("shows only enabled steps for upgrade", () => {
+        renderWithProviders(<StepNavigation currentStep="welcome" enabledSteps={kubernetesUpgradeSteps} />, {
+          wrapperProps: {
+            authenticated: true,
+            contextValues: defaultContextValues,
+            target: "kubernetes",
+            mode: "upgrade"
+          },
+        });
+
+        // Should show welcome, installation (as upgrade), and completion
+        expect(screen.getByText("Welcome")).toBeInTheDocument();
+        expect(screen.getByText("Upgrade")).toBeInTheDocument();
+        expect(screen.getByText("Completion")).toBeInTheDocument();
+
+        // Should not show configuration or setup steps
+        expect(screen.queryByText("Configuration")).not.toBeInTheDocument();
+        expect(screen.queryByText("Setup")).not.toBeInTheDocument();
+
+        // Should show 3 steps total
+        const stepElements = screen.getAllByRole("listitem");
+        expect(stepElements).toHaveLength(3);
       });
     });
   });

--- a/web/src/contexts/InitialStateContext.tsx
+++ b/web/src/contexts/InitialStateContext.tsx
@@ -4,7 +4,7 @@ import { InitialState } from "../types";
 export const defaultInitialState: InitialState = {
   title: "My App",
   installTarget: "linux", // default to "linux" if not provided
-  mode: "upgrade", // default to "install" if not provided
+  mode: "install", // default to "install" if not provided
 };
 
 export const InitialStateContext = createContext<InitialState>(defaultInitialState);

--- a/web/src/contexts/InitialStateContext.tsx
+++ b/web/src/contexts/InitialStateContext.tsx
@@ -1,7 +1,13 @@
 import { createContext, useContext } from "react";
 import { InitialState } from "../types";
 
-export const InitialStateContext = createContext<InitialState>({ title: "My App", installTarget: "linux" });
+export const defaultInitialState: InitialState = {
+  title: "My App",
+  installTarget: "linux", // default to "linux" if not provided
+  mode: "upgrade", // default to "install" if not provided
+};
+
+export const InitialStateContext = createContext<InitialState>(defaultInitialState);
 
 export const useInitialState = () => {
   const context = useContext(InitialStateContext);

--- a/web/src/contexts/WizardModeContext.tsx
+++ b/web/src/contexts/WizardModeContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext } from "react";
 import { InstallationTarget } from "../types/installation-target";
-import { WizardMode, WizardText } from "../types";
+import { WizardText } from "../types";
+import { WizardMode } from "../types/wizard-mode";
 
 interface WizardModeContextType {
   target: InstallationTarget;

--- a/web/src/contexts/tests/InitialStateContext.test.tsx
+++ b/web/src/contexts/tests/InitialStateContext.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import { InitialStateContext, useInitialState } from "../InitialStateContext";
 import { InitialStateProvider } from "../../providers/InitialStateProvider";
 import { InstallationTarget } from "../../types/installation-target";
+import { WizardMode } from "../../types/wizard-mode";
 
 // Window type with optional __INITIAL_STATE__ property
 type WindowWithInitialState = typeof window & {
@@ -32,6 +33,7 @@ describe("InitialStateContext", () => {
         title: "Test App",
         icon: "test-icon.png",
         installTarget: "linux" as InstallationTarget,
+        mode: "install" as WizardMode,
       };
 
       const TestComponent = () => {

--- a/web/src/providers/InitialStateProvider.tsx
+++ b/web/src/providers/InitialStateProvider.tsx
@@ -1,7 +1,15 @@
 import React from "react";
-import { InitialStateContext } from "../contexts/InitialStateContext";
+import { InitialStateContext, defaultInitialState } from "../contexts/InitialStateContext";
 import { InstallationTarget, isInstallationTarget } from "../types/installation-target";
+import { WizardMode, isWizardMode } from "../types/wizard-mode";
 import { InitialState } from "../types";
+
+function parseWizardMode(mode: string): WizardMode {
+  if (isWizardMode(mode)) {
+    return mode;
+  }
+  throw new Error(`Invalid wizard mode: ${mode}`);
+}
 
 function parseInstallationTarget(target: string): InstallationTarget {
   if (isInstallationTarget(target)) {
@@ -18,9 +26,10 @@ export const InitialStateProvider: React.FC<{ children: React.ReactNode }> = ({
   const initialState: Partial<InitialState> = window.__INITIAL_STATE__ || {};
 
   const state = {
-    title: initialState.title || "My App",
+    title: initialState.title || defaultInitialState.title,
     icon: initialState.icon,
-    installTarget: parseInstallationTarget(initialState.installTarget || "linux"), // default to "linux" if not provided
+    installTarget: parseInstallationTarget(initialState.installTarget || defaultInitialState.installTarget),
+    mode: parseWizardMode(initialState.mode || defaultInitialState.mode),
   };
 
   return (

--- a/web/src/providers/WizardProvider.tsx
+++ b/web/src/providers/WizardProvider.tsx
@@ -1,7 +1,8 @@
 import React from "react";
-import { WizardText, WizardMode } from "../types";
+import { WizardText } from "../types";
 import { useInitialState } from "../contexts/InitialStateContext";
 import { WizardContext } from "../contexts/WizardModeContext";
+import { WizardMode } from "../types/wizard-mode";
 
 const getTextVariations = (isLinux: boolean, title: string): Record<WizardMode, WizardText> => ({
   install: {
@@ -47,8 +48,9 @@ const getTextVariations = (isLinux: boolean, title: string): Record<WizardMode, 
     linuxValidationDescription: "Validating the host requirements",
     linuxInstallationTitle: "Infrastructure Upgrade",
     linuxInstallationDescription: "Upgrading infrastructure components",
-    appValidationTitle: `${title} Preflight Checks`,
-    appValidationDescription: "Validating the application requirements",
+    // TODO Upgrade we're using the app preflights phase to just confirm the upgrade for now. We need to change back the title and description once those are in place
+    appValidationTitle: `${title} Upgrade Confirmation`,
+    appValidationDescription: "Confirm the app upgrade",
     appInstallationTitle: `${title} Upgrade`,
     appInstallationDescription: `Upgrading ${title} components`,
     welcomeButtonText: "Start Upgrade",
@@ -57,8 +59,7 @@ const getTextVariations = (isLinux: boolean, title: string): Record<WizardMode, 
 });
 
 export const WizardProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const { title, installTarget } = useInitialState();
-  const mode = "install"; // TODO: get mode from initial state
+  const { title, installTarget, mode } = useInitialState();
   const isLinux = installTarget === "linux";
   const text = getTextVariations(isLinux, title)[mode];
 

--- a/web/src/test/setup.tsx
+++ b/web/src/test/setup.tsx
@@ -5,8 +5,9 @@ import { createMemoryRouter, RouterProvider, RouteObject } from "react-router-do
 import { vi } from "vitest";
 import { JSX } from "react/jsx-runtime";
 
-import { InitialState, LinuxConfig, KubernetesConfig, WizardMode, WizardText } from "../types";
+import { InitialState, LinuxConfig, KubernetesConfig, WizardText } from "../types";
 import { InstallationTarget } from "../types/installation-target";
+import { WizardMode } from "../types/wizard-mode";
 import { createQueryClient } from "../query-client";
 import { LinuxConfigContext } from "../contexts/LinuxConfigContext";
 import { KubernetesConfigContext } from "../contexts/KubernetesConfigContext";
@@ -98,6 +99,7 @@ interface RenderWithProvidersOptions extends RenderOptions {
     authenticated?: boolean;
     authToken?: string;
     target?: InstallationTarget;
+    mode?: WizardMode;
   };
   wrapper?: React.ComponentType<{ children: React.ReactNode }>;
 }
@@ -107,7 +109,7 @@ export const renderWithProviders = (
   options: RenderWithProvidersOptions = {},
 ) => {
   const defaultContextValues: MockProviderProps["contexts"] = {
-    initialStateContext: { title: "My App", installTarget: options.wrapperProps?.target || "linux" },
+    initialStateContext: { title: "My App", installTarget: options.wrapperProps?.target || "linux", mode: options.wrapperProps?.mode || "install" },
     linuxConfigContext: {
       config: {
         adminConsolePort: 8800,
@@ -132,7 +134,7 @@ export const renderWithProviders = (
     },
     wizardModeContext: {
       target: options.wrapperProps?.target || "linux",
-      mode: "install",
+      mode: options.wrapperProps?.mode || "install",
       text: {
         title: "My App",
         subtitle: "Installation Wizard",

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -1,4 +1,5 @@
 import { InstallationTarget } from "./installation-target";
+import { WizardMode } from "./wizard-mode";
 
 // Window type with optional __INITIAL_STATE__ property
 export type WindowWithInitialState = typeof window & {
@@ -9,6 +10,7 @@ export interface InitialState {
   title: string;
   icon?: string;
   installTarget: InstallationTarget;
+  mode: WizardMode;
 }
 
 export type State = "Pending" | "Running" | "Succeeded" | "Failed";
@@ -50,9 +52,6 @@ export interface KubernetesConfig {
   noProxy?: string;
   installCommand?: string;
 }
-
-// WizardMode tells us in which mode the installer wizard is running, upgrade or install
-export type WizardMode = "install" | "upgrade";
 
 // WizardText type holds the text fields for the multiple wizard step text fields
 export interface WizardText {

--- a/web/src/types/wizard-mode.ts
+++ b/web/src/types/wizard-mode.ts
@@ -1,0 +1,8 @@
+export const wizardModes = ["install", "upgrade"] as const;
+
+// WizardMode tells us in which mode the installer wizard is running, upgrade or install
+export type WizardMode = (typeof wizardModes)[number];
+
+export function isWizardMode(value: string): value is WizardMode {
+  return (wizardModes as readonly string[]).includes(value);
+}

--- a/web/src/utils/api-base.test.ts
+++ b/web/src/utils/api-base.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { getApiBase } from "./api-base";
+
+describe("getApiBase", () => {
+  it("returns install base for install mode", () => {
+    expect(getApiBase("linux", "install")).toBe("/api/linux/install");
+    expect(getApiBase("kubernetes", "install")).toBe("/api/kubernetes/install");
+  });
+
+  it("returns upgrade base for upgrade mode", () => {
+    expect(getApiBase("linux", "upgrade")).toBe("/api/linux/upgrade");
+    expect(getApiBase("kubernetes", "upgrade")).toBe("/api/kubernetes/upgrade");
+  });
+});

--- a/web/src/utils/api-base.ts
+++ b/web/src/utils/api-base.ts
@@ -1,0 +1,11 @@
+import { InstallationTarget } from "../types/installation-target";
+import { WizardMode } from "../types/wizard-mode";
+
+/**
+ * Returns base API path for wizard operations
+ * Currently returns install base for all modes until backend upgrade endpoints ready
+ */
+export const getApiBase = (target: InstallationTarget, mode: WizardMode): string => {
+  // TODO: Switch to upgrade endpoints when available
+  return `/api/${target}/${mode}`;
+};


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds the base UI changes for the new upgrade flow for the V3 installer experience.

A loom preview that doesn't go through the full flow yet - https://www.loom.com/share/87475f5c1fb5418f82932a08e7856b87?sid=af9ad7b3-a48c-421a-ba2c-f1af1cef1942

Update ☝️ with the API in place:
<img width="1354" height="1051" alt="image" src="https://github.com/user-attachments/assets/4dee4935-2b60-446c-a3ae-2d7d2bff6e88" />

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/129000/iteration-1-frontend-upgrade-wizard-flow

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
yes

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Basic upgrade flow for the V3 installer experience
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
