### PR TITLE
Fix melange build errors

### DIFF
--- a/local-artifact-mirror/deploy/apko.tmpl.yaml
+++ b/local-artifact-mirror/deploy/apko.tmpl.yaml
@@ -1,12 +1,12 @@
 contents:
   repositories:
-    - https://packages.wolfi.dev/os
+    - https://apk.cve0.io
     - ./packages/
   keyring:
-    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    - https://apk.cve0.io/key/cve0-signing.rsa.pub
     - ./melange.rsa.pub
   packages:
-    - wolfi-base
+    - ca-certificates-bundle
     - local-artifact-mirror  # This is expected to be built locally by `melange`.
 
 accounts:

--- a/local-artifact-mirror/deploy/melange.tmpl.yaml
+++ b/local-artifact-mirror/deploy/melange.tmpl.yaml
@@ -9,18 +9,22 @@ package:
 environment:
   contents:
     repositories:
-      - https://packages.wolfi.dev/os
+      - https://apk.cve0.io
     keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+      - https://apk.cve0.io/key/cve0-signing.rsa.pub
     packages:
       - busybox
+      - build-base
+      - bash
       - git
       - go
-      - make
+      - ca-certificates-bundle
   environment:
     GOCACHE: /cache/melange/gocache
     GOMODCACHE: /cache/melange/gomodcache
     K0S_MINOR_VERSION: ${K0S_MINOR_VERSION}
+    GOPROXY: 'https://proxy.golang.org,direct'
+    GOSUMDB: 'sum.golang.org'
 
 pipeline:
   - runs: |

--- a/operator/deploy/apko.tmpl.yaml
+++ b/operator/deploy/apko.tmpl.yaml
@@ -1,9 +1,9 @@
 contents:
   repositories:
-    - https://packages.wolfi.dev/os
+    - https://apk.cve0.io
     - ./packages/
   keyring:
-    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    - https://apk.cve0.io/key/cve0-signing.rsa.pub
     - ./melange.rsa.pub
   packages:
     - ec-operator  # This is expected to be built locally by `melange`.

--- a/operator/deploy/melange.tmpl.yaml
+++ b/operator/deploy/melange.tmpl.yaml
@@ -9,19 +9,23 @@ package:
 environment:
   contents:
     repositories:
-      - https://packages.wolfi.dev/os
+      - https://apk.cve0.io
     keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+      - https://apk.cve0.io/key/cve0-signing.rsa.pub
     packages:
       - busybox
-      - git
+      - build-base
+      - bash
       - go
-      - make
+      - git
+      - ca-certificates-bundle
   environment:
     GOCACHE: /cache/melange/gocache
     GOMODCACHE: /cache/melange/gomodcache
     VERSION: ${PACKAGE_VERSION}
     K0S_MINOR_VERSION: ${K0S_MINOR_VERSION}
+    GOPROXY: 'https://proxy.golang.org,direct'
+    GOSUMDB: 'sum.golang.org'
 
 pipeline:
   - runs: |


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Currently melange build is failing with this error

```
2026/08/07 17:44:32 INFO installing scanelf (1.3.11-r1)
2026/08/07 17:44:33 WARN + make -C operator build
2026/08/07 17:44:33 WARN make: /bin/bash: No such file or directory
```

This PR switches build from wolfi to cve0 and adds all necessary dependencies in melange specs.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
