### PR TITLE
fix: ensure registry secret creation handles existing secrets correctly

### DIFF
--- a/operator/pkg/artifacts/registry.go
+++ b/operator/pkg/artifacts/registry.go
@@ -40,13 +40,11 @@ func EnsureRegistrySecretInECNamespace(ctx context.Context, cli client.Client, i
 	}
 
 	op, err = ctrl.CreateOrUpdate(ctx, cli, obj, func() error {
-		if in.GetUID() != "" {
-			err := ctrl.SetControllerReference(in, obj, cli.Scheme())
-			if err != nil {
-				return fmt.Errorf("set controller reference: %w", err)
-			}
-		}
-
+		// Note: this secret is intentionally not owned by the Installation. It is shared
+		// across installations and its lifecycle is not tied to any single one of them. Old
+		// Installations are never deleted (only marked obsolete), so a controller reference set
+		// here would eventually point at a stale/obsolete Installation and cause every
+		// subsequent update to fail with an AlreadyOwnedError.
 		obj.Labels = applyECOperatorLabels(obj.Labels, "upgrader")
 
 		obj.Type = corev1.SecretTypeDockerConfigJson

--- a/operator/pkg/artifacts/registry_test.go
+++ b/operator/pkg/artifacts/registry_test.go
@@ -1,0 +1,81 @@
+package artifacts
+
+import (
+	"context"
+	"testing"
+
+	clusterv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestEnsureRegistrySecretInECNamespace(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, clusterv1beta1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	kotsadmSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      RegistryCredsSecretName,
+			Namespace: "kotsadm",
+		},
+		Data: map[string][]byte{".dockerconfigjson": []byte("some-creds")},
+	}
+
+	currentInstallation := &clusterv1beta1.Installation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "current-installation",
+			UID:  "current-uid",
+		},
+	}
+
+	t.Run("owned by an obsolete installation does not error", func(t *testing.T) {
+		obsoleteInstallation := &clusterv1beta1.Installation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "obsolete-installation",
+				UID:  "obsolete-uid",
+			},
+		}
+
+		existingSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      RegistryCredsSecretName,
+				Namespace: ecNamespace,
+			},
+			Type: corev1.SecretTypeDockerConfigJson,
+		}
+		require.NoError(t, ctrl.SetControllerReference(obsoleteInstallation, existingSecret, scheme))
+
+		cli := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(kotsadmSecret, existingSecret).
+			Build()
+
+		_, err := EnsureRegistrySecretInECNamespace(context.Background(), cli, currentInstallation)
+		require.NoError(t, err)
+
+		var got corev1.Secret
+		require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: RegistryCredsSecretName, Namespace: ecNamespace}, &got))
+		require.Equal(t, kotsadmSecret.Data, got.Data)
+	})
+
+	t.Run("no existing secret creates one without an owner", func(t *testing.T) {
+		cli := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(kotsadmSecret).
+			Build()
+
+		_, err := EnsureRegistrySecretInECNamespace(context.Background(), cli, currentInstallation)
+		require.NoError(t, err)
+
+		var got corev1.Secret
+		require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: RegistryCredsSecretName, Namespace: ecNamespace}, &got))
+		require.Empty(t, got.OwnerReferences)
+		require.Equal(t, kotsadmSecret.Data, got.Data)
+	})
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
Airgap app-only upgrades fail with `AlreadyOwnedError` when the `registry-creds` secret in the `embedded-cluster` namespace is controller-owned by an obsolete `Installation`. Obsolete Installations are never deleted (kept for history), so once an owner mismatch occurs, every subsequent app-only upgrade fails permanently until the owner reference is manually removed.

This secret is shared across installations and its lifecycle was never tied to Installation GC, so this PR stops setting a controller reference on it in `EnsureRegistrySecretInECNamespace`.

#### Which issue(s) this PR fixes:
https://app.shortcut.com/replicated/story/138799/fix-embedded-cluster-airgap-app-only-upgrade-fails-with-alreadyownederror-when-registry-creds-is-owned-by-an-obsolete-installation

#### Does this PR require a test?
Added `operator/pkg/artifacts/registry_test.go`, covering the previously-failing case (secret owned by a different/obsolete Installation) and the no-owner-reference case.

#### Does this PR require a release note?
```release-note
Fix airgap app-only upgrades failing with AlreadyOwnedError when the registry-creds secret is owned by an obsolete Installation
```

#### Does this PR require documentation?
NONE
