### PR TITLE
fix(reset): continue to k0s reset even when k0s stop fails

### DIFF
--- a/cmd/installer/cli/reset.go
+++ b/cmd/installer/cli/reset.go
@@ -193,9 +193,7 @@ func ResetCmd(ctx context.Context, appTitle string) *cobra.Command {
 				return fmt.Errorf("failed to remove proxy worker config directory: %w", err)
 			}
 
-			// Belt-and-suspenders: explicitly remove the k0s unit files. k0s reset
-			// normally handles this, but if it failed (e.g. due to EBUSY), a stale
-			// unit will prevent the next install from succeeding.
+			// Remove k0s unit files explicitly in case k0s reset failed to do so.
 			if err := helpers.RemoveAll("/etc/systemd/system/k0scontroller.service"); err != nil {
 				return fmt.Errorf("failed to remove k0scontroller service file: %w", err)
 			}
@@ -618,9 +616,7 @@ func stopAndResetK0s(dataDir string) error {
 
 	out, err := helpers.RunCommand(k0sBinPath, "stop")
 	if err != nil {
-		// Log and continue — k0s reset must still run to unmount kubelet pod-volume
-		// mounts. Skipping it causes subsequent RemoveAll calls to hit EBUSY and
-		// leave stale files (binary, systemd unit) that block the next install.
+		// k0s reset must still run to unmount kubelet pod-volume mounts.
 		logrus.Warnf("Failed to stop k0s (continuing with reset anyway): %v, %s", err, out)
 	}
 	out, err = helpers.RunCommand(k0sBinPath, "reset", "--data-dir", dataDir)

--- a/cmd/installer/cli/reset.go
+++ b/cmd/installer/cli/reset.go
@@ -193,6 +193,16 @@ func ResetCmd(ctx context.Context, appTitle string) *cobra.Command {
 				return fmt.Errorf("failed to remove proxy worker config directory: %w", err)
 			}
 
+			// Belt-and-suspenders: explicitly remove the k0s unit files. k0s reset
+			// normally handles this, but if it failed (e.g. due to EBUSY), a stale
+			// unit will prevent the next install from succeeding.
+			if err := helpers.RemoveAll("/etc/systemd/system/k0scontroller.service"); err != nil {
+				return fmt.Errorf("failed to remove k0scontroller service file: %w", err)
+			}
+			if err := helpers.RemoveAll("/etc/systemd/system/k0sworker.service"); err != nil {
+				return fmt.Errorf("failed to remove k0sworker service file: %w", err)
+			}
+
 			// Now that k0s is nested under the data directory, we see the following error in the
 			// dev environment because k0s is mounted in the docker container:
 			//  "failed to remove embedded cluster directory: remove k0s: unlinkat /var/lib/embedded-cluster/k0s: device or resource busy"
@@ -608,7 +618,10 @@ func stopAndResetK0s(dataDir string) error {
 
 	out, err := helpers.RunCommand(k0sBinPath, "stop")
 	if err != nil {
-		return fmt.Errorf("could not stop k0s service: %w, %s", err, out)
+		// Log and continue — k0s reset must still run to unmount kubelet pod-volume
+		// mounts. Skipping it causes subsequent RemoveAll calls to hit EBUSY and
+		// leave stale files (binary, systemd unit) that block the next install.
+		logrus.Warnf("Failed to stop k0s (continuing with reset anyway): %v, %s", err, out)
 	}
 	out, err = helpers.RunCommand(k0sBinPath, "reset", "--data-dir", dataDir)
 	if err != nil {


### PR DESCRIPTION
#### What this PR does / why we need it:

When `k0s stop` fails (e.g. due to slow disks causing etcd to time out), `stopAndResetK0s` was returning early and skipping `k0s reset`. `k0s reset` is what unmounts kubelet pod-volume mounts; without it, subsequent `RemoveAll` calls hit `EBUSY` and silently leave stale files behind. Reset then reboots anyway, leaving the host with a stale binary or `k0scontroller.service` that blocks the next install.

Fix by logging the stop failure and continuing to `k0s reset`. Also explicitly remove `k0scontroller.service` and `k0sworker.service` after the k0s reset call so that even if `k0s reset` itself fails, the unit files cannot survive to block reinstall.

#### Which issue(s) this PR fixes:
Fixes https://app.shortcut.com/replicated/story/138696

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Make <installer> reset resilient to k0s stop command failure
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
