### PR TITLE
chore(api): use success state for preflight failures

### DIFF
--- a/api/controllers/linux/install/hostpreflight.go
+++ b/api/controllers/linux/install/hostpreflight.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/replicatedhq/embedded-cluster/api/internal/managers/linux/preflight"
+	"github.com/replicatedhq/embedded-cluster/api/internal/statemachine"
 	"github.com/replicatedhq/embedded-cluster/api/internal/states"
 	"github.com/replicatedhq/embedded-cluster/api/internal/utils"
 	"github.com/replicatedhq/embedded-cluster/api/types"
@@ -105,22 +106,30 @@ func (c *InstallController) RunHostPreflights(ctx context.Context, opts RunHostP
 			return fmt.Errorf("run host preflights: %w", err)
 		}
 
+		// Transition state machine based on whether there are failures
+		// This is used internally for workflow state tracking
+		var smState statemachine.State
 		if output.HasFail() {
-			if err := c.stateMachine.Transition(lock, states.StateHostPreflightsFailed, output); err != nil {
-				return fmt.Errorf("transition states: %w", err)
-			}
-
-			if err := c.setHostPreflightStatus(types.StateFailed, "Host preflights failed"); err != nil {
-				return fmt.Errorf("set status to failed: %w", err)
-			}
+			smState = states.StateHostPreflightsFailed
 		} else {
-			if err := c.stateMachine.Transition(lock, states.StateHostPreflightsSucceeded, output); err != nil {
-				return fmt.Errorf("transition states: %w", err)
-			}
+			smState = states.StateHostPreflightsSucceeded
+		}
 
-			if err := c.setHostPreflightStatus(types.StateSucceeded, "Host preflights succeeded"); err != nil {
-				return fmt.Errorf("set status to succeeded: %w", err)
-			}
+		if err := c.stateMachine.Transition(lock, smState, output); err != nil {
+			return fmt.Errorf("transition states: %w", err)
+		}
+
+		// Always set status to StateSucceeded to indicate execution completed successfully
+		// The output will contain failures/warnings for the caller to check
+		var statusDescription string
+		if output.HasFail() {
+			statusDescription = "Host preflights completed with failures"
+		} else {
+			statusDescription = "Host preflights succeeded"
+		}
+
+		if err := c.setHostPreflightStatus(types.StateSucceeded, statusDescription); err != nil {
+			return fmt.Errorf("set status to succeeded: %w", err)
 		}
 
 		return nil

