### PR TITLE
fix(upgrade): consistent upgrade API status routes

### DIFF
--- a/api/integration/app/upgrade/appupgrade_test.go
+++ b/api/integration/app/upgrade/appupgrade_test.go
@@ -275,7 +275,7 @@ func (s *AppUpgradeTestSuite) TestGetAppUpgradeStatus() {
 		apiInstance.RegisterRoutes(router)
 
 		// Create request
-		req := httptest.NewRequest(http.MethodGet, s.baseURL+"/app/upgrade/status", nil)
+		req := httptest.NewRequest(http.MethodGet, s.baseURL+"/app/status", nil)
 		req.Header.Set("Authorization", "Bearer TOKEN")
 		rec := httptest.NewRecorder()
 
@@ -316,7 +316,7 @@ func (s *AppUpgradeTestSuite) TestGetAppUpgradeStatus() {
 		apiInstance.RegisterRoutes(router)
 
 		// Create request with invalid token
-		req := httptest.NewRequest(http.MethodGet, s.baseURL+"/app/upgrade/status", nil)
+		req := httptest.NewRequest(http.MethodGet, s.baseURL+"/app/status", nil)
 		req.Header.Set("Authorization", "Bearer INVALID_TOKEN")
 		rec := httptest.NewRecorder()
 

--- a/api/routes.go
+++ b/api/routes.go
@@ -58,7 +58,7 @@ func (a *API) registerLinuxRoutes(router *mux.Router) {
 
 	upgradeRouter := linuxRouter.PathPrefix("/upgrade").Subrouter()
 	upgradeRouter.HandleFunc("/app/upgrade", a.handlers.linux.PostUpgradeApp).Methods("POST")
-	upgradeRouter.HandleFunc("/app/upgrade/status", a.handlers.linux.GetAppUpgradeStatus).Methods("GET")
+	upgradeRouter.HandleFunc("/app/status", a.handlers.linux.GetAppUpgradeStatus).Methods("GET")
 }
 
 func (a *API) registerKubernetesRoutes(router *mux.Router) {
@@ -84,7 +84,7 @@ func (a *API) registerKubernetesRoutes(router *mux.Router) {
 
 	upgradeRouter := kubernetesRouter.PathPrefix("/upgrade").Subrouter()
 	upgradeRouter.HandleFunc("/app/upgrade", a.handlers.kubernetes.PostUpgradeApp).Methods("POST")
-	upgradeRouter.HandleFunc("/app/upgrade/status", a.handlers.kubernetes.GetAppUpgradeStatus).Methods("GET")
+	upgradeRouter.HandleFunc("/app/status", a.handlers.kubernetes.GetAppUpgradeStatus).Methods("GET")
 }
 
 func (a *API) registerConsoleRoutes(router *mux.Router) {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Make the upgrade status path consistent with what's documented (and with the install flow):
- https://github.com/replicatedhq/embedded-cluster/blob/2a36974ebee916e12d0cfb3a57b2425421018bd3/api/internal/handlers/linux/upgrade.go#L49

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
Part of https://app.shortcut.com/replicated/story/129405/iteration-1-integrate-all-changes-together

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Updated

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
