### PR TITLE
chore(registry): unpin registry image from 2.8.3

### DIFF
--- a/cmd/buildtools/registry.go
+++ b/cmd/buildtools/registry.go
@@ -25,10 +25,8 @@ var registryImageComponents = map[string]addonComponent{
 		name: "registry",
 		getCustomImageName: func(opts addonComponentOptions) (string, error) {
 			ref := "proxy.replicated.com/library/registry"
-			// TODO: unpin this
-			return fmt.Sprintf("%s:%s", ref, "2.8.3"), nil
-			// constraints := mustParseSemverConstraints(latestPatchConstraint(opts.upstreamVersion))
-			// return getLatestImageNameAndTag(opts.ctx, ref, constraints)
+			constraints := mustParseSemverConstraints(latestMinorConstraint(opts.upstreamVersion))
+			return getLatestImageNameAndTag(opts.ctx, ref, constraints)
 		},
 		upstreamVersionInputOverride: "INPUT_REGISTRY_VERSION",
 	},

--- a/cmd/buildtools/utils.go
+++ b/cmd/buildtools/utils.go
@@ -191,6 +191,10 @@ func latestPatchConstraint(s *semver.Version) string {
 	return fmt.Sprintf(">=%d.%d,<%d.%d", s.Major(), s.Minor(), s.Major(), s.Minor()+1)
 }
 
+func latestMinorConstraint(s *semver.Version) string {
+	return fmt.Sprintf(">=%d.0.0,<%d.0.0", s.Major(), s.Major()+1)
+}
+
 type filterFn func(string) bool
 
 func GetGitHubRelease(ctx context.Context, owner, repo string, filter filterFn) (string, error) {

--- a/pkg/addons/registry/static/metadata.yaml
+++ b/pkg/addons/registry/static/metadata.yaml
@@ -11,5 +11,5 @@ images:
     registry:
         repo: proxy.replicated.com/library/registry
         tag:
-            amd64: 3.0.0-amd64@sha256:3ccd201fd48d4779344f27f34f04f4a590239feb1acf5c3be40f9295bada27d0
-            arm64: 3.0.0-arm64@sha256:6cbe1c2aba126e69797af74c12411e560cea69c11c39ee9bff2715d65cb9cfe3
+            amd64: 3.1.1-amd64@sha256:7d06149b247db4732c90a6660af0b47e9601963c3ab580ccf296fa72d96c96e5
+            arm64: 3.1.1-arm64@sha256:268650ec823f6fe2102d2e22b6f02ef8ced74bed7f80d2e6701e785518d8084f

--- a/pkg/addons/registry/static/metadata.yaml
+++ b/pkg/addons/registry/static/metadata.yaml
@@ -11,5 +11,5 @@ images:
     registry:
         repo: proxy.replicated.com/library/registry
         tag:
-            amd64: 2.8.3-amd64@sha256:dba57f43326cbb6aa18bebe68cb70757f581952d68db6f560b4999a38350bdfd
-            arm64: 2.8.3-arm64@sha256:8db21e9230b21ad6fbc99537b649c7e1633603d29130fe9326b24a5dee94557d
+            amd64: 3.0.0-amd64@sha256:3ccd201fd48d4779344f27f34f04f4a590239feb1acf5c3be40f9295bada27d0
+            arm64: 3.0.0-arm64@sha256:6cbe1c2aba126e69797af74c12411e560cea69c11c39ee9bff2715d65cb9cfe3

--- a/pkg/addons/registry/static/values-ha.tpl.yaml
+++ b/pkg/addons/registry/static/values-ha.tpl.yaml
@@ -39,6 +39,7 @@ replicaCount: 2
 s3:
   bucket: registry
   encrypt: false
+  forcepathstyle: true
   region: us-east-1
   regionEndpoint: DYNAMIC
   rootdirectory: /registry


### PR DESCRIPTION
Removes the hardcoded registry 2.8.3 pin from buildtools.

**Changes:**
- **Unpin registry image:** Removes the hardcoded `"2.8.3"` override in `cmd/buildtools/registry.go` and resolves the latest image dynamically.
- **Use `latestMinorConstraint` for registry:** Changed from `latestPatchConstraint` (which bounds to `3.0.x`) to `latestMinorConstraint` (which bounds to `3.x.x`). This allows the registry image to automatically upgrade to newer minor versions (e.g., `3.1.x`) when available in the proxy registry, rather than being locked to the minor version specified by the twuni chart.
- **Add `s3.forcepathstyle: true` to HA values:** Registry 3.0.0's S3 driver defaults to virtual-hosted-style addressing, which breaks with SeaweedFS's IP-based S3 endpoint. Setting `forcepathstyle: true` restores path-style addressing (`http://<ip>:8333/registry/...`) and fixes the `dial tcp: lookup registry.<ip>` errors seen in e2e tests.

**Why the S3 fix is needed:**
The twuni docker-registry Helm chart v3.0.0 bumped the default image from registry 2.8.x to 3.0.0. Registry 3.0.0 uses the `distribution/distribution` v3 codebase, where the S3 driver's default addressing mode changed. Since SeaweedFS's S3 endpoint is an IP address (not a DNS-resolvable hostname), the registry pod cannot resolve `bucket.<endpoint-ip>` and returns 500 errors on image operations.

This PR also updates the generated `metadata.yaml` to reflect the un-pinned version.