### PR TITLE
almalinux was removed from CMX, disable selinux tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -975,7 +975,6 @@ jobs:
       matrix:
         test:
           - TestSingleNodeAirgapAppOnlyUpgrade
-          - TestSingleNodeAirgapUpgradeSelinux
           - TestMultiNodeAirgapUpgradePreviousStable
           - TestSingleNodeAirgapDisasterRecovery
           - TestMultiNodeAirgapHADisasterRecovery

--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -554,7 +554,6 @@ jobs:
       fail-fast: false
       matrix:
         test:
-          - TestSingleNodeAirgapUpgradeSelinux
           - TestMultiNodeAirgapUpgradePreviousStable
           - TestSingleNodeAirgapDisasterRecovery
           - TestMultiNodeAirgapHADisasterRecovery

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -261,6 +261,7 @@ func TestUpgradeFromReplicatedAppPreviousK0s(t *testing.T) {
 }
 
 func TestSingleNodeAirgapUpgradeSelinux(t *testing.T) {
+	t.Skip("almalinux distribution was removed from Compatibility Matrix")
 	t.Parallel()
 
 	RequireEnvVars(t, []string{"SHORT_SHA"})


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
CI tests fail due to almalinux not being a supported CMX distribution.  Disable those tests so that CI can pass, until we find an alternative for SELinux tests.


#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
Partial fix for [sc-138684]


#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE