### PR TITLE
Reinstate TestSingleNodeAirgapUpgradeSelinux on ubuntu

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -975,6 +975,7 @@ jobs:
       matrix:
         test:
           - TestSingleNodeAirgapAppOnlyUpgrade
+          - TestSingleNodeAirgapUpgradeSelinux
           - TestMultiNodeAirgapUpgradePreviousStable
           - TestSingleNodeAirgapDisasterRecovery
           - TestMultiNodeAirgapHADisasterRecovery

--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -558,6 +558,7 @@ jobs:
           - TestSingleNodeAirgapDisasterRecovery
           - TestMultiNodeAirgapHADisasterRecovery
           - TestSingleNodeAirgapAppOnlyUpgrade
+          - TestSingleNodeAirgapUpgradeSelinux
         include:
           - test: TestVersion
             is-lxd: true

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ $ export KUBECONFIG="/var/lib/embedded-cluster/k0s/pki/admin.conf"
 $ export PATH="$PATH:/var/lib/embedded-cluster/bin"
 $ source <(kubectl completion bash)
 $ source /etc/bash_completion
-$ 
+$
 ```
 
 ### Creating additional nodes
@@ -140,12 +140,6 @@ make create-node1
 ```
 
 These additional nodes can either be joined to your existing Embedded Cluster installation, or used to set up separate, independent Embedded Cluster instances.
