### PR TITLE
fix: don't fail pipeline when EC release notes dispatch fails

### DIFF
--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -638,11 +638,21 @@ jobs:
 
       - name: Generate EC Release Notes PR
         if: steps.check-main.outputs.is_from_main == 'true'
+        continue-on-error: true
         env:
           GIT_TAG: ${{ needs.get-tag.outputs.tag-name }}
           GH_PAT: ${{ secrets.GH_PAT }}
         run: |
-          curl -H "Authorization: token $GH_PAT" \
+          http_code=$(curl -s -o response.txt -w "%{http_code}" \
+            -H "Authorization: token $GH_PAT" \
             -H 'Accept: application/json' \
             -d "{\"event_type\": \"embedded-cluster-release-notes\", \"client_payload\": {\"version\": \"${GIT_TAG}\"}}" \
-            "https://api.github.com/repos/replicatedhq/replicated-docs/dispatches"
+            "https://api.github.com/repos/replicatedhq/replicated-docs/dispatches")
+
+          echo "HTTP status: $http_code"
+          cat response.txt
+
+          if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+            echo "Repository dispatch failed with HTTP status $http_code"
+            exit 1
+          fi


### PR DESCRIPTION
#### What this PR does / why we need it:
The repository_dispatch call to replicated-docs previously always "succeeded" since curl doesn't fail on non-2xx HTTP responses by default. Explicitly check the HTTP status and mark the step as failed on a bad response, but use continue-on-error so a failed dispatch doesn't fail the overall release pipeline.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
