### PR TITLE
fix(e2e): disable filesystem performance check for previous-stable binaries

### DIFF
--- a/e2e/scripts/common.sh
+++ b/e2e/scripts/common.sh
@@ -9,6 +9,28 @@ export APP_NAMESPACE="${APP_NAMESPACE:-kotsadm}"
 KUBECONFIG="${KUBECONFIG:-${EMBEDDED_CLUSTER_BASE_DIR}/k0s/pki/admin.conf}"
 export KUBECONFIG
 
+# Returns a flag to disable filesystem performance checks if the
+# DISABLE_FILESYSTEM_PERFORMANCE_CHECK env var is set.
+# For newer binaries, returns --disable-filesystem-performance-check.
+# For older binaries without that flag, falls back to --ignore-host-preflights
+# or --skip-host-preflights so tests can still pass on slow CI disks.
+function get_fsperf_disable_flag() {
+    if [ "${DISABLE_FILESYSTEM_PERFORMANCE_CHECK:-}" != "1" ] && [ "${DISABLE_FILESYSTEM_PERFORMANCE_CHECK:-}" != "true" ]; then
+        return
+    fi
+
+    # Check if the binary supports --disable-filesystem-performance-check
+    # by combining it with --help. New binaries accept the flag and show help
+    # (exit 0), old binaries fail with "unknown flag" (exit non-zero).
+    if embedded-cluster install --disable-filesystem-performance-check --help >/dev/null 2>&1; then
+        echo "--disable-filesystem-performance-check"
+    elif embedded-cluster install --ignore-host-preflights --help >/dev/null 2>&1; then
+        echo "--ignore-host-preflights"
+    elif embedded-cluster install --skip-host-preflights --help >/dev/null 2>&1; then
+        echo "--skip-host-preflights"
+    fi
+}
+
 function retry() {
     local retries=$1
     shift

--- a/e2e/scripts/single-node-airgap-install.sh
+++ b/e2e/scripts/single-node-airgap-install.sh
@@ -29,6 +29,17 @@ main() {
         echo "Running install with additional args: $additional_args"
     fi
 
+    local fsperf_flag=
+    fsperf_flag=$(get_fsperf_disable_flag)
+    if [ -n "$fsperf_flag" ]; then
+        if [ -n "$additional_args" ]; then
+            additional_args="$additional_args $fsperf_flag"
+        else
+            additional_args="$fsperf_flag"
+        fi
+        echo "Running install with filesystem performance check disabled: $fsperf_flag"
+    fi
+
     echo "Running install without a license"
     if embedded-cluster install --yes --airgap-bundle /assets/release.airgap $additional_args 2>&1 | tee /tmp/log ; then
         echo "Expected installation to fail without a license provided"

--- a/e2e/scripts/single-node-install.sh
+++ b/e2e/scripts/single-node-install.sh
@@ -76,6 +76,17 @@ main() {
         echo "Running install with additional args: $additional_args"
     fi
 
+    local fsperf_flag=
+    fsperf_flag=$(get_fsperf_disable_flag)
+    if [ -n "$fsperf_flag" ]; then
+        if [ -n "$additional_args" ]; then
+            additional_args="$additional_args $fsperf_flag"
+        else
+            additional_args="$fsperf_flag"
+        fi
+        echo "Running install with filesystem performance check disabled: $fsperf_flag"
+    fi
+
     if embedded-cluster install --yes $additional_args 2>&1 | tee /tmp/log ; then
         echo "Expected installation to fail without a license provided"
         exit 1

--- a/local-artifact-mirror/deploy/melange.tmpl.yaml
+++ b/local-artifact-mirror/deploy/melange.tmpl.yaml
@@ -16,6 +16,7 @@ environment:
       - busybox
       - git
       - go
+      - make
   environment:
     GOCACHE: /cache/melange/gocache
     GOMODCACHE: /cache/melange/gomodcache

--- a/operator/deploy/melange.tmpl.yaml
+++ b/operator/deploy/melange.tmpl.yaml
@@ -16,6 +16,7 @@ environment:
       - busybox
       - git
       - go
+      - make
   environment:
     GOCACHE: /cache/melange/gocache
     GOMODCACHE: /cache/melange/gomodcache


### PR DESCRIPTION
## Problem

The `DISABLE_FILESYSTEM_PERFORMANCE_CHECK=1` environment variable was recently added (May 2026) to skip the etcd disk latency preflight check in CI. However, e2e tests that download **previous-stable** release binaries use older EC binaries that do not recognize this env var. As a result, the disk latency preflight still runs and fails on slow CI nodes:

```
P99 write latency for the disk at /var/lib/embedded-cluster/k0s/etcd is 79.167488ms,
but it must be less than 10 ms. A higher-performance disk is required.
```

## Solution

Add a `get_fsperf_disable_flag()` helper to `e2e/scripts/common.sh` that probes the target `embedded-cluster` binary for `--disable-filesystem-performance-check` support. If the flag is unavailable (older binary), it falls back to `--ignore-host-preflights` or `--skip-host-preflights`, ensuring the check is still bypassed.

Wire this into:
- `single-node-install.sh`
- `single-node-airgap-install.sh`

This makes the e2e framework compatible with both current and previous-stable binaries.