### PR TITLE
fix: correct the Calico cleanup comment in reset

### DIFF
--- a/cmd/installer/cli/reset.go
+++ b/cmd/installer/cli/reset.go
@@ -695,16 +695,12 @@ func forceK0sTeardown(homeDir, k0sDataDir string) {
 		}
 	}
 
-	// Remove vxlan.calico (holds port 4789/UDP), the Calico veth interfaces and
-	// the blackhole routes so the pod CIDR can be reused. k0s does this in its own
-	// cni cleanup step, which is one of the steps that did not run.
-	for _, cmd := range [][]string{
-		{"ip", "link", "delete", "vxlan.calico"},
-		{"sh", "-c", "ip link show | grep -oE ' cali[0-9a-f]+' | xargs -r -L1 ip link delete"},
-		{"sh", "-c", "ip route show table all | grep blackhole | grep 'proto 80' | awk '{print $1, $2}' | xargs -r -L1 ip route delete"},
-	} {
-		_, _ = helpers.RunCommand(cmd[0], cmd[1:]...)
-	}
+	// Remove vxlan.calico (holds port 4789/UDP) and Calico veth interfaces.
+	_, _ = helpers.RunCommand("ip", "link", "delete", "vxlan.calico")
+	_, _ = helpers.RunCommand("sh", "-c", "ip link show | grep -oE ' cali[0-9a-f]+' | xargs -r -L1 ip link delete")
+
+	// Remove Calico blackhole routes so the pod CIDR can be reused.
+	_, _ = helpers.RunCommand("sh", "-c", "ip route show table all | grep blackhole | grep 'proto 80' | awk '{print $1, $2}' | xargs -r -L1 ip route delete")
 }
 
 // lineLogWriter streams command output to logrus as it is written, so that


### PR DESCRIPTION
#### What this PR does / why we need it:

Comment-only follow-up to #3893. Review feedback there pointed out that this comment is wrong:

```go
// k0s does this in its own cni cleanup step, which is one of the steps that did not run.
```

It isn't. `pkg/cleanup/cni_linux.go` does exactly one thing:

```go
files := []string{
    "/etc/cni/net.d/10-calico.conflist",
    "/etc/cni/net.d/calico-kubeconfig",
    "/etc/cni/net.d/10-kuberouter.conflist",
}
for _, f := range files {
    os.Remove(f)
}
```

Three `os.Remove` calls on config files — no netlink, no interfaces, no routes. The only netlink call anywhere in k0s's cleanup is the `bridge` step, and it deletes `kube-bridge` alone. Grepping the whole `pkg/cleanup` package for `vxlan|blackhole|cali|LinkDel|RouteDel` turns up nothing else on Linux; the remaining `cali` hits are those three filenames and Windows HNS code.

Worth recording, because it strengthens the case for keeping these commands: since no k0s step removes this state on **any** path, it is left behind by a successful reset too, not just a timed-out one. It has always been EC's job — which is why v3 has carried the same commands independently of any timeout work.

This adopts the wording v3 already uses for the identical commands, which only describes what they do and claims nothing about k0s. The comments are now byte-identical between the two codebases.

No behaviour change: same commands, same order. The loop is unrolled only so the two comments sit where they do in v3; `TestForceK0sTeardown` is untouched and passes.

#### Which issue(s) this PR fixes:

Follow-up to #3893 (sc-138696 — https://app.shortcut.com/replicated/story/138696)

#### Does this PR require a test?

NONE — comment-only, existing coverage unchanged.

#### Does this PR require a release note?

New features:
 ```release-notes-features
 
 ```
 Bug fixes:
 ```release-notes-fixes
 
 ```
 Improvements:
 ```release-notes-improvements
 
 ```

#### Does this PR require documentation?

NONE

🤖 Generated with [Claude Code](https://claude.com/claude-code)
