### PR TITLE
fix: stream k0s stop/reset output to logs live

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -237,7 +237,10 @@ jobs:
         uses: azure/setup-helm@v5
         with:
           version: ${{ needs.output-vars.outputs.helm_version }}
-      - name: Fix registries.conf format # go.podman.io/image/v5 5.40.0+ rejects the runner's v1-format file
+      # go.podman.io/image/v5 5.40.0+ rejects the runner's v1-format registries.conf.
+      # Fixed upstream but not yet rolled out to ubuntu-latest as of 2026-08-07; remove
+      # once it is: https://github.com/actions/runner-images/issues/14406
+      - name: Fix registries.conf format
         run: &fix-registries-conf |
           sudo tee /etc/containers/registries.conf > /dev/null <<'EOF'
           unqualified-search-registries = ["docker.io"]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -237,6 +237,11 @@ jobs:
         uses: azure/setup-helm@v5
         with:
           version: ${{ needs.output-vars.outputs.helm_version }}
+      - name: Fix registries.conf format # go.podman.io/image/v5 5.40.0+ rejects the runner's v1-format file
+        run: &fix-registries-conf |
+          sudo tee /etc/containers/registries.conf > /dev/null <<'EOF'
+          unqualified-search-registries = ["docker.io"]
+          EOF
       - name: Run tests
         run: |
           export VERSION=${{ needs.output-vars.outputs.ec_version }}
@@ -267,6 +272,8 @@ jobs:
         uses: azure/setup-helm@v5
         with:
           version: ${{ needs.output-vars.outputs.helm_version }}
+      - name: Fix registries.conf format
+        run: *fix-registries-conf
       - name: Run tests
         run: |
           export VERSION=${{ needs.output-vars.outputs.ec_version }}

--- a/cmd/installer/cli/reset.go
+++ b/cmd/installer/cli/reset.go
@@ -614,14 +614,32 @@ func stopAndResetK0s(dataDir string) error {
 		return nil
 	}
 
-	out, err := helpers.RunCommand(k0sBinPath, "stop")
+	stopOut := &lineLogWriter{prefix: "k0s stop"}
+	err := helpers.RunCommandWithOptions(helpers.RunCommandOptions{Stdout: stopOut, Stderr: stopOut}, k0sBinPath, "stop", "--verbose")
 	if err != nil {
 		// k0s reset must still run to unmount kubelet pod-volume mounts.
-		logrus.Warnf("Failed to stop k0s (continuing with reset anyway): %v, %s", err, out)
+		logrus.Warnf("Failed to stop k0s (continuing with reset anyway): %v", err)
 	}
-	out, err = helpers.RunCommand(k0sBinPath, "reset", "--data-dir", dataDir)
+
+	resetOut := &lineLogWriter{prefix: "k0s reset"}
+	err = helpers.RunCommandWithOptions(helpers.RunCommandOptions{Stdout: resetOut, Stderr: resetOut}, k0sBinPath, "reset", "--data-dir", dataDir, "--verbose")
 	if err != nil {
-		return fmt.Errorf("could not reset k0s: %w, %s", err, out)
+		return fmt.Errorf("could not reset k0s: %w", err)
 	}
 	return nil
+}
+
+// lineLogWriter streams command output to logrus as it is written, so that
+// partial output is captured in the logs even if the command is interrupted.
+type lineLogWriter struct {
+	prefix string
+}
+
+func (w *lineLogWriter) Write(p []byte) (int, error) {
+	for _, line := range strings.Split(strings.TrimRight(string(p), "\n"), "\n") {
+		if line != "" {
+			logrus.Debugf("%s: %s", w.prefix, line)
+		}
+	}
+	return len(p), nil
 }

--- a/cmd/installer/cli/reset.go
+++ b/cmd/installer/cli/reset.go
@@ -615,14 +615,14 @@ func stopAndResetK0s(dataDir string) error {
 	}
 
 	stopOut := &lineLogWriter{prefix: "k0s stop"}
-	err := helpers.RunCommandWithOptions(helpers.RunCommandOptions{Stdout: stopOut, Stderr: stopOut}, k0sBinPath, "stop", "--verbose")
+	err := helpers.RunCommandWithOptions(helpers.RunCommandOptions{Stdout: stopOut, Stderr: stopOut, SkipLogOutput: true}, k0sBinPath, "stop", "--verbose")
 	if err != nil {
 		// k0s reset must still run to unmount kubelet pod-volume mounts.
 		logrus.Warnf("Failed to stop k0s (continuing with reset anyway): %v", err)
 	}
 
 	resetOut := &lineLogWriter{prefix: "k0s reset"}
