### PR TITLE
feat: nftables support for Linux kernel 6.17+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ tests/dryrun/web/
 
 # Claude worktrees
 .claude/worktrees/
+
+# Superpowers worktrees
+.worktrees/

--- a/cmd/installer/cli/join.go
+++ b/cmd/installer/cli/join.go
@@ -505,6 +505,10 @@ func applyNetworkConfiguration(networkInterface string, rc runtimeconfig.Runtime
 		clusterSpec.Spec.API.ExtraArgs["service-node-port-range"] = rc.NodePortRange()
 	}
 
+	if err := config.ApplyHostK0sConfigOverrides(context.Background(), clusterSpec); err != nil {
+		return fmt.Errorf("apply host k0s config overrides: %w", err)
+	}
+
 	clusterSpecYaml, err := k8syaml.Marshal(clusterSpec)
 	if err != nil {
 		return fmt.Errorf("unable to marshal cluster spec: %w", err)

--- a/cmd/installer/cli/join.go
+++ b/cmd/installer/cli/join.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/replicatedhq/embedded-cluster/cmd/installer/goods"
@@ -506,9 +505,7 @@ func applyNetworkConfiguration(networkInterface string, rc runtimeconfig.Runtime
 		clusterSpec.Spec.API.ExtraArgs["service-node-port-range"] = rc.NodePortRange()
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	if err := config.ApplyHostK0sConfigOverrides(ctx, clusterSpec); err != nil {
+	if err := config.ApplyHostK0sConfigOverrides(context.TODO(), clusterSpec); err != nil {
 		return fmt.Errorf("apply host k0s config overrides: %w", err)
 	}
 

--- a/cmd/installer/cli/join.go
+++ b/cmd/installer/cli/join.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/replicatedhq/embedded-cluster/cmd/installer/goods"
@@ -505,7 +506,9 @@ func applyNetworkConfiguration(networkInterface string, rc runtimeconfig.Runtime
 		clusterSpec.Spec.API.ExtraArgs["service-node-port-range"] = rc.NodePortRange()
 	}
 
-	if err := config.ApplyHostK0sConfigOverrides(context.Background(), clusterSpec); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := config.ApplyHostK0sConfigOverrides(ctx, clusterSpec); err != nil {
 		return fmt.Errorf("apply host k0s config overrides: %w", err)
 	}
 

--- a/pkg-new/hostutils/static/modules-load.d/99-embedded-cluster.conf
+++ b/pkg-new/hostutils/static/modules-load.d/99-embedded-cluster.conf
@@ -1,6 +1,8 @@
 # from https://github.com/k0sproject/k0s/blob/fb9fb09cdbea20afa64fbb0218c7eca0ac0a61c7/pkg/component/worker/kernelsetup_linux.go#L63-L75
 overlay
 ip_tables
+nf_tables
+nft_compat
 #ip6_tables
 br_netfilter
 nf_conntrack

--- a/pkg-new/hostutils/system.go
+++ b/pkg-new/hostutils/system.go
@@ -169,7 +169,7 @@ func (h *HostUtils) ConfigureKernelModules() error {
 		return fmt.Errorf("materialize kernel modules config: %w", err)
 	}
 
-	if err := ensureKernelModulesLoaded(); err != nil {
+	if err := ensureKernelModulesLoaded(h.logger); err != nil {
 		return fmt.Errorf("ensure kernel modules are loaded: %w", err)
 	}
 	return nil
@@ -190,7 +190,7 @@ func kernelModulesConfig() error {
 // ensureKernelModulesLoaded ensures the kernel modules are loaded by iterating over the modules in
 // the config file and calling modprobe for each one. Modules that are not available on the host
 // kernel are skipped gracefully.
-func ensureKernelModulesLoaded() (finalErr error) {
+func ensureKernelModulesLoaded(logger logrus.FieldLogger) (finalErr error) {
 	scanner := bufio.NewScanner(bytes.NewReader(embeddedClusterModulesConf))
 	for scanner.Scan() {
 		module := strings.TrimSpace(scanner.Text())
@@ -198,7 +198,7 @@ func ensureKernelModulesLoaded() (finalErr error) {
 			continue
 		}
 		if !_moduleExistsFunc(module) {
-			logrus.Debugf("Module %s not available on this kernel, skipping", module)
+			logger.Debugf("Module %s not available on this kernel, skipping", module)
 			continue
 		}
 		if err := modprobe(module); err != nil {

--- a/pkg-new/hostutils/system.go
+++ b/pkg-new/hostutils/system.go
@@ -187,16 +187,22 @@ func kernelModulesConfig() error {
 }
 
 // ensureKernelModulesLoaded ensures the kernel modules are loaded by iterating over the modules in
-// the config file and calling modprobe for each one.
+// the config file and calling modprobe for each one. Modules that are not available on the host
+// kernel are skipped gracefully.
 func ensureKernelModulesLoaded() (finalErr error) {
 	scanner := bufio.NewScanner(bytes.NewReader(embeddedClusterModulesConf))
 	for scanner.Scan() {
 		module := strings.TrimSpace(scanner.Text())
-		if module != "" && !strings.HasPrefix(module, "#") {
-			if err := modprobe(module); err != nil {
-				err = fmt.Errorf("modprobe %s: %w", module, err)
-				finalErr = multierr.Append(finalErr, err)
-			}
+		if module == "" || strings.HasPrefix(module, "#") {
+			continue
+		}
+		if !checkModuleExists(module) {
+			logrus.Debugf("Module %s not available on this kernel, skipping", module)
+			continue
+		}
+		if err := modprobe(module); err != nil {
+			err = fmt.Errorf("modprobe %s: %w", module, err)
+			finalErr = multierr.Append(finalErr, err)
 		}
 	}
 	return
@@ -205,6 +211,13 @@ func ensureKernelModulesLoaded() (finalErr error) {
 func modprobe(module string) error {
 	_, err := helpers.RunCommand("modprobe", module)
 	return err
+}
+
+// checkModuleExists verifies whether a kernel module is available (loadable or builtin)
+// using modprobe --dry-run.
+func checkModuleExists(module string) bool {
+	_, err := helpers.RunCommand("modprobe", "-n", module)
+	return err == nil
 }
 
 // CreateSystemdUnitFiles links the k0s systemd unit file. this also creates a new

--- a/pkg-new/hostutils/system.go
+++ b/pkg-new/hostutils/system.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/replicatedhq/embedded-cluster/cmd/installer/goods"
 	"github.com/replicatedhq/embedded-cluster/pkg/helpers"
+	"github.com/replicatedhq/embedded-cluster/pkg/helpers/kernel"
 	"github.com/replicatedhq/embedded-cluster/pkg/helpers/systemd"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	"github.com/sirupsen/logrus"
@@ -196,7 +197,7 @@ func ensureKernelModulesLoaded() (finalErr error) {
 		if module == "" || strings.HasPrefix(module, "#") {
 			continue
 		}
-		if !checkModuleExists(module) {
+		if !_moduleExistsFunc(module) {
 			logrus.Debugf("Module %s not available on this kernel, skipping", module)
 			continue
 		}
@@ -213,11 +214,10 @@ func modprobe(module string) error {
 	return err
 }
 
-// checkModuleExists verifies whether a kernel module is available (loadable or builtin)
-// using modprobe --dry-run.
-func checkModuleExists(module string) bool {
-	_, err := helpers.RunCommand("modprobe", "-n", module)
-	return err == nil
+// _moduleExistsFunc is a testable hook that delegates to kernel.ModuleExists.
+// Tests can replace it to avoid executing real modprobe dry-runs.
+var _moduleExistsFunc = func(module string) bool {
+	return kernel.ModuleExists(context.Background(), module)
 }
 
 // CreateSystemdUnitFiles links the k0s systemd unit file. this also creates a new

--- a/pkg-new/hostutils/system_test.go
+++ b/pkg-new/hostutils/system_test.go
@@ -146,25 +146,26 @@ func Test_ensureKernelModulesLoaded(t *testing.T) {
 		helpers.Set(&helpers.Helpers{})
 	})
 
+	// Mock module existence check so all modules are considered available
+	origModuleExists := _moduleExistsFunc
+	_moduleExistsFunc = func(module string) bool { return true }
+	t.Cleanup(func() {
+		_moduleExistsFunc = origModuleExists
+	})
+
 	// Run the function being tested
 	err := ensureKernelModulesLoaded()
 	if err != nil {
 		t.Errorf("ensureKernelModulesLoaded() returned error: %v", err)
 	}
 
-	// Expected modprobe commands
+	// Expected modprobe commands (load only; dry-run checks now live in kernel package)
 	expectedCommands := []string{
-		"modprobe -n overlay",
 		"modprobe overlay",
-		"modprobe -n ip_tables",
 		"modprobe ip_tables",
-		"modprobe -n nf_tables",
 		"modprobe nf_tables",
-		"modprobe -n nft_compat",
 		"modprobe nft_compat",
-		"modprobe -n br_netfilter",
 		"modprobe br_netfilter",
-		"modprobe -n nf_conntrack",
 		"modprobe nf_conntrack",
 	}
 

--- a/pkg-new/hostutils/system_test.go
+++ b/pkg-new/hostutils/system_test.go
@@ -154,9 +154,17 @@ func Test_ensureKernelModulesLoaded(t *testing.T) {
 
 	// Expected modprobe commands
 	expectedCommands := []string{
+		"modprobe -n overlay",
 		"modprobe overlay",
+		"modprobe -n ip_tables",
 		"modprobe ip_tables",
+		"modprobe -n nf_tables",
+		"modprobe nf_tables",
+		"modprobe -n nft_compat",
+		"modprobe nft_compat",
+		"modprobe -n br_netfilter",
 		"modprobe br_netfilter",
+		"modprobe -n nf_conntrack",
 		"modprobe nf_conntrack",
 	}
 

--- a/pkg-new/hostutils/system_test.go
+++ b/pkg-new/hostutils/system_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/replicatedhq/embedded-cluster/pkg/helpers"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -154,7 +155,7 @@ func Test_ensureKernelModulesLoaded(t *testing.T) {
 	})
 
 	// Run the function being tested
-	err := ensureKernelModulesLoaded()
+	err := ensureKernelModulesLoaded(logrus.New())
 	if err != nil {
 		t.Errorf("ensureKernelModulesLoaded() returned error: %v", err)
 	}

--- a/pkg-new/hostutils/system_test.go
+++ b/pkg-new/hostutils/system_test.go
@@ -2,6 +2,7 @@ package hostutils
 
 import (
 	_ "embed"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -155,7 +156,9 @@ func Test_ensureKernelModulesLoaded(t *testing.T) {
 	})
 
 	// Run the function being tested
-	err := ensureKernelModulesLoaded(logrus.New())
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	err := ensureKernelModulesLoaded(logger)
 	if err != nil {
 		t.Errorf("ensureKernelModulesLoaded() returned error: %v", err)
 	}

--- a/pkg-new/k0s/k0s.go
+++ b/pkg-new/k0s/k0s.go
@@ -136,7 +136,9 @@ func (k *K0s) NewK0sConfig(networkInterface string, isAirgap bool, podCIDR strin
 	cfg.Spec.Network.PodCIDR = podCIDR
 	cfg.Spec.Network.ServiceCIDR = serviceCIDR
 
-	if err := config.ApplyHostK0sConfigOverrides(context.Background(), cfg); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := config.ApplyHostK0sConfigOverrides(ctx, cfg); err != nil {
 		return nil, fmt.Errorf("apply host k0s config overrides: %w", err)
 	}
 

--- a/pkg-new/k0s/k0s.go
+++ b/pkg-new/k0s/k0s.go
@@ -136,9 +136,7 @@ func (k *K0s) NewK0sConfig(networkInterface string, isAirgap bool, podCIDR strin
 	cfg.Spec.Network.PodCIDR = podCIDR
 	cfg.Spec.Network.ServiceCIDR = serviceCIDR
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	if err := config.ApplyHostK0sConfigOverrides(ctx, cfg); err != nil {
+	if err := config.ApplyHostK0sConfigOverrides(context.TODO(), cfg); err != nil {
 		return nil, fmt.Errorf("apply host k0s config overrides: %w", err)
 	}
 

--- a/pkg-new/k0s/k0s.go
+++ b/pkg-new/k0s/k0s.go
@@ -136,6 +136,10 @@ func (k *K0s) NewK0sConfig(networkInterface string, isAirgap bool, podCIDR strin
 	cfg.Spec.Network.PodCIDR = podCIDR
 	cfg.Spec.Network.ServiceCIDR = serviceCIDR
 
+	if err := config.ApplyHostK0sConfigOverrides(context.Background(), cfg); err != nil {
+		return nil, fmt.Errorf("apply host k0s config overrides: %w", err)
+	}
+
 	if mutate != nil {
 		if err := mutate(cfg); err != nil {
 			return nil, err

--- a/pkg-new/preflights/specs/host-preflight-common.yaml
+++ b/pkg-new/preflights/specs/host-preflight-common.yaml
@@ -17,7 +17,8 @@ spec:
           - |
             if modprobe -n ip_tables 2>/dev/null || lsmod | grep -q "^ip_tables"; then
               echo "backend=legacy"
-            elif modprobe -n nf_tables 2>/dev/null || lsmod | grep -q "^nf_tables"; then
+            elif (modprobe -n nf_tables 2>/dev/null || lsmod | grep -q "^nf_tables") && \
+                 (modprobe -n nft_compat 2>/dev/null || lsmod | grep -q "^nft_compat"); then
               echo "backend=nft"
             else
               echo "backend=none"

--- a/pkg-new/preflights/specs/host-preflight-common.yaml
+++ b/pkg-new/preflights/specs/host-preflight-common.yaml
@@ -10,6 +10,19 @@ spec:
     - ipv4Interfaces: {}
     - kernelModules: {}
     - run:
+        collectorName: 'check-netfilter-backend'
+        command: 'sh'
+        args:
+          - '-c'
+          - |
+            if modprobe -n ip_tables 2>/dev/null || lsmod | grep -q "^ip_tables"; then
+              echo "backend=legacy"
+            elif modprobe -n nf_tables 2>/dev/null || lsmod | grep -q "^nf_tables"; then
+              echo "backend=nft"
+            else
+              echo "backend=none"
+            fi
+    - run:
         collectorName: 'ip-route-table'
         command: 'ip'
         args: ['route']
@@ -611,18 +624,6 @@ spec:
               when: ""
               message: The 'overlay' kernel module is not loaded or loadable
     - kernelModules:
-        checkName: "IP tables kernel module"
-        outcomes:
-          - pass:
-              when: "rosetta == loaded"
-              message: The kernel is likely linuxkit, skipping kernel module check
-          - pass:
-              when: "ip_tables == loaded,loadable"
-              message: The 'ip_tables' kernel module is loaded or loadable
-          - fail:
-              when: ""
-              message: The 'ip_tables' kernel module is not loaded or loadable
-    - kernelModules:
         checkName: "BR Netfilter kernel module"
         outcomes:
           - pass:
@@ -646,6 +647,17 @@ spec:
           - fail:
               when: ""
               message: The 'nf_conntrack' kernel module is not loaded or loadable
+    - textAnalyze:
+        checkName: "Netfilter backend"
+        fileName: host-collectors/run-host/check-netfilter-backend.txt
+        regex: 'backend=(legacy|nft)'
+        outcomes:
+          - pass:
+              when: "true"
+              message: "Host has a usable netfilter backend (legacy iptables or nftables)"
+          - fail:
+              when: "false"
+              message: "No usable netfilter backend found. Neither ip_tables (legacy iptables) nor nf_tables (nftables) kernel module is available."
 {{- range $index, $element := .TCPConnectionsRequired}}
     - tcpConnect:
         checkName: "TCP Connection to {{ $element }}"

--- a/pkg-new/preflights/template_test.go
+++ b/pkg-new/preflights/template_test.go
@@ -670,6 +670,36 @@ func TestGetClusterHostPreflightsDefaultMode(t *testing.T) {
 	req.Equal("embedded-cluster-install", hpfc[1].Name)
 }
 
+func TestTemplateNetfilterBackendCollector(t *testing.T) {
+	req := require.New(t)
+	tl := types.HostPreflightTemplateData{}
+	hpfc, err := GetClusterHostPreflights(context.Background(), apitypes.ModeInstall, tl)
+	req.NoError(err)
+
+	commonSpec := hpfc[0].Spec
+
+	var foundCollector bool
+	for _, c := range commonSpec.Collectors {
+		if c.HostRun != nil && c.HostRun.CollectorName == "check-netfilter-backend" {
+			foundCollector = true
+			req.Equal("sh", c.HostRun.Command)
+			break
+		}
+	}
+	req.True(foundCollector, "expected check-netfilter-backend run collector")
+
+	var foundAnalyzer bool
+	for _, a := range commonSpec.Analyzers {
+		if a.TextAnalyze != nil && a.TextAnalyze.CheckName == "Netfilter backend" {
+			foundAnalyzer = true
+			req.Equal("host-collectors/run-host/check-netfilter-backend.txt", a.TextAnalyze.FileName)
+			req.Equal("backend=(legacy|nft)", a.TextAnalyze.RegexPattern)
+			break
+		}
+	}
+	req.True(foundAnalyzer, "expected Netfilter backend textAnalyze analyzer")
+}
+
 func TestCalculateAirgapStorageSpace(t *testing.T) {
 	embeddedAssetsSize := int64(1024 * 1024 * 1024)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,6 +2,7 @@
 package config
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -12,9 +13,11 @@ import (
 	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	k0sconfig "github.com/k0sproject/k0s/pkg/config"
 	embeddedclusterv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"github.com/sirupsen/logrus"
 	"go.yaml.in/yaml/v3"
 	k8syaml "sigs.k8s.io/yaml"
 
+	"github.com/replicatedhq/embedded-cluster/pkg/helpers/kernel"
 	"github.com/replicatedhq/embedded-cluster/pkg/release"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 )
@@ -30,6 +33,9 @@ var disableUpdateProber = canDisableUpdateProber()
 
 // k0sConfigPathOverride is used during tests to override the path to the k0s config file.
 var k0sConfigPathOverride string
+
+// detectIPTablesBackend is used during tests to mock kernel.DetectIPTablesBackend.
+var detectIPTablesBackend = kernel.DetectIPTablesBackend
 
 // RenderK0sConfig renders a k0s cluster configuration.
 func RenderK0sConfig(proxyRegistryDomain string) *k0sv1beta1.ClusterConfig {
@@ -73,6 +79,33 @@ func enableCalicoNetworkProvider(cfg *k0sv1beta1.ClusterConfig) {
 		cfg.Spec.Network.Calico.EnvVars = make(map[string]string)
 	}
 	cfg.Spec.Network.Calico.EnvVars["FELIX_USAGEREPORTINGENABLED"] = "false"
+}
+
+// ApplyHostK0sConfigOverrides detects the host's netfilter backend capability
+// and applies any host-specific overrides to the k0s config.
+func ApplyHostK0sConfigOverrides(ctx context.Context, cfg *k0sv1beta1.ClusterConfig) error {
+	if cfg == nil {
+		return fmt.Errorf("cluster config is nil")
+	}
+	if cfg.Spec == nil {
+		cfg.Spec = &k0sv1beta1.ClusterSpec{}
+	}
+	backend, err := detectIPTablesBackend(ctx)
+	if err != nil {
+		logrus.WithError(err).Warn("Failed to detect iptables backend, leaving kube-proxy mode unchanged")
+		return nil
+	}
+	if backend == kernel.BackendNFT {
+		logrus.Info("Host lacks legacy iptables, configuring kube-proxy for nftables mode")
+		if cfg.Spec.Network == nil {
+			cfg.Spec.Network = &k0sv1beta1.Network{}
+		}
+		if cfg.Spec.Network.KubeProxy == nil {
+			cfg.Spec.Network.KubeProxy = &k0sv1beta1.KubeProxy{}
+		}
+		cfg.Spec.Network.KubeProxy.Mode = "nftables"
+	}
+	return nil
 }
 
 // extractK0sConfigPatch extracts the k0s config portion of the provided patch.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -92,11 +92,11 @@ func ApplyHostK0sConfigOverrides(ctx context.Context, cfg *k0sv1beta1.ClusterCon
 	}
 	backend, err := detectIPTablesBackend(ctx)
 	if err != nil {
-		logrus.WithError(err).Warn("Failed to detect iptables backend, leaving kube-proxy mode unchanged")
+		logrus.WithError(err).Debug("Failed to detect iptables backend, leaving kube-proxy mode unchanged")
 		return nil
 	}
 	if backend == kernel.BackendNFT {
-		logrus.Info("Host lacks legacy iptables, configuring kube-proxy for nftables mode")
+		logrus.Debug("Host lacks legacy iptables, configuring kube-proxy for nftables mode")
 		if cfg.Spec.Network == nil {
 			cfg.Spec.Network = &k0sv1beta1.Network{}
 		}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,8 +1,11 @@
 package config
 
 import (
+	"context"
 	"embed"
 	"encoding/json"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,8 +13,10 @@ import (
 
 	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	embeddedclusterv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"github.com/replicatedhq/embedded-cluster/pkg/helpers/kernel"
 	"github.com/replicatedhq/embedded-cluster/pkg/release"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v3"
@@ -277,6 +282,116 @@ spec:
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, tt.expectedFlags, flags)
+			}
+		})
+	}
+}
+
+func TestApplyHostK0sConfigOverrides(t *testing.T) {
+	origOutput := logrus.StandardLogger().Out
+	logrus.SetOutput(io.Discard)
+	t.Cleanup(func() { logrus.SetOutput(origOutput) })
+
+	tests := []struct {
+		name          string
+		backend       kernel.IPTablesBackend
+		detectErr     error
+		inputCfg      *k0sv1beta1.ClusterConfig
+		expectedMode  string
+		expectNetwork bool
+	}{
+		{
+			name:    "BackendNFT sets kube-proxy mode to nftables",
+			backend: kernel.BackendNFT,
+			inputCfg: func() *k0sv1beta1.ClusterConfig {
+				cfg := &k0sv1beta1.ClusterConfig{Spec: &k0sv1beta1.ClusterSpec{}}
+				return cfg
+			}(),
+			expectedMode:  "nftables",
+			expectNetwork: true,
+		},
+		{
+			name:    "BackendLegacy leaves mode unchanged",
+			backend: kernel.BackendLegacy,
+			inputCfg: func() *k0sv1beta1.ClusterConfig {
+				cfg := &k0sv1beta1.ClusterConfig{Spec: &k0sv1beta1.ClusterSpec{}}
+				cfg.Spec.Network = &k0sv1beta1.Network{
+					KubeProxy: &k0sv1beta1.KubeProxy{
+						Mode: "ipvs",
+					},
+				}
+				return cfg
+			}(),
+			expectedMode:  "ipvs",
+			expectNetwork: true,
+		},
+		{
+			name:      "detection error leaves config unchanged",
+			backend:   "",
+			detectErr: fmt.Errorf("modprobe failed"),
+			inputCfg: func() *k0sv1beta1.ClusterConfig {
+				cfg := &k0sv1beta1.ClusterConfig{Spec: &k0sv1beta1.ClusterSpec{}}
+				cfg.Spec.Network = &k0sv1beta1.Network{
+					KubeProxy: &k0sv1beta1.KubeProxy{
+						Mode: "ipvs",
+					},
+				}
+				return cfg
+			}(),
+			expectedMode:  "ipvs",
+			expectNetwork: true,
+		},
+		{
+			name:    "nil kube-proxy inside existing network is initialized for nft",
+			backend: kernel.BackendNFT,
+			inputCfg: func() *k0sv1beta1.ClusterConfig {
+				cfg := &k0sv1beta1.ClusterConfig{Spec: &k0sv1beta1.ClusterSpec{}}
+				cfg.Spec.Network = &k0sv1beta1.Network{} // Network exists, KubeProxy nil
+				return cfg
+			}(),
+			expectedMode:  "nftables",
+			expectNetwork: true,
+		},
+		{
+			name:          "nil config returns error",
+			backend:       kernel.BackendNFT,
+			inputCfg:      nil,
+			expectNetwork: false,
+		},
+		{
+			name:    "legacy backend leaves nil network untouched",
+			backend: kernel.BackendLegacy,
+			inputCfg: func() *k0sv1beta1.ClusterConfig {
+				return &k0sv1beta1.ClusterConfig{Spec: &k0sv1beta1.ClusterSpec{}}
+			}(),
+			expectedMode:  "",
+			expectNetwork: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := detectIPTablesBackend
+			detectIPTablesBackend = func(ctx context.Context) (kernel.IPTablesBackend, error) {
+				return tt.backend, tt.detectErr
+			}
+			t.Cleanup(func() {
+				detectIPTablesBackend = original
+			})
+
+			err := ApplyHostK0sConfigOverrides(context.Background(), tt.inputCfg)
+			if tt.inputCfg == nil {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			if tt.expectNetwork {
+				require.NotNil(t, tt.inputCfg.Spec.Network)
+				require.NotNil(t, tt.inputCfg.Spec.Network.KubeProxy)
+				assert.Equal(t, tt.expectedMode, tt.inputCfg.Spec.Network.KubeProxy.Mode)
+			} else {
+				assert.Nil(t, tt.inputCfg.Spec.Network)
 			}
 		})
 	}

--- a/pkg/helpers/kernel/kernel.go
+++ b/pkg/helpers/kernel/kernel.go
@@ -2,11 +2,15 @@
 package kernel
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 // IPTablesBackend represents the detected netfilter backend on the host.
@@ -18,9 +22,44 @@ const (
 	BackendUnknown IPTablesBackend = "unknown"
 )
 
+var (
+	_stat       = os.Stat
+	_readFile   = os.ReadFile
+	_execCmdCtx = exec.CommandContext
+)
+
+// DetectIPTablesBackend determines if legacy iptables is available.
+// Returns BackendLegacy if ip_tables module is available (loaded, loadable, or builtin).
+// Returns BackendNFT if ip_tables is absent but nf_tables and nft_compat are available.
+// Returns BackendUnknown if neither backend is detectable.
+func DetectIPTablesBackend(ctx context.Context) (IPTablesBackend, error) {
+	// 1. Check if ip_tables is loaded or builtin via /proc/net/ip_tables_names
+	if _, err := _stat("/proc/net/ip_tables_names"); err == nil {
+		return BackendLegacy, nil
+	}
+
+	// 2. Check if ip_tables module is loadable or already loaded
+	if moduleExists(ctx, "ip_tables") || moduleLoaded("ip_tables") {
+		return BackendLegacy, nil
+	}
+	logrus.Debugf("Kernel module ip_tables not detected (may not be available)")
+
+	// 3. ip_tables is absent; check for nf_tables + nft_compat
+	if moduleExists(ctx, "nf_tables") || moduleLoaded("nf_tables") {
+		if moduleExists(ctx, "nft_compat") || moduleLoaded("nft_compat") {
+			return BackendNFT, nil
+		}
+		logrus.Debugf("Kernel module nft_compat not detected (may not be available)")
+	} else {
+		logrus.Debugf("Kernel module nf_tables not detected (may not be available)")
+	}
+
+	return BackendUnknown, fmt.Errorf("neither ip_tables (legacy iptables) nor nf_tables+nft_compat (nftables) is available")
+}
+
 // moduleExists uses modprobe --dry-run to check if a kernel module is available.
-func moduleExists(module string) bool {
-	cmd := exec.Command("modprobe", "-n", module)
+func moduleExists(ctx context.Context, module string) bool {
+	cmd := _execCmdCtx(ctx, "modprobe", "-n", module)
 	if err := cmd.Run(); err != nil {
 		return false
 	}
@@ -29,34 +68,19 @@ func moduleExists(module string) bool {
 
 // moduleLoaded checks /proc/modules for an already-loaded module.
 func moduleLoaded(module string) bool {
-	data, err := os.ReadFile("/proc/modules")
+	data, err := _readFile("/proc/modules")
 	if err != nil {
 		return false
 	}
-	return strings.Contains(string(data), module+" ")
-}
-
-// DetectIPTablesBackend determines if legacy iptables is available.
-// Returns BackendLegacy if ip_tables module is available (loaded, loadable, or builtin).
-// Returns BackendNFT if ip_tables is absent but nf_tables and nft_compat are available.
-// Returns BackendUnknown if neither backend is detectable.
-func DetectIPTablesBackend(ctx context.Context) (IPTablesBackend, error) {
-	// 1. Check if ip_tables is loaded or builtin via /proc/net/ip_tables_names
-	if _, err := os.Stat("/proc/net/ip_tables_names"); err == nil {
-		return BackendLegacy, nil
-	}
-
-	// 2. Check if ip_tables module is loadable or already loaded
-	if moduleExists("ip_tables") || moduleLoaded("ip_tables") {
-		return BackendLegacy, nil
-	}
-
-	// 3. ip_tables is absent; check for nf_tables + nft_compat
-	if moduleExists("nf_tables") || moduleLoaded("nf_tables") {
-		if moduleExists("nft_compat") || moduleLoaded("nft_compat") {
-			return BackendNFT, nil
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		if strings.HasPrefix(scanner.Text(), module+" ") {
+			return true
 		}
 	}
-
-	return BackendUnknown, fmt.Errorf("neither ip_tables (legacy iptables) nor nf_tables+nft_compat (nftables) is available")
+	if err := scanner.Err(); err != nil {
+		logrus.WithError(err).Debugf("Failed to scan /proc/modules for %s", module)
+		return false
+	}
+	return false
 }

--- a/pkg/helpers/kernel/kernel.go
+++ b/pkg/helpers/kernel/kernel.go
@@ -1,0 +1,62 @@
+// Package kernel provides host kernel capability detection for embedded-cluster.
+package kernel
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// IPTablesBackend represents the detected netfilter backend on the host.
+type IPTablesBackend string
+
+const (
+	BackendLegacy  IPTablesBackend = "legacy"
+	BackendNFT     IPTablesBackend = "nft"
+	BackendUnknown IPTablesBackend = "unknown"
+)
+
+// moduleExists uses modprobe --dry-run to check if a kernel module is available.
+func moduleExists(module string) bool {
+	cmd := exec.Command("modprobe", "-n", module)
+	if err := cmd.Run(); err != nil {
+		return false
+	}
+	return true
+}
+
+// moduleLoaded checks /proc/modules for an already-loaded module.
+func moduleLoaded(module string) bool {
+	data, err := os.ReadFile("/proc/modules")
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(data), module+" ")
+}
+
+// DetectIPTablesBackend determines if legacy iptables is available.
+// Returns BackendLegacy if ip_tables module is available (loaded, loadable, or builtin).
+// Returns BackendNFT if ip_tables is absent but nf_tables and nft_compat are available.
+// Returns BackendUnknown if neither backend is detectable.
+func DetectIPTablesBackend(ctx context.Context) (IPTablesBackend, error) {
+	// 1. Check if ip_tables is loaded or builtin via /proc/net/ip_tables_names
+	if _, err := os.Stat("/proc/net/ip_tables_names"); err == nil {
+		return BackendLegacy, nil
+	}
+
+	// 2. Check if ip_tables module is loadable or already loaded
+	if moduleExists("ip_tables") || moduleLoaded("ip_tables") {
+		return BackendLegacy, nil
+	}
+
+	// 3. ip_tables is absent; check for nf_tables + nft_compat
+	if moduleExists("nf_tables") || moduleLoaded("nf_tables") {
+		if moduleExists("nft_compat") || moduleLoaded("nft_compat") {
+			return BackendNFT, nil
+		}
+	}
+
+	return BackendUnknown, fmt.Errorf("neither ip_tables (legacy iptables) nor nf_tables+nft_compat (nftables) is available")
+}

--- a/pkg/helpers/kernel/kernel.go
+++ b/pkg/helpers/kernel/kernel.go
@@ -39,14 +39,14 @@ func DetectIPTablesBackend(ctx context.Context) (IPTablesBackend, error) {
 	}
 
 	// 2. Check if ip_tables module is loadable or already loaded
-	if moduleExists(ctx, "ip_tables") || moduleLoaded("ip_tables") {
+	if ModuleExists(ctx, "ip_tables") || moduleLoaded("ip_tables") {
 		return BackendLegacy, nil
 	}
 	logrus.Debugf("Kernel module ip_tables not detected (may not be available)")
 
 	// 3. ip_tables is absent; check for nf_tables + nft_compat
-	if moduleExists(ctx, "nf_tables") || moduleLoaded("nf_tables") {
-		if moduleExists(ctx, "nft_compat") || moduleLoaded("nft_compat") {
+	if ModuleExists(ctx, "nf_tables") || moduleLoaded("nf_tables") {
+		if ModuleExists(ctx, "nft_compat") || moduleLoaded("nft_compat") {
 			return BackendNFT, nil
 		}
 		logrus.Debugf("Kernel module nft_compat not detected (may not be available)")
@@ -57,8 +57,8 @@ func DetectIPTablesBackend(ctx context.Context) (IPTablesBackend, error) {
 	return BackendUnknown, fmt.Errorf("neither ip_tables (legacy iptables) nor nf_tables+nft_compat (nftables) is available")
 }
 
-// moduleExists uses modprobe --dry-run to check if a kernel module is available.
-func moduleExists(ctx context.Context, module string) bool {
+// ModuleExists uses modprobe --dry-run to check if a kernel module is available.
+func ModuleExists(ctx context.Context, module string) bool {
 	cmd := _execCmdCtx(ctx, "modprobe", "-n", module)
 	if err := cmd.Run(); err != nil {
 		return false

--- a/pkg/helpers/kernel/kernel_test.go
+++ b/pkg/helpers/kernel/kernel_test.go
@@ -192,3 +192,44 @@ func TestModuleLoaded(t *testing.T) {
 		})
 	}
 }
+
+func TestModuleExists(t *testing.T) {
+	tests := []struct {
+		name       string
+		execCmdCtx func(context.Context, string, ...string) *exec.Cmd
+		module     string
+		expected   bool
+	}{
+		{
+			name: "module available",
+			execCmdCtx: func(ctx context.Context, name string, args ...string) *exec.Cmd {
+				if name == "modprobe" && len(args) == 2 && args[0] == "-n" && args[1] == "nf_tables" {
+					return exec.Command("true")
+				}
+				return exec.Command("false")
+			},
+			module:   "nf_tables",
+			expected: true,
+		},
+		{
+			name: "module not available",
+			execCmdCtx: func(ctx context.Context, name string, args ...string) *exec.Cmd {
+				return exec.Command("false")
+			},
+			module:   "definitely_not_a_real_module_12345",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origExec := _execCmdCtx
+			_execCmdCtx = tt.execCmdCtx
+			t.Cleanup(func() {
+				_execCmdCtx = origExec
+			})
+
+			assert.Equal(t, tt.expected, ModuleExists(context.Background(), tt.module))
+		})
+	}
+}

--- a/pkg/helpers/kernel/kernel_test.go
+++ b/pkg/helpers/kernel/kernel_test.go
@@ -1,0 +1,26 @@
+package kernel
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectIPTablesBackend_ProcNetIpTablesNames(t *testing.T) {
+	tmpDir := t.TempDir()
+	procNetPath := filepath.Join(tmpDir, "ip_tables_names")
+
+	// Simulate /proc/net/ip_tables_names existing
+	require.NoError(t, os.WriteFile(procNetPath, []byte("filter\nnat\n"), 0644))
+
+	// We can't easily override os.Stat in this simple test without build tags,
+	// so we test the helper functions directly.
+	assert.True(t, moduleLoaded("nf_conntrack") || !moduleLoaded("nf_conntrack")) // no-op sanity check
+}
+
+func TestModuleExists_InvalidModule(t *testing.T) {
+	assert.False(t, moduleExists("definitely_not_a_real_module_12345"))
+}

--- a/pkg/helpers/kernel/kernel_test.go
+++ b/pkg/helpers/kernel/kernel_test.go
@@ -1,26 +1,194 @@
 package kernel
 
 import (
+	"context"
 	"os"
-	"path/filepath"
+	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func TestDetectIPTablesBackend_ProcNetIpTablesNames(t *testing.T) {
-	tmpDir := t.TempDir()
-	procNetPath := filepath.Join(tmpDir, "ip_tables_names")
+func TestDetectIPTablesBackend(t *testing.T) {
+	tests := []struct {
+		name        string
+		stat        func(string) (os.FileInfo, error)
+		execCmdCtx  func(context.Context, string, ...string) *exec.Cmd
+		readFile    func(string) ([]byte, error)
+		expected    IPTablesBackend
+		expectError bool
+	}{
+		{
+			name: "ip_tables_names exists",
+			stat: func(path string) (os.FileInfo, error) {
+				if path == "/proc/net/ip_tables_names" {
+					return nil, nil
+				}
+				return nil, os.ErrNotExist
+			},
+			execCmdCtx: func(context.Context, string, ...string) *exec.Cmd {
+				return exec.Command("false")
+			},
+			readFile:    func(name string) ([]byte, error) { return nil, os.ErrNotExist },
+			expected:    BackendLegacy,
+			expectError: false,
+		},
+		{
+			name: "ip_tables modprobe succeeds",
+			stat: func(path string) (os.FileInfo, error) {
+				return nil, os.ErrNotExist
+			},
+			execCmdCtx: func(ctx context.Context, name string, args ...string) *exec.Cmd {
+				if name == "modprobe" && len(args) == 2 && args[1] == "ip_tables" {
+					return exec.Command("true")
+				}
+				return exec.Command("false")
+			},
+			readFile:    func(name string) ([]byte, error) { return nil, os.ErrNotExist },
+			expected:    BackendLegacy,
+			expectError: false,
+		},
+		{
+			name: "nf_tables and nft_compat available",
+			stat: func(path string) (os.FileInfo, error) {
+				return nil, os.ErrNotExist
+			},
+			execCmdCtx: func(ctx context.Context, name string, args ...string) *exec.Cmd {
+				if name == "modprobe" && len(args) == 2 {
+					switch args[1] {
+					case "ip_tables":
+						return exec.Command("false")
+					case "nf_tables":
+						return exec.Command("true")
+					case "nft_compat":
+						return exec.Command("true")
+					}
+				}
+				return exec.Command("false")
+			},
+			readFile:    func(name string) ([]byte, error) { return nil, os.ErrNotExist },
+			expected:    BackendNFT,
+			expectError: false,
+		},
+		{
+			name: "nothing available",
+			stat: func(path string) (os.FileInfo, error) {
+				return nil, os.ErrNotExist
+			},
+			execCmdCtx: func(ctx context.Context, name string, args ...string) *exec.Cmd {
+				return exec.Command("false")
+			},
+			readFile:    func(name string) ([]byte, error) { return nil, os.ErrNotExist },
+			expected:    BackendUnknown,
+			expectError: true,
+		},
+		{
+			name: "nf_tables without nft_compat",
+			stat: func(path string) (os.FileInfo, error) {
+				return nil, os.ErrNotExist
+			},
+			execCmdCtx: func(ctx context.Context, name string, args ...string) *exec.Cmd {
+				if name == "modprobe" && len(args) == 2 {
+					switch args[1] {
+					case "ip_tables":
+						return exec.Command("false")
+					case "nf_tables":
+						return exec.Command("true")
+					case "nft_compat":
+						return exec.Command("false")
+					}
+				}
+				return exec.Command("false")
+			},
+			readFile:    func(name string) ([]byte, error) { return nil, os.ErrNotExist },
+			expected:    BackendUnknown,
+			expectError: true,
+		},
+		{
+			name: "moduleLoaded fallback ip_tables",
+			stat: func(path string) (os.FileInfo, error) {
+				return nil, os.ErrNotExist
+			},
+			execCmdCtx: func(ctx context.Context, name string, args ...string) *exec.Cmd {
+				return exec.Command("false")
+			},
+			readFile: func(name string) ([]byte, error) {
+				return []byte("ip_tables 28672 4 iptable_filter,iptable_nat,iptable_mangle,iptable_raw, Live 0x0000000000000000\n"), nil
+			},
+			expected:    BackendLegacy,
+			expectError: false,
+		},
+	}
 
-	// Simulate /proc/net/ip_tables_names existing
-	require.NoError(t, os.WriteFile(procNetPath, []byte("filter\nnat\n"), 0644))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origStat := _stat
+			origExec := _execCmdCtx
+			origReadFile := _readFile
+			_stat = tt.stat
+			_execCmdCtx = tt.execCmdCtx
+			_readFile = tt.readFile
+			t.Cleanup(func() {
+				_stat = origStat
+				_execCmdCtx = origExec
+				_readFile = origReadFile
+			})
 
-	// We can't easily override os.Stat in this simple test without build tags,
-	// so we test the helper functions directly.
-	assert.True(t, moduleLoaded("nf_conntrack") || !moduleLoaded("nf_conntrack")) // no-op sanity check
+			backend, err := DetectIPTablesBackend(context.Background())
+			assert.Equal(t, tt.expected, backend)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }
 
-func TestModuleExists_InvalidModule(t *testing.T) {
-	assert.False(t, moduleExists("definitely_not_a_real_module_12345"))
+func TestModuleLoaded(t *testing.T) {
+	tests := []struct {
+		name     string
+		readFile func(string) ([]byte, error)
+		module   string
+		expected bool
+	}{
+		{
+			name: "module present in data",
+			readFile: func(name string) ([]byte, error) {
+				return []byte("nf_tables 245760 2 nft_compat,xt_set, Live 0x0000000000000000\n" +
+					"nft_compat 16384 0 - Live 0x0000000000000000\n" +
+					"ip_tables 28672 4 iptable_filter,iptable_nat,iptable_mangle,iptable_raw, Live 0x0000000000000000\n"), nil
+			},
+			module:   "ip_tables",
+			expected: true,
+		},
+		{
+			name: "module absent in data",
+			readFile: func(name string) ([]byte, error) {
+				return []byte("nf_tables 245760 2 nft_compat,xt_set, Live 0x0000000000000000\n"), nil
+			},
+			module:   "ip_tables",
+			expected: false,
+		},
+		{
+			name: "read file returns error",
+			readFile: func(name string) ([]byte, error) {
+				return nil, os.ErrNotExist
+			},
+			module:   "ip_tables",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origReadFile := _readFile
+			_readFile = tt.readFile
+			t.Cleanup(func() {
+				_readFile = origReadFile
+			})
+
+			assert.Equal(t, tt.expected, moduleLoaded(tt.module))
+		})
+	}
 }

--- a/scripts/ci-release-app.sh
+++ b/scripts/ci-release-app.sh
@@ -68,18 +68,30 @@ function create_release() {
     # Clean up backup files
     find output/tmp/release -name "*.bak" -type f -delete
 
-    # Package the Helm charts
+    # Package the Helm charts that have a corresponding HelmChart CR in the release directory
     for CHART in nginx-app redis-app; do
         if [ -d "e2e/helm-charts/$CHART" ]; then
-            echo "Packaging Helm chart: $CHART..."
-            helm package -u e2e/helm-charts/$CHART -d output/tmp/release
+            # Only package the chart if a HelmChart CR referencing it exists in the release YAMLs
+            has_cr=false
+            for f in "$RELEASE_YAML_DIR"/*.yaml; do
+                if [ -f "$f" ] && grep -q "kind: HelmChart" "$f" && grep -q "name: $CHART" "$f"; then
+                    has_cr=true
+                    break
+                fi
+            done
+            if [ "$has_cr" = true ]; then
+                echo "Packaging Helm chart: $CHART..."
+                helm package -u e2e/helm-charts/$CHART -d output/tmp/release
 
-            # Get the packaged chart filename
-            CHART_FILENAME=$(find output/tmp/release -name "$CHART-*.tgz" -type f | head -1)
-            if [ -n "$CHART_FILENAME" ]; then
-                echo "Created Helm chart package: $CHART_FILENAME"
+                # Get the packaged chart filename
+                CHART_FILENAME=$(find output/tmp/release -name "$CHART-*.tgz" -type f | head -1)
+                if [ -n "$CHART_FILENAME" ]; then
+                    echo "Created Helm chart package: $CHART_FILENAME"
+                else
+                    echo "Warning: Failed to create Helm chart package for $CHART"
+                fi
             else
-                echo "Warning: Failed to create Helm chart package for $CHART"
+                echo "Skipping Helm chart '$CHART': no matching HelmChart CR found in $RELEASE_YAML_DIR"
             fi
         else
             echo "Helm chart directory not found at e2e/helm-charts/$CHART"


### PR DESCRIPTION
## Summary

- Adds host capability detection (`pkg/helpers/kernel`) to determine if legacy iptables or nftables is available
- Conditionally sets `kube-proxy` mode to `nftables` on hosts lacking legacy iptables (kernel 6.17+)
- Updates preflights to accept either `ip_tables` (legacy) or `nf_tables`+`nft_compat` (nftables) backend
- Makes kernel module loading graceful — skips modules that don't exist instead of failing
- Adds `nf_tables` and `nft_compat` to the static modules-load config

## Test Plan

- [ ] Unit tests for `DetectIPTablesBackend` covering all 6 return paths (legacy via proc, legacy via modprobe, legacy via /proc/modules fallback, nftables, unknown, nftables without nft_compat)
- [ ] Unit tests for `ApplyHostK0sConfigOverrides` covering BackendNFT, BackendLegacy, detection error, nil guards
- [ ] Preflight template test verifying netfilter backend collector and analyzer
- [ ] Hostutils test verifying graceful module skip and new module list
- [ ] Full regression: `go test ./pkg/helpers/kernel/... ./pkg/config/... ./pkg-new/k0s/... ./pkg-new/preflights/... ./pkg-new/hostutils/... ./cmd/installer/cli/...`
- [ ] E2E on legacy-capable host (zero behavior change expected)
- [ ] Manual test on nftables-only host (e.g., AL2023 with kernel 6.18)

## Backwards Compatibility

- Legacy-capable hosts (ip_tables present): zero behavior change
- nftables-only hosts (ip_tables absent, nf_tables+nft_compat present): passes preflight + kube-proxy nftables mode
- Hosts with neither backend: still fails preflight (clearer message)