### PR TITLE
Don't prefix tag with v when triggering release notes dispatch

### DIFF
--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag-name: ${{ steps.get-tag.outputs.tag-name }}
-      securebuild-version: ${{ steps.get-tag.outputs.securebuild-version }}
       is-stable: ${{ steps.get-tag.outputs.is-stable }}
       k0s_version: ${{ steps.export.outputs.k0s_version }}
       k0s_minor_version: ${{ steps.export.outputs.k0s_minor_version }}
@@ -33,7 +32,6 @@ jobs:
           export V_TAG=$(echo "$RAW_TAG" | sed 's/^[^v]/v&/')
           # store the tag name in an output for later steps
           echo "tag-name=${V_TAG}" >> $GITHUB_OUTPUT
-          echo "securebuild-version=${RAW_TAG}" >> "$GITHUB_OUTPUT"
           if [[ "$V_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+\+k8s-1\.[0-9]+$ ]]; then
             echo "is-stable=true" >> "$GITHUB_OUTPUT"
           else
@@ -82,7 +80,7 @@ jobs:
     if: needs.get-tag.outputs.is-stable == 'true'
     uses: ./.github/workflows/publish-securebuild.yml
     with:
-      version: ${{ needs.get-tag.outputs.securebuild-version }}
+      version: ${{ github.ref_name }}
     secrets: inherit
 
   publish-operator-image:
@@ -666,7 +664,7 @@ jobs:
         if: steps.check-main.outputs.is_from_main == 'true'
         continue-on-error: true
         env:
-          GIT_TAG: ${{ needs.get-tag.outputs.tag-name }}
+          GIT_TAG: ${{ github.ref_name }}
           DEPOT_TOKEN: ${{ secrets.DEPOT_CI_DISPATCH_TOKEN }}
         run: |
           depot ci dispatch \


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Fixes this error when release notes get generated because of the extra `v` in the diff URL

> 2026/08/25 22:36:44 Failed to get release notes: GET https://api.github.com/repos/replicatedhq/embedded-cluster/compare/2.19.6%2Bk8s-1.36...v2.19.6%2Bk8s-1.36?per_page=100: 404 Not Found []

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. One release note per line. Blank lines will be ignored.
-->
New features:
 ```release-notes-features
 
 ```
 Bug fixes:
 ```release-notes-fixes
 
 ```
 Improvements:
 ```release-notes-improvements
 
 ```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
