### PR TITLE
fix: disable SSA for operator chart upgrade to avoid CRD ownership conflict

### DIFF
--- a/pkg/addons/embeddedclusteroperator/install.go
+++ b/pkg/addons/embeddedclusteroperator/install.go
@@ -28,7 +28,11 @@ func (e *EmbeddedClusterOperator) Install(
 		Values:       values,
 		Namespace:    e.Namespace(),
 		Labels:       getBackupLabels(),
-		LogFn:        helm.LogFn(logf),
+		// CRDs are bootstrapped by kubeutils.EnsureInstallationCRD before this runs, which claims SSA
+		// field ownership under "embedded-cluster" and conflicts with Helm 4's default server-side apply
+		// on .metadata.annotations.controller-gen.kubebuilder.io/version. Mirrors the upgrade path.
+		DisableSSA: true,
+		LogFn:      helm.LogFn(logf),
 	}
 
 	if e.DryRun {

--- a/pkg/addons/embeddedclusteroperator/upgrade.go
+++ b/pkg/addons/embeddedclusteroperator/upgrade.go
@@ -42,7 +42,12 @@ func (e *EmbeddedClusterOperator) Upgrade(
 		Namespace:    e.Namespace(),
 		Labels:       getBackupLabels(),
 		Force:        false,
-		LogFn:        helm.LogFn(logf),
+		// CRDs are bootstrapped by kubeutils.EnsureInstallationCRD before this runs, which claims SSA
+		// field ownership under "embedded-cluster". Server-side apply on the chart's bundled CRDs
+		// then conflicts on .metadata.annotations.controller-gen.kubebuilder.io/version. Disabling
+		// SSA falls back to client-side apply, matching the Helm 3 behavior this chart was designed against.
+		DisableSSA: true,
+		LogFn:      helm.LogFn(logf),
 	})
 	if err != nil {
 		return errors.Wrap(err, "helm upgrade")


### PR DESCRIPTION
## Summary

- Set `DisableSSA: true` on the embedded-cluster-operator addon's Helm upgrade so it uses client-side apply, matching the Helm 3 behavior the chart's dual-management pattern was designed against.
- Fixes the `TestSingleNodeUpgradePreviousStable` failure across all k8s variants (1.33, 1.34, 1.35) on the 2.18.0 release.

## Root cause

The operator chart bundles its CRDs as a subchart, while `kubeutils.EnsureInstallationCRD` also installs/updates those same CRDs via the controller-runtime client before the chart upgrade runs. Under Helm 3 (client-side apply) this dual-write was invisible — last write wins, no field ownership tracking. Helm 4's default move to server-side apply surfaces it as a hard error because `controller-runtime`'s `client.Update` claims SSA ownership under field manager `"embedded-cluster"`, and Helm then conflicts on:

```
.metadata.annotations.controller-gen.kubebuilder.io/version
```

on both `configs.embeddedcluster.replicated.com` and `installations.embeddedcluster.replicated.com`. Helm rolls the operator release back, the cluster stays on the previous operator version, kotsadm detects a version mismatch with the 2.18.0 payload, and the e2e Playwright test times out on "Deploy".

Verified directly from the support bundle of [run 26047432390](https://github.com/replicatedhq/embedded-cluster/actions/runs/26047432390) (`embedded-cluster-upgrade-*` pod logs) — same error string across 5 deterministic retries.

## Scope

Operator addon only. Storage upgraded cleanly in the failing run, so SSA isn't broken globally — only this dual-managed resource. Other addons retain SSA. If a downstream addon turns out to have the same pattern, we can add the flag there separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)