### PR TITLE
Fix regex in melange files

### DIFF
--- a/securebuild/package/embedded-cluster-operator-k8s1.33/melange.yaml
+++ b/securebuild/package/embedded-cluster-operator-k8s1.33/melange.yaml
@@ -11,11 +11,11 @@ package:
 
 var-transforms:
   - from: ${{package.name}}
-    match: ^.+-k8s1\.(\d+)(-head)?$
+    match: ^.+-k8s1\.(\d+)(-head)?(-\d+\.\d+)?$
     replace: "$1"
     to: k0s-minor-version
   - from: ${{package.name}}
-    match: ^.+-(k8s)(1\.\d+)(-head)?$
+    match: ^.+-(k8s)(1\.\d+)(-head)?(-\d+\.\d+)?$
     replace: "$1-$2"
     to: k8s-version
   - from: ${{package.version}}

--- a/securebuild/package/embedded-cluster-operator-k8s1.34/melange.yaml
+++ b/securebuild/package/embedded-cluster-operator-k8s1.34/melange.yaml
@@ -11,11 +11,11 @@ package:
 
 var-transforms:
   - from: ${{package.name}}
-    match: ^.+-k8s1\.(\d+)(-head)?$
+    match: ^.+-k8s1\.(\d+)(-head)?(-\d+\.\d+)?$
     replace: "$1"
     to: k0s-minor-version
   - from: ${{package.name}}
-    match: ^.+-(k8s)(1\.\d+)(-head)?$
+    match: ^.+-(k8s)(1\.\d+)(-head)?(-\d+\.\d+)?$
     replace: "$1-$2"
     to: k8s-version
   - from: ${{package.version}}

--- a/securebuild/package/embedded-cluster-operator-k8s1.35/melange.yaml
+++ b/securebuild/package/embedded-cluster-operator-k8s1.35/melange.yaml
@@ -11,11 +11,11 @@ package:
 
 var-transforms:
   - from: ${{package.name}}
-    match: ^.+-k8s1\.(\d+)(-head)?$
+    match: ^.+-k8s1\.(\d+)(-head)?(-\d+\.\d+)?$
     replace: "$1"
     to: k0s-minor-version
   - from: ${{package.name}}
-    match: ^.+-(k8s)(1\.\d+)(-head)?$
+    match: ^.+-(k8s)(1\.\d+)(-head)?(-\d+\.\d+)?$
     replace: "$1-$2"
     to: k8s-version
   - from: ${{package.version}}

--- a/securebuild/package/embedded-cluster-operator-k8s1.36/melange.yaml
+++ b/securebuild/package/embedded-cluster-operator-k8s1.36/melange.yaml
@@ -11,11 +11,11 @@ package:
 
 var-transforms:
   - from: ${{package.name}}
-    match: ^.+-k8s1\.(\d+)(-head)?$
+    match: ^.+-k8s1\.(\d+)(-head)?(-\d+\.\d+)?$
     replace: "$1"
     to: k0s-minor-version
   - from: ${{package.name}}
-    match: ^.+-(k8s)(1\.\d+)(-head)?$
+    match: ^.+-(k8s)(1\.\d+)(-head)?(-\d+\.\d+)?$
     replace: "$1-$2"
     to: k8s-version
   - from: ${{package.version}}

--- a/securebuild/package/local-artifact-mirror-k8s1.33/melange.yaml
+++ b/securebuild/package/local-artifact-mirror-k8s1.33/melange.yaml
@@ -11,11 +11,11 @@ package:
 
 var-transforms:
   - from: ${{package.name}}
-    match: ^.+-k8s1\.(\d+)(-head)?$
+    match: ^.+-k8s1\.(\d+)(-head)?(-\d+\.\d+)?$
     replace: "$1"
     to: k0s-minor-version
   - from: ${{package.name}}
-    match: ^.+-(k8s)(1\.\d+)(-head)?$
+    match: ^.+-(k8s)(1\.\d+)(-head)?(-\d+\.\d+)?$
     replace: "$1-$2"
     to: k8s-version
   - from: ${{package.version}}

--- a/securebuild/package/local-artifact-mirror-k8s1.34/melange.yaml
+++ b/securebuild/package/local-artifact-mirror-k8s1.34/melange.yaml
@@ -11,11 +11,11 @@ package:
 
 var-transforms:
   - from: ${{package.name}}
-    match: ^.+-k8s1\.(\d+)(-head)?$
+    match: ^.+-k8s1\.(\d+)(-head)?(-\d+\.\d+)?$
     replace: "$1"
     to: k0s-minor-version
   - from: ${{package.name}}
-    match: ^.+-(k8s)(1\.\d+)(-head)?$
+    match: ^.+-(k8s)(1\.\d+)(-head)?(-\d+\.\d+)?$
     replace: "$1-$2"
     to: k8s-version
   - from: ${{package.version}}

--- a/securebuild/package/local-artifact-mirror-k8s1.35/melange.yaml
+++ b/securebuild/package/local-artifact-mirror-k8s1.35/melange.yaml
@@ -11,11 +11,11 @@ package:
 
 var-transforms:
   - from: ${{package.name}}
-    match: ^.+-k8s1\.(\d+)(-head)?$
+    match: ^.+-k8s1\.(\d+)(-head)?(-\d+\.\d+)?$
     replace: "$1"
     to: k0s-minor-version
   - from: ${{package.name}}
-    match: ^.+-(k8s)(1\.\d+)(-head)?$
+    match: ^.+-(k8s)(1\.\d+)(-head)?(-\d+\.\d+)?$
     replace: "$1-$2"
     to: k8s-version
   - from: ${{package.version}}

--- a/securebuild/package/local-artifact-mirror-k8s1.36/melange.yaml
+++ b/securebuild/package/local-artifact-mirror-k8s1.36/melange.yaml
@@ -11,11 +11,11 @@ package:
 
 var-transforms:
   - from: ${{package.name}}
-    match: ^.+-k8s1\.(\d+)(-head)?$
+    match: ^.+-k8s1\.(\d+)(-head)?(-\d+\.\d+)?$
     replace: "$1"
     to: k0s-minor-version
   - from: ${{package.name}}
-    match: ^.+-(k8s)(1\.\d+)(-head)?$
+    match: ^.+-(k8s)(1\.\d+)(-head)?(-\d+\.\d+)?$
     replace: "$1-$2"
     to: k8s-version
   - from: ${{package.version}}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

This adds support for SecureBuild-injected package names.

- SecureBuild injects a package name such as `embedded-cluster-operator-k8s1.36-2.19`.
- The existing regex does not match the appended `-2.19`, so `k8s-version` retains the entire package name.
- Consequently, `tag: ${{package.version}}+${{vars.k8s-version}}` becomes `2.19.5+embedded-cluster-operator-k8s1.36-2.19`.
- The expected Git tag is `2.19.5+k8s-1.36`.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. One release note per line. Blank lines will be ignored.
-->
New features:
 ```release-notes-features
 
 ```
 Bug fixes:
 ```release-notes-fixes
 
 ```
 Improvements:
 ```release-notes-improvements
 
 ```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
