### PR TITLE
fix: bound k0s reset so a stuck container runtime cannot hang teardown

### DIFF
--- a/cmd/installer/cli/assets/unmount.sh
+++ b/cmd/installer/cli/assets/unmount.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Detach every mount below a directory.
+#
+# reset runs this before removing the k0s data and run directories when
+# `k0s reset` did not get far enough to do it itself.
+# rm returns EBUSY on a mountpoint, and a torn-down node is left covered in
+# them: kubelet leaves tmpfs and bind mounts under the pod volume tree, and
+# containerd leaves sandbox shm and task rootfs overlays under the run dir.
+#
+# Usage: unmount.sh <directory>
+
+set -u
+
+dir="$1"
+
+# Field 2 of the mount table is the mount point. Collect the ones strictly below
+# $dir, then emit them in reverse mount order so that nested mounts and
+# over-mounts are detached before the mounts they sit on.
+#
+# $dir itself is deliberately excluded: if it is a mount, it is one the user
+# provided (a data dir on its own partition), not one we created. k0s leaves
+# those alone for the same reason, and rm still clears the contents.
+awk -v d="$dir" '
+    index($2, d "/") == 1 { mounts[++n] = $2 }
+    END { for (i = n; i > 0; i--) print mounts[i] }
+' /proc/self/mounts |
+while IFS= read -r mount; do
+    # A mount still pinned by an orphaned container process needs a lazy detach.
+    umount "$mount" 2>/dev/null && continue
+    umount -l "$mount" 2>/dev/null || true
+done

--- a/cmd/installer/cli/assets/unmount.sh
+++ b/cmd/installer/cli/assets/unmount.sh
@@ -20,8 +20,20 @@ dir="$1"
 # $dir itself is deliberately excluded: if it is a mount, it is one the user
 # provided (a data dir on its own partition), not one we created. k0s leaves
 # those alone for the same reason, and rm still clears the contents.
-awk -v d="$dir" '
-    index($2, d "/") == 1 { mounts[++n] = $2 }
+#
+# The kernel escapes space and tab in mount points, so those are decoded before
+# comparing — a data dir containing a space would otherwise match nothing. $dir
+# is passed through the environment rather than -v, which would itself interpret
+# backslash escapes in the value.
+DIR="$dir" awk '
+    function unescape(p) {
+        gsub(/\\040/, " ", p)
+        gsub(/\\011/, "\t", p)
+        return p
+    }
+    BEGIN { d = ENVIRON["DIR"] }
+    { mountpoint = unescape($2) }
+    index(mountpoint, d "/") == 1 { mounts[++n] = mountpoint }
     END { for (i = n; i > 0; i--) print mounts[i] }
 ' /proc/self/mounts |
 while IFS= read -r mount; do

