### PR TITLE
Use depot CLI to trigger release notes workflow

### DIFF
--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -636,23 +636,21 @@ jobs:
             echo "is_from_main=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Setup Depot CLI
+        if: steps.check-main.outputs.is_from_main == 'true'
+        uses: depot/setup-action@v1
+
       - name: Generate EC Release Notes PR
         if: steps.check-main.outputs.is_from_main == 'true'
         continue-on-error: true
         env:
           GIT_TAG: ${{ needs.get-tag.outputs.tag-name }}
-          GH_PAT: ${{ secrets.GH_PAT }}
+          DEPOT_TOKEN: ${{ secrets.DEPOT_CI_DISPATCH_TOKEN }}
         run: |
-          http_code=$(curl -s -o response.txt -w "%{http_code}" \
-            -H "Authorization: token $GH_PAT" \
-            -H 'Accept: application/json' \
-            -d "{\"event_type\": \"embedded-cluster-release-notes\", \"client_payload\": {\"version\": \"${GIT_TAG}\"}}" \
-            "https://api.github.com/repos/replicatedhq/replicated-docs/dispatches")
-
-          echo "HTTP status: $http_code"
-          cat response.txt
-
-          if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
-            echo "Repository dispatch failed with HTTP status $http_code"
-            exit 1
-          fi
+          depot ci dispatch \
+            --repo replicatedhq/replicated-docs \
+            --workflow release-notes.yml \
+            --ref main \
+            --input event_type=embedded-cluster-release-notes \
+            --input version="${GIT_TAG}" \
+            --input dry_run=false


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Use depot CLI to trigger release notes workflow

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. One release note per line. Blank lines will be ignored.
-->
New features:
 ```release-notes-features
 
 ```
 Bug fixes:
 ```release-notes-fixes
 
 ```
 Improvements:
 ```release-notes-improvements
 
 ```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
