### PR TITLE
fix(ci): don't fail open when EC release-notes dispatch fails

### DIFF
--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -638,7 +638,6 @@ jobs:
 
       - name: Generate EC Release Notes PR
         if: steps.check-main.outputs.is_from_main == 'true'
-        continue-on-error: true
         env:
           GIT_TAG: ${{ needs.get-tag.outputs.tag-name }}
           GH_PAT: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
The `generate-ec-release-notes-pr` step already checks the HTTP status of the `repository_dispatch` to replicated-docs and `exit 1`s on a non-2xx response. But `continue-on-error: true` **masked** that failure: GitHub reports the step conclusion as `success`, so a 404 (e.g. an under-privileged `GH_PAT`) still passed green — the exact fail-open this was meant to catch.

Removing `continue-on-error: true` lets the 404 fail the step and surface as a real, red failure. This job runs last (`needs: [release, release-app, get-tag]`), so the product release is already complete when it runs — a failure here only flags that the docs release-notes dispatch failed, it does not undo or block the release itself.

Verified against run [31411065177](https://github.com/replicatedhq/embedded-cluster/actions/runs/31411065177/job/93533183864): the dispatch returned 404, the step `exit 1`d, but the step conclusion was `success` because of `continue-on-error`.

Note: this makes the failure *visible*; the dispatch itself still 404s until the `GH_PAT` secret holds a token with write (`Contents: write`) access to replicated-docs (tracked separately).