--- a/cmd/installer/cli/reset.go
+++ b/cmd/installer/cli/reset.go
@@ -2,12 +2,15 @@ package cli
 
 import (
 	"context"
+	_ "embed"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	autopilot "github.com/k0sproject/k0s/pkg/apis/autopilot/v1beta2"
@@ -28,9 +31,27 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// k0sBinPath is the k0s binary this command stops and resets. Overridden by tests.
+var k0sBinPath = "/usr/local/bin/k0s"
+
 const (
-	k0sBinPath = "/usr/local/bin/k0s"
+	// k0sRunDir holds k0s runtime state: the containerd socket, sandbox shm
+	// mounts and task rootfs overlays.
+	k0sRunDir = "/run/k0s"
 )
+
+// k0sResetTimeout bounds the `k0s reset` call. k0s issues its container-runtime
+// calls with no deadline, so a containerd that stops responding hangs reset
+// forever and none of the teardown after it ever runs. Generous enough not to
+// cut short a slow disk. Overridden by tests.
+var k0sResetTimeout = 2 * time.Minute
+
+// k0sResetDumpLead is how long before the deadline k0s is asked for a goroutine
+// dump, leaving it time to print the stacks before the deadline kills it.
+var k0sResetDumpLead = 15 * time.Second
+
+//go:embed assets/unmount.sh
+var unmountScript string
 
 type hostInfo struct {
 	Hostname         string
@@ -156,6 +177,11 @@ func ResetCmd(ctx context.Context, appTitle string) *cobra.Command {
 			err = stopAndResetK0s(rc.EmbeddedClusterK0sSubDir())
 			if err != nil {
 				logrus.Warnf("Failed to stop and reset k0s (continuing with reset anyway): %v", err)
+				// k0s did not finish its own cleanup, so nothing killed the processes
+				// holding the kubelet and containerd mounts or detached them. Without
+				// this the removals below fail with EBUSY and the node is left with an
+				// installation the next install refuses to overwrite.
+				forceK0sTeardown(rc.EmbeddedClusterHomeDirectory(), rc.EmbeddedClusterK0sSubDir())
 			}
 
 			logrus.Debugf("Resetting firewalld...")
@@ -164,8 +190,11 @@ func ResetCmd(ctx context.Context, appTitle string) *cobra.Command {
 				return fmt.Errorf("failed to reset firewalld: %w", err)
 			}
 
-			if err := helpers.RemoveAll(runtimeconfig.K0sConfigPath); err != nil {
-				return fmt.Errorf("failed to remove k0s config: %w", err)
+			// The whole directory, not just k0s.yaml: it also holds containerd
+			// drop-ins and registry certs, and nothing else removes them — k0s's
+			// own cleanup only covers its data and run dirs.
+			if err := helpers.RemoveAll(filepath.Dir(runtimeconfig.K0sConfigPath)); err != nil {
+				return fmt.Errorf("failed to remove k0s config directory: %w", err)
 			}
 
 			lamPath := "/etc/systemd/system/local-artifact-mirror.service"
@@ -621,12 +650,61 @@ func stopAndResetK0s(dataDir string) error {
 		logrus.Warnf("Failed to stop k0s (continuing with reset anyway): %v", err)
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), k0sResetTimeout)
+	defer cancel()
+
+	// Shortly before the deadline, ask k0s for a goroutine dump. SIGQUIT makes it
+	// print every stack and exit, and its output is streamed to the log, so the
+	// stuck call (in practice a CRI RemovePodSandbox) is recorded. Signalling
+	// containerd instead yields nothing: its output is piped to this k0s process,
+	// which the deadline is about to kill.
+	var dumped atomic.Bool
+	dump := time.AfterFunc(k0sResetTimeout-k0sResetDumpLead, func() {
+		dumped.Store(true)
+		logrus.Warnf("k0s reset is taking too long, collecting a stack dump")
+		_, _ = helpers.RunCommand("pkill", "-QUIT", "-f", "k0s reset --data-dir")
+	})
+	defer dump.Stop()
+
 	resetOut := &lineLogWriter{prefix: "k0s reset"}
-	err = helpers.RunCommandWithOptions(helpers.RunCommandOptions{Stdout: resetOut, Stderr: resetOut, SkipLogOutput: true}, k0sBinPath, "reset", "--data-dir", dataDir, "--verbose")
+	err = helpers.RunCommandWithOptions(helpers.RunCommandOptions{Context: ctx, Stdout: resetOut, Stderr: resetOut, SkipLogOutput: true}, k0sBinPath, "reset", "--data-dir", dataDir, "--verbose")
 	if err != nil {
+		if ctx.Err() != nil || dumped.Load() {
+			return fmt.Errorf("k0s reset timed out after %s: %w", k0sResetTimeout, err)
+		}
 		return fmt.Errorf("could not reset k0s: %w", err)
 	}
 	return nil
+}
+
+// forceK0sTeardown does the cleanup `k0s reset` would have done itself: kill the
+// processes still holding the kubelet and containerd mounts, then detach the
+// mounts so the directories can be removed. Every step is best-effort — pkill
+// exits non-zero when nothing matches, which is the normal case.
+func forceK0sTeardown(homeDir, k0sDataDir string) {
+	logrus.Infof("Force killing any stale k0s processes")
+	for _, proc := range []string{"k0s", "kube-apiserver", "kube-controller-manager", "kube-scheduler", "kubelet", "containerd"} {
+		_, _ = helpers.RunCommand("pkill", "-9", "-f", proc)
+	}
+
+	// homeDir is listed as well because reset removes it whole, and it is not
+	// always a parent of k0sDataDir — K0sDataDirOverride moves the latter out.
+	for _, dir := range []string{homeDir, k0sDataDir, k0sRunDir} {
+		if out, err := helpers.RunCommand("sh", "-c", unmountScript, "sh", dir); err != nil {
+			logrus.Debugf("Failed to unmount below %s (ignored): %v, %s", dir, err, out)
+		}
+	}
+
+	// Remove vxlan.calico (holds port 4789/UDP), the Calico veth interfaces and
+	// the blackhole routes so the pod CIDR can be reused. k0s does this in its own
+	// cni cleanup step, which is one of the steps that did not run.
+	for _, cmd := range [][]string{
+		{"ip", "link", "delete", "vxlan.calico"},
+		{"sh", "-c", "ip link show | grep -oE ' cali[0-9a-f]+' | xargs -r -L1 ip link delete"},
+		{"sh", "-c", "ip route show table all | grep blackhole | grep 'proto 80' | awk '{print $1, $2}' | xargs -r -L1 ip route delete"},
+	} {
+		_, _ = helpers.RunCommand(cmd[0], cmd[1:]...)
+	}
 }
 
 // lineLogWriter streams command output to logrus as it is written, so that

--- a/cmd/installer/cli/reset_test.go
+++ b/cmd/installer/cli/reset_test.go
@@ -1,0 +1,143 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/replicatedhq/embedded-cluster/pkg/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeHelpers records every command and can block one of them until the
+// caller's context is cancelled, reproducing a `k0s reset` stuck on a container
+// runtime call that never returns.
+type fakeHelpers struct {
+	mu      sync.Mutex
+	calls   []string
+	blockOn string
+}
+
+func (f *fakeHelpers) record(bin string, args ...string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, strings.TrimSpace(bin+" "+strings.Join(args, " ")))
+}
+
+func (f *fakeHelpers) ran(prefix string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, c := range f.calls {
+		if strings.HasPrefix(c, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *fakeHelpers) RunCommand(bin string, args ...string) (string, error) {
+	f.record(bin, args...)
+	if bin == "systemctl" {
+		// Make stopAndResetK0s believe the controller unit exists.
+		return "k0scontroller.service enabled", nil
+	}
+	return "", nil
+}
+
+func (f *fakeHelpers) RunCommandWithOptions(opts helpers.RunCommandOptions, bin string, args ...string) error {
+	f.record(bin, args...)
+	if f.blockOn != "" && strings.Contains(strings.Join(args, " "), f.blockOn) {
+		ctx := opts.Context
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	return nil
+}
+
+func (f *fakeHelpers) IsSystemdServiceActive(context.Context, string) (bool, error) {
+	return false, nil
+}
+
+// installFakeHelpers swaps in the fake for the duration of the test and points
+// k0sBinPath at a file that exists, so stopAndResetK0s does not bail out early.
+func installFakeHelpers(t *testing.T, f *fakeHelpers) {
+	t.Helper()
+
+	bin := filepath.Join(t.TempDir(), "k0s")
+	require.NoError(t, os.WriteFile(bin, []byte("fake k0s"), 0755))
+
+	origBin, origHelpers := k0sBinPath, helpers.HelpersInterface(&helpers.Helpers{})
+	k0sBinPath = bin
+	helpers.Set(f)
+	t.Cleanup(func() {
+		k0sBinPath = origBin
+		helpers.Set(origHelpers)
+	})
+}
+
+// TestStopAndResetK0s_TimesOut covers the failure Rockwell hit: `k0s reset`
+// blocks forever on a containerd that stopped responding, so reset never
+// returns and every cleanup step after it is skipped. It must give up instead.
+func TestStopAndResetK0s_TimesOut(t *testing.T) {
+	origTimeout, origLead := k0sResetTimeout, k0sResetDumpLead
+	k0sResetTimeout, k0sResetDumpLead = 400*time.Millisecond, 200*time.Millisecond
+	t.Cleanup(func() { k0sResetTimeout, k0sResetDumpLead = origTimeout, origLead })
+
+	f := &fakeHelpers{blockOn: "reset --data-dir"}
+	installFakeHelpers(t, f)
+
+	done := make(chan error, 1)
+	go func() { done <- stopAndResetK0s("/var/lib/embedded-cluster/k0s") }()
+
+	var err error
+	select {
+	case err = <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("stopAndResetK0s did not return: the k0s reset call is still unbounded")
+	}
+
+	require.Error(t, err, "should report that k0s reset timed out")
+	assert.Contains(t, err.Error(), "timed out")
+
+	// k0s is asked for a goroutine dump before the deadline kills it; its output
+	// is streamed to the log, so this is what identifies the stuck CRI call.
+	assert.True(t, f.ran("pkill -QUIT -f k0s reset --data-dir"),
+		"should ask k0s for a goroutine dump before the deadline")
+}
+
+// TestForceK0sTeardown asserts reset performs the cleanup k0s did not: killing
+// the processes holding the mounts, then detaching them so the directory
+// removals that follow do not fail with EBUSY.
+func TestForceK0sTeardown(t *testing.T) {
+	f := &fakeHelpers{}
+	installFakeHelpers(t, f)
+
+	homeDir := "/var/lib/embedded-cluster"
+	k0sDataDir := "/var/lib/embedded-cluster/k0s"
+	forceK0sTeardown(homeDir, k0sDataDir)
+
+	for _, proc := range []string{"k0s", "kube-apiserver", "kubelet", "containerd"} {
+		assert.True(t, f.ran("pkill -9 -f "+proc), "should force-kill orphaned %s", proc)
+	}
+
+	for _, dir := range []string{homeDir, k0sDataDir, k0sRunDir} {
+		assert.True(t, f.ran(strings.TrimSpace("sh -c "+unmountScript+" sh "+dir)),
+			"should unmount everything below %s", dir)
+	}
+
+	// Calico state is torn down by k0s's cni cleanup step, which did not run.
+	assert.True(t, f.ran("ip link delete vxlan.calico"),
+		"should remove the calico vxlan interface")
+	assert.True(t, f.ran("sh -c ip link show"),
+		"should remove the calico veth interfaces")
+	assert.True(t, f.ran("sh -c ip route show table all"),
+		"should remove the calico blackhole routes")
+}

--- a/pkg/helpers/command.go
+++ b/pkg/helpers/command.go
@@ -7,9 +7,16 @@ import (
 	"io"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
+
+// commandWaitDelay bounds how long a command may hold its output pipes open
+// after the process itself is gone. cmd.Run only returns once the pipes close,
+// and a grandchild that inherited them keeps them open after the process we
+// spawned is killed.
+var commandWaitDelay = 10 * time.Second
 
 // RunCommandWithOptions runs a the provided command with the options specified.
 func (h *Helpers) RunCommandWithOptions(opts RunCommandOptions, bin string, args ...string) error {
@@ -24,6 +31,7 @@ func (h *Helpers) RunCommandWithOptions(opts RunCommandOptions, bin string, args
 	stderr := bytes.NewBuffer(nil)
 	stdout := bytes.NewBuffer(nil)
 	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.WaitDelay = commandWaitDelay
 
 	cmd.Stdout = stdout
 	if opts.Stdout != nil {


### PR DESCRIPTION
#### What this PR does / why we need it:

`k0s reset` issues its container-runtime calls with `context.TODO()` — no deadline anywhere. When containerd stops responding, the call never returns and reset hangs indefinitely.

The damage is what *doesn't* happen next. k0s's cleanup runs in fixed order (containers → users → services → directories → cni) and the hang is in step 1, so nothing unmounts the kubelet volumes. Reset never reaches the removals or the reboot, and the node is left with an installation the next install refuses to overwrite — matching the customer's `Device or resource busy` on every `kube-api-access-*` path.

Reproduced on a real node and captured the stack:

```
grpc waitOnHeader                                       ← blocked, no deadline
cri-api (*runtimeServiceClient).RemovePodSandbox
k0s/pkg/container/runtime.(*CRIRuntime).RemoveContainer   cri.go:69
k0s/pkg/cleanup.(*containers).stopAllContainers           containers.go:96
```

`pkg/cleanup/containers.go` is byte-identical between k0s 1.35 and 1.36, so this affects every version in the field.

#### What changed:

- Bound `k0s reset` at 2 minutes (measured resets finish in under 3 seconds).
- On timeout, SIGQUIT k0s 15s before the deadline for a goroutine dump; its output is already streamed to the log, so the stuck CRI call is recorded.
- `forceK0sTeardown()` does what k0s could not: kill the orphaned processes, detach mounts below the home, k0s and run dirs, and remove the Calico interfaces and blackhole routes.
- Remove `/etc/k0s` wholesale rather than just `k0s.yaml` — it also holds containerd drop-ins and registry certs, and nothing else cleans them up.
- Set `WaitDelay` so a lingering grandchild cannot hold output pipes open past a deadline.

The node no longer depends on the reboot to come out clean, which matters because thirteen `return` statements sit between the k0s teardown and that reboot.

#### Verification:

End-to-end on a CMX node with real k0s 1.36.2 at EC's layout, 4 pods with secret/subPath/tmpfs mounts (32 mounts, 6 shims), freezing the containerd whose parent is the `k0s reset` process, `reboot` neutralised so the node could be inspected:

```
17:46:00  k0s reset started
17:46:01  froze k0s reset's containerd
17:47:52  k0s reset timed out after 2m0s
          (*CRIRuntime).StopContainer   ← stack captured
```

Node after, **before any reboot**: mounts 0 under both trees, `k0scontroller` unit gone, k0s binary gone, orphan shims 0, `/etc/k0s` emptied. A fresh k0s install onto that node then succeeded.

`unmount.sh` separately tested in privileged alpine and ubuntu containers against a synthetic kubelet tree — nested over-mounts, a bind-mounted subpath, and a `/data/k0s-other` decoy that must survive.

#### Notes for reviewers:

- `k0sBinPath` const → var, purely so tests can point it at a temp file.
- **The Calico cleanup is not covered by the node test.** Plain k0s uses kube-router, so the test node had no `vxlan.calico`, no `cali*` veths and zero blackhole routes. It is the same code v3 runs, and it is unit-tested, but it was not exercised against real Calico state.
- The timeout test is a real regression guard: remove `Context: ctx` and it hangs 30s and fails.
- Companion PR for v3: replicatedhq/ec#554

#### Which issue(s) this PR fixes:

sc-138696 — https://app.shortcut.com/replicated/story/138696

#### Does this PR require a test?

Yes — included.

#### Does this PR require a release note?

New features:
 ```release-notes-features
 
 ```
 Bug fixes:
 ```release-notes-fixes
 Reset no longer hangs indefinitely when the container runtime stops responding. If k0s cannot complete its own teardown, reset now bounds the wait, records what it was stuck on, and cleans up the mounts, processes and services itself.
 ```
 Improvements:
 ```release-notes-improvements
 
 ```

#### Does this PR require documentation?

NONE

🤖 Generated with [Claude Code](https://claude.com/claude-code)
