### PR TITLE
Ensure compatbility with mswjs >v2.13.0

### DIFF
--- a/web/src/components/common/tests/ConnectionMonitor.test.tsx
+++ b/web/src/components/common/tests/ConnectionMonitor.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, afterEach, afterAll } from 'vitest';
 import { setupServer } from 'msw/node';
 import { mockHandlers, createHandler } from '../../../test/mockHandlers';
 import ConnectionMonitor from '../ConnectionMonitor';
@@ -9,13 +9,17 @@ const server = setupServer(
 );
 
 describe('ConnectionMonitor', () => {
-  beforeEach(() => {
+  beforeAll(() => {
     server.listen({ onUnhandledRequest: 'warn' });
   });
 
   afterEach(() => {
     server.resetHandlers();
     vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    server.close();
   });
 
   it('should not show modal when API is available', async () => {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

msw 2.13.0 introduced a stricter state check. calling listen() on an already-running server now throws an Invariant Violation rather than silently succeeding. The tests were calling listen() in beforeEach but never calling close() in afterEach, so every test after the first was hitting this.

Switched to the beforeAll/afterAll pattern (start once, stop once) with resetHandlers() still running between tests for isolation. This is the pattern msw's own docs recommend.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
