### PR TITLE
fix: add upgrade preflight for stale containerd tmpmounts

### DIFF
--- a/pkg-new/preflights/specs/host-preflight-upgrade.yaml
+++ b/pkg-new/preflights/specs/host-preflight-upgrade.yaml
@@ -4,5 +4,37 @@ metadata:
   name: embedded-cluster-upgrade
 spec:
   # upgrade only collectors and analyzers should be added here
-  collectors: []
-  analyzers: []
+  collectors:
+    - run:
+        collectorName: 'check-stale-containerd-tmpmounts'
+        command: 'sh'
+        args:
+          - -c
+          - |
+            # Detect stale containerd overlay mounts left by interrupted image pulls.
+            # These cause "device or resource busy" errors on subsequent pulls.
+            if grep -q 'containerd/tmpmounts' /proc/mounts 2>/dev/null; then
+              echo "stale_mounts_found=true"
+              echo "---"
+              grep 'containerd/tmpmounts' /proc/mounts
+            else
+              echo "stale_mounts_found=false"
+            fi
+  analyzers:
+    - textAnalyze:
+        checkName: Stale Containerd Temporary Mounts
+        fileName: host-collectors/run-host/check-stale-containerd-tmpmounts.txt
+        regex: 'stale_mounts_found=true'
+        outcomes:
+          - fail:
+              when: 'true'
+              message: >-
+                Stale containerd temporary mounts were detected. These leftover overlay
+                mounts from a previous interrupted operation will cause image pull failures
+                with "device or resource busy" errors during the upgrade. To resolve, run:
+                mount | grep containerd-mount | awk '{print $3}' | xargs -r umount -l
+                Then restart the k0s service with: systemctl restart k0scontroller.service
+                (or k0sworker.service on worker nodes).
+          - pass:
+              when: 'false'
+              message: No stale containerd temporary mounts detected

--- a/pkg-new/preflights/template_test.go
+++ b/pkg-new/preflights/template_test.go
@@ -634,10 +634,10 @@ func TestGetClusterHostPreflightsUpgradeMode(t *testing.T) {
 	// Verify we loaded the upgdrade spec
 	req.Equal("embedded-cluster-upgrade", hpfc[1].Name)
 
-	// Verify the spec has collectors and analyzers
+	// Verify the upgrade spec has collectors and analyzers
 	spec := hpfc[1].Spec
-	req.Empty(spec.Collectors, "Upgrade spec  does not have collectors for now")
-	req.Empty(spec.Analyzers, "Upgrade spec does not have analyzers for now")
+	req.NotEmpty(spec.Collectors, "Upgrade spec should have collectors")
+	req.NotEmpty(spec.Analyzers, "Upgrade spec should have analyzers")
 }
 
 func TestGetClusterHostPreflightsInstallMode(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add a preflight check to the upgrade spec that detects stale containerd overlay mounts under `containerd/tmpmounts/` and fails with a clear remediation message before the upgrade proceeds
- These stale mounts (left by interrupted image pulls, often caused by security software holding files open) cause "device or resource busy" errors that cascade into broken CNI, unreachable services, and an unrecoverable cluster state

## Context

Investigation of [sc-136511](https://app.shortcut.com/replicated/story/136511) found that neither v2 nor v3 has a preflight check for this condition. The previously referenced ec#277 improved security tool detection in the *support bundle* (diagnostic), not preflights (preventive).

The collector greps `/proc/mounts` for entries under `containerd/tmpmounts`. On a healthy system at upgrade time, there should be zero such mounts — false positives are unlikely.

## Test plan

- [x] YAML validates
- [x] `go vet ./pkg-new/preflights/...` passes
- [x] `go test ./pkg-new/preflights/...` passes (updated test that previously asserted upgrade spec was empty)
- [ ] Manual verification on a test cluster with simulated stale mounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)