### PR TITLE
chore: comment out selinux tests for embedded cluster

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -975,7 +975,9 @@ jobs:
       matrix:
         test:
           - TestSingleNodeAirgapAppOnlyUpgrade
-          - TestSingleNodeAirgapUpgradeSelinux
+          # TODO: Commenting out as we have not almalinux runners in CMX anymore. Comment back in or remove
+          # once we resolve https://app.shortcut.com/replicated/story/138684/selinux-tests-for-embedded-cluster-v2
+          # - TestSingleNodeAirgapUpgradeSelinux
           - TestMultiNodeAirgapUpgradePreviousStable
           - TestSingleNodeAirgapDisasterRecovery
           - TestMultiNodeAirgapHADisasterRecovery

--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -554,7 +554,9 @@ jobs:
       fail-fast: false
       matrix:
         test:
-          - TestSingleNodeAirgapUpgradeSelinux
+          # TODO: Commenting out as we have not almalinux runners in CMX anymore. Comment back in or remove
+          # once we resolve https://app.shortcut.com/replicated/story/138684/selinux-tests-for-embedded-cluster-v2
+          # - TestSingleNodeAirgapUpgradeSelinux
           - TestMultiNodeAirgapUpgradePreviousStable
           - TestSingleNodeAirgapDisasterRecovery
           - TestMultiNodeAirgapHADisasterRecovery


### PR DESCRIPTION
#### What this PR does / why we need it:
Comment out e2e tests that require almalinux nodes in CMX. These were recently removed

#### Which issue(s) this PR fixes:

https://app.shortcut.com/replicated/story/138684/selinux-tests-for-embedded-cluster-v2

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
