### PR TITLE
Fix securebuild specs

### DIFF
--- a/securebuild/image/apko-local-artifact-mirror-k8s1.34.yaml
+++ b/securebuild/image/apko-local-artifact-mirror-k8s1.34.yaml
@@ -7,6 +7,7 @@ contents:
     - busybox
     - ca-certificates-bundle
     - local-artifact-mirror-k8s1.34
+    - local-artifact-mirror-k8s1.34-compat
 
 accounts:
   groups:

--- a/securebuild/image/apko-local-artifact-mirror-k8s1.35.yaml
+++ b/securebuild/image/apko-local-artifact-mirror-k8s1.35.yaml
@@ -7,6 +7,7 @@ contents:
     - busybox
     - ca-certificates-bundle
     - local-artifact-mirror-k8s1.35
+    - local-artifact-mirror-k8s1.35-compat
 
 accounts:
   groups:

--- a/securebuild/image/apko-local-artifact-mirror-k8s1.36.yaml
+++ b/securebuild/image/apko-local-artifact-mirror-k8s1.36.yaml
@@ -7,6 +7,7 @@ contents:
     - busybox
     - ca-certificates-bundle
     - local-artifact-mirror-k8s1.36
+    - local-artifact-mirror-k8s1.36-compat
 
 accounts:
   groups:

--- a/securebuild/package/embedded-cluster-operator-k8s1.34/melange.yaml
+++ b/securebuild/package/embedded-cluster-operator-k8s1.34/melange.yaml
@@ -38,6 +38,7 @@ environment:
     keyring:
       - https://apk.cve0.io/key/cve0-signing.rsa.pub
     packages:
+      - bash
       - busybox
       - build-base
       - go
@@ -57,3 +58,19 @@ pipeline:
       cp operator/bin/manager ${{targets.destdir}}/manager
 
   - uses: strip
+
+test:
+  environment:
+    contents:
+      repositories:
+        - https://apk.cve0.io
+      keyring:
+        - https://apk.cve0.io/key/cve0-signing.rsa.pub
+      packages:
+        - ${{package.name}}=${{package.full-version}}
+        - busybox
+  pipeline:
+    - name: Verify operator binary
+      runs: |
+        test -x /manager
+        /manager --help

--- a/securebuild/package/embedded-cluster-operator-k8s1.35/melange.yaml
+++ b/securebuild/package/embedded-cluster-operator-k8s1.35/melange.yaml
@@ -38,6 +38,7 @@ environment:
     keyring:
       - https://apk.cve0.io/key/cve0-signing.rsa.pub
     packages:
+      - bash
       - busybox
       - build-base
       - go
@@ -57,3 +58,19 @@ pipeline:
       cp operator/bin/manager ${{targets.destdir}}/manager
 
   - uses: strip
+
+test:
+  environment:
+    contents:
+      repositories:
+        - https://apk.cve0.io
+      keyring:
+        - https://apk.cve0.io/key/cve0-signing.rsa.pub
+      packages:
+        - ${{package.name}}=${{package.full-version}}
+        - busybox
+  pipeline:
+    - name: Verify operator binary
+      runs: |
+        test -x /manager
+        /manager --help

--- a/securebuild/package/embedded-cluster-operator-k8s1.36/melange.yaml
+++ b/securebuild/package/embedded-cluster-operator-k8s1.36/melange.yaml
@@ -38,6 +38,7 @@ environment:
     keyring:
       - https://apk.cve0.io/key/cve0-signing.rsa.pub
     packages:
+      - bash
       - busybox
       - build-base
       - go
@@ -57,3 +58,19 @@ pipeline:
       cp operator/bin/manager ${{targets.destdir}}/manager
 
   - uses: strip
+
+test:
+  environment:
+    contents:
+      repositories:
+        - https://apk.cve0.io
+      keyring:
+        - https://apk.cve0.io/key/cve0-signing.rsa.pub
+      packages:
+        - ${{package.name}}=${{package.full-version}}
+        - busybox
+  pipeline:
+    - name: Verify operator binary
+      runs: |
+        test -x /manager
+        /manager --help

--- a/securebuild/package/local-artifact-mirror-k8s1.34/melange.yaml
+++ b/securebuild/package/local-artifact-mirror-k8s1.34/melange.yaml
@@ -38,6 +38,7 @@ environment:
     keyring:
       - https://apk.cve0.io/key/cve0-signing.rsa.pub
     packages:
+      - bash
       - busybox
       - build-base
       - go
@@ -54,10 +55,52 @@ pipeline:
       make -C local-artifact-mirror build-deps build
 
       mkdir -p ${{targets.destdir}}/usr/bin
-      mkdir -p ${{targets.destdir}}/usr/local/bin
       cp local-artifact-mirror/bin/local-artifact-mirror-linux-$(go env GOARCH) \
         ${{targets.destdir}}/usr/bin/local-artifact-mirror
-      # support for legacy path
-      ln -s /usr/bin/local-artifact-mirror ${{targets.destdir}}/usr/local/bin/local-artifact-mirror
 
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: Compatibility package for the legacy local artifact mirror path
+    dependencies:
+      runtime:
+        - ${{package.name}}
+      provides:
+        - local-artifact-mirror-compat=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/local/bin
+          ln -s /usr/bin/local-artifact-mirror \
+            ${{targets.subpkgdir}}/usr/local/bin/local-artifact-mirror
+    test:
+      environment:
+        contents:
+          repositories:
+            - https://apk.cve0.io
+          keyring:
+            - https://apk.cve0.io/key/cve0-signing.rsa.pub
+          packages:
+            - ${{package.name}}-compat=${{package.full-version}}
+            - busybox
+      pipeline:
+        - name: Verify legacy binary path
+          runs: |
+            test -L /usr/local/bin/local-artifact-mirror
+            /usr/local/bin/local-artifact-mirror --help
+
+test:
+  environment:
+    contents:
+      repositories:
+        - https://apk.cve0.io
+      keyring:
+        - https://apk.cve0.io/key/cve0-signing.rsa.pub
+      packages:
+        - ${{package.name}}=${{package.full-version}}
+        - busybox
+  pipeline:
+    - name: Verify local artifact mirror binary
+      runs: |
+        test -x /usr/bin/local-artifact-mirror
+        /usr/bin/local-artifact-mirror --help

--- a/securebuild/package/local-artifact-mirror-k8s1.35/melange.yaml
+++ b/securebuild/package/local-artifact-mirror-k8s1.35/melange.yaml
@@ -38,6 +38,7 @@ environment:
     keyring:
       - https://apk.cve0.io/key/cve0-signing.rsa.pub
     packages:
+      - bash
       - busybox
       - build-base
       - go
@@ -54,10 +55,52 @@ pipeline:
       make -C local-artifact-mirror build-deps build
 
       mkdir -p ${{targets.destdir}}/usr/bin
-      mkdir -p ${{targets.destdir}}/usr/local/bin
       cp local-artifact-mirror/bin/local-artifact-mirror-linux-$(go env GOARCH) \
         ${{targets.destdir}}/usr/bin/local-artifact-mirror
-      # support for legacy path
-      ln -s /usr/bin/local-artifact-mirror ${{targets.destdir}}/usr/local/bin/local-artifact-mirror
 
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: Compatibility package for the legacy local artifact mirror path
+    dependencies:
+      runtime:
+        - ${{package.name}}
+      provides:
+        - local-artifact-mirror-compat=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/local/bin
+          ln -s /usr/bin/local-artifact-mirror \
+            ${{targets.subpkgdir}}/usr/local/bin/local-artifact-mirror
+    test:
+      environment:
+        contents:
+          repositories:
+            - https://apk.cve0.io
+          keyring:
+            - https://apk.cve0.io/key/cve0-signing.rsa.pub
+          packages:
+            - ${{package.name}}-compat=${{package.full-version}}
+            - busybox
+      pipeline:
+        - name: Verify legacy binary path
+          runs: |
+            test -L /usr/local/bin/local-artifact-mirror
+            /usr/local/bin/local-artifact-mirror --help
+
+test:
+  environment:
+    contents:
+      repositories:
+        - https://apk.cve0.io
+      keyring:
+        - https://apk.cve0.io/key/cve0-signing.rsa.pub
+      packages:
+        - ${{package.name}}=${{package.full-version}}
+        - busybox
+  pipeline:
+    - name: Verify local artifact mirror binary
+      runs: |
+        test -x /usr/bin/local-artifact-mirror
+        /usr/bin/local-artifact-mirror --help

--- a/securebuild/package/local-artifact-mirror-k8s1.36/melange.yaml
+++ b/securebuild/package/local-artifact-mirror-k8s1.36/melange.yaml
@@ -38,6 +38,7 @@ environment:
     keyring:
       - https://apk.cve0.io/key/cve0-signing.rsa.pub
     packages:
+      - bash
       - busybox
       - build-base
       - go
@@ -54,10 +55,52 @@ pipeline:
       make -C local-artifact-mirror build-deps build
 
       mkdir -p ${{targets.destdir}}/usr/bin
-      mkdir -p ${{targets.destdir}}/usr/local/bin
       cp local-artifact-mirror/bin/local-artifact-mirror-linux-$(go env GOARCH) \
         ${{targets.destdir}}/usr/bin/local-artifact-mirror
-      # support for legacy path
-      ln -s /usr/bin/local-artifact-mirror ${{targets.destdir}}/usr/local/bin/local-artifact-mirror
 
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: Compatibility package for the legacy local artifact mirror path
+    dependencies:
+      runtime:
+        - ${{package.name}}
+      provides:
+        - local-artifact-mirror-compat=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/local/bin
+          ln -s /usr/bin/local-artifact-mirror \
+            ${{targets.subpkgdir}}/usr/local/bin/local-artifact-mirror
+    test:
+      environment:
+        contents:
+          repositories:
+            - https://apk.cve0.io
+          keyring:
+            - https://apk.cve0.io/key/cve0-signing.rsa.pub
+          packages:
+            - ${{package.name}}-compat=${{package.full-version}}
+            - busybox
+      pipeline:
+        - name: Verify legacy binary path
+          runs: |
+            test -L /usr/local/bin/local-artifact-mirror
+            /usr/local/bin/local-artifact-mirror --help
+
+test:
+  environment:
+    contents:
+      repositories:
+        - https://apk.cve0.io
+      keyring:
+        - https://apk.cve0.io/key/cve0-signing.rsa.pub
+      packages:
+        - ${{package.name}}=${{package.full-version}}
+        - busybox
+  pipeline:
+    - name: Verify local artifact mirror binary
+      runs: |
+        test -x /usr/bin/local-artifact-mirror
+        /usr/bin/local-artifact-mirror --help


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Fixes securebuild specs:
- add `bash` dependency because Makefile uses bash
- add tests
- add compatibility package for local-artifact-mirror to clear out a linter warning about `/usr/local/bin` path.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. One release note per line. Blank lines will be ignored.
-->
New features:
 ```release-notes-features
 
 ```
 Bug fixes:
 ```release-notes-fixes
 
 ```
 Improvements:
 ```release-notes-improvements
 
 ```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
