### PR TITLE
fix: resolve dependabot security alerts

### DIFF
--- a/kinds/go.mod
+++ b/kinds/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
-	github.com/moby/spdystream v0.5.0 // indirect
+	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/moby/sys/mountinfo v0.7.2 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/kinds/go.sum
+++ b/kinds/go.sum
@@ -163,8 +163,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
-github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
-github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
+github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
+github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/moby/sys/mountinfo v0.7.2 h1:1shs6aH5s4o5H2zQLn796ADW1wMrIwHsyJ2v9KouLrg=
 github.com/moby/sys/mountinfo v0.7.2/go.mod h1:1YOa8w8Ih7uW0wALDUgT1dTTSBrZ+HiBLGws92L2RU4=
 github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g=


### PR DESCRIPTION
## Summary

- Fixes Dependabot alert #168: upgrades `github.com/moby/spdystream` in `kinds/go.mod` from v0.5.0 to v0.5.1 (CVE-2026-35469 — SpdyStream DOS on CRI)
- Documents that Dependabot alert #140 (`github.com/docker/docker` CVE-2026-34040) cannot be fixed at this time

## Fixed

| Alert | Package | CVE | Fix |
|-------|---------|-----|-----|
| #168 | `kinds/go.mod`: `github.com/moby/spdystream` | CVE-2026-35469 (HIGH) | Upgraded v0.5.0 → v0.5.1 |

## Unfixed (no patch available)

| Alert | Package | CVE | Reason |
|-------|---------|-----|--------|
| #140 | `go.mod`: `github.com/docker/docker` | CVE-2026-34040 (HIGH) | Patched version (v29.3.1) not yet released in Go module ecosystem. Current latest is v28.5.2+incompatible. |

### Risk assessment for CVE-2026-34040

CVE-2026-34040 is a Moby AuthZ plugin bypass via oversized request bodies (vulnerable range `< 29.3.1`). The `github.com/docker/docker` package is an **indirect** dependency in embedded-cluster. The risk surface depends on whether EC exposes AuthZ plugin endpoints — in typical embedded-cluster deployments, the Docker daemon's AuthZ plugin API is not externally exposed, which limits exploitability. Recommend updating once v29.3.1 is available.

## Test plan

- [x] `go build ./...` passes in root module
- [x] `go build ./...` passes in `kinds/` module
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)