### PR TITLE
Add -c/--command flag to shell command

### DIFF
--- a/cmd/installer/cli/shell.go
+++ b/cmd/installer/cli/shell.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -98,7 +99,8 @@ func executeCommand(shpath string, command string, rc runtimeconfig.RuntimeConfi
 	// Execute and return exit code
 	if err := shell.Run(); err != nil {
 		// Preserve exit code from the command
-		if exitErr, ok := err.(*exec.ExitError); ok {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
 			os.Exit(exitErr.ExitCode())
 		}
 		return err


### PR DESCRIPTION
## Summary

Adds a `-c/--command` flag to the `shell` command that enables running commands in the embedded cluster environment without opening an interactive shell. This solves the problem where `./embedded-cluster shell && kubectl get po` doesn't work in CI/automation because the shell command blocks waiting for the interactive shell to exit.

## Changes

- Added `-c/--command` flag to `shell` command
- Refactored `shell.go` to support two modes:
  - **Interactive mode** (existing behavior when no flag provided)
  - **Command execution mode** (new, when `-c` flag provided)
- Properly preserves exit codes for CI/CD pipelines
- No breaking changes to existing interactive shell behavior

## Usage

### Interactive mode (unchanged)
```bash
./embedded-cluster shell
```

### Command execution mode (new)
```bash
# Single command
./embedded-cluster shell -c "kubectl get po -A"

# Multiple commands
./embedded-cluster shell -c "kubectl get po && kubectl get nodes"

# In CI pipelines
./embedded-cluster install && ./embedded-cluster shell -c "kubectl wait --for=condition=ready pod -l app=myapp"
```

## Demo

```
root@node0:/replicatedhq/embedded-cluster# sudo ./output/bin/embedded-cluster shell

    __4___
 _  \ \ \ \   Welcome to alex-ec-dev debug shell.
<'\ /_/_/_/   This terminal is now configured to access your cluster.
 ((____!___/) Type 'exit' (or Ctrl+D) to exit.
  \0\0\0\0\/
 ~~~~~~~~~~~
root@node0:/replicatedhq/embedded-cluster# export KUBECONFIG="/var/lib/embedded-cluster/k0s/pki/admin.conf"
root@node0:/replicatedhq/embedded-cluster# export PATH="$PATH:/var/lib/embedded-cluster/bin"
root@node0:/replicatedhq/embedded-cluster# exit
exit
root@node0:/replicatedhq/embedded-cluster# sudo ./output/bin/embedded-cluster shell -c "kubectl get po -A"
NAMESPACE          NAME                                           READY   STATUS    RESTARTS   AGE
embedded-cluster   embedded-cluster-operator-5c67669d68-4msc4     1/1     Running   0          4m28s
goldpinger         goldpinger-clk88                               1/1     Running   0          2m9s
ingress-nginx      ingress-nginx-controller-9646fc6c6-7vn87       1/1     Running   0          2m34s
kotsadm            kotsadm-6744d4bf78-sbn5q                       1/1     Running   0          2m55s
kotsadm            kotsadm-rqlite-0                               1/1     Running   0          4m9s
kotsadm            kurl-proxy-kotsadm-78f4cb8b84-lwlmm            1/1     Running   0          4m9s
kotsadm            nginx-c58f6f47-62rrk                           1/1     Running   0          33s
kube-system        calico-kube-controllers-8679955db8-w9gwz       1/1     Running   0          5m53s
kube-system        calico-node-nzsbp                              1/1     Running   0          5m48s
kube-system        coredns-775bc49f6b-scbk6                       1/1     Running   0          5m55s
kube-system        kube-proxy-89xzq                               1/1     Running   0          5m48s
kube-system        metrics-server-6b8fc7f9f-5v74f                 1/1     Running   0          5m49s
kube-system        nllb-node0                                     1/1     Running   0          5m48s
nginx-app          nginx-app-6fd59854b5-swm2g                     1/1     Running   0          33s
nginx-app          nginx-app-client-577dbdc6fb-262qq              1/1     Running   0          33s
nginx-app          replicated-647d4dd7b7-29qdg                    1/1     Running   0          33s
openebs            openebs-localpv-provisioner-7d4978bffd-b8h5m   1/1     Running   0          4m56s
root@node0:/replicatedhq/embedded-cluster# echo $?
0
root@node0:/replicatedhq/embedded-cluster# sudo ./output/bin/embedded-cluster shell -c "kubectl get fake"
error: the server doesn't have a resource type "fake"
root@node0:/replicatedhq/embedded-cluster# echo $?
1
root@node0:/replicatedhq/embedded-cluster#
```

## Benefits

- Enables automation and CI testing with proper environment setup
- Matches familiar `bash -c` pattern that users already understand
- Clean alternative to manually exporting environment variables
- Properly propagates exit codes for error handling in scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)