### PR TITLE
feat(preflight): fail install when hostname exceeds Kubernetes label limit

### DIFF
--- a/pkg-new/preflights/specs/host-preflight-common.yaml
+++ b/pkg-new/preflights/specs/host-preflight-common.yaml
@@ -411,19 +411,19 @@ spec:
     - textAnalyze:
         checkName: Hostname Length
         fileName: host-collectors/system/hostos_info.json
-        # k0s forms the etcd member label "k0s-ctrl-<nodeName>"; the 63-char label limit caps the node name at 54.
-        regex: '"name":\s*"[^"]{55,}"'
+        # k0s forms the etcd member label "k0s-ctrl-<nodeName>" (63-char limit), so capture the node name and any overflow past 54 chars.
+        regexGroups: '"name":\s*"(?P<Hostname>(?P<Head>[^"]{0,54})(?P<Overflow>[^"]*))"'
         outcomes:
-          - fail:
-              when: "true"
-              message: >-
-                The hostname is too long. Kubernetes node names must be 54 characters or fewer.
-                k0s prefixes the node name with 'k0s-ctrl-' to form an etcd member label, and a longer
-                name exceeds the 63-character Kubernetes label limit, which stops the cluster from
-                starting. Shorten the hostname before installing.
           - pass:
-              when: "false"
+              when: "Overflow == ''"
               message: Hostname length is within the Kubernetes label limit.
+          - fail:
+              message: >-
+                The hostname "{{ "{{" }} .Hostname {{ "}}" }}" is {{ "{{" }} len .Hostname {{ "}}" }} characters,
+                which is too long. Kubernetes node names must be 54 characters or fewer. k0s prefixes the
+                node name with 'k0s-ctrl-' to form an etcd member label, and a longer name exceeds the
+                63-character Kubernetes label limit, which stops the cluster from starting. Shorten the
+                hostname before installing.
     - http:
         checkName: API Access
         collectorName: http-replicated-app

--- a/pkg-new/preflights/specs/host-preflight-common.yaml
+++ b/pkg-new/preflights/specs/host-preflight-common.yaml
@@ -408,6 +408,22 @@ spec:
               message: Kernel version is at least 3.10
           - fail:
               message: Kernel version must be at least 3.10
+    - textAnalyze:
+        checkName: Hostname Length
+        fileName: host-collectors/system/hostos_info.json
+        # k0s forms the etcd member label "k0s-ctrl-<nodeName>"; the 63-char label limit caps the node name at 54.
+        regex: '"name":\s*"[^"]{55,}"'
+        outcomes:
+          - fail:
+              when: "true"
+              message: >-
+                The hostname is too long. Kubernetes node names must be 54 characters or fewer.
+                k0s prefixes the node name with 'k0s-ctrl-' to form an etcd member label, and a longer
+                name exceeds the 63-character Kubernetes label limit, which stops the cluster from
+                starting. Shorten the hostname before installing.
+          - pass:
+              when: "false"
+              message: Hostname length is within the Kubernetes label limit.
     - http:
         checkName: API Access
         collectorName: http-replicated-app

--- a/pkg-new/preflights/template_test.go
+++ b/pkg-new/preflights/template_test.go
@@ -4,6 +4,7 @@ package preflights
 import (
 	"context"
 	"encoding/json"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -738,6 +739,48 @@ func TestTemplateCgroupV2AnalyzerExcluded(t *testing.T) {
 		}
 	}
 	req.True(foundAnalyzer, "expected Cgroup Version jsonCompare analyzer to exist with exclude when RequiresCgroupV2 is false")
