### PR TITLE
Add k8s version to image name

### DIFF
--- a/.github/workflows/publish-securebuild.yml
+++ b/.github/workflows/publish-securebuild.yml
@@ -60,7 +60,9 @@ jobs:
             --api-token "$SECUREBUILD_API_TOKEN"
 
   build-images:
-    needs: build-packages
+    needs:
+      - validate-version
+      - build-packages
     runs-on: ubuntu-latest
     continue-on-error: true
     strategy:
@@ -80,6 +82,6 @@ jobs:
           SECUREBUILD_API_TOKEN: ${{ secrets.SECUREBUILD_API_TOKEN }}
         run: |
           ./securebuild build image \
-            --image-name "${{ matrix.image-name }}" \
+            --image-name "${{ matrix.image-name }}-k8s1.${{ needs.validate-version.outputs.k0s-minor-version }}" \
             --tag "${{ inputs.version }}" \
             --api-token "$SECUREBUILD_API_TOKEN"


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Securebuild image name is embedded-cluster-operator-k8s1.36, not `embedded-cluster-operator`

```
  ./securebuild build image \
    --image-name "embedded-cluster-operator" \
    --tag "2.19.5+k8s-1.36" \
    --api-token "$SECUREBUILD_API_TOKEN"
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. One release note per line. Blank lines will be ignored.
-->
New features:
 ```release-notes-features
 
 ```
 Bug fixes:
 ```release-notes-fixes
 
 ```
 Improvements:
 ```release-notes-improvements
 
 ```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
