### PR TITLE
chore: bump k0s-oldest TODO markers by one minor

### DIFF
--- a/e2e/shared.go
+++ b/e2e/shared.go
@@ -341,7 +341,7 @@ func checkPostUpgradeStateWithOptions(t *testing.T, tc cluster.Cluster, opts pos
 
 // checkContainerdRegistryConfigAbsent asserts the containerd registry drop-in is
 // absent: online installs don't use the in-cluster registry.
-// TODO(k0s-1.36-oldest): drop this check along with the migration.
+// TODO(k0s-1.37-oldest): drop this check along with the migration.
 func checkContainerdRegistryConfigAbsent(t *testing.T, tc cluster.Cluster, node int) {
 	t.Logf("%s: verifying containerd registry drop-in is absent on node %d", time.Now().Format(time.RFC3339), node)
 	line := []string{"test", "!", "-f", "/etc/k0s/containerd.d/embedded-registry.toml"}

--- a/operator/pkg/artifacts/upgrade.go
+++ b/operator/pkg/artifacts/upgrade.go
@@ -68,7 +68,7 @@ var copyArtifactsJob = &batchv1.Job{
 						// containerd config so it can reconcile the registry drop-in for the
 						// containerd v1 -> v2 (k0s 1.36+) schema change before k0s restarts:
 						// migrate it on airgap, delete it on online.
-						// TODO(k0s-1.36-oldest): drop this mount and the migration.
+						// TODO(k0s-1.37-oldest): drop this mount and the migration.
 						Name: "etc-k0s",
 						VolumeSource: corev1.VolumeSource{
 							HostPath: &corev1.HostPathVolumeSource{
@@ -111,7 +111,7 @@ var copyArtifactsJobCommandOnline = []string{
 		// Remove the registry drop-in before k0s 1.36 restarts (it rejects the legacy
 		// schema); online doesn't use the in-cluster registry. Run the freshly-pulled
 		// target binary, not the image's /usr/local/bin copy.
-		// TODO(k0s-1.36-oldest): drop this migration.
+		// TODO(k0s-1.37-oldest): drop this migration.
 		"/embedded-cluster/bin/local-artifact-mirror migrate-containerd-config; \n" +
 		"sleep 10; \n" + // wait for LAM to restart so k0s can pull from it. LAM restarts when it detects an EC binary update.
 		"echo 'done'",

--- a/pkg-new/hostutils/containerd.go
+++ b/pkg-new/hostutils/containerd.go
@@ -14,7 +14,7 @@ import (
 
 // registryConfigTemplateV2 skips TLS verification for the airgap registry on
 // containerd 1.7.x (k0s 1.34/1.35), using the legacy io.containerd.grpc.v1.cri path.
-// TODO(k0s-1.36-oldest): drop the v2 templates and useContainerdV3Schema.
+// TODO(k0s-1.37-oldest): drop the v2 templates and useContainerdV3Schema.
 const registryConfigTemplateV2 = `
 [plugins."io.containerd.grpc.v1.cri".registry]
   [plugins."io.containerd.grpc.v1.cri".registry.configs]

--- a/pkg-new/preflights/specs/host-preflight-common.yaml
+++ b/pkg-new/preflights/specs/host-preflight-common.yaml
@@ -223,7 +223,7 @@ spec:
     - jsonCompare:
         checkName: Cgroups
         # Lenient v1-or-v2 check for k8s <= 1.34; 1.35+ uses the strict "Cgroup
-        # Version" check below. TODO(k0s-1.35-oldest): drop this and the gate.
+        # Version" check below. TODO(k0s-1.36-oldest): drop this and the gate.
         exclude: '{{ .RequiresCgroupV2 }}'
         fileName: host-collectors/system/cgroups.json
         path: 'cgroup-enabled'
@@ -386,7 +386,7 @@ spec:
               when: "false"
               message: "'umount' command must exist in PATH"
     # k8s 1.35+ needs kernel >= 4.5 (cgroup v2); older minors keep the 3.10 floor.
-    # TODO(k0s-1.35-oldest): drop the legacy 3.10 check and the gate.
+    # TODO(k0s-1.36-oldest): drop the legacy 3.10 check and the gate.
     - hostOS:
         checkName: Kernel Version
         exclude: '{{ not .RequiresCgroupV2 }}'

--- a/pkg/config/images.go
+++ b/pkg/config/images.go
@@ -12,7 +12,7 @@ import (
 // version-specific airgap.GetImageURIs call (its signature changed in k0s 1.36)
 // is isolated in the build-tagged allK0sImageURIs; see images_targetenv.go and
 // images_legacy.go.
-// TODO(k0s-1.36-oldest): once the oldest supported minor is >= 1.36, drop
+// TODO(k0s-1.37-oldest): once the oldest supported minor is >= 1.37, drop
 // images_legacy.go + the build tag and inline the call here.
 func ListK0sImages(cfg *k0sv1beta1.ClusterConfig) []string {
 	var images []string

--- a/pkg/config/images_legacy.go
+++ b/pkg/config/images_legacy.go
@@ -10,7 +10,7 @@ import (
 // allK0sImageURIs returns the full set of k0s image URIs for k0s <= 1.35, where
 // airgap.GetImageURIs takes a bare *ClusterSpec. Selected by the
 // k0s_legacy_airgap build tag (see images.go).
-// TODO(k0s-1.36-oldest): drop this file and the build tag.
+// TODO(k0s-1.37-oldest): drop this file and the build tag.
 func allK0sImageURIs(cfg *k0sv1beta1.ClusterConfig) []string {
 	return airgap.GetImageURIs(cfg.Spec, true)
 }

--- a/versions.mk
+++ b/versions.mk
@@ -74,7 +74,7 @@ check-k0s-version:
 # sub-builds (which include this file) pick it up. K0S_MINOR_VERSION is the source of
 # truth: the build re-pins go.mod to K0S_GO_VERSION for the selected minor.
 # Assumes common.mk (which defines GO_BUILD_TAGS) is included before this file.
-# TODO(k0s-1.36-oldest): drop this gate when the oldest supported minor is >= 1.36.
+# TODO(k0s-1.37-oldest): drop this gate when the oldest supported minor is >= 1.37.
 GO_INSTALLER_BUILD_TAGS := osusergo,netgo
 ifeq ($(shell [ "$(K0S_MINOR_VERSION)" -lt 36 ] && echo legacy),legacy)
 GO_BUILD_TAGS := $(GO_BUILD_TAGS),k0s_legacy_airgap


### PR DESCRIPTION
#### What this PR does / why we need it:
Migration/legacy code must survive while the prior minor is still supported (e.g. 1.35→1.36 upgrades still need the containerd migration), so each marker can only be dropped one minor later than first assumed:
  TODO(k0s-1.36-oldest) -> TODO(k0s-1.37-oldest)
  TODO(k0s-1.35-oldest) -> TODO(k0s-1.36-oldest)

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