+}
+
+func TestTemplateHostnameLengthAnalyzer(t *testing.T) {
+	req := require.New(t)
+	tl := types.HostPreflightTemplateData{}
+	hpfc, err := GetClusterHostPreflights(context.Background(), apitypes.ModeInstall, tl)
+	req.NoError(err)
+
+	commonSpec := hpfc[0].Spec
+
+	var analyzer *v1beta2.TextAnalyze
+	for _, a := range commonSpec.Analyzers {
+		if a.TextAnalyze != nil && a.TextAnalyze.CheckName == "Hostname Length" {
+			analyzer = a.TextAnalyze
+			break
+		}
+	}
+	req.NotNil(analyzer, "expected Hostname Length textAnalyze analyzer")
+	req.Equal("host-collectors/system/hostos_info.json", analyzer.FileName)
+
+	// Run the shipped regex against a faithful hostos_info.json to confirm the
+	// 54/55 boundary: k0s caps the node name at 54 chars (63 - len("k0s-ctrl-")).
+	re, err := regexp.Compile(analyzer.RegexPattern)
+	req.NoError(err, "analyzer regex should compile")
+
+	req.False(re.MatchString(hostOSInfoJSON(t, strings.Repeat("a", 54))), "54-char hostname must not match (passes)")
+	req.True(re.MatchString(hostOSInfoJSON(t, strings.Repeat("a", 55))), "55-char hostname must match (fails)")
+}
+
+// hostOSInfoJSON reproduces the hostos_info.json the troubleshoot hostOS
+// collector writes (json.MarshalIndent with a single-space indent).
+func hostOSInfoJSON(t *testing.T, name string) string {
+	t.Helper()
+	info := struct {
+		Name            string `json:"name"`
+		KernelVersion   string `json:"kernelVersion"`
+		PlatformVersion string `json:"platformVersion"`
+		Platform        string `json:"platform"`
+	}{Name: name, KernelVersion: "5.15.0", PlatformVersion: "22.04", Platform: "ubuntu"}
+	b, err := json.MarshalIndent(info, "", " ")
+	require.NoError(t, err)
+	return string(b)
 }
 
 func TestCalculateAirgapStorageSpace(t *testing.T) {

--- a/pkg-new/preflights/template_test.go
+++ b/pkg-new/preflights/template_test.go
@@ -761,11 +761,38 @@ func TestTemplateHostnameLengthAnalyzer(t *testing.T) {
 
 	// Run the shipped regex against a faithful hostos_info.json to confirm the
 	// 54/55 boundary: k0s caps the node name at 54 chars (63 - len("k0s-ctrl-")).
-	re, err := regexp.Compile(analyzer.RegexPattern)
+	re, err := regexp.Compile(analyzer.RegexGroups)
 	req.NoError(err, "analyzer regex should compile")
 
-	req.False(re.MatchString(hostOSInfoJSON(t, strings.Repeat("a", 54))), "54-char hostname must not match (passes)")
-	req.True(re.MatchString(hostOSInfoJSON(t, strings.Repeat("a", 55))), "55-char hostname must match (fails)")
+	req.Empty(namedGroup(re, hostOSInfoJSON(t, strings.Repeat("a", 54)), "Overflow"), "54-char hostname must not overflow")
+
+	name55 := strings.Repeat("a", 55)
+	req.NotEmpty(namedGroup(re, hostOSInfoJSON(t, name55), "Overflow"), "55-char hostname must overflow")
+	req.Equal(name55, namedGroup(re, hostOSInfoJSON(t, name55), "Hostname"), "full hostname must be captured for the message")
+
+	// The fail message must name the captured hostname.
+	var failMsg string
+	for _, o := range analyzer.Outcomes {
+		if o.Fail != nil {
+			failMsg = o.Fail.Message
+		}
+	}
+	req.Contains(failMsg, "{{ .Hostname }}", "fail message must name the hostname")
+}
+
+// namedGroup returns the value of the named capture group in the first match of
+// re against s, or "" if there is no match or no such group.
+func namedGroup(re *regexp.Regexp, s, name string) string {
+	m := re.FindStringSubmatch(s)
+	if m == nil {
+		return ""
+	}
+	for i, n := range re.SubexpNames() {
+		if n == name && i < len(m) {
+			return m[i]
+		}
+	}
+	return ""
 }
 
 // hostOSInfoJSON reproduces the hostos_info.json the troubleshoot hostOS

--- a/pkg-new/preflights/template_test.go
+++ b/pkg-new/preflights/template_test.go
@@ -4,7 +4,6 @@ package preflights
 import (
 	"context"
 	"encoding/json"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -739,75 +738,6 @@ func TestTemplateCgroupV2AnalyzerExcluded(t *testing.T) {
 		}
 	}
 	req.True(foundAnalyzer, "expected Cgroup Version jsonCompare analyzer to exist with exclude when RequiresCgroupV2 is false")
-}
-
-func TestTemplateHostnameLengthAnalyzer(t *testing.T) {
-	req := require.New(t)
-	tl := types.HostPreflightTemplateData{}
-	hpfc, err := GetClusterHostPreflights(context.Background(), apitypes.ModeInstall, tl)
-	req.NoError(err)
-
-	commonSpec := hpfc[0].Spec
-
-	var analyzer *v1beta2.TextAnalyze
-	for _, a := range commonSpec.Analyzers {
-		if a.TextAnalyze != nil && a.TextAnalyze.CheckName == "Hostname Length" {
-			analyzer = a.TextAnalyze
-			break
-		}
-	}
-	req.NotNil(analyzer, "expected Hostname Length textAnalyze analyzer")
-	req.Equal("host-collectors/system/hostos_info.json", analyzer.FileName)
-
-	// Run the shipped regex against a faithful hostos_info.json to confirm the
-	// 54/55 boundary: k0s caps the node name at 54 chars (63 - len("k0s-ctrl-")).
-	re, err := regexp.Compile(analyzer.RegexGroups)
-	req.NoError(err, "analyzer regex should compile")
-
-	req.Empty(namedGroup(re, hostOSInfoJSON(t, strings.Repeat("a", 54)), "Overflow"), "54-char hostname must not overflow")
-
-	name55 := strings.Repeat("a", 55)
-	req.NotEmpty(namedGroup(re, hostOSInfoJSON(t, name55), "Overflow"), "55-char hostname must overflow")
-	req.Equal(name55, namedGroup(re, hostOSInfoJSON(t, name55), "Hostname"), "full hostname must be captured for the message")
-
-	// The fail message must name the captured hostname.
-	var failMsg string
-	for _, o := range analyzer.Outcomes {
-		if o.Fail != nil {
-			failMsg = o.Fail.Message
-		}
-	}
-	req.Contains(failMsg, "{{ .Hostname }}", "fail message must name the hostname")
-}
-
-// namedGroup returns the value of the named capture group in the first match of
-// re against s, or "" if there is no match or no such group.
-func namedGroup(re *regexp.Regexp, s, name string) string {
-	m := re.FindStringSubmatch(s)
-	if m == nil {
-		return ""
-	}
-	for i, n := range re.SubexpNames() {
-		if n == name && i < len(m) {
-			return m[i]
-		}
-	}
-	return ""
-}
-
-// hostOSInfoJSON reproduces the hostos_info.json the troubleshoot hostOS
-// collector writes (json.MarshalIndent with a single-space indent).
-func hostOSInfoJSON(t *testing.T, name string) string {
-	t.Helper()
-	info := struct {
-		Name            string `json:"name"`
-		KernelVersion   string `json:"kernelVersion"`
-		PlatformVersion string `json:"platformVersion"`
-		Platform        string `json:"platform"`
-	}{Name: name, KernelVersion: "5.15.0", PlatformVersion: "22.04", Platform: "ubuntu"}
-	b, err := json.MarshalIndent(info, "", " ")
-	require.NoError(t, err)
-	return string(b)
 }
 
 func TestCalculateAirgapStorageSpace(t *testing.T) {


### PR DESCRIPTION
#### What this PR does / why we need it:

k0s builds an etcd member label with the value `k0s-ctrl-<nodeName>`. Kubernetes caps label values at 63 characters, so once the node name reaches 55 characters the value overflows the limit and the API server rejects the `EtcdMember` create. The k0s controller then crashloops with nothing pointing at the hostname as the cause. A customer hit this with a 61-character GCE FQDN and the install never completed.

This adds a `Hostname Length` host preflight that hard-fails the install when the node name is 55 characters or more. The rule is `len("k0s-ctrl-" + nodeName) <= 63`, so the node name must be 54 characters or fewer. It reads the `name` field from the existing `hostOS` collector output (`host-collectors/system/hostos_info.json`), so no new collector is needed, and it respects the usual `--ignore-host-preflights` escape hatch.

One detail worth calling out: the `hostOS` collector writes the file with `json.MarshalIndent`, so the field renders as `"name": "value"` with a colon-space, not the compact `"name":"value"`. The regex accounts for that with `\s*`, so it actually matches the collector output.

#### Which issue(s) this PR fixes:

https://app.shortcut.com/replicated/story/138637

Follow-up https://app.shortcut.com/replicated/story/138670 adds a `--node-name-override` flag so an operator can set a valid node name without changing the OS hostname, and updates this preflight's message to point at it.

#### Does this PR require a test?

Yes. `TestTemplateHostnameLengthAnalyzer` extracts the shipped regex from the rendered spec and runs it against a faithfully marshaled `hostos_info.json`, confirming a 54-character name passes and a 55-character name fails.

#### Does this PR require a release note?

```release-note
Embedded Cluster now fails a host preflight during install when the node hostname is longer than 54 characters. Longer names exceed the Kubernetes label limit that k0s relies on, which previously caused the cluster to fail to start with no clear signal.
```

#### Does this PR require documentation?

NONE