--- a/cmd/installer/cli/headless/install/orchestrator_test.go
+++ b/cmd/installer/cli/headless/install/orchestrator_test.go
@@ -295,7 +295,7 @@ func Test_orchestrator_runHostPreflights(t *testing.T) {
 			mockGetStatusFunc: func(ctx context.Context) (apitypes.InstallHostPreflightsStatusResponse, error) {
 				return apitypes.InstallHostPreflightsStatusResponse{
 					Status: apitypes.Status{
-						State:       apitypes.StateFailed,
+						State:       apitypes.StateSucceeded,
 						Description: "Completed with failures",
 					},
 					Output: &apitypes.PreflightsOutput{
@@ -328,7 +328,7 @@ func Test_orchestrator_runHostPreflights(t *testing.T) {
 			mockGetStatusFunc: func(ctx context.Context) (apitypes.InstallHostPreflightsStatusResponse, error) {
 				return apitypes.InstallHostPreflightsStatusResponse{
 					Status: apitypes.Status{
-						State:       apitypes.StateFailed,
+						State:       apitypes.StateSucceeded,
 						Description: "Completed with failures",
 					},
 					Output: &apitypes.PreflightsOutput{
@@ -645,7 +645,7 @@ func Test_orchestrator_runAppPreflights(t *testing.T) {
 			mockGetStatusFunc: func(ctx context.Context) (apitypes.InstallAppPreflightsStatusResponse, error) {
 				return apitypes.InstallAppPreflightsStatusResponse{
 					Status: apitypes.Status{
-						State:       apitypes.StateFailed,
+						State:       apitypes.StateSucceeded,
 						Description: "Completed with failures",
 					},
 					Output: &apitypes.PreflightsOutput{
@@ -677,7 +677,7 @@ func Test_orchestrator_runAppPreflights(t *testing.T) {
 			mockGetStatusFunc: func(ctx context.Context) (apitypes.InstallAppPreflightsStatusResponse, error) {
 				return apitypes.InstallAppPreflightsStatusResponse{
 					Status: apitypes.Status{
-						State:       apitypes.StateFailed,
+						State:       apitypes.StateSucceeded,
 						Description: "Completed with failures",
 					},
 					Output: &apitypes.PreflightsOutput{

--- a/tests/dryrun/v3_install_preflights_test.go
+++ b/tests/dryrun/v3_install_preflights_test.go
@@ -130,14 +130,13 @@ func TestV3Install_HostPreflights_WithFailuresBypass(t *testing.T) {
 	}()
 
 	runV3Install(t, v3InstallArgs{
-		managerPort:              30080,
-		password:                 "password123",
-		isAirgap:                 false,
-		configValuesFile:         configFile,
-		installationConfig:       apitypes.LinuxInstallationConfig{},
-		ignoreHostPreflights:     true, // Bypass host preflight failures
-		ignoreAppPreflights:      false,
-		shouldHostPreflightsFail: true,
+		managerPort:          30080,
+		password:             "password123",
+		isAirgap:             false,
+		configValuesFile:     configFile,
+		installationConfig:   apitypes.LinuxInstallationConfig{},
+		ignoreHostPreflights: true, // Bypass host preflight failures
+		ignoreAppPreflights:  false,
 	})
 
 	require.NoError(t, dryrun.Dump(), "fail to dump dryrun output")
@@ -332,14 +331,13 @@ func TestV3Install_AppPreflights_WithFailuresBypass(t *testing.T) {
 	}()
 
 	runV3Install(t, v3InstallArgs{
-		managerPort:             30080,
-		password:                "password123",
-		isAirgap:                false,
-		configValuesFile:        configFile,
-		installationConfig:      apitypes.LinuxInstallationConfig{},
-		ignoreHostPreflights:    false,
-		ignoreAppPreflights:     true, // Bypass app preflight failures
-		shouldAppPreflightsFail: true,
+		managerPort:          30080,
+		password:             "password123",
+		isAirgap:             false,
+		configValuesFile:     configFile,
+		installationConfig:   apitypes.LinuxInstallationConfig{},
+		ignoreHostPreflights: false,
+		ignoreAppPreflights:  true, // Bypass app preflight failures
 	})
 
 	preflightRunner.AssertExpectations(t)

--- a/web/src/components/wizard/installation/tests/AppPreflightCheck.test.tsx
+++ b/web/src/components/wizard/installation/tests/AppPreflightCheck.test.tsx
@@ -9,7 +9,7 @@ const TEST_TOKEN = "test-auth-token";
 
 const createServer = (target: 'linux' | 'kubernetes') => setupServer(
   mockHandlers.preflights.app.getStatus({
-    status: { state: "Failed" },
+    status: { state: "Succeeded" },
     output: {
       pass: [{ title: "CPU Check", message: "CPU requirements met" }],
       warn: [{ title: "Memory Warning", message: "Memory is below recommended" }],
@@ -131,10 +131,10 @@ describe.each([
   });
 
   it("receives allowIgnoreAppPreflights field in preflight response", async () => {
-    // Mock preflight status endpoint with allowIgnoreAppPreflights: true
+    // Mock preflight status endpoint with allowIgnoreAppPreflights: true - execution succeeds but checks fail
     server.use(
       mockHandlers.preflights.app.getStatus({
-        status: { state: "Failed" },
+        status: { state: "Succeeded" },
         output: {
           pass: [{ title: "CPU Check", message: "CPU requirements met" }],
           warn: [],
@@ -161,10 +161,10 @@ describe.each([
   });
 
   it("passes allowIgnoreAppPreflights false to onComplete callback", async () => {
-    // Mock preflight status endpoint with allowIgnoreAppPreflights: false
+    // Mock preflight status endpoint with allowIgnoreAppPreflights: false - execution succeeds but checks fail
     server.use(
       mockHandlers.preflights.app.getStatus({
-        status: { state: "Failed" },
+        status: { state: "Succeeded" },
         output: {
           pass: [{ title: "CPU Check", message: "CPU requirements met" }],
           warn: [],
@@ -192,10 +192,10 @@ describe.each([
 
   // New tests for strict preflight functionality
   it("displays strict failures with visual distinction", async () => {
-    // Mock preflight status endpoint with strict and non-strict failures
+    // Mock preflight status endpoint with strict and non-strict failures - execution succeeds but checks fail
     server.use(
       mockHandlers.preflights.app.getStatus({
-        status: { state: "Failed" },
+        status: { state: "Succeeded" },
         output: {
           pass: [],
           warn: [],
@@ -232,10 +232,10 @@ describe.each([
   });
 
   it("shows appropriate guidance for strict failures in What's Next section", async () => {
-    // Mock preflight status endpoint with strict failures
+    // Mock preflight status endpoint with strict failures - execution succeeds but checks fail
     server.use(
       mockHandlers.preflights.app.getStatus({
-        status: { state: "Failed" },
+        status: { state: "Succeeded" },
         output: {
           pass: [],
           warn: [],
@@ -262,10 +262,10 @@ describe.each([
   });
 
   it("passes hasStrictAppPreflightFailures from API response to onComplete", async () => {
-    // Mock preflight status endpoint with hasStrictAppPreflightFailures field
+    // Mock preflight status endpoint with hasStrictAppPreflightFailures field - execution succeeds but checks fail
     server.use(
       mockHandlers.preflights.app.getStatus({
-        status: { state: "Failed" },
+        status: { state: "Succeeded" },
         output: {
           pass: [],
           warn: [],

--- a/web/src/components/wizard/installation/tests/AppPreflightPhase.test.tsx
+++ b/web/src/components/wizard/installation/tests/AppPreflightPhase.test.tsx
@@ -37,10 +37,10 @@ describe.each([
   });
 
   it('enables Start Installation button when allowIgnoreAppPreflights is true and preflights fail', async () => {
-    // Mock preflight status endpoint - returns failures with allowIgnoreAppPreflights: true
+    // Mock preflight status endpoint - execution succeeds but checks fail
     server.use(
       mockHandlers.preflights.app.getStatus({
-        status: { state: 'Failed' },
+        status: { state: 'Succeeded' },
         output: preflightPresets.failed('Not enough disk space available'),
         allowIgnoreAppPreflights: true
       }, target, 'install')
@@ -73,10 +73,10 @@ describe.each([
   });
 
   it('disables Start Installation button when allowIgnoreAppPreflights is false and preflights fail', async () => {
-    // Mock preflight status endpoint - returns failures with allowIgnoreAppPreflights: false
+    // Mock preflight status endpoint - execution succeeds but checks fail
     server.use(
       mockHandlers.preflights.app.getStatus({
-        status: { state: 'Failed' },
+        status: { state: 'Succeeded' },
         output: preflightPresets.failed('Not enough disk space available'),
         allowIgnoreAppPreflights: false
       }, target, 'install')
@@ -115,10 +115,10 @@ describe.each([
   });
 
   it('shows modal when Start Installation clicked and allowIgnoreAppPreflights is true and preflights fail', async () => {
-    // Mock preflight status endpoint - returns failures with allowIgnoreAppPreflights: true
+    // Mock preflight status endpoint - execution succeeds but checks fail
     server.use(
       mockHandlers.preflights.app.getStatus({
-        status: { state: 'Failed' },
+        status: { state: 'Succeeded' },
         output: preflightPresets.failed('Not enough disk space available'),
         allowIgnoreAppPreflights: true
       }, target, 'install')
@@ -275,10 +275,10 @@ describe.each([
 
   // Verify ignoreAppPreflights parameter is sent
   it('sends ignoreAppPreflights parameter when starting installation with failed preflights', async () => {
-    // Mock preflight status endpoint - returns failures with allowIgnoreAppPreflights: true
+    // Mock preflight status endpoint - execution succeeds but checks fail
     server.use(
       mockHandlers.preflights.app.getStatus({
-        status: { state: 'Failed' },
+        status: { state: 'Succeeded' },
         output: preflightPresets.failed('Not enough disk space available'),
         allowIgnoreAppPreflights: true
       }, target, 'install'),
@@ -372,10 +372,10 @@ describe.each([
 
   // New tests for strict preflight blocking
   it('disables Start Installation button when strict failures exist regardless of allowIgnoreAppPreflights', async () => {
-    // Mock preflight status endpoint - returns strict failures with allowIgnoreAppPreflights: true
+    // Mock preflight status endpoint - execution succeeds but has strict failures
     server.use(
       mockHandlers.preflights.app.getStatus({
-        status: { state: 'Failed' },
+        status: { state: 'Succeeded' },
         output: {
           fail: [
             { title: 'Critical Security Check', message: 'Security requirement not met', strict: true },
@@ -416,10 +416,10 @@ describe.each([
   });
 
   it('does not show modal when strict failures exist because button is disabled', async () => {
-    // Mock preflight status endpoint - returns strict failures
+    // Mock preflight status endpoint - execution succeeds but has strict failures
     server.use(
       mockHandlers.preflights.app.getStatus({
-        status: { state: 'Failed' },
+        status: { state: 'Succeeded' },
         output: {
           fail: [
             { title: 'Critical Security Check', message: 'Security requirement not met', strict: true }
@@ -543,10 +543,10 @@ describe.each([
   });
 
   it('calls onStateChange with "Failed" when preflights complete with failures', async () => {
-    // Mock preflight status endpoint - returns failures
+    // Mock preflight status endpoint - execution succeeds but checks fail
     server.use(
       mockHandlers.preflights.app.getStatus({
-        status: { state: 'Failed' },
+        status: { state: 'Succeeded' },
         output: preflightPresets.failed('Not enough disk space available'),
         allowIgnoreAppPreflights: false
       }, target, 'install')
@@ -576,10 +576,10 @@ describe.each([
   });
 
   it('calls onStateChange("Running") when rerun button is clicked', async () => {
-    // Mock preflight status to show failures initially
+    // Mock preflight status to show failures initially - execution succeeds but checks fail
     server.use(
       mockHandlers.preflights.app.getStatus({
-        status: { state: 'Failed' },
+        status: { state: 'Succeeded' },
         output: preflightPresets.failed('Not enough disk space'),
         allowIgnoreAppPreflights: false
       }, target, 'install'),

--- a/web/src/components/wizard/installation/tests/LinuxPreflightCheck.test.tsx
+++ b/web/src/components/wizard/installation/tests/LinuxPreflightCheck.test.tsx
@@ -9,7 +9,7 @@ const TEST_TOKEN = "test-auth-token";
 
 const server = setupServer(
   mockHandlers.preflights.host.getStatus({
-    status: { state: "Failed" },
+    status: { state: "Succeeded" },
     output: {
       pass: [{ title: "CPU Check", message: "CPU requirements met" }],
       warn: [{ title: "Memory Warning", message: "Memory is below recommended" }],
@@ -118,10 +118,10 @@ describe("LinuxPreflightCheck", () => {
   });
 
   it("receives allowIgnoreHostPreflights field in preflight response", async () => {
-    // Mock preflight status endpoint with allowIgnoreHostPreflights: true
+    // Mock preflight status endpoint with allowIgnoreHostPreflights: true - execution succeeds but checks fail
     server.use(
       mockHandlers.preflights.host.getStatus({
-        status: { state: "Failed" },
+        status: { state: "Succeeded" },
         output: preflightPresets.failed("Insufficient disk space"),
         allowIgnoreHostPreflights: true,
       })
@@ -143,10 +143,10 @@ describe("LinuxPreflightCheck", () => {
   });
 
   it("passes allowIgnoreHostPreflights false to onComplete callback", async () => {
-    // Mock preflight status endpoint with allowIgnoreHostPreflights: false
+    // Mock preflight status endpoint with allowIgnoreHostPreflights: false - execution succeeds but checks fail
     server.use(
       mockHandlers.preflights.host.getStatus({
-        status: { state: "Failed" },
+        status: { state: "Succeeded" },
         output: preflightPresets.failed("Insufficient disk space"),
         allowIgnoreHostPreflights: false,
       })

--- a/web/src/components/wizard/installation/tests/LinuxPreflightPhase.test.tsx
+++ b/web/src/components/wizard/installation/tests/LinuxPreflightPhase.test.tsx
@@ -34,10 +34,10 @@ describe('LinuxPreflightPhase', () => {
   });
 
   it('enables Start Installation button when allowIgnoreHostPreflights is true and preflights fail', async () => {
-    // Mock preflight status endpoint - returns failures with allowIgnoreHostPreflights: true
+    // Mock preflight status endpoint - execution succeeds but checks fail
     server.use(
       mockHandlers.preflights.host.getStatus({
-        status: { state: 'Failed' },
+        status: { state: 'Succeeded' },
         output: preflightPresets.failed('Not enough disk space available'),
         allowIgnoreHostPreflights: true,
       })
@@ -69,10 +69,10 @@ describe('LinuxPreflightPhase', () => {
   });
 
   it('disables Start Installation button when allowIgnoreHostPreflights is false and preflights fail', async () => {
-    // Mock preflight status endpoint - returns failures with allowIgnoreHostPreflights: false
+    // Mock preflight status endpoint - execution succeeds but checks fail
     server.use(
       mockHandlers.preflights.host.getStatus({
-        status: { state: 'Failed' },
+        status: { state: 'Succeeded' },
         output: preflightPresets.failed('Not enough disk space available'),
         allowIgnoreHostPreflights: false,
       })
@@ -110,10 +110,10 @@ describe('LinuxPreflightPhase', () => {
   });
 
   it('shows modal when Start Installation clicked and allowIgnoreHostPreflights is true and preflights fail', async () => {
-    // Mock preflight status endpoint - returns failures with allowIgnoreHostPreflights: true
+    // Mock preflight status endpoint - execution succeeds but checks fail
     server.use(
       mockHandlers.preflights.host.getStatus({
-        status: { state: 'Failed' },
+        status: { state: 'Succeeded' },
         output: preflightPresets.failed('Not enough disk space available'),
         allowIgnoreHostPreflights: true,
       })
@@ -267,10 +267,10 @@ describe('LinuxPreflightPhase', () => {
 
   // Verify ignoreHostPreflights parameter is sent
   it('sends ignoreHostPreflights parameter when starting installation with failed preflights', async () => {
-    // Mock preflight status endpoint - returns failures with allowIgnoreHostPreflights: true
+    // Mock preflight status endpoint - execution succeeds but checks fail
     server.use(
       mockHandlers.preflights.host.getStatus({
-        status: { state: 'Failed' },
+        status: { state: 'Succeeded' },
         output: preflightPresets.failed('Not enough disk space available'),
         allowIgnoreHostPreflights: true,
       }),
@@ -372,10 +372,10 @@ describe('LinuxPreflightPhase - Error Handling & Edge Cases', () => {
   });
 
   it('properly handles modal cancellation flow', async () => {
-    // Mock preflight status endpoint - returns failures
+    // Mock preflight status endpoint - execution succeeds but checks fail
     server.use(
       mockHandlers.preflights.host.getStatus({
-        status: { state: 'Failed' },
+        status: { state: 'Succeeded' },
         output: preflightPresets.failed('Not enough disk space'),
         allowIgnoreHostPreflights: true,
       })
@@ -496,10 +496,10 @@ describe('LinuxPreflightPhase - onStateChange Tests', () => {
   });
 
   it('calls onStateChange with "Failed" when preflights complete with failures', async () => {
-    // Mock preflight status endpoint - returns failures
+    // Mock preflight status endpoint - execution succeeds but checks fail
     server.use(
       mockHandlers.preflights.host.getStatus({
-        status: { state: 'Failed' },
+        status: { state: 'Succeeded' },
         output: preflightPresets.failed('Not enough disk space available'),
         allowIgnoreHostPreflights: false,
       })
@@ -529,10 +529,10 @@ describe('LinuxPreflightPhase - onStateChange Tests', () => {
   });
 
   it('calls onStateChange("Running") when rerun button is clicked', async () => {
-    // Mock preflight status to show failures initially
+    // Mock preflight status to show failures initially - execution succeeds but checks fail
     server.use(
       mockHandlers.preflights.host.getStatus({
-        status: { state: 'Failed' },
+        status: { state: 'Succeeded' },
         output: preflightPresets.failed('Not enough disk space'),
         allowIgnoreHostPreflights: false,
       })


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR changes the preflight status state model to better distinguish between execution success and check results. Previously, the status state would be set to "Failed" when preflight checks failed, which conflated execution failure with check failure.

**Key changes:**
- The status state now represents whether the preflight **execution** completed successfully, not whether the checks passed
- When preflights complete execution successfully:
  - Status is always set to `StateSucceeded`
  - Description indicates whether checks passed or failed ("App preflights completed with failures" vs "App preflights succeeded")
  - The actual pass/fail results are contained in the preflight output
- The internal state machine still transitions to `StateAppPreflightsFailed` or `StateAppPreflightsSucceeded` for workflow tracking
- Frontend components now check `status.state === "Succeeded"` AND `!hasFailures(output)` to determine overall success

**Affected areas:**
- App preflight controller (`api/controllers/app/apppreflight.go`)
- Host preflight controller (`api/controllers/linux/install/hostpreflight.go`)
- Headless installer orchestrator (`cmd/installer/cli/headless/install/orchestrator.go`)
- Frontend components (`AppPreflightCheck.tsx`, `LinuxPreflightCheck.tsx`)
- Tests updated to reflect new behavior

This provides clearer semantics: execution succeeded but checks may have failed, versus execution itself failing (e.g., due to an error running the preflight binary).

#### Which issue(s) this PR fixes:

<!-- No linked issue found in commit message -->

#### Does this PR require a test?

Tests have been updated:
- `tests/dryrun/v3_install_preflights_test.go` - Updated to check for succeeded state
- `web/src/components/wizard/installation/tests/AppPreflightCheck.test.tsx` - Updated assertions
- `web/src/components/wizard/installation/tests/AppPreflightPhase.test.tsx` - Updated test expectations
- `web/src/components/wizard/installation/tests/LinuxPreflightCheck.test.tsx` - Updated assertions
- `web/src/components/wizard/installation/tests/LinuxPreflightPhase.test.tsx` - Updated test expectations

#### Does this PR require a release note?

```release-note
NONE
```

#### Does this PR require documentation?

NONE
