### PR TITLE
Ensure all API calls to replicated saas have user-agent header

### DIFF
--- a/cmd/installer/cli/release.go
+++ b/cmd/installer/cli/release.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/replicatedhq/embedded-cluster/pkg/versions"
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 )
 
@@ -41,6 +42,7 @@ func getCurrentAppChannelRelease(ctx context.Context, license *kotsv1beta1.Licen
 
 	auth := fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", license.Spec.LicenseID, license.Spec.LicenseID))))
 	req.Header.Set("Authorization", auth)
+	req.Header.Set("User-Agent", fmt.Sprintf("Embedded-Cluster/%s", versions.Version))
 
 	// This will use the proxy from the environment if set by the cli command.
 	client := &http.Client{

--- a/cmd/installer/cli/release.go
+++ b/cmd/installer/cli/release.go
@@ -42,7 +42,7 @@ func getCurrentAppChannelRelease(ctx context.Context, license *kotsv1beta1.Licen
 
 	auth := fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", license.Spec.LicenseID, license.Spec.LicenseID))))
 	req.Header.Set("Authorization", auth)
-	req.Header.Set("User-Agent", fmt.Sprintf("Embedded-Cluster/%s", versions.Version))
+	req.Header.Set("User-Agent", versions.UserAgent())
 
 	// This will use the proxy from the environment if set by the cli command.
 	client := &http.Client{

--- a/cmd/local-artifact-mirror/pull_binaries.go
+++ b/cmd/local-artifact-mirror/pull_binaries.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/replicatedhq/embedded-cluster/pkg/versions"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -178,6 +179,7 @@ func doBinaryRequest(url, licenseID string) (io.ReadCloser, error) {
 
 	// Set basic auth with license ID
 	req.SetBasicAuth(licenseID, licenseID)
+	req.Header.Set("User-Agent", fmt.Sprintf("Embedded-Cluster/%s", versions.Version))
 
 	// Make the request
 	resp, err := http.DefaultClient.Do(req)

--- a/cmd/local-artifact-mirror/pull_binaries.go
+++ b/cmd/local-artifact-mirror/pull_binaries.go
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/replicatedhq/embedded-cluster/pkg/versions"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -179,7 +178,6 @@ func doBinaryRequest(url, licenseID string) (io.ReadCloser, error) {
 
 	// Set basic auth with license ID
 	req.SetBasicAuth(licenseID, licenseID)
-	req.Header.Set("User-Agent", fmt.Sprintf("Embedded-Cluster/%s", versions.Version))
 
 	// Make the request
 	resp, err := http.DefaultClient.Do(req)

--- a/operator/pkg/metadata/metadata.go
+++ b/operator/pkg/metadata/metadata.go
@@ -12,6 +12,7 @@ import (
 	"github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/operator/pkg/release"
 	"github.com/replicatedhq/embedded-cluster/pkg/artifacts"
+	"github.com/replicatedhq/embedded-cluster/pkg/versions"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -121,6 +122,7 @@ func getRemoteMetadataOnline(ctx context.Context, in *v1beta1.Installation) ([]b
 	if err != nil {
 		return nil, fmt.Errorf("new request: %w", err)
 	}
+	req.Header.Set("User-Agent", fmt.Sprintf("Embedded-Cluster/%s", versions.Version))
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/operator/pkg/metadata/metadata.go
+++ b/operator/pkg/metadata/metadata.go
@@ -122,7 +122,7 @@ func getRemoteMetadataOnline(ctx context.Context, in *v1beta1.Installation) ([]b
 	if err != nil {
 		return nil, fmt.Errorf("new request: %w", err)
 	}
-	req.Header.Set("User-Agent", fmt.Sprintf("Embedded-Cluster/%s", versions.Version))
+	req.Header.Set("User-Agent", versions.UserAgent())
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/operator/pkg/metrics/metrics.go
+++ b/operator/pkg/metrics/metrics.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/replicatedhq/embedded-cluster/pkg/versions"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -70,6 +71,7 @@ func sendEvent(ctx context.Context, evname, baseURL string, ev interface{}) erro
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", fmt.Sprintf("Embedded-Cluster/%s", versions.Version))
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to send event: %w", err)

--- a/operator/pkg/metrics/metrics.go
+++ b/operator/pkg/metrics/metrics.go
@@ -71,7 +71,7 @@ func sendEvent(ctx context.Context, evname, baseURL string, ev interface{}) erro
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", fmt.Sprintf("Embedded-Cluster/%s", versions.Version))
+	req.Header.Set("User-Agent", versions.UserAgent())
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to send event: %w", err)

--- a/operator/pkg/release/release.go
+++ b/operator/pkg/release/release.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gosimple/slug"
 	"github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	ectypes "github.com/replicatedhq/embedded-cluster/kinds/types"
+	"github.com/replicatedhq/embedded-cluster/pkg/versions"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -103,6 +104,7 @@ func remoteMetadataFor(ctx context.Context, in *v1beta1.Installation) (*ectypes.
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
+	req.Header.Set("User-Agent", fmt.Sprintf("Embedded-Cluster/%s", versions.Version))
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/operator/pkg/release/release.go
+++ b/operator/pkg/release/release.go
@@ -104,7 +104,7 @@ func remoteMetadataFor(ctx context.Context, in *v1beta1.Installation) (*ectypes.
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
-	req.Header.Set("User-Agent", fmt.Sprintf("Embedded-Cluster/%s", versions.Version))
+	req.Header.Set("User-Agent", versions.UserAgent())
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/pkg-new/replicatedapi/client.go
+++ b/pkg-new/replicatedapi/client.go
@@ -139,7 +139,7 @@ func (c *client) newRetryableRequest(ctx context.Context, method string, url str
 // injectHeaders injects the basic auth header, user agent header, and reporting info headers into the http.Header.
 func (c *client) injectHeaders(header http.Header) {
 	header.Set("Authorization", "Basic "+basicAuth(c.license.Spec.LicenseID, c.license.Spec.LicenseID))
-	header.Set("User-Agent", fmt.Sprintf("Embedded-Cluster/%s", versions.Version))
+	header.Set("User-Agent", versions.UserAgent())
 
 	c.injectReportingInfoHeaders(header)
 }

--- a/pkg/lint/api_client.go
+++ b/pkg/lint/api_client.go
@@ -121,7 +121,7 @@ func (c *APIClient) GetCustomDomains() ([]string, error) {
 
 	req.Header.Set("Authorization", c.apiToken)
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("User-Agent", fmt.Sprintf("Embedded-Cluster/%s", versions.Version))
+	req.Header.Set("User-Agent", versions.UserAgent())
 
 	resp, err := c.client.Do(req)
 	if err != nil {
@@ -208,7 +208,7 @@ func (c *APIClient) getDomainsFromChannelReleases() ([]string, error) {
 
 	req.Header.Set("Authorization", c.apiToken)
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("User-Agent", fmt.Sprintf("Embedded-Cluster/%s", versions.Version))
+	req.Header.Set("User-Agent", versions.UserAgent())
 
 	resp, err := c.client.Do(req)
 	if err != nil {
@@ -250,7 +250,7 @@ func (c *APIClient) getDomainsFromChannelReleases() ([]string, error) {
 
 		req.Header.Set("Authorization", c.apiToken)
 		req.Header.Set("Accept", "application/json")
-		req.Header.Set("User-Agent", fmt.Sprintf("Embedded-Cluster/%s", versions.Version))
+		req.Header.Set("User-Agent", versions.UserAgent())
 
 		resp, err := c.client.Do(req)
 		if err != nil {
@@ -315,7 +315,7 @@ func (c *APIClient) getDomainsFromApp() ([]string, error) {
 
 	req.Header.Set("Authorization", c.apiToken)
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("User-Agent", fmt.Sprintf("Embedded-Cluster/%s", versions.Version))
+	req.Header.Set("User-Agent", versions.UserAgent())
 
 	resp, err := c.client.Do(req)
 	if err != nil {

--- a/pkg/lint/api_client.go
+++ b/pkg/lint/api_client.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/replicatedhq/embedded-cluster/pkg/versions"
 )
 
 // APIClient handles communication with the Replicated API
@@ -119,6 +121,7 @@ func (c *APIClient) GetCustomDomains() ([]string, error) {
 
 	req.Header.Set("Authorization", c.apiToken)
 	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", fmt.Sprintf("Embedded-Cluster/%s", versions.Version))
 
 	resp, err := c.client.Do(req)
 	if err != nil {
@@ -205,6 +208,7 @@ func (c *APIClient) getDomainsFromChannelReleases() ([]string, error) {
 
 	req.Header.Set("Authorization", c.apiToken)
 	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", fmt.Sprintf("Embedded-Cluster/%s", versions.Version))
 
 	resp, err := c.client.Do(req)
 	if err != nil {
@@ -246,6 +250,7 @@ func (c *APIClient) getDomainsFromChannelReleases() ([]string, error) {
 
 		req.Header.Set("Authorization", c.apiToken)
 		req.Header.Set("Accept", "application/json")
+		req.Header.Set("User-Agent", fmt.Sprintf("Embedded-Cluster/%s", versions.Version))
 
 		resp, err := c.client.Do(req)
 		if err != nil {
@@ -310,6 +315,7 @@ func (c *APIClient) getDomainsFromApp() ([]string, error) {
 
 	req.Header.Set("Authorization", c.apiToken)
 	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", fmt.Sprintf("Embedded-Cluster/%s", versions.Version))
 
 	resp, err := c.client.Do(req)
 	if err != nil {

--- a/pkg/metrics/sender.go
+++ b/pkg/metrics/sender.go
@@ -3,10 +3,12 @@ package metrics
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/replicatedhq/embedded-cluster/pkg/metrics/types"
+	"github.com/replicatedhq/embedded-cluster/pkg/versions"
 	"github.com/sirupsen/logrus"
 )
 
@@ -25,6 +27,7 @@ func (s *Sender) Send(ctx context.Context, baseURL string, ev types.Event) {
 		return
 	}
 	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("User-Agent", fmt.Sprintf("Embedded-Cluster/%s", versions.Version))
 
 	client := &http.Client{
 		Timeout: 5 * time.Second,

--- a/pkg/metrics/sender.go
+++ b/pkg/metrics/sender.go
@@ -3,7 +3,6 @@ package metrics
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -27,7 +26,7 @@ func (s *Sender) Send(ctx context.Context, baseURL string, ev types.Event) {
 		return
 	}
 	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("User-Agent", fmt.Sprintf("Embedded-Cluster/%s", versions.Version))
+	request.Header.Set("User-Agent", versions.UserAgent())
 
 	client := &http.Client{
 		Timeout: 5 * time.Second,

--- a/pkg/versions/versions.go
+++ b/pkg/versions/versions.go
@@ -1,6 +1,10 @@
 // Package versions
 package versions
 
+import (
+	"fmt"
+)
+
 var (
 	// Version holds the EmbeddedCluster version.
 	Version = "v0.0.0"
@@ -24,3 +28,7 @@ var (
 	// time using LD_FLAGS in the Makefile
 	OperatorBinaryURLOverride string
 )
+
+func UserAgent() string {
+	return fmt.Sprintf("Embedded-Cluster/%s", Version)
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
Ensure all API calls to replicated SAAS have user agent headers. Some APIs like the ones used to fetch releases filter based on the version of the client making the API call

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
