### PR TITLE
Switch melange and apko specs to cve0 repo

### DIFF
--- a/.github/actions/e2e-lxd-setup/action.yml
+++ b/.github/actions/e2e-lxd-setup/action.yml
@@ -3,11 +3,17 @@ description: Setup steps for local e2e testing environment
 runs:
   using: composite
   steps:
+  - name: Use primary Ubuntu mirror
+    shell: bash
+    run: |
+      if [ -f /etc/apt/apt-mirrors.txt ]; then
+        sudo sed -i '\|azure.archive.ubuntu.com|d' /etc/apt/apt-mirrors.txt
+      fi
   - name: Remove MS repo
     shell: bash
     run: |
       apt-add-repository --list
-      sudo apt-add-repository -y -r deb [arch=amd64,arm64,armhf] https://packages.microsoft.com/ubuntu/22.04/prod jammy main
+      sudo apt-add-repository --no-update -y -r deb [arch=amd64,arm64,armhf] https://packages.microsoft.com/ubuntu/22.04/prod jammy main
       apt-add-repository --list
   - name: Move Docker aside
     shell: bash
@@ -36,6 +42,5 @@ runs:
   - name: Set AppArmor mode to complain
     shell: bash
     run: |
-      sudo apt-get update -y
       sudo apt install apparmor-utils -y
       sudo aa-complain /etc/apparmor.d/* 

--- a/.github/workflows/publish-securebuild.yml
+++ b/.github/workflows/publish-securebuild.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   validate-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       k0s-minor-version: ${{ steps.version.outputs.k0s-minor-version }}
     steps:
@@ -36,7 +36,7 @@ jobs:
 
   build-packages:
     needs: validate-version
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     continue-on-error: true
     strategy:
       matrix:
@@ -61,7 +61,7 @@ jobs:
 
   build-images:
     needs: build-packages
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     continue-on-error: true
     strategy:
       matrix:

--- a/.github/workflows/publish-securebuild.yml
+++ b/.github/workflows/publish-securebuild.yml
@@ -1,0 +1,85 @@
+name: Publish SecureBuild packages and images
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: Stable embedded-cluster version (for example, v2.18.1+k8s-1.33)
+        required: true
+        type: string
+    secrets:
+      SECUREBUILD_API_TOKEN:
+        required: true
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Stable embedded-cluster version (for example, v2.18.1+k8s-1.33)
+        required: true
+        type: string
+
+jobs:
+  validate-version:
+    runs-on: ubuntu-22.04
+    outputs:
+      k0s-minor-version: ${{ steps.version.outputs.k0s-minor-version }}
+    steps:
+      - name: Require a stable release version
+        id: version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! [[ "$VERSION" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+\+k8s-1\.([0-9]+)$ ]]; then
+            echo "SecureBuild only supports stable release versions (for example, v2.18.1+k8s-1.33): $VERSION"
+            exit 1
+          fi
+          echo "k0s-minor-version=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+
+  build-packages:
+    needs: validate-version
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    strategy:
+      matrix:
+        package-family:
+          - embedded-cluster-operator
+          - local-artifact-mirror
+    steps:
+      - name: Install SecureBuild CLI
+        run: |
+          LATEST_TAG=$(curl -fsSL https://api.github.com/repos/securebuildhq/securebuild/releases/latest | jq -r .tag_name)
+          curl -fsSL "https://github.com/securebuildhq/securebuild/releases/download/${LATEST_TAG}/securebuild-cli-linux-amd64" -o securebuild
+          chmod +x securebuild
+
+      - name: Build package
+        env:
+          SECUREBUILD_API_TOKEN: ${{ secrets.SECUREBUILD_API_TOKEN }}
+        run: |
+          ./securebuild build package \
+            --package-family-name "${{ matrix.package-family }}-k8s1.${{ needs.validate-version.outputs.k0s-minor-version }}" \
+            --tag "${{ inputs.version }}" \
+            --api-token "$SECUREBUILD_API_TOKEN"
+
+  build-images:
+    needs: build-packages
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    strategy:
+      matrix:
+        image-name:
+          - embedded-cluster-operator
+          - local-artifact-mirror
+    steps:
+      - name: Install SecureBuild CLI
+        run: |
+          LATEST_TAG=$(curl -fsSL https://api.github.com/repos/securebuildhq/securebuild/releases/latest | jq -r .tag_name)
+          curl -fsSL "https://github.com/securebuildhq/securebuild/releases/download/${LATEST_TAG}/securebuild-cli-linux-amd64" -o securebuild
+          chmod +x securebuild
+
+      - name: Build image
+        env:
+          SECUREBUILD_API_TOKEN: ${{ secrets.SECUREBUILD_API_TOKEN }}
+        run: |
+          ./securebuild build image \
+            --image-name "${{ matrix.image-name }}" \
+            --tag "${{ inputs.version }}" \
+            --api-token "$SECUREBUILD_API_TOKEN"

--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag-name: ${{ steps.get-tag.outputs.tag-name }}
+      securebuild-version: ${{ steps.get-tag.outputs.securebuild-version }}
+      is-stable: ${{ steps.get-tag.outputs.is-stable }}
       k0s_version: ${{ steps.export.outputs.k0s_version }}
       k0s_minor_version: ${{ steps.export.outputs.k0s_minor_version }}
     steps:
@@ -31,6 +33,12 @@ jobs:
           export V_TAG=$(echo "$RAW_TAG" | sed 's/^[^v]/v&/')
           # store the tag name in an output for later steps
           echo "tag-name=${V_TAG}" >> $GITHUB_OUTPUT
+          echo "securebuild-version=${RAW_TAG}" >> "$GITHUB_OUTPUT"
+          if [[ "$V_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+\+k8s-1\.[0-9]+$ ]]; then
+            echo "is-stable=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is-stable=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Export k0s version
         id: export
@@ -67,6 +75,15 @@ jobs:
         with:
           name: buildtools
           path: output/bin/buildtools
+
+  # SecureBuild publishing is a non-blocking preview during the transition release.
+  publish-securebuild:
+    needs: [get-tag]
+    if: needs.get-tag.outputs.is-stable == 'true'
+    uses: ./.github/workflows/publish-securebuild.yml
+    with:
+      version: ${{ needs.get-tag.outputs.securebuild-version }}
+    secrets: inherit
 
   publish-operator-image:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -156,10 +156,30 @@ cmd/installer/goods/internal/bins/kubectl-kots:
 	fi
 	touch $@
 
-output/bins/kubectl-kots-%:
+.PHONY: force-kubectl-kots-extract
+force-kubectl-kots-extract:
+
+# Extract kubectl-kots from the image, resolving its filesystem symlink.
+output/bins/kubectl-kots-%: force-kubectl-kots-extract
 	mkdir -p output/bins
 	mkdir -p output/tmp
-	crane export kotsadm/kotsadm:$(call split-underscore,$*,1) --platform linux/$(call split-underscore,$*,2) - | tar -Oxf - kots > $@
+	tmpdir=$$(mktemp -d output/tmp/kubectl-kots.XXXXXX); \
+	trap 'rm -rf "$$tmpdir"' EXIT; \
+	crane export kotsadm/kotsadm:$(call split-underscore,$*,1) --platform linux/$(call split-underscore,$*,2) "$$tmpdir/image.tar"; \
+	archive_path=kots; \
+	tar -xf "$$tmpdir/image.tar" -C "$$tmpdir" "$$archive_path"; \
+	binary="$$tmpdir/$$archive_path"; \
+	while [ -L "$$binary" ]; do \
+		target=$$(readlink "$$binary"); \
+		case "$$target" in \
+			/*) archive_path=$${target#/} ;; \
+			*) archive_path=$$(dirname "$$archive_path")/$$target ;; \
+		esac; \
+		tar -xf "$$tmpdir/image.tar" -C "$$tmpdir" "$$archive_path"; \
+		binary="$$tmpdir/$$archive_path"; \
+	done; \
+	test -s "$$binary"; \
+	cp "$$binary" $@
 	chmod +x $@
 	touch $@
 

--- a/common.mk
+++ b/common.mk
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 MAKEFLAGS += --no-print-directory
 
 ARCH ?= $(shell go env GOARCH)
-CURRENT_USER := $(if $(GITHUB_USER),$(GITHUB_USER),$(shell id -u -n))
+CURRENT_USER := $(if $(GITHUB_USER),$(GITHUB_USER),$(if $(GITHUB_RUN_ID),$(shell id -u -n)-$(GITHUB_RUN_ID)-$(GITHUB_JOB)-$(GITHUB_RUN_ATTEMPT),$(shell id -u -n)))
 
 ## Location to install dependencies to
 LOCALBIN ?= $(shell pwd)/bin

--- a/dagger/pipelines/git-checkout.yaml
+++ b/dagger/pipelines/git-checkout.yaml
@@ -1,0 +1,12 @@
+name: Use source from the local workspace
+
+inputs:
+  repository:
+    description: Unused; the repository has already been checked out by the workflow
+    required: true
+  tag:
+    description: Unused; the workflow checkout determines the source revision
+
+pipeline:
+  - runs: |
+      echo "Using source already checked out by the workflow"

--- a/e2e/preflights_test.go
+++ b/e2e/preflights_test.go
@@ -84,11 +84,10 @@ func TestPreflights(t *testing.T) {
 					}
 				}
 				for _, res := range results.Fail {
-					if !strings.Contains(res.Message, "Write latency is high") {
-						t.Errorf("fio test failed: %s", res.Message)
+					if res.Title == "Filesystem Write Latency" {
+						t.Logf("fio test failed: %s", res.Message)
+						return
 					}
-					// as long as fio ran successfully, we're good
-					t.Logf("fio test failed: %s", res.Message)
 				}
 
 				t.Errorf("fio test not found")

--- a/pkg-new/upgrade/upgrade.go
+++ b/pkg-new/upgrade/upgrade.go
@@ -44,19 +44,25 @@ func Upgrade(ctx context.Context, cli client.Client, hcli helm.Client, rc runtim
 	// installation data dirs from the previous installation.
 	rc.Set(in.Spec.RuntimeConfig)
 
-	// Update the cluster config before upgrading k0s: 1.35 and older pin
-	// spec.images.pause by digest, but containerd 2.x (k0s 1.36+) rejects a
-	// digest-pinned sandbox image, so it must become a tag-only ref before k0s 1.36
-	// restarts, otherwise no pod can get a sandbox. Updating it now doesn't affect
-	// the running k0s/containerd; it's only picked up when k0s restarts below.
-	err = updateClusterConfig(ctx, cli, in, logger)
+	// Update only the pause image before upgrading k0s: 1.35 and older pin it by
+	// digest, but containerd 2.x (k0s 1.36+) rejects a digest-pinned sandbox image.
+	// Updating all component images here would roll them out using the old k0s
+	// manifests and RBAC, which may not support the newer images.
+	err = updatePauseImage(ctx, cli, in, logger)
 	if err != nil {
-		return fmt.Errorf("cluster config update: %w", err)
+		return fmt.Errorf("pause image update: %w", err)
 	}
 
 	err = upgradeK0s(ctx, cli, rc, in, logger)
 	if err != nil {
 		return fmt.Errorf("k0s upgrade: %w", err)
+	}
+
+	// The new k0s binary is now running on every node, so its manifests and RBAC
+	// are compatible with the target component images.
+	err = updateClusterConfig(ctx, cli, in, logger)
+	if err != nil {
+		return fmt.Errorf("cluster config update: %w", err)
 	}
 
 	logger.Info("Upgrading addons")
@@ -81,6 +87,28 @@ func Upgrade(ctx context.Context, cli client.Client, hcli helm.Client, rc runtim
 		return fmt.Errorf("set installation state: %w", err)
 	}
 
+	return nil
+}
+
+// updatePauseImage updates only the sandbox image needed by the target k0s
+// version without prematurely rolling out the other target component images.
+func updatePauseImage(ctx context.Context, cli client.Client, in *ecv1beta1.Installation, logger logrus.FieldLogger) error {
+	var currentCfg k0sv1beta1.ClusterConfig
+	if err := cli.Get(ctx, client.ObjectKey{Name: "k0s", Namespace: "kube-system"}, &currentCfg); err != nil {
+		return fmt.Errorf("get cluster config: %w", err)
+	}
+
+	domains := domains.GetDomains(in.Spec.Config, nil)
+	targetCfg := config.RenderK0sConfig(domains.ProxyRegistryDomain)
+	if currentCfg.Spec.Images == nil || reflect.DeepEqual(currentCfg.Spec.Images.Pause, targetCfg.Spec.Images.Pause) {
+		return nil
+	}
+
+	currentCfg.Spec.Images.Pause = targetCfg.Spec.Images.Pause.DeepCopy()
+	if err := cli.Update(ctx, &currentCfg); err != nil {
+		return fmt.Errorf("update cluster config: %w", err)
+	}
+	logger.Info("Updated cluster config with new pause image")
 	return nil
 }
 

--- a/pkg-new/upgrade/upgrade_test.go
+++ b/pkg-new/upgrade/upgrade_test.go
@@ -7,6 +7,7 @@ import (
 
 	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"github.com/replicatedhq/embedded-cluster/pkg/config"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,6 +16,38 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func TestUpdatePauseImage(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, k0sv1beta1.Install(scheme))
+
+	currentConfig := k0sv1beta1.DefaultClusterConfig()
+	currentConfig.Name = "k0s"
+	currentConfig.Namespace = "kube-system"
+	originalImages := currentConfig.Spec.Images.DeepCopy()
+
+	installation := &ecv1beta1.Installation{
+		Spec: ecv1beta1.InstallationSpec{
+			Config: &ecv1beta1.ConfigSpec{
+				Domains: ecv1beta1.Domains{ProxyRegistryDomain: "registry.com"},
+			},
+		},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(currentConfig).Build()
+	require.NoError(t, updatePauseImage(context.Background(), cli, installation, logger))
+
+	var updatedConfig k0sv1beta1.ClusterConfig
+	require.NoError(t, cli.Get(context.Background(), client.ObjectKey{Name: "k0s", Namespace: "kube-system"}, &updatedConfig))
+
+	targetConfig := config.RenderK0sConfig("registry.com")
+	assert.Equal(t, targetConfig.Spec.Images.Pause, updatedConfig.Spec.Images.Pause)
+	updatedConfig.Spec.Images.Pause = originalImages.Pause
+	assert.Equal(t, originalImages, updatedConfig.Spec.Images, "non-pause images must not change before the k0s upgrade")
+}
 
 func TestUpdateClusterConfig(t *testing.T) {
 	// Discard log messages

--- a/securebuild/image/apko-embedded-cluster-operator-k8s1.33.yaml
+++ b/securebuild/image/apko-embedded-cluster-operator-k8s1.33.yaml
@@ -1,0 +1,34 @@
+contents:
+  repositories:
+    - https://apk.cve0.io
+  keyring:
+    - https://apk.cve0.io/key/cve0-signing.rsa.pub
+  packages:
+    - ca-certificates-bundle
+    - helm~4
+    - embedded-cluster-operator-k8s1.33
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+entrypoint:
+  command: /manager
+
+archs:
+  - x86_64
+  - aarch64
+
+annotations:
+  org.opencontainers.image.title: "Embedded Cluster Operator"
+  org.opencontainers.image.description: "Embedded Cluster Operator for Kubernetes"
+  org.opencontainers.image.vendor: "SecureBuild"

--- a/securebuild/image/apko-embedded-cluster-operator-k8s1.34.yaml
+++ b/securebuild/image/apko-embedded-cluster-operator-k8s1.34.yaml
@@ -1,0 +1,34 @@
+contents:
+  repositories:
+    - https://apk.cve0.io
+  keyring:
+    - https://apk.cve0.io/key/cve0-signing.rsa.pub
+  packages:
+    - ca-certificates-bundle
+    - helm~4
+    - embedded-cluster-operator-k8s1.34
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+entrypoint:
+  command: /manager
+
+archs:
+  - x86_64
+  - aarch64
+
+annotations:
+  org.opencontainers.image.title: "Embedded Cluster Operator"
+  org.opencontainers.image.description: "Embedded Cluster Operator for Kubernetes"
+  org.opencontainers.image.vendor: "SecureBuild"

--- a/securebuild/image/apko-embedded-cluster-operator-k8s1.35.yaml
+++ b/securebuild/image/apko-embedded-cluster-operator-k8s1.35.yaml
@@ -1,0 +1,34 @@
+contents:
+  repositories:
+    - https://apk.cve0.io
+  keyring:
+    - https://apk.cve0.io/key/cve0-signing.rsa.pub
+  packages:
+    - ca-certificates-bundle
+    - helm~4
+    - embedded-cluster-operator-k8s1.35
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+entrypoint:
+  command: /manager
+
+archs:
+  - x86_64
+  - aarch64
+
+annotations:
+  org.opencontainers.image.title: "Embedded Cluster Operator"
+  org.opencontainers.image.description: "Embedded Cluster Operator for Kubernetes"
+  org.opencontainers.image.vendor: "SecureBuild"

--- a/securebuild/image/apko-embedded-cluster-operator-k8s1.36.yaml
+++ b/securebuild/image/apko-embedded-cluster-operator-k8s1.36.yaml
@@ -1,0 +1,34 @@
+contents:
+  repositories:
+    - https://apk.cve0.io
+  keyring:
+    - https://apk.cve0.io/key/cve0-signing.rsa.pub
+  packages:
+    - ca-certificates-bundle
+    - helm~4
+    - embedded-cluster-operator-k8s1.36
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+entrypoint:
+  command: /manager
+
+archs:
+  - x86_64
+  - aarch64
+
+annotations:
+  org.opencontainers.image.title: "Embedded Cluster Operator"
+  org.opencontainers.image.description: "Embedded Cluster Operator for Kubernetes"
+  org.opencontainers.image.vendor: "SecureBuild"

--- a/securebuild/image/apko-local-artifact-mirror-k8s1.33.yaml
+++ b/securebuild/image/apko-local-artifact-mirror-k8s1.33.yaml
@@ -1,0 +1,35 @@
+contents:
+  repositories:
+    - https://apk.cve0.io
+  keyring:
+    - https://apk.cve0.io/key/cve0-signing.rsa.pub
+  packages:
+    - busybox
+    - ca-certificates-bundle
+    - local-artifact-mirror-k8s1.33
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  # many embedded-cluster commands must be run as root
+  run-as: 0
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+entrypoint:
+  command: /usr/bin/local-artifact-mirror
+
+archs:
+  - x86_64
+  - aarch64
+
+annotations:
+  org.opencontainers.image.title: "Local Artifact Mirror"
+  org.opencontainers.image.description: "Local Artifact Mirror for Embedded Cluster"
+  org.opencontainers.image.vendor: "SecureBuild"

--- a/securebuild/image/apko-local-artifact-mirror-k8s1.34.yaml
+++ b/securebuild/image/apko-local-artifact-mirror-k8s1.34.yaml
@@ -1,0 +1,35 @@
+contents:
+  repositories:
+    - https://apk.cve0.io
+  keyring:
+    - https://apk.cve0.io/key/cve0-signing.rsa.pub
+  packages:
+    - busybox
+    - ca-certificates-bundle
+    - local-artifact-mirror-k8s1.34
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  # many embedded-cluster commands must be run as root
+  run-as: 0
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+entrypoint:
+  command: /usr/bin/local-artifact-mirror
+
+archs:
+  - x86_64
+  - aarch64
+
+annotations:
+  org.opencontainers.image.title: "Local Artifact Mirror"
+  org.opencontainers.image.description: "Local Artifact Mirror for Embedded Cluster"
+  org.opencontainers.image.vendor: "SecureBuild"

--- a/securebuild/image/apko-local-artifact-mirror-k8s1.35.yaml
+++ b/securebuild/image/apko-local-artifact-mirror-k8s1.35.yaml
@@ -1,0 +1,35 @@
+contents:
+  repositories:
+    - https://apk.cve0.io
+  keyring:
+    - https://apk.cve0.io/key/cve0-signing.rsa.pub
+  packages:
+    - busybox
+    - ca-certificates-bundle
+    - local-artifact-mirror-k8s1.35
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  # many embedded-cluster commands must be run as root
+  run-as: 0
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+entrypoint:
+  command: /usr/bin/local-artifact-mirror
+
+archs:
+  - x86_64
+  - aarch64
+
+annotations:
+  org.opencontainers.image.title: "Local Artifact Mirror"
+  org.opencontainers.image.description: "Local Artifact Mirror for Embedded Cluster"
+  org.opencontainers.image.vendor: "SecureBuild"

--- a/securebuild/image/apko-local-artifact-mirror-k8s1.36.yaml
+++ b/securebuild/image/apko-local-artifact-mirror-k8s1.36.yaml
@@ -1,0 +1,35 @@
+contents:
+  repositories:
+    - https://apk.cve0.io
+  keyring:
+    - https://apk.cve0.io/key/cve0-signing.rsa.pub
+  packages:
+    - busybox
+    - ca-certificates-bundle
+    - local-artifact-mirror-k8s1.36
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  # many embedded-cluster commands must be run as root
+  run-as: 0
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+entrypoint:
+  command: /usr/bin/local-artifact-mirror
+
+archs:
+  - x86_64
+  - aarch64
+
+annotations:
+  org.opencontainers.image.title: "Local Artifact Mirror"
+  org.opencontainers.image.description: "Local Artifact Mirror for Embedded Cluster"
+  org.opencontainers.image.vendor: "SecureBuild"

--- a/securebuild/package/embedded-cluster-operator-k8s1.33/melange.yaml
+++ b/securebuild/package/embedded-cluster-operator-k8s1.33/melange.yaml
@@ -1,0 +1,65 @@
+package:
+  name: embedded-cluster-operator-k8s1.33-head
+  version: "1000.0.0"
+  epoch: 0
+  description: Embedded Cluster Operator
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - embedded-cluster-operator-k8s1.33=${{package.full-version}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^.+-k8s1\\.(\\d+)-head$
+    replace: "$1"
+    to: k0s-minor-version
+  - from: ${{package.name}}
+    match: ^.+-(k8s)(1\\.\\d+)-head$
+    replace: "$1-$2"
+    to: k8s-version
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+$
+    replace: "$1"
+    to: major-minor-version
+  - from: ${{package.version}}
+    match: ^(\d+).*
+    replace: $1
+    to: major-version
+
+environment:
+  environment:
+    K0S_MINOR_VERSION: ${{vars.k0s-minor-version}}
+    GOPROXY: https://proxy.golang.org,direct
+    GOSUMDB: sum.golang.org
+  contents:
+    repositories:
+      - https://apk.cve0.io
+    keyring:
+      - https://apk.cve0.io/key/cve0-signing.rsa.pub
+    packages:
+      - busybox
+      - build-base
+      - go
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/replicatedhq/embedded-cluster
+      tag: ${{package.version}}+${{vars.k8s-version}}
+
+  - name: build-go-binary
+    runs: |
+      cd operator
+      VERSION="${VERSION:-${{package.version}}+${{vars.k8s-version}}}"
+      export GOPROXY=https://proxy.golang.org,direct
+      export GOSUMDB=sum.golang.org
+      mkdir -p bin
+      CGO_ENABLED=0 go build \
+        -tags osusergo,netgo,k0s_legacy_airgap,containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper,exclude_graphdriver_overlay \
+        -ldflags="-s -w -X github.com/replicatedhq/embedded-cluster/pkg/versions.Version=$VERSION -extldflags=-static" \
+        -o bin/manager main.go
+      cp bin/manager ${{targets.destdir}}/manager
+
+  - uses: strip

--- a/securebuild/package/embedded-cluster-operator-k8s1.33/melange.yaml
+++ b/securebuild/package/embedded-cluster-operator-k8s1.33/melange.yaml
@@ -11,11 +11,11 @@ package:
 
 var-transforms:
   - from: ${{package.name}}
-    match: ^.+-k8s1\\.(\\d+)-head$
+    match: ^.+-k8s1\.(\d+)(-head)?$
     replace: "$1"
     to: k0s-minor-version
   - from: ${{package.name}}
-    match: ^.+-(k8s)(1\\.\\d+)-head$
+    match: ^.+-(k8s)(1\.\d+)(-head)?$
     replace: "$1-$2"
     to: k8s-version
   - from: ${{package.version}}
@@ -42,6 +42,7 @@ environment:
       - build-base
       - go
       - ca-certificates-bundle
+      - curl
 
 pipeline:
   - uses: git-checkout
@@ -51,15 +52,8 @@ pipeline:
 
   - name: build-go-binary
     runs: |
-      cd operator
-      VERSION="${VERSION:-${{package.version}}+${{vars.k8s-version}}}"
-      export GOPROXY=https://proxy.golang.org,direct
-      export GOSUMDB=sum.golang.org
-      mkdir -p bin
-      CGO_ENABLED=0 go build \
-        -tags osusergo,netgo,k0s_legacy_airgap,containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper,exclude_graphdriver_overlay \
-        -ldflags="-s -w -X github.com/replicatedhq/embedded-cluster/pkg/versions.Version=$VERSION -extldflags=-static" \
-        -o bin/manager main.go
-      cp bin/manager ${{targets.destdir}}/manager
+      make -C operator build-deps build \
+        VERSION=${{package.version}}+${{vars.k8s-version}}
+      cp operator/bin/manager ${{targets.destdir}}/manager
 
   - uses: strip

--- a/securebuild/package/embedded-cluster-operator-k8s1.34/melange.yaml
+++ b/securebuild/package/embedded-cluster-operator-k8s1.34/melange.yaml
@@ -11,11 +11,11 @@ package:
 
 var-transforms:
   - from: ${{package.name}}
-    match: ^.+-k8s1\\.(\\d+)-head$
+    match: ^.+-k8s1\.(\d+)(-head)?$
     replace: "$1"
     to: k0s-minor-version
   - from: ${{package.name}}
-    match: ^.+-(k8s)(1\\.\\d+)-head$
+    match: ^.+-(k8s)(1\.\d+)(-head)?$
     replace: "$1-$2"
     to: k8s-version
   - from: ${{package.version}}
@@ -42,6 +42,7 @@ environment:
       - build-base
       - go
       - ca-certificates-bundle
+      - curl
 
 pipeline:
   - uses: git-checkout
@@ -51,15 +52,8 @@ pipeline:
 
   - name: build-go-binary
     runs: |
-      cd operator
-      VERSION="${VERSION:-${{package.version}}+${{vars.k8s-version}}}"
-      export GOPROXY=https://proxy.golang.org,direct
-      export GOSUMDB=sum.golang.org
-      mkdir -p bin
-      CGO_ENABLED=0 go build \
-        -tags osusergo,netgo,k0s_legacy_airgap,containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper,exclude_graphdriver_overlay \
-        -ldflags="-s -w -X github.com/replicatedhq/embedded-cluster/pkg/versions.Version=$VERSION -extldflags=-static" \
-        -o bin/manager main.go
-      cp bin/manager ${{targets.destdir}}/manager
+      make -C operator build-deps build \
+        VERSION=${{package.version}}+${{vars.k8s-version}}
+      cp operator/bin/manager ${{targets.destdir}}/manager
 
   - uses: strip

--- a/securebuild/package/embedded-cluster-operator-k8s1.34/melange.yaml
+++ b/securebuild/package/embedded-cluster-operator-k8s1.34/melange.yaml
@@ -1,0 +1,65 @@
+package:
+  name: embedded-cluster-operator-k8s1.34-head
+  version: "1000.0.0"
+  epoch: 0
+  description: Embedded Cluster Operator
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - embedded-cluster-operator-k8s1.34=${{package.full-version}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^.+-k8s1\\.(\\d+)-head$
+    replace: "$1"
+    to: k0s-minor-version
+  - from: ${{package.name}}
+    match: ^.+-(k8s)(1\\.\\d+)-head$
+    replace: "$1-$2"
+    to: k8s-version
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+$
+    replace: "$1"
+    to: major-minor-version
+  - from: ${{package.version}}
+    match: ^(\d+).*
+    replace: $1
+    to: major-version
+
+environment:
+  environment:
+    K0S_MINOR_VERSION: ${{vars.k0s-minor-version}}
+    GOPROXY: https://proxy.golang.org,direct
+    GOSUMDB: sum.golang.org
+  contents:
+    repositories:
+      - https://apk.cve0.io
+    keyring:
+      - https://apk.cve0.io/key/cve0-signing.rsa.pub
+    packages:
+      - busybox
+      - build-base
+      - go
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/replicatedhq/embedded-cluster
+      tag: ${{package.version}}+${{vars.k8s-version}}
+
+  - name: build-go-binary
+    runs: |
+      cd operator
+      VERSION="${VERSION:-${{package.version}}+${{vars.k8s-version}}}"
+      export GOPROXY=https://proxy.golang.org,direct
+      export GOSUMDB=sum.golang.org
+      mkdir -p bin
+      CGO_ENABLED=0 go build \
+        -tags osusergo,netgo,k0s_legacy_airgap,containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper,exclude_graphdriver_overlay \
+        -ldflags="-s -w -X github.com/replicatedhq/embedded-cluster/pkg/versions.Version=$VERSION -extldflags=-static" \
+        -o bin/manager main.go
+      cp bin/manager ${{targets.destdir}}/manager
+
+  - uses: strip

--- a/securebuild/package/embedded-cluster-operator-k8s1.35/melange.yaml
+++ b/securebuild/package/embedded-cluster-operator-k8s1.35/melange.yaml
@@ -1,0 +1,65 @@
+package:
+  name: embedded-cluster-operator-k8s1.35-head
+  version: "1000.0.0"
+  epoch: 0
+  description: Embedded Cluster Operator
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - embedded-cluster-operator-k8s1.35=${{package.full-version}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^.+-k8s1\\.(\\d+)-head$
+    replace: "$1"
+    to: k0s-minor-version
+  - from: ${{package.name}}
+    match: ^.+-(k8s)(1\\.\\d+)-head$
+    replace: "$1-$2"
+    to: k8s-version
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+$
+    replace: "$1"
+    to: major-minor-version
+  - from: ${{package.version}}
+    match: ^(\d+).*
+    replace: $1
+    to: major-version
+
+environment:
+  environment:
+    K0S_MINOR_VERSION: ${{vars.k0s-minor-version}}
+    GOPROXY: https://proxy.golang.org,direct
+    GOSUMDB: sum.golang.org
+  contents:
+    repositories:
+      - https://apk.cve0.io
+    keyring:
+      - https://apk.cve0.io/key/cve0-signing.rsa.pub
+    packages:
+      - busybox
+      - build-base
+      - go
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/replicatedhq/embedded-cluster
+      tag: ${{package.version}}+${{vars.k8s-version}}
+
+  - name: build-go-binary
+    runs: |
+      cd operator
+      VERSION="${VERSION:-${{package.version}}+${{vars.k8s-version}}}"
+      export GOPROXY=https://proxy.golang.org,direct
+      export GOSUMDB=sum.golang.org
+      mkdir -p bin
+      CGO_ENABLED=0 go build \
+        -tags osusergo,netgo,k0s_legacy_airgap,containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper,exclude_graphdriver_overlay \
+        -ldflags="-s -w -X github.com/replicatedhq/embedded-cluster/pkg/versions.Version=$VERSION -extldflags=-static" \
+        -o bin/manager main.go
+      cp bin/manager ${{targets.destdir}}/manager
+
+  - uses: strip

--- a/securebuild/package/embedded-cluster-operator-k8s1.35/melange.yaml
+++ b/securebuild/package/embedded-cluster-operator-k8s1.35/melange.yaml
@@ -11,11 +11,11 @@ package:
 
 var-transforms:
   - from: ${{package.name}}
-    match: ^.+-k8s1\\.(\\d+)-head$
+    match: ^.+-k8s1\.(\d+)(-head)?$
     replace: "$1"
     to: k0s-minor-version
   - from: ${{package.name}}
-    match: ^.+-(k8s)(1\\.\\d+)-head$
+    match: ^.+-(k8s)(1\.\d+)(-head)?$
     replace: "$1-$2"
     to: k8s-version
   - from: ${{package.version}}
@@ -42,6 +42,7 @@ environment:
       - build-base
       - go
       - ca-certificates-bundle
+      - curl
 
 pipeline:
   - uses: git-checkout
@@ -51,15 +52,8 @@ pipeline:
 
   - name: build-go-binary
     runs: |
-      cd operator
-      VERSION="${VERSION:-${{package.version}}+${{vars.k8s-version}}}"
-      export GOPROXY=https://proxy.golang.org,direct
-      export GOSUMDB=sum.golang.org
-      mkdir -p bin
-      CGO_ENABLED=0 go build \
-        -tags osusergo,netgo,k0s_legacy_airgap,containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper,exclude_graphdriver_overlay \
-        -ldflags="-s -w -X github.com/replicatedhq/embedded-cluster/pkg/versions.Version=$VERSION -extldflags=-static" \
-        -o bin/manager main.go
-      cp bin/manager ${{targets.destdir}}/manager
+      make -C operator build-deps build \
+        VERSION=${{package.version}}+${{vars.k8s-version}}
+      cp operator/bin/manager ${{targets.destdir}}/manager
 
   - uses: strip

--- a/securebuild/package/embedded-cluster-operator-k8s1.36/melange.yaml
+++ b/securebuild/package/embedded-cluster-operator-k8s1.36/melange.yaml
@@ -11,11 +11,11 @@ package:
 
 var-transforms:
   - from: ${{package.name}}
-    match: ^.+-k8s1\\.(\\d+)-head$
+    match: ^.+-k8s1\.(\d+)(-head)?$
     replace: "$1"
     to: k0s-minor-version
   - from: ${{package.name}}
-    match: ^.+-(k8s)(1\\.\\d+)-head$
+    match: ^.+-(k8s)(1\.\d+)(-head)?$
     replace: "$1-$2"
     to: k8s-version
   - from: ${{package.version}}
@@ -42,6 +42,7 @@ environment:
       - build-base
       - go
       - ca-certificates-bundle
+      - curl
 
 pipeline:
   - uses: git-checkout
@@ -51,15 +52,8 @@ pipeline:
 
   - name: build-go-binary
     runs: |
-      cd operator
-      VERSION="${VERSION:-${{package.version}}+${{vars.k8s-version}}}"
-      export GOPROXY=https://proxy.golang.org,direct
-      export GOSUMDB=sum.golang.org
-      mkdir -p bin
-      CGO_ENABLED=0 go build \
-        -tags osusergo,netgo,containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper,exclude_graphdriver_overlay \
-        -ldflags="-s -w -X github.com/replicatedhq/embedded-cluster/pkg/versions.Version=$VERSION -extldflags=-static" \
-        -o bin/manager main.go
-      cp bin/manager ${{targets.destdir}}/manager
+      make -C operator build-deps build \
+        VERSION=${{package.version}}+${{vars.k8s-version}}
+      cp operator/bin/manager ${{targets.destdir}}/manager
 
   - uses: strip

--- a/securebuild/package/embedded-cluster-operator-k8s1.36/melange.yaml
+++ b/securebuild/package/embedded-cluster-operator-k8s1.36/melange.yaml
@@ -1,0 +1,65 @@
+package:
+  name: embedded-cluster-operator-k8s1.36-head
+  version: "1000.0.0"
+  epoch: 0
+  description: Embedded Cluster Operator
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - embedded-cluster-operator-k8s1.36=${{package.full-version}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^.+-k8s1\\.(\\d+)-head$
+    replace: "$1"
+    to: k0s-minor-version
+  - from: ${{package.name}}
+    match: ^.+-(k8s)(1\\.\\d+)-head$
+    replace: "$1-$2"
+    to: k8s-version
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+$
+    replace: "$1"
+    to: major-minor-version
+  - from: ${{package.version}}
+    match: ^(\d+).*
+    replace: $1
+    to: major-version
+
+environment:
+  environment:
+    K0S_MINOR_VERSION: ${{vars.k0s-minor-version}}
+    GOPROXY: https://proxy.golang.org,direct
+    GOSUMDB: sum.golang.org
+  contents:
+    repositories:
+      - https://apk.cve0.io
+    keyring:
+      - https://apk.cve0.io/key/cve0-signing.rsa.pub
+    packages:
+      - busybox
+      - build-base
+      - go
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/replicatedhq/embedded-cluster
+      tag: ${{package.version}}+${{vars.k8s-version}}
+
+  - name: build-go-binary
+    runs: |
+      cd operator
+      VERSION="${VERSION:-${{package.version}}+${{vars.k8s-version}}}"
+      export GOPROXY=https://proxy.golang.org,direct
+      export GOSUMDB=sum.golang.org
+      mkdir -p bin
+      CGO_ENABLED=0 go build \
+        -tags osusergo,netgo,containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper,exclude_graphdriver_overlay \
+        -ldflags="-s -w -X github.com/replicatedhq/embedded-cluster/pkg/versions.Version=$VERSION -extldflags=-static" \
+        -o bin/manager main.go
+      cp bin/manager ${{targets.destdir}}/manager
+
+  - uses: strip

--- a/securebuild/package/local-artifact-mirror-k8s1.33/melange.yaml
+++ b/securebuild/package/local-artifact-mirror-k8s1.33/melange.yaml
@@ -1,0 +1,67 @@
+package:
+  name: local-artifact-mirror-k8s1.33-head
+  version: "1000.0.0"
+  epoch: 0
+  description: Local Artifact Mirror
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - local-artifact-mirror-k8s1.33=${{package.full-version}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^.+-k8s1\\.(\\d+)-head$
+    replace: "$1"
+    to: k0s-minor-version
+  - from: ${{package.name}}
+    match: ^.+-(k8s)(1\\.\\d+)-head$
+    replace: "$1-$2"
+    to: k8s-version
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+$
+    replace: "$1"
+    to: major-minor-version
+  - from: ${{package.version}}
+    match: ^(\d+).*
+    replace: $1
+    to: major-version
+
+environment:
+  environment:
+    K0S_MINOR_VERSION: ${{vars.k0s-minor-version}}
+    GOPROXY: https://proxy.golang.org,direct
+    GOSUMDB: sum.golang.org
+  contents:
+    repositories:
+      - https://apk.cve0.io
+    keyring:
+      - https://apk.cve0.io/key/cve0-signing.rsa.pub
+    packages:
+      - busybox
+      - build-base
+      - go
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/replicatedhq/embedded-cluster
+      tag: ${{package.version}}+${{vars.k8s-version}}
+  - name: build-go-binary
+    runs: |
+      export GOPROXY=https://proxy.golang.org,direct
+      export GOSUMDB=sum.golang.org
+      mkdir -p bin
+      CGO_ENABLED=0 go build \
+        -tags osusergo,netgo,k0s_legacy_airgap \
+        -ldflags="-s -w -extldflags=-static" \
+        -o bin/local-artifact-mirror ./cmd/local-artifact-mirror
+
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mkdir -p ${{targets.destdir}}/usr/local/bin
+      cp bin/local-artifact-mirror ${{targets.destdir}}/usr/bin/local-artifact-mirror
+      # support for legacy path
+      ln -s /usr/bin/local-artifact-mirror ${{targets.destdir}}/usr/local/bin/local-artifact-mirror
+
+  - uses: strip

--- a/securebuild/package/local-artifact-mirror-k8s1.33/melange.yaml
+++ b/securebuild/package/local-artifact-mirror-k8s1.33/melange.yaml
@@ -11,11 +11,11 @@ package:
 
 var-transforms:
   - from: ${{package.name}}
-    match: ^.+-k8s1\\.(\\d+)-head$
+    match: ^.+-k8s1\.(\d+)(-head)?$
     replace: "$1"
     to: k0s-minor-version
   - from: ${{package.name}}
-    match: ^.+-(k8s)(1\\.\\d+)-head$
+    match: ^.+-(k8s)(1\.\d+)(-head)?$
     replace: "$1-$2"
     to: k8s-version
   - from: ${{package.version}}
@@ -42,6 +42,7 @@ environment:
       - build-base
       - go
       - ca-certificates-bundle
+      - curl
 
 pipeline:
   - uses: git-checkout
@@ -50,17 +51,12 @@ pipeline:
       tag: ${{package.version}}+${{vars.k8s-version}}
   - name: build-go-binary
     runs: |
-      export GOPROXY=https://proxy.golang.org,direct
-      export GOSUMDB=sum.golang.org
-      mkdir -p bin
-      CGO_ENABLED=0 go build \
-        -tags osusergo,netgo,k0s_legacy_airgap \
-        -ldflags="-s -w -extldflags=-static" \
-        -o bin/local-artifact-mirror ./cmd/local-artifact-mirror
+      make -C local-artifact-mirror build-deps build
 
       mkdir -p ${{targets.destdir}}/usr/bin
       mkdir -p ${{targets.destdir}}/usr/local/bin
-      cp bin/local-artifact-mirror ${{targets.destdir}}/usr/bin/local-artifact-mirror
+      cp local-artifact-mirror/bin/local-artifact-mirror-linux-$(go env GOARCH) \
+        ${{targets.destdir}}/usr/bin/local-artifact-mirror
       # support for legacy path
       ln -s /usr/bin/local-artifact-mirror ${{targets.destdir}}/usr/local/bin/local-artifact-mirror
 

--- a/securebuild/package/local-artifact-mirror-k8s1.34/melange.yaml
+++ b/securebuild/package/local-artifact-mirror-k8s1.34/melange.yaml
@@ -1,0 +1,67 @@
+package:
+  name: local-artifact-mirror-k8s1.34-head
+  version: "1000.0.0"
+  epoch: 0
+  description: Local Artifact Mirror
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - local-artifact-mirror-k8s1.34=${{package.full-version}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^.+-k8s1\\.(\\d+)-head$
+    replace: "$1"
+    to: k0s-minor-version
+  - from: ${{package.name}}
+    match: ^.+-(k8s)(1\\.\\d+)-head$
+    replace: "$1-$2"
+    to: k8s-version
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+$
+    replace: "$1"
+    to: major-minor-version
+  - from: ${{package.version}}
+    match: ^(\d+).*
+    replace: $1
+    to: major-version
+
+environment:
+  environment:
+    K0S_MINOR_VERSION: ${{vars.k0s-minor-version}}
+    GOPROXY: https://proxy.golang.org,direct
+    GOSUMDB: sum.golang.org
+  contents:
+    repositories:
+      - https://apk.cve0.io
+    keyring:
+      - https://apk.cve0.io/key/cve0-signing.rsa.pub
+    packages:
+      - busybox
+      - build-base
+      - go
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/replicatedhq/embedded-cluster
+      tag: ${{package.version}}+${{vars.k8s-version}}
+  - name: build-go-binary
+    runs: |
+      export GOPROXY=https://proxy.golang.org,direct
+      export GOSUMDB=sum.golang.org
+      mkdir -p bin
+      CGO_ENABLED=0 go build \
+        -tags osusergo,netgo,k0s_legacy_airgap \
+        -ldflags="-s -w -extldflags=-static" \
+        -o bin/local-artifact-mirror ./cmd/local-artifact-mirror
+
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mkdir -p ${{targets.destdir}}/usr/local/bin
+      cp bin/local-artifact-mirror ${{targets.destdir}}/usr/bin/local-artifact-mirror
+      # support for legacy path
+      ln -s /usr/bin/local-artifact-mirror ${{targets.destdir}}/usr/local/bin/local-artifact-mirror
+
+  - uses: strip

--- a/securebuild/package/local-artifact-mirror-k8s1.34/melange.yaml
+++ b/securebuild/package/local-artifact-mirror-k8s1.34/melange.yaml
@@ -11,11 +11,11 @@ package:
 
 var-transforms:
   - from: ${{package.name}}
-    match: ^.+-k8s1\\.(\\d+)-head$
+    match: ^.+-k8s1\.(\d+)(-head)?$
     replace: "$1"
     to: k0s-minor-version
   - from: ${{package.name}}
-    match: ^.+-(k8s)(1\\.\\d+)-head$
+    match: ^.+-(k8s)(1\.\d+)(-head)?$
     replace: "$1-$2"
     to: k8s-version
   - from: ${{package.version}}
@@ -42,6 +42,7 @@ environment:
       - build-base
       - go
       - ca-certificates-bundle
+      - curl
 
 pipeline:
   - uses: git-checkout
@@ -50,17 +51,12 @@ pipeline:
       tag: ${{package.version}}+${{vars.k8s-version}}
   - name: build-go-binary
     runs: |
-      export GOPROXY=https://proxy.golang.org,direct
-      export GOSUMDB=sum.golang.org
-      mkdir -p bin
-      CGO_ENABLED=0 go build \
-        -tags osusergo,netgo,k0s_legacy_airgap \
-        -ldflags="-s -w -extldflags=-static" \
-        -o bin/local-artifact-mirror ./cmd/local-artifact-mirror
+      make -C local-artifact-mirror build-deps build
 
       mkdir -p ${{targets.destdir}}/usr/bin
       mkdir -p ${{targets.destdir}}/usr/local/bin
-      cp bin/local-artifact-mirror ${{targets.destdir}}/usr/bin/local-artifact-mirror
+      cp local-artifact-mirror/bin/local-artifact-mirror-linux-$(go env GOARCH) \
+        ${{targets.destdir}}/usr/bin/local-artifact-mirror
       # support for legacy path
       ln -s /usr/bin/local-artifact-mirror ${{targets.destdir}}/usr/local/bin/local-artifact-mirror
 

--- a/securebuild/package/local-artifact-mirror-k8s1.35/melange.yaml
+++ b/securebuild/package/local-artifact-mirror-k8s1.35/melange.yaml
@@ -1,0 +1,67 @@
+package:
+  name: local-artifact-mirror-k8s1.35-head
+  version: "1000.0.0"
+  epoch: 0
+  description: Local Artifact Mirror
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - local-artifact-mirror-k8s1.35=${{package.full-version}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^.+-k8s1\\.(\\d+)-head$
+    replace: "$1"
+    to: k0s-minor-version
+  - from: ${{package.name}}
+    match: ^.+-(k8s)(1\\.\\d+)-head$
+    replace: "$1-$2"
+    to: k8s-version
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+$
+    replace: "$1"
+    to: major-minor-version
+  - from: ${{package.version}}
+    match: ^(\d+).*
+    replace: $1
+    to: major-version
+
+environment:
+  environment:
+    K0S_MINOR_VERSION: ${{vars.k0s-minor-version}}
+    GOPROXY: https://proxy.golang.org,direct
+    GOSUMDB: sum.golang.org
+  contents:
+    repositories:
+      - https://apk.cve0.io
+    keyring:
+      - https://apk.cve0.io/key/cve0-signing.rsa.pub
+    packages:
+      - busybox
+      - build-base
+      - go
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/replicatedhq/embedded-cluster
+      tag: ${{package.version}}+${{vars.k8s-version}}
+  - name: build-go-binary
+    runs: |
+      export GOPROXY=https://proxy.golang.org,direct
+      export GOSUMDB=sum.golang.org
+      mkdir -p bin
+      CGO_ENABLED=0 go build \
+        -tags osusergo,netgo,k0s_legacy_airgap \
+        -ldflags="-s -w -extldflags=-static" \
+        -o bin/local-artifact-mirror ./cmd/local-artifact-mirror
+
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mkdir -p ${{targets.destdir}}/usr/local/bin
+      cp bin/local-artifact-mirror ${{targets.destdir}}/usr/bin/local-artifact-mirror
+      # support for legacy path
+      ln -s /usr/bin/local-artifact-mirror ${{targets.destdir}}/usr/local/bin/local-artifact-mirror
+
+  - uses: strip

--- a/securebuild/package/local-artifact-mirror-k8s1.35/melange.yaml
+++ b/securebuild/package/local-artifact-mirror-k8s1.35/melange.yaml
@@ -11,11 +11,11 @@ package:
 
 var-transforms:
   - from: ${{package.name}}
-    match: ^.+-k8s1\\.(\\d+)-head$
+    match: ^.+-k8s1\.(\d+)(-head)?$
     replace: "$1"
     to: k0s-minor-version
   - from: ${{package.name}}
-    match: ^.+-(k8s)(1\\.\\d+)-head$
+    match: ^.+-(k8s)(1\.\d+)(-head)?$
     replace: "$1-$2"
     to: k8s-version
   - from: ${{package.version}}
@@ -42,6 +42,7 @@ environment:
       - build-base
       - go
       - ca-certificates-bundle
+      - curl
 
 pipeline:
   - uses: git-checkout
@@ -50,17 +51,12 @@ pipeline:
       tag: ${{package.version}}+${{vars.k8s-version}}
   - name: build-go-binary
     runs: |
-      export GOPROXY=https://proxy.golang.org,direct
-      export GOSUMDB=sum.golang.org
-      mkdir -p bin
-      CGO_ENABLED=0 go build \
-        -tags osusergo,netgo,k0s_legacy_airgap \
-        -ldflags="-s -w -extldflags=-static" \
-        -o bin/local-artifact-mirror ./cmd/local-artifact-mirror
+      make -C local-artifact-mirror build-deps build
 
       mkdir -p ${{targets.destdir}}/usr/bin
       mkdir -p ${{targets.destdir}}/usr/local/bin
-      cp bin/local-artifact-mirror ${{targets.destdir}}/usr/bin/local-artifact-mirror
+      cp local-artifact-mirror/bin/local-artifact-mirror-linux-$(go env GOARCH) \
+        ${{targets.destdir}}/usr/bin/local-artifact-mirror
       # support for legacy path
       ln -s /usr/bin/local-artifact-mirror ${{targets.destdir}}/usr/local/bin/local-artifact-mirror
 

--- a/securebuild/package/local-artifact-mirror-k8s1.36/melange.yaml
+++ b/securebuild/package/local-artifact-mirror-k8s1.36/melange.yaml
@@ -11,11 +11,11 @@ package:
 
 var-transforms:
   - from: ${{package.name}}
-    match: ^.+-k8s1\\.(\\d+)-head$
+    match: ^.+-k8s1\.(\d+)(-head)?$
     replace: "$1"
     to: k0s-minor-version
   - from: ${{package.name}}
-    match: ^.+-(k8s)(1\\.\\d+)-head$
+    match: ^.+-(k8s)(1\.\d+)(-head)?$
     replace: "$1-$2"
     to: k8s-version
   - from: ${{package.version}}
@@ -42,6 +42,7 @@ environment:
       - build-base
       - go
       - ca-certificates-bundle
+      - curl
 
 pipeline:
   - uses: git-checkout
@@ -50,17 +51,12 @@ pipeline:
       tag: ${{package.version}}+${{vars.k8s-version}}
   - name: build-go-binary
     runs: |
-      export GOPROXY=https://proxy.golang.org,direct
-      export GOSUMDB=sum.golang.org
-      mkdir -p bin
-      CGO_ENABLED=0 go build \
-        -tags osusergo,netgo \
-        -ldflags="-s -w -extldflags=-static" \
-        -o bin/local-artifact-mirror ./cmd/local-artifact-mirror
+      make -C local-artifact-mirror build-deps build
 
       mkdir -p ${{targets.destdir}}/usr/bin
       mkdir -p ${{targets.destdir}}/usr/local/bin
-      cp bin/local-artifact-mirror ${{targets.destdir}}/usr/bin/local-artifact-mirror
+      cp local-artifact-mirror/bin/local-artifact-mirror-linux-$(go env GOARCH) \
+        ${{targets.destdir}}/usr/bin/local-artifact-mirror
       # support for legacy path
       ln -s /usr/bin/local-artifact-mirror ${{targets.destdir}}/usr/local/bin/local-artifact-mirror
 

--- a/securebuild/package/local-artifact-mirror-k8s1.36/melange.yaml
+++ b/securebuild/package/local-artifact-mirror-k8s1.36/melange.yaml
@@ -1,0 +1,67 @@
+package:
+  name: local-artifact-mirror-k8s1.36-head
+  version: "1000.0.0"
+  epoch: 0
+  description: Local Artifact Mirror
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - local-artifact-mirror-k8s1.36=${{package.full-version}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^.+-k8s1\\.(\\d+)-head$
+    replace: "$1"
+    to: k0s-minor-version
+  - from: ${{package.name}}
+    match: ^.+-(k8s)(1\\.\\d+)-head$
+    replace: "$1-$2"
+    to: k8s-version
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+$
+    replace: "$1"
+    to: major-minor-version
+  - from: ${{package.version}}
+    match: ^(\d+).*
+    replace: $1
+    to: major-version
+
+environment:
+  environment:
+    K0S_MINOR_VERSION: ${{vars.k0s-minor-version}}
+    GOPROXY: https://proxy.golang.org,direct
+    GOSUMDB: sum.golang.org
+  contents:
+    repositories:
+      - https://apk.cve0.io
+    keyring:
+      - https://apk.cve0.io/key/cve0-signing.rsa.pub
+    packages:
+      - busybox
+      - build-base
+      - go
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/replicatedhq/embedded-cluster
+      tag: ${{package.version}}+${{vars.k8s-version}}
+  - name: build-go-binary
+    runs: |
+      export GOPROXY=https://proxy.golang.org,direct
+      export GOSUMDB=sum.golang.org
+      mkdir -p bin
+      CGO_ENABLED=0 go build \
+        -tags osusergo,netgo \
+        -ldflags="-s -w -extldflags=-static" \
+        -o bin/local-artifact-mirror ./cmd/local-artifact-mirror
+
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mkdir -p ${{targets.destdir}}/usr/local/bin
+      cp bin/local-artifact-mirror ${{targets.destdir}}/usr/bin/local-artifact-mirror
+      # support for legacy path
+      ln -s /usr/bin/local-artifact-mirror ${{targets.destdir}}/usr/local/bin/local-artifact-mirror
+
+  - uses: strip

--- a/tests/integration/kind/registry/ha_test.go
+++ b/tests/integration/kind/registry/ha_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/distribution/reference"
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons/adminconsole"
@@ -493,7 +494,7 @@ func buildOperatorImage(t *testing.T) string {
 		t.Logf("%s building operator image", formattedTime())
 
 		cmd := exec.CommandContext(
-			t.Context(), "make", "-C", operatorDir, "build-ttl.sh", "USE_CHAINGUARD=0",
+			t.Context(), "make", "-C", operatorDir, "build-ttl.sh",
 		)
 
 		var errBuf bytes.Buffer
@@ -510,20 +511,42 @@ func buildOperatorImage(t *testing.T) string {
 		t.Fatalf("failed to read operator image file: %v", err)
 	}
 
-	parts := strings.Split(strings.TrimSpace(string(image)), ":")
-	if len(parts) != 2 {
-		t.Fatalf("invalid operator image: %s", string(image))
+	repo, tag, err := splitOperatorImageReference(strings.TrimSpace(string(image)))
+	if err != nil {
+		t.Fatalf("invalid operator image %q: %v", strings.TrimSpace(string(image)), err)
 	}
 
 	embeddedclusteroperator.Metadata.Images["embedded-cluster-operator"] = release.AddonImage{
-		Repo: parts[0],
+		Repo: repo,
 		Tag: map[string]string{
-			"amd64": parts[1],
-			"arm64": parts[1],
+			"amd64": tag,
+			"arm64": tag,
 		},
 	}
 
 	return string(image)
+}
+
+func splitOperatorImageReference(image string) (string, string, error) {
+	ref, err := reference.Parse(image)
+	if err != nil {
+		return "", "", err
+	}
+
+	named, ok := ref.(reference.Named)
+	if !ok {
+		return "", "", fmt.Errorf("reference has no repository")
+	}
+	tagged, ok := ref.(reference.Tagged)
+	if !ok {
+		return "", "", fmt.Errorf("reference has no tag")
+	}
+
+	tag := tagged.Tag()
+	if digested, ok := ref.(reference.Digested); ok {
+		tag = fmt.Sprintf("%s@%s", tag, digested.Digest())
+	}
+	return named.Name(), tag, nil
 }
 
 func newTestingSpinner(t *testing.T) *spinner.MessageWriter {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

- Updates melange and apko specs to use cve0 APK repo
- Switches to securebuild CLI to create release packages and images

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. One release note per line. Blank lines will be ignored.
-->
New features:
 ```release-notes-features
 
 ```
 Bug fixes:
 ```release-notes-fixes
 
 ```
 Improvements:
 ```release-notes-improvements
 
 ```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
