### PR TITLE
Fix containerd format in upgrade tests

### DIFF
--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -182,7 +182,11 @@ func TestSingleNodeUpgradePreviousStable(t *testing.T) {
 	}
 
 	checkPostUpgradeState(t, tc)
-	checkContainerdRegistryConfigAbsent(t, tc, 0)
+	if usesContainerdV3Schema() {
+		checkContainerdRegistryConfigAbsent(t, tc, 0)
+	} else {
+		checkContainerdRegistryConfigV2(t, tc, 0)
+	}
 
 	line = []string{"collect-support-bundle-host-in-cluster.sh"}
 	stdout, stderr, err := tc.RunCommandOnNode(0, line)
@@ -416,12 +420,14 @@ func TestSingleNodeAirgapUpgradeSelinux(t *testing.T) {
 
 	checkPostUpgradeState(t, tc)
 
-	// The 1.35 -> 1.36 upgrade must migrate the airgap registry drop-in to the v3
-	// containerd schema, or k0s 1.36 won't start.
-	t.Logf("%s: verifying containerd registry drop-in migrated to v3 schema", time.Now().Format(time.RFC3339))
-	line = []string{"grep -q 'io.containerd.cri.v1.images' /etc/k0s/containerd.d/embedded-registry.toml && ! grep -q 'io.containerd.grpc.v1.cri' /etc/k0s/containerd.d/embedded-registry.toml"}
-	if stdout, stderr, err := tc.RunCommandOnNode(0, line); err != nil {
-		t.Fatalf("containerd registry drop-in was not migrated to the v3 schema: %v: %s: %s", err, stdout, stderr)
+	if usesContainerdV3Schema() {
+		// A 1.35 -> 1.36 upgrade must migrate the airgap registry drop-in to
+		// the v3 schema, or k0s 1.36 won't start.
+		checkContainerdRegistryConfigV3(t, tc, 0)
+	} else {
+		// A 1.34 -> 1.35 upgrade must leave the registry drop-in on the v2
+		// schema supported by containerd 1.7.
+		checkContainerdRegistryConfigV2(t, tc, 0)
 	}
 
 	t.Logf("%s: test complete", time.Now().Format(time.RFC3339))

--- a/e2e/shared.go
+++ b/e2e/shared.go
@@ -370,3 +370,23 @@ func checkContainerdRegistryConfigAbsent(t *testing.T, tc cluster.Cluster, node 
 		t.Fatalf("containerd registry drop-in should be absent on online installs on node %d: %v: %s: %s", node, err, stdout, stderr)
 	}
 }
+
+// checkContainerdRegistryConfigV2 asserts the registry drop-in still uses the
+// containerd 1.7 schema required by k0s 1.34 and 1.35.
+func checkContainerdRegistryConfigV2(t *testing.T, tc cluster.Cluster, node int) {
+	t.Logf("%s: verifying containerd registry drop-in uses the v2 schema on node %d", time.Now().Format(time.RFC3339), node)
+	line := []string{"grep -q 'io.containerd.grpc.v1.cri' /etc/k0s/containerd.d/embedded-registry.toml && ! grep -q 'io.containerd.cri.v1.images' /etc/k0s/containerd.d/embedded-registry.toml"}
+	if stdout, stderr, err := tc.RunCommandOnNode(node, line); err != nil {
+		t.Fatalf("containerd registry drop-in does not use the v2 schema on node %d: %v: %s: %s", node, err, stdout, stderr)
+	}
+}
+
+// checkContainerdRegistryConfigV3 asserts the registry drop-in was migrated to
+// the containerd 2.x schema required by k0s 1.36 and later.
+func checkContainerdRegistryConfigV3(t *testing.T, tc cluster.Cluster, node int) {
+	t.Logf("%s: verifying containerd registry drop-in uses the v3 schema on node %d", time.Now().Format(time.RFC3339), node)
+	line := []string{"grep -q 'io.containerd.cri.v1.images' /etc/k0s/containerd.d/embedded-registry.toml && ! grep -q 'io.containerd.grpc.v1.cri' /etc/k0s/containerd.d/embedded-registry.toml"}
+	if stdout, stderr, err := tc.RunCommandOnNode(node, line); err != nil {
+		t.Fatalf("containerd registry drop-in does not use the v3 schema on node %d: %v: %s: %s", node, err, stdout, stderr)
+	}
+}

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Masterminds/semver/v3"
 )
 
 func RequireEnvVars(t *testing.T, envVars []string) {
@@ -67,6 +69,14 @@ func k8sVersion() string {
 		panic(fmt.Sprintf("failed to parse k8s version %q", os.Getenv("EXPECT_K0S_VERSION")))
 	}
 	return verParts[0]
+}
+
+func usesContainerdV3Schema() bool {
+	version, err := semver.NewVersion(k8sVersion())
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse k8s version %q: %v", k8sVersion(), err))
+	}
+	return version.Major() == 1 && version.Minor() >= 36
 }
 
 func k8sVersionPrevious(n int) string {


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes upgrade E2E assertions for releases targeting Kubernetes 1.34 and 1.35. This error only happens in the tagged release workflows. It does not happen on PRs and on main.

The containerd migration command runs unconditionally during upgrades, but `MigrateContainerdConfigToV3` intentionally no-ops for k0s versions below 1.36. Kubernetes 1.34 and 1.35 ship containerd 1.7 and must retain the v2 registry schema; Kubernetes 1.36 ships containerd 2.x and requires the v3 schema.

The tests incorrectly expected the 1.36 result for every supported Kubernetes version, causing successful 1.34 and 1.35 upgrades to be reported as failures. Assertions are now conditional on the target Kubernetes version.

#### Which issue(s) this PR fixes:

NONE

#### Does this PR require a test?

Covered by the existing upgrade E2E tests.

#### Does this PR require a release note?

NONE

#### Does this PR require documentation?

NONE