### PR TITLE
ci: set explicit author/committer on automated PRs

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -81,6 +81,8 @@ jobs:
       uses: peter-evans/create-pull-request@v8
       with:
         token: ${{ secrets.GH_PAT }}
+        author: replicated-ci-ec <replicated-ci-ec@replicated.com>
+        committer: replicated-ci-ec <replicated-ci-ec@replicated.com>
         commit-message: Update Makefile versions
         title: 'Update Makefile versions'
         branch: automation/update-makefile

--- a/.github/workflows/image-deps-updater.yaml
+++ b/.github/workflows/image-deps-updater.yaml
@@ -103,6 +103,8 @@ jobs:
         id: cpr
         with:
           token: ${{ secrets.GH_PAT }}
+          author: replicated-ci-ec <replicated-ci-ec@replicated.com>
+          committer: replicated-ci-ec <replicated-ci-ec@replicated.com>
           commit-message: 'Update image versions'
           title: "chore: update ${{ matrix.addon }} images"
           branch: ${{ steps.determine-target.outputs.target_branch }}
@@ -162,6 +164,8 @@ jobs:
         id: cpr
         with:
           token: ${{ secrets.GH_PAT }}
+          author: replicated-ci-ec <replicated-ci-ec@replicated.com>
+          committer: replicated-ci-ec <replicated-ci-ec@replicated.com>
           commit-message: 'Update image versions'
           title: "chore: update k0s images"
           branch: ${{ steps.determine-target.outputs.target_branch }}

--- a/.github/workflows/update-addons.yaml
+++ b/.github/workflows/update-addons.yaml
@@ -100,6 +100,8 @@ jobs:
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GH_PAT }}
+          author: replicated-ci-ec <replicated-ci-ec@replicated.com>
+          committer: replicated-ci-ec <replicated-ci-ec@replicated.com>
           commit-message: updated ${{ matrix.addon }} version
           title: "feat: update ${{ matrix.addon }} version"
           branch: ${{ steps.determine-target.outputs.target_branch }}


### PR DESCRIPTION
## What

Set explicit `author:` and `committer:` on all `peter-evans/create-pull-request` steps in the automation workflows:

- `.github/workflows/dependencies.yaml`
- `.github/workflows/update-addons.yaml`
- `.github/workflows/image-deps-updater.yaml` (2 steps)

## Why

These workflows don't set an `author:` input, so the action falls back to its default:

```
author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
```

For `schedule`-triggered runs there is no triggering user, so GitHub sets `github.actor` to **the user who last modified the `cron` syntax in the workflow file**. In these workflows the `cron:` lines haven't changed since the files were created (later edits, e.g. dependabot bumps, don't touch the schedule), so `github.actor` is effectively frozen to that original author. The result is that every automated PR commit (e.g. #3804) is stamped with that person's name/noreply email — even though the PR is opened and pushed by the `replicated-ci-ec` machine account via `secrets.GH_PAT`. This only affects git commit-author metadata.

Pinning `author`/`committer` to `replicated-ci-ec` attributes automation commits consistently, independent of who last touched the cron schedule.