-
-By default, a Debian-based node will be created. If you want to use a different distribution, you can set the `DISTRO` environment variable:
-
-```bash
-make create-node0 DISTRO=almalinux-8
-```
 
 To view the list of available distributions:
 

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -268,8 +268,9 @@ func TestUpgradeFromReplicatedAppPreviousK0s(t *testing.T) {
 // The mount_t rules let the mount command resolve /proc/<kubelet-pid>/fd/N
 // magic links (labeled with kubelet's domain, initrc_t) which kubelet uses as
 // bind mount sources when preparing subPath volume mounts, and tear them down
-// again. The initrc_t rules let ingress-nginx's LuaJIT generate code at
-// runtime (execmem) and use anonymous memfd files (self:file).
+// again. The initrc_t rules mirror what container-selinux grants all
+// container domains: runtime code generation (execmem, needed by JIT runtimes
+// such as ingress-nginx's LuaJIT) and anonymous memfd files (self:file).
 const ecSelinuxPolicy = `module ec-selinux 1.2;
 
 require {

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -260,6 +260,30 @@ func TestUpgradeFromReplicatedAppPreviousK0s(t *testing.T) {
 	t.Logf("%s: test complete", time.Now().Format(time.RFC3339))
 }
 
+// kubeletSubpathPolicy allows the mount command (mount_t) to resolve
+// /proc/<kubelet-pid>/fd/N magic links (labeled with kubelet's domain,
+// initrc_t) which kubelet uses as bind mount sources when preparing subPath
+// volume mounts, as well as tear them down again.
+const kubeletSubpathPolicy = `module ec-kubelet-subpath 1.1;
+
+require {
+	type mount_t;
+	type initrc_t;
+	type initrc_runtime_t;
+	type tmpfs_t;
+	class dir search;
+	class file { read getattr mounton };
+	class lnk_file read;
+	class filesystem unmount;
+}
+
+allow mount_t initrc_t:dir search;
+allow mount_t initrc_t:file read;
+allow mount_t initrc_t:lnk_file read;
+allow mount_t initrc_runtime_t:file { getattr mounton };
+allow mount_t tmpfs_t:filesystem unmount;
+`
+
 func TestSingleNodeAirgapUpgradeSelinux(t *testing.T) {
 	t.Parallel()
 
@@ -313,6 +337,20 @@ func TestSingleNodeAirgapUpgradeSelinux(t *testing.T) {
 	tc.WaitForReboot()
 
 	waitForSelinuxEnabled(t, tc, 0)
+
+	// kubelet bind mounts subPath volumes through /proc/<pid>/fd/N magic
+	// links, which ubuntu's selinux reference policy does not allow the mount
+	// command (mount_t) to resolve, silently (dontaudit) failing containers
+	// with subPath volume mounts. install a policy module allowing this.
+	t.Logf("%s: installing selinux policy module for kubelet subpath mounts", time.Now().Format(time.RFC3339))
+	if stdout, stderr, err := tc.RunCommandOnNode(0, []string{
+		"cat > /tmp/ec-kubelet-subpath.te <<'EOF'\n" + kubeletSubpathPolicy + "EOF\n" +
+			"checkmodule -M -m -o /tmp/ec-kubelet-subpath.mod /tmp/ec-kubelet-subpath.te && " +
+			"semodule_package -o /tmp/ec-kubelet-subpath.pp -m /tmp/ec-kubelet-subpath.mod && " +
+			"sudo semodule -i /tmp/ec-kubelet-subpath.pp",
+	}); err != nil {
+		t.Fatalf("fail to install selinux policy module on node %s: %v: %s: %s", tc.Nodes[0], err, stdout, stderr)
+	}
 
 	t.Logf("%s: airgapping cluster", time.Now().Format(time.RFC3339))
 	if err := tc.Airgap(); err != nil {

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -261,7 +261,6 @@ func TestUpgradeFromReplicatedAppPreviousK0s(t *testing.T) {
 }
 
 func TestSingleNodeAirgapUpgradeSelinux(t *testing.T) {
-	t.Skip("almalinux distribution was removed from Compatibility Matrix")
 	t.Parallel()
 
 	RequireEnvVars(t, []string{"SHORT_SHA"})
@@ -269,8 +268,8 @@ func TestSingleNodeAirgapUpgradeSelinux(t *testing.T) {
 	tc := cmx.NewCluster(&cmx.ClusterInput{
 		T:            t,
 		Nodes:        1,
-		Distribution: "almalinux",
-		Version:      "9",
+		Distribution: "ubuntu",
+		Version:      "24.04",
 	})
 	defer tc.Cleanup()
 
@@ -285,10 +284,25 @@ func TestSingleNodeAirgapUpgradeSelinux(t *testing.T) {
 		},
 	)
 
-	t.Logf("%s: installing policycoreutils-python-utils", time.Now().Format(time.RFC3339))
-	if stdout, stderr, err := tc.RunCommandOnNode(0, []string{"sudo dnf makecache --refresh && sudo dnf install -y policycoreutils-python-utils"}); err != nil {
-		t.Fatalf("fail to install policycoreutils-python-utils on node %s: %v: %s: %s", tc.Nodes[0], err, stdout, stderr)
+	t.Logf("%s: installing selinux packages", time.Now().Format(time.RFC3339))
+	if stdout, stderr, err := tc.RunCommandOnNode(0, []string{"sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y selinux-basics selinux-policy-default auditd policycoreutils-python-utils"}); err != nil {
+		t.Fatalf("fail to install selinux packages on node %s: %v: %s: %s", tc.Nodes[0], err, stdout, stderr)
 	}
+
+	// ubuntu ships with apparmor; selinux-activate configures the bootloader to
+	// boot with selinux enabled in permissive mode and schedules a filesystem
+	// relabel on the next boot
+	t.Logf("%s: activating selinux", time.Now().Format(time.RFC3339))
+	if stdout, stderr, err := tc.RunCommandOnNode(0, []string{"sudo selinux-activate"}); err != nil {
+		t.Fatalf("fail to activate selinux on node %s: %v: %s: %s", tc.Nodes[0], err, stdout, stderr)
+	}
+
+	t.Logf("%s: rebooting node to relabel the filesystem", time.Now().Format(time.RFC3339))
+	// the ssh connection is dropped by the reboot so an error is expected
+	tc.RunCommandOnNode(0, []string{"sudo reboot"})
+	tc.WaitForReboot()
+
+	waitForSelinuxEnabled(t, tc, 0)
 
 	t.Logf("%s: airgapping cluster", time.Now().Format(time.RFC3339))
 	if err := tc.Airgap(); err != nil {
@@ -296,7 +310,7 @@ func TestSingleNodeAirgapUpgradeSelinux(t *testing.T) {
 	}
 
 	t.Logf("%s: setting selinux to Enforcing mode", time.Now().Format(time.RFC3339))
-	if stdout, stderr, err := tc.RunCommandOnNode(0, []string{"setenforce 1"}); err != nil {
+	if stdout, stderr, err := tc.RunCommandOnNode(0, []string{"setenforce 1 && getenforce"}); err != nil || !strings.Contains(stdout, "Enforcing") {
 		t.Fatalf("fail to set selinux to Enforcing mode %s: %v: %s: %s", tc.Nodes[0], err, stdout, stderr)
 	}
 

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -284,8 +284,18 @@ func TestSingleNodeAirgapUpgradeSelinux(t *testing.T) {
 		},
 	)
 
+	// apparmor may not be installed at all so this is best-effort
+	t.Logf("%s: deactivating and uninstalling apparmor", time.Now().Format(time.RFC3339))
+	if stdout, stderr, err := tc.RunCommandOnNode(0, []string{
+		"sudo systemctl disable --now apparmor 2>/dev/null; sudo DEBIAN_FRONTEND=noninteractive apt-get purge -y apparmor 2>/dev/null; true",
+	}); err != nil {
+		t.Fatalf("fail to uninstall apparmor on node %s: %v: %s: %s", tc.Nodes[0], err, stdout, stderr)
+	}
+
 	t.Logf("%s: installing selinux packages", time.Now().Format(time.RFC3339))
-	if stdout, stderr, err := tc.RunCommandOnNode(0, []string{"sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y selinux-basics selinux-policy-default auditd policycoreutils-python-utils"}); err != nil {
+	if stdout, stderr, err := tc.RunCommandOnNode(0, []string{
+		"sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y selinux-basics selinux-policy-default auditd policycoreutils-python-utils",
+	}); err != nil {
 		t.Fatalf("fail to install selinux packages on node %s: %v: %s: %s", tc.Nodes[0], err, stdout, stderr)
 	}
 

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -260,11 +260,17 @@ func TestUpgradeFromReplicatedAppPreviousK0s(t *testing.T) {
 	t.Logf("%s: test complete", time.Now().Format(time.RFC3339))
 }
 
-// kubeletSubpathPolicy allows the mount command (mount_t) to resolve
-// /proc/<kubelet-pid>/fd/N magic links (labeled with kubelet's domain,
-// initrc_t) which kubelet uses as bind mount sources when preparing subPath
-// volume mounts, as well as tear them down again.
-const kubeletSubpathPolicy = `module ec-kubelet-subpath 1.1;
+// ecSelinuxPolicy covers the operations embedded cluster workloads need that
+// ubuntu's selinux reference policy denies. On RHEL derivatives these are
+// granted by container-selinux, which has no ubuntu equivalent. k0s and all
+// containers run in the generic initrc_t domain.
+//
+// The mount_t rules let the mount command resolve /proc/<kubelet-pid>/fd/N
+// magic links (labeled with kubelet's domain, initrc_t) which kubelet uses as
+// bind mount sources when preparing subPath volume mounts, and tear them down
+// again. The initrc_t rules let ingress-nginx's LuaJIT generate code at
+// runtime (execmem) and use anonymous memfd files (self:file).
+const ecSelinuxPolicy = `module ec-selinux 1.2;
 
 require {
 	type mount_t;
@@ -272,9 +278,10 @@ require {
 	type initrc_runtime_t;
 	type tmpfs_t;
 	class dir search;
-	class file { read getattr mounton };
+	class file { read write create open getattr map mounton };
 	class lnk_file read;
 	class filesystem unmount;
+	class process execmem;
 }
 
 allow mount_t initrc_t:dir search;
@@ -282,6 +289,9 @@ allow mount_t initrc_t:file read;
 allow mount_t initrc_t:lnk_file read;
 allow mount_t initrc_runtime_t:file { getattr mounton };
 allow mount_t tmpfs_t:filesystem unmount;
+
+allow initrc_t self:process execmem;
+allow initrc_t self:file { read write create open getattr map };
 `
 
 func TestSingleNodeAirgapUpgradeSelinux(t *testing.T) {
@@ -338,16 +348,14 @@ func TestSingleNodeAirgapUpgradeSelinux(t *testing.T) {
 
 	waitForSelinuxEnabled(t, tc, 0)
 
-	// kubelet bind mounts subPath volumes through /proc/<pid>/fd/N magic
-	// links, which ubuntu's selinux reference policy does not allow the mount
-	// command (mount_t) to resolve, silently (dontaudit) failing containers
-	// with subPath volume mounts. install a policy module allowing this.
-	t.Logf("%s: installing selinux policy module for kubelet subpath mounts", time.Now().Format(time.RFC3339))
+	// install a policy module allowing operations that ubuntu's selinux
+	// reference policy denies; see ecSelinuxPolicy for details.
+	t.Logf("%s: installing selinux policy module for embedded cluster workloads", time.Now().Format(time.RFC3339))
 	if stdout, stderr, err := tc.RunCommandOnNode(0, []string{
-		"cat > /tmp/ec-kubelet-subpath.te <<'EOF'\n" + kubeletSubpathPolicy + "EOF\n" +
-			"checkmodule -M -m -o /tmp/ec-kubelet-subpath.mod /tmp/ec-kubelet-subpath.te && " +
-			"semodule_package -o /tmp/ec-kubelet-subpath.pp -m /tmp/ec-kubelet-subpath.mod && " +
-			"sudo semodule -i /tmp/ec-kubelet-subpath.pp",
+		"cat > /tmp/ec-selinux.te <<'EOF'\n" + ecSelinuxPolicy + "EOF\n" +
+			"checkmodule -M -m -o /tmp/ec-selinux.mod /tmp/ec-selinux.te && " +
+			"semodule_package -o /tmp/ec-selinux.pp -m /tmp/ec-selinux.mod && " +
+			"sudo semodule -i /tmp/ec-selinux.pp",
 	}); err != nil {
 		t.Fatalf("fail to install selinux policy module on node %s: %v: %s: %s", tc.Nodes[0], err, stdout, stderr)
 	}

--- a/e2e/shared.go
+++ b/e2e/shared.go
@@ -262,6 +262,27 @@ func checkWorkerProfile(t *testing.T, tc cluster.Cluster, node int) {
 	}
 }
 
+// waitForSelinuxEnabled waits for selinux to report enabled on the node. The
+// filesystem relabel scheduled by selinux-activate triggers an additional
+// reboot, so ssh may drop while polling.
+func waitForSelinuxEnabled(t *testing.T, tc cluster.Cluster, node int) {
+	t.Logf("%s: waiting for selinux to be enabled on node %d", time.Now().Format(time.RFC3339), node)
+	timeout := time.After(10 * time.Minute)
+	tick := time.Tick(10 * time.Second)
+	for {
+		select {
+		case <-timeout:
+			stdout, stderr, err := tc.RunCommandOnNode(node, []string{"getenforce"})
+			t.Fatalf("timeout waiting for selinux to be enabled on node %d: %v: %s: %s", node, err, stdout, stderr)
+		case <-tick:
+			stdout, _, err := tc.RunCommandOnNode(node, []string{"getenforce"})
+			if err == nil && strings.Contains(stdout, "Permissive") {
+				return
+			}
+		}
+	}
+}
+
 func checkNodeJoinCommand(t *testing.T, tc cluster.Cluster, node int) {
 	t.Logf("node join command generation on node %d", node)
 	line := []string{"/usr/local/bin/check-node-join-command.sh"}


### PR DESCRIPTION
#### What this PR does / why we need it:

Reinstates `TestSingleNodeAirgapUpgradeSelinux`, which was disabled in #3793 because AlmaLinux (the only Red Hat derivative, and therefore the only SELinux-enabled distribution) was removed from Compatibility Matrix.

CMX now only offers Ubuntu, which ships with AppArmor and no SELinux, so the test bootstraps SELinux itself before installing Embedded Cluster:

- Deactivates and uninstalls AppArmor if present (best-effort).
- Installs the SELinux packages (`selinux-basics`, `selinux-policy-default`, `auditd`, `policycoreutils-python-utils`).
- Activates SELinux via `selinux-activate` and reboots to relabel the filesystem, waiting for SELinux to report enabled (new `waitForSelinuxEnabled` helper, tolerant of the extra relabel reboot).
- Compiles and loads a small SELinux policy module (`ec-selinux`) covering operations that Ubuntu's reference policy denies but RHEL's `container-selinux` (which has no Ubuntu equivalent) grants:
  - `mount_t` resolving `/proc/<kubelet-pid>/fd/N` magic links, which kubelet uses as bind mount sources when preparing `subPath` volume mounts (the denial is dontaudited, so containers with subPath mounts — e.g. `kotsadm-rqlite` — fail silently with `CreateContainerConfigError`).
  - Runtime code generation (`execmem`) and anonymous memfd files for container processes, mirroring what container-selinux grants all container domains (surfaced by ingress-nginx's LuaJIT, which panics without it).
- Airgaps the node and sets enforcing mode, verifying with `getenforce`.

The rest of the test (labeling the EC binary directory with `semanage`, airgap install, app deploy, airgap upgrade) is unchanged. The test is re-added to the e2e matrices in `ci.yaml` and `release-prod.yaml`.

Validation: the policy module was derived from live AVC captures on a CMX Ubuntu 24.04 node and validated under enforcing mode including k0s restart, node reboot (module persists), and deleting all pods across all namespaces. The full e2e test passes locally end to end (install → app deploy → airgap upgrade k0s 1.35→1.36 → containerd v3 schema check) in ~26 minutes.

#### Which issue(s) this PR fixes:

https://app.shortcut.com/replicated/story/138684

#### Does this PR require a test?

This PR is itself a test change (reinstates an e2e test).

#### Does this PR require a release note?

```release-note
NONE
```

#### Does this PR require documentation?

NONE