### PR TITLE
Install missing dagger

### DIFF
--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -189,6 +189,11 @@ jobs:
 
       - uses: imjasonh/setup-crane@v0.7
 
+      - name: Install dagger
+        run: |
+          curl -fsSL https://dl.dagger.io/dagger/install.sh | sh
+          sudo mv ./bin/dagger /usr/local/bin/dagger
+
       - name: Download buildtools artifact
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

The release job is failing randomly when building fio if it's not up to date

```
make output/bins/fio-3.42-amd64
mkdir -p output/bins
dagger call build-fio --version=3.42 --arch=amd64 export --path=output/bins/fio-3.42-amd64
/bin/bash: line 1: dagger: command not found
make[1]: *** [Makefile:135: output/bins/fio-3.42-amd64] Error 127
make: *** [Makefile:142: cmd/installer/goods/bins/fio] Error 2
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. One release note per line. Blank lines will be ignored.
-->
New features:
 ```release-notes-features
 
 ```
 Bug fixes:
 ```release-notes-fixes
 
 ```
 Improvements:
 ```release-notes-improvements
 
 ```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