-	err = helpers.RunCommandWithOptions(helpers.RunCommandOptions{Stdout: resetOut, Stderr: resetOut}, k0sBinPath, "reset", "--data-dir", dataDir, "--verbose")
+	err = helpers.RunCommandWithOptions(helpers.RunCommandOptions{Stdout: resetOut, Stderr: resetOut, SkipLogOutput: true}, k0sBinPath, "reset", "--data-dir", dataDir, "--verbose")
 	if err != nil {
 		return fmt.Errorf("could not reset k0s: %w", err)
 	}

--- a/local-artifact-mirror/deploy/melange.tmpl.yaml
+++ b/local-artifact-mirror/deploy/melange.tmpl.yaml
@@ -13,6 +13,7 @@ environment:
     keyring:
       - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
+      - bash
       - busybox
       - git
       - go

--- a/operator/deploy/melange.tmpl.yaml
+++ b/operator/deploy/melange.tmpl.yaml
@@ -13,6 +13,7 @@ environment:
     keyring:
       - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
+      - bash
       - busybox
       - git
       - go

--- a/pkg/helpers/command.go
+++ b/pkg/helpers/command.go
@@ -46,9 +46,11 @@ func (h *Helpers) RunCommandWithOptions(opts RunCommandOptions, bin string, args
 	cmd.Env = cmdEnv
 
 	if err := cmd.Run(); err != nil {
-		logrus.Debugf("failed to run command:")
-		logrus.Debugf("stdout: %s", stdout.String())
-		logrus.Debugf("stderr: %s", stderr.String())
+		if !opts.SkipLogOutput {
+			logrus.Debugf("failed to run command:")
+			logrus.Debugf("stdout: %s", stdout.String())
+			logrus.Debugf("stderr: %s", stderr.String())
+		}
 
 		// Check if it's a context error and return it instead
 		if ctx.Err() != nil {
@@ -60,7 +62,7 @@ func (h *Helpers) RunCommandWithOptions(opts RunCommandOptions, bin string, args
 		return err
 	}
 
-	if !opts.LogOnSuccess {
+	if !opts.LogOnSuccess || opts.SkipLogOutput {
 		return nil
 	}
 

--- a/pkg/helpers/interface.go
+++ b/pkg/helpers/interface.go
@@ -39,6 +39,10 @@ type RunCommandOptions struct {
 	Stdin io.Reader
 	// LogOnSuccess makes the command output to be logged even when it succeeds.
 	LogOnSuccess bool
+	// SkipLogOutput skips logging the captured stdout/stderr as a single blob on
+	// completion. Use this when Stdout/Stderr are already being logged as they're
+	// produced, to avoid duplicating the same output a second time.
+	SkipLogOutput bool
 }
 
 // Convenience functions


### PR DESCRIPTION
Previously stdout/stderr from `k0s stop`/`k0s reset` were buffered until the command exited, so an interrupted or hung call left no trace in the logs. Stream both to logrus live instead.

#### What this PR does / why we need it:
`k0s stop`/`k0s reset` output was only logged after the command returned. When one of these calls hangs (e.g. on orphaned processes holding kubelet volume mounts open), nothing is logged and there's no way to tell how far it got. This streams output line-by-line as it's produced, and adds `--verbose` to both commands for more detail. If one of the commands never completes, we can still see partial logs which would be helpful in troubleshooting.

How the logs will look like on disk
```sh
sudo cat /var/log/embedded-cluster/embedded-cluster-smoke-test-staging-app-20260807143644.890.log
time="2026-08-07T14:36:44Z" level=debug msg="command line: [./embedded-cluster-smoke-test-staging-app reset --force]"
time="2026-08-07T14:36:44Z" level=debug msg="Embedded Cluster: 2.19.3+k8s-1.36-18-g2b94, k0s: v1.36.2+k0s.0"
time="2026-08-07T14:36:45Z" level=debug msg="Got runtime config from installation with k0s data dir /var/lib/embedded-cluster/k0s"
time="2026-08-07T14:36:45Z" level=warning msg="This will remove this node from the cluster and completely reset it, removing all data stored on the node."
time="2026-08-07T14:36:45Z" level=warning msg="This node will also reboot. Do not reset another node until this is complete."
time="2026-08-07T14:36:45Z" level=info msg="Resetting node..."
time="2026-08-07T14:36:45Z" level=debug msg="running command: [systemctl list-unit-files k0scontroller.service]"
time="2026-08-07T14:36:45Z" level=debug msg="running command: [systemctl list-unit-files k0sworker.service]"
time="2026-08-07T14:36:45Z" level=debug msg="failed to run command:"
time="2026-08-07T14:36:45Z" level=debug msg="stdout: UNIT FILE STATE PRESET\n\n0 unit files listed.\n"
time="2026-08-07T14:36:45Z" level=debug msg="stderr: "
time="2026-08-07T14:36:45Z" level=debug msg="running command: [/usr/local/bin/k0s stop --verbose]"
time="2026-08-07T14:36:46Z" level=debug msg="running command: [/usr/local/bin/k0s reset --data-dir /var/lib/embedded-cluster/k0s --verbose]"
time="2026-08-07T14:36:47Z" level=debug msg="k0s reset: time=\"2026-08-07 14:36:47\" level=info msg=\"* containers steps\""
time="2026-08-07T14:36:47Z" level=debug msg="k0s reset: time=\"2026-08-07 14:36:47\" level=info msg=Staging path=/var/lib/embedded-cluster/k0s/bin/runc"
time="2026-08-07T14:36:47Z" level=debug msg="k0s reset: time=\"2026-08-07 14:36:47\" level=info msg=Staging path=/var/lib/embedded-cluster/k0s/bin/containerd-shim-runc-v2"
time="2026-08-07T14:36:47Z" level=debug msg="k0s reset: time=\"2026-08-07 14:36:47\" level=info msg=Staging path=/var/lib/embedded-cluster/k0s/bin/containerd"
time="2026-08-07T14:36:47Z" level=debug msg="k0s reset: time=\"2026-08-07 14:36:47\" level=info msg=\"Starting containerd\" component=containerd"
time="2026-08-07T14:36:47Z" level=debug msg="k0s reset: time=\"2026-08-07 14:36:47\" level=info msg=\"Starting to supervise\" component=containerd"
time="2026-08-07T14:36:47Z" level=debug msg="k0s reset: time=\"2026-08-07 14:36:47\" level=info msg=\"Started successfully, go nuts pid 3516\" component=containerd"
time="2026-08-07T14:36:47Z" level=debug msg="k0s reset: time=\"2026-08-07 14:36:47\" level=info msg=\"[core] original dial target is: \\\"unix:///run/k0s/containerd.sock\\\"\" component=grpc"
time="2026-08-07T14:36:47Z" level=debug msg="k0s reset: time=\"2026-08-07 14:36:47\" level=info msg=\"[core] [Channel #1] Channel created for target \\\"unix:///run/k0s/containerd.sock\\\"\" component=grpc"
time="2026-08-07T14:36:47Z" level=debug msg="k0s reset: time=\"2026-08-07 14:36:47\" level=info msg=\"[core] [Channel #1] parsed dial target is: resolver.Target{URL:url.URL{Scheme:\\\"unix\\\", Opaque:\\\"\\\", User:(*url.Userinfo)(nil), Host:\\\"\\\", Path:\\\"/run/k0s/containerd.sock\\\", Fragment:\\\"\\\", RawQuery:\\\"\\\", RawPath:\\\"\\\", RawFragment:\\\"\\\", ForceQuery:false, OmitHost:false}}\" component=grpc"
time="2026-08-07T14:36:47Z" level=debug msg="k0s reset: time=\"2026-08-07 14:36:47\" level=info msg=\"[core] [Channel #1] Channel authority set to \\\"localhost\\\"\" component=grpc"
time="2026-08-07T14:36:47Z" level=debug msg="k0s reset: time=\"2026-08-07 14:36:47\" level=info msg=\"started to watch events on /etc/k0s/containerd.d/\" component=containerd"
```

#### Which issue(s) this PR fixes:
https://app.shortcut.com/replicated/story/138696/fix-embedded-cluster-reset-leaves-stale-binary-or-systemd-unit-after-reboot-when-pod-volume-mounts-are-busy

#### Does this PR require a test?
NONE

#### Does this PR require a release note?
```release-note
Stream `k0s stop`/`k0s reset` output to the installer log as it's produced, instead of only after the command exits, to aid debugging hangs during reset.
```

#### Does this PR require documentation?
NONE
