### PR TITLE
build(deps): add missing k8s.io/cri-streaming replace directive in kinds

### DIFF
--- a/kinds/go.mod
+++ b/kinds/go.mod
@@ -167,6 +167,7 @@ replace (
 	k8s.io/controller-manager => k8s.io/controller-manager v0.36.2
 	k8s.io/cri-api => k8s.io/cri-api v0.36.2
 	k8s.io/cri-client => k8s.io/cri-client v0.36.2
+	k8s.io/cri-streaming => k8s.io/cri-streaming v0.36.2
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.36.2
 	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.36.2
 	k8s.io/endpointslice => k8s.io/endpointslice v0.36.2


### PR DESCRIPTION
k8s.io/cri-streaming is a Kubernetes staging module that needs to be mirrored in the replace block alongside the other k8s.io staging repos. Without it, `go list -m -u` fails with:

```
go: k8s.io/cri-streaming@v0.0.0: invalid version: unknown revision v0.0.0
```

Add the missing replace directive to keep the k8s.io module versions consistent.