### PR TITLE
feat: apply KOTS redactor specs in CLI support-bundle command [sc-139425]

### DIFF
--- a/cmd/installer/cli/supportbundle.go
+++ b/cmd/installer/cli/supportbundle.go
@@ -25,48 +25,11 @@ import (
 
 const (
 	// kotsadmNamespace is the namespace where the KOTS admin console and its redactor
-	// secrets are deployed. This is currently hardcoded for backwards compatibility; it
-	// should be replaced with runtimeconfig.KotsadmNamespace once custom namespaces are
-	// supported.
+	// secrets are deployed. This is currently hardcoded because
+	// runtimeconfig.KotsadmNamespace requires a controller-runtime client.Client, while
+	// this code uses a typed kubernetes.Interface clientset.
 	kotsadmNamespace = "kotsadm"
 )
-
-// buildRedactorURIs returns the list of KOTS redactor URIs that should be passed to
-// kubectl-support_bundle. It checks for the existence of each redactor secret in the
-// cluster and only includes URIs for secrets that exist. A warning is logged when the
-// app-specific redactor secret is missing because that means vendor-defined redactors
-// will not be applied.
-func buildRedactorURIs(ctx context.Context, appSlug string, clientset kubernetes.Interface) []string {
-	uris := []string{}
-
-	if secretExists(ctx, kotsadmNamespace, "kotsadm-redact-spec", clientset) {
-		uris = append(uris, fmt.Sprintf("secret/%s/kotsadm-redact-spec/redact-spec", kotsadmNamespace))
-	}
-
-	appRedactorSecretName := fmt.Sprintf("kotsadm-%s-redact-spec", appSlug)
-	if secretExists(ctx, kotsadmNamespace, appRedactorSecretName, clientset) {
-		uris = append(uris, fmt.Sprintf("secret/%s/%s/redact-spec", kotsadmNamespace, appRedactorSecretName))
-	} else {
-		logrus.Warnf("App-specific redactor secret %q not found in namespace %q; support bundle may contain unredacted application data", appRedactorSecretName, kotsadmNamespace)
-	}
-
-	if secretExists(ctx, kotsadmNamespace, "kotsadm-redact-default-spec", clientset) {
-		uris = append(uris, fmt.Sprintf("secret/%s/kotsadm-redact-default-spec/default-redactor", kotsadmNamespace))
-	}
-
-	return uris
-}
-
-func secretExists(ctx context.Context, namespace, name string, clientset kubernetes.Interface) bool {
-	_, err := clientset.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
-	if err != nil {
-		if !k8serrors.IsNotFound(err) {
-			logrus.Debugf("Failed to check for secret %s/%s: %v", namespace, name, err)
-		}
-		return false
-	}
-	return true
-}
 
 func SupportBundleCmd(ctx context.Context) *cobra.Command {
 	var rc runtimeconfig.RuntimeConfig
@@ -80,11 +43,7 @@ func SupportBundleCmd(ctx context.Context) *cobra.Command {
 			}
 
 			rc = rcutil.InitBestRuntimeConfig(cmd.Context())
-			if err := rc.SetEnv(); err != nil {
-				return fmt.Errorf("unable to set runtime environment: %w", err)
-			}
-
-			return nil
+			return rc.SetEnv()
 		},
 		PostRun: func(cmd *cobra.Command, args []string) {
 			rc.Cleanup()
@@ -159,4 +118,41 @@ func SupportBundleCmd(ctx context.Context) *cobra.Command {
 	}
 
 	return cmd
+}
+
+// buildRedactorURIs returns the list of KOTS redactor URIs that should be passed to
+// kubectl-support_bundle. It checks for the existence of each redactor secret in the
+// cluster and only includes URIs for secrets that exist. A warning is logged when the
+// app-specific redactor secret is missing because that means vendor-defined redactors
+// will not be applied.
+func buildRedactorURIs(ctx context.Context, appSlug string, clientset kubernetes.Interface) []string {
+	uris := []string{}
+
+	if secretExists(ctx, kotsadmNamespace, "kotsadm-redact-spec", clientset) {
+		uris = append(uris, fmt.Sprintf("secret/%s/kotsadm-redact-spec/redact-spec", kotsadmNamespace))
+	}
+
+	appRedactorSecretName := fmt.Sprintf("kotsadm-%s-redact-spec", appSlug)
+	if secretExists(ctx, kotsadmNamespace, appRedactorSecretName, clientset) {
+		uris = append(uris, fmt.Sprintf("secret/%s/%s/redact-spec", kotsadmNamespace, appRedactorSecretName))
+	} else {
+		logrus.Warnf("App-specific redactor secret %q not found in namespace %q; support bundle may contain unredacted application data", appRedactorSecretName, kotsadmNamespace)
+	}
+
+	if secretExists(ctx, kotsadmNamespace, "kotsadm-redact-default-spec", clientset) {
+		uris = append(uris, fmt.Sprintf("secret/%s/kotsadm-redact-default-spec/default-redactor", kotsadmNamespace))
+	}
+
+	return uris
+}
+
+func secretExists(ctx context.Context, namespace, name string, clientset kubernetes.Interface) bool {
+	_, err := clientset.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			logrus.Debugf("Failed to check for secret %s/%s: %v", namespace, name, err)
+		}
+		return false
+	}
+	return true
 }

--- a/cmd/installer/cli/supportbundle.go
+++ b/cmd/installer/cli/supportbundle.go
@@ -8,14 +8,65 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/replicatedhq/embedded-cluster/pkg/helpers"
+	"github.com/replicatedhq/embedded-cluster/pkg/kubeutils"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 	rcutil "github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig/util"
 	"github.com/replicatedhq/embedded-cluster/pkg/spinner"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
+
+const (
+	// kotsadmNamespace is the namespace where the KOTS admin console and its redactor
+	// secrets are deployed. This is currently hardcoded for backwards compatibility; it
+	// should be replaced with runtimeconfig.KotsadmNamespace once custom namespaces are
+	// supported.
+	kotsadmNamespace = "kotsadm"
+)
+
+// buildRedactorURIs returns the list of KOTS redactor URIs that should be passed to
+// kubectl-support_bundle. It checks for the existence of each redactor secret in the
+// cluster and only includes URIs for secrets that exist. A warning is logged when the
+// app-specific redactor secret is missing because that means vendor-defined redactors
+// will not be applied.
+func buildRedactorURIs(ctx context.Context, appSlug string, clientset kubernetes.Interface) []string {
+	uris := []string{}
+
+	if secretExists(ctx, kotsadmNamespace, "kotsadm-redact-spec", clientset) {
+		uris = append(uris, fmt.Sprintf("secret/%s/kotsadm-redact-spec/redact-spec", kotsadmNamespace))
+	}
+
+	appRedactorSecretName := fmt.Sprintf("kotsadm-%s-redact-spec", appSlug)
+	if secretExists(ctx, kotsadmNamespace, appRedactorSecretName, clientset) {
+		uris = append(uris, fmt.Sprintf("secret/%s/%s/redact-spec", kotsadmNamespace, appRedactorSecretName))
+	} else {
+		logrus.Warnf("App-specific redactor secret %q not found in namespace %q; support bundle may contain unredacted application data", appRedactorSecretName, kotsadmNamespace)
+	}
+
+	if secretExists(ctx, kotsadmNamespace, "kotsadm-redact-default-spec", clientset) {
+		uris = append(uris, fmt.Sprintf("secret/%s/kotsadm-redact-default-spec/default-redactor", kotsadmNamespace))
+	}
+
+	return uris
+}
+
+func secretExists(ctx context.Context, namespace, name string, clientset kubernetes.Interface) bool {
+	_, err := clientset.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			logrus.Debugf("Failed to check for secret %s/%s: %v", namespace, name, err)
+		}
+		return false
+	}
+	return true
+}
 
 func SupportBundleCmd(ctx context.Context) *cobra.Command {
 	var rc runtimeconfig.RuntimeConfig
@@ -29,7 +80,9 @@ func SupportBundleCmd(ctx context.Context) *cobra.Command {
 			}
 
 			rc = rcutil.InitBestRuntimeConfig(cmd.Context())
-			os.Setenv("TMPDIR", rc.EmbeddedClusterTmpSubDir())
+			if err := rc.SetEnv(); err != nil {
+				return fmt.Errorf("unable to set runtime environment: %w", err)
+			}
 
 			return nil
 		},
@@ -59,6 +112,16 @@ func SupportBundleCmd(ctx context.Context) *cobra.Command {
 			arguments := []string{}
 			if _, err := os.Stat(kubeConfig); err == nil {
 				arguments = append(arguments, fmt.Sprintf("--kubeconfig=%s", kubeConfig))
+			}
+
+			clientset, err := kubeutils.GetClientset()
+			if err != nil {
+				logrus.Warnf("Unable to create kubernetes client, redactor specs will not be applied: %v", err)
+			} else {
+				redactorURIs := buildRedactorURIs(cmd.Context(), runtimeconfig.AppSlug(), clientset)
+				if len(redactorURIs) > 0 {
+					arguments = append(arguments, fmt.Sprintf("--redactors=%s", strings.Join(redactorURIs, ",")))
+				}
 			}
 
 			arguments = append(

--- a/cmd/installer/cli/supportbundle_test.go
+++ b/cmd/installer/cli/supportbundle_test.go
@@ -2,14 +2,41 @@ package cli
 
 import (
 	"context"
+	"sync"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 )
+
+type testLogHook struct {
+	mu       sync.Mutex
+	warnings []string
+	disabled bool
+}
+
+func (h *testLogHook) Levels() []logrus.Level {
+	return []logrus.Level{logrus.WarnLevel}
+}
+
+func (h *testLogHook) Fire(entry *logrus.Entry) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if !h.disabled {
+		h.warnings = append(h.warnings, entry.Message)
+	}
+	return nil
+}
+
+func (h *testLogHook) Disable() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.disabled = true
+}
 
 func TestBuildRedactorURIs(t *testing.T) {
 	ctx := context.Background()
@@ -33,6 +60,7 @@ func TestBuildRedactorURIs(t *testing.T) {
 				"secret/kotsadm/kotsadm-my-app-redact-spec/redact-spec",
 				"secret/kotsadm/kotsadm-redact-default-spec/default-redactor",
 			},
+			expectedWarns: 0,
 		},
 		{
 			name: "only admin console and default redactors exist",
@@ -44,6 +72,7 @@ func TestBuildRedactorURIs(t *testing.T) {
 				"secret/kotsadm/kotsadm-redact-spec/redact-spec",
 				"secret/kotsadm/kotsadm-redact-default-spec/default-redactor",
 			},
+			expectedWarns: 1,
 		},
 		{
 			name: "only app-specific redactor exists",
@@ -53,11 +82,13 @@ func TestBuildRedactorURIs(t *testing.T) {
 			expectedURIs: []string{
 				"secret/kotsadm/kotsadm-my-app-redact-spec/redact-spec",
 			},
+			expectedWarns: 0,
 		},
 		{
-			name:         "no redactor secrets exist",
-			secrets:      []string{},
-			expectedURIs: []string{},
+			name:          "no redactor secrets exist",
+			secrets:       []string{},
+			expectedURIs:  []string{},
+			expectedWarns: 1,
 		},
 	}
 
@@ -74,8 +105,13 @@ func TestBuildRedactorURIs(t *testing.T) {
 			}
 			clientset := fake.NewSimpleClientset(objects...)
 
+			hook := &testLogHook{}
+			logrus.AddHook(hook)
+			t.Cleanup(hook.Disable)
+
 			got := buildRedactorURIs(ctx, appSlug, clientset)
 			assert.Equal(t, tc.expectedURIs, got)
+			assert.Len(t, hook.warnings, tc.expectedWarns)
 		})
 	}
 }

--- a/cmd/installer/cli/supportbundle_test.go
+++ b/cmd/installer/cli/supportbundle_test.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestBuildRedactorURIs(t *testing.T) {
+	ctx := context.Background()
+	appSlug := "my-app"
+
+	cases := []struct {
+		name          string
+		secrets       []string
+		expectedURIs  []string
+		expectedWarns int
+	}{
+		{
+			name: "all redactor secrets exist",
+			secrets: []string{
+				"kotsadm-redact-spec",
+				"kotsadm-redact-default-spec",
+				"kotsadm-my-app-redact-spec",
+			},
+			expectedURIs: []string{
+				"secret/kotsadm/kotsadm-redact-spec/redact-spec",
+				"secret/kotsadm/kotsadm-my-app-redact-spec/redact-spec",
+				"secret/kotsadm/kotsadm-redact-default-spec/default-redactor",
+			},
+		},
+		{
+			name: "only admin console and default redactors exist",
+			secrets: []string{
+				"kotsadm-redact-spec",
+				"kotsadm-redact-default-spec",
+			},
+			expectedURIs: []string{
+				"secret/kotsadm/kotsadm-redact-spec/redact-spec",
+				"secret/kotsadm/kotsadm-redact-default-spec/default-redactor",
+			},
+		},
+		{
+			name: "only app-specific redactor exists",
+			secrets: []string{
+				"kotsadm-my-app-redact-spec",
+			},
+			expectedURIs: []string{
+				"secret/kotsadm/kotsadm-my-app-redact-spec/redact-spec",
+			},
+		},
+		{
+			name:         "no redactor secrets exist",
+			secrets:      []string{},
+			expectedURIs: []string{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			objects := make([]runtime.Object, 0, len(tc.secrets))
+			for _, name := range tc.secrets {
+				objects = append(objects, &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: kotsadmNamespace,
+					},
+				})
+			}
+			clientset := fake.NewSimpleClientset(objects...)
+
+			got := buildRedactorURIs(ctx, appSlug, clientset)
+			assert.Equal(t, tc.expectedURIs, got)
+		})
+	}
+}

--- a/e2e/scripts/create-test-redactor.sh
+++ b/e2e/scripts/create-test-redactor.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euox pipefail
 
+DIR=/usr/local/bin
+. $DIR/common.sh
+
 main() {
     # Create a KOTS admin-console redactor spec that masks the known license ID.
     # This secret is read by the embedded-cluster support-bundle command via the

--- a/e2e/scripts/create-test-redactor.sh
+++ b/e2e/scripts/create-test-redactor.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+main() {
+    # Create a KOTS admin-console redactor spec that masks the known license ID.
+    # This secret is read by the embedded-cluster support-bundle command via the
+    # --redactors flag and proves that redactors are applied to CLI-generated bundles.
+    kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kotsadm-redact-spec
+  namespace: kotsadm
+type: Opaque
+stringData:
+  redact-spec: |
+    apiVersion: troubleshoot.sh/v1beta2
+    kind: Redactor
+    metadata:
+      name: license-id-redactor
+    spec:
+      redactors:
+        - name: License ID
+          removals:
+            regex:
+              - redactor: "2cQCFfBxG7gXDmq1yAgPSM4OViF"
+EOF
+}
+
+main "$@"

--- a/e2e/scripts/create-test-redactor.sh
+++ b/e2e/scripts/create-test-redactor.sh
@@ -8,6 +8,8 @@ main() {
     # Create a KOTS admin-console redactor spec that masks the known license ID.
     # This secret is read by the embedded-cluster support-bundle command via the
     # --redactors flag and proves that redactors are applied to CLI-generated bundles.
+    # The regex must use a capturing group named "mask" so that troubleshoot replaces
+    # the matched value with ***HIDDEN*** instead of removing it entirely.
     kubectl apply -f - <<EOF
 apiVersion: v1
 kind: Secret
@@ -26,7 +28,7 @@ stringData:
         - name: License ID
           removals:
             regex:
-              - redactor: "2cQCFfBxG7gXDmq1yAgPSM4OViF"
+              - redactor: "(?P<mask>2cQCFfBxG7gXDmq1yAgPSM4OViF)"
 EOF
 }
 

--- a/e2e/scripts/validate-support-bundle.sh
+++ b/e2e/scripts/validate-support-bundle.sh
@@ -16,24 +16,37 @@ main() {
     fi
     rm -rf cluster.tar.gz
 
-    tar -zxvf support-bundle-*.tar.gz
-    rm -rf support-bundle-*.tar.gz
+    bundle_tar=$(ls support-bundle-*.tar.gz)
+    tar -zxvf "$bundle_tar"
+    bundle_dir=${bundle_tar%.tar.gz}
+    rm -rf "$bundle_tar"
 
     echo "checking for the k0s sysinfo file"
-    if ! ls support-bundle-*/host-collectors/run-host/k0s-sysinfo.txt; then
+    if ! ls "$bundle_dir/host-collectors/run-host/k0s-sysinfo.txt"; then
         echo "Failed to find 'k0s sysinfo' inside the support bundle generated with the embedded cluster binary"
         return 1
     fi
 
     echo "checking for the embedded-cluster-operator logs"
-    if ! ls support-bundle-*/podlogs/embedded-cluster-operator; then
+    if ! ls "$bundle_dir/podlogs/embedded-cluster-operator"; then
         echo "Failed to find operator logs inside the support bundle generated with the embedded cluster binary"
         return 1
     fi
 
+    license_file="$bundle_dir/host-collectors/embedded-cluster/license.yaml"
     echo "checking for the license file inside the support bundle"
-    if ! ls support-bundle-*/host-collectors/embedded-cluster/license.yaml; then
+    if ! ls "$license_file"; then
         echo "Failed to find license file inside the support bundle generated with the embedded cluster binary"
+        return 1
+    fi
+
+    echo "checking that the license ID was redacted in the CLI-generated support bundle"
+    if grep -q "licenseID: 2cQCFfBxG7gXDmq1yAgPSM4OViF" "$license_file"; then
+        echo "License ID was not redacted in the CLI-generated support bundle"
+        return 1
+    fi
+    if ! grep -Fq "licenseID: ***HIDDEN***" "$license_file"; then
+        echo "Expected redaction marker not found in the CLI-generated support bundle"
         return 1
     fi
 }

--- a/e2e/scripts/validate-support-bundle.sh
+++ b/e2e/scripts/validate-support-bundle.sh
@@ -47,6 +47,8 @@ main() {
     fi
     if ! grep -Fq "licenseID: ***HIDDEN***" "$license_file"; then
         echo "Expected redaction marker not found in the CLI-generated support bundle"
+        echo "License file contents:"
+        cat "$license_file"
         return 1
     fi
 }

--- a/e2e/support-bundle_test.go
+++ b/e2e/support-bundle_test.go
@@ -38,6 +38,11 @@ func TestCollectSupportBundle(t *testing.T) {
 	stdout, stderr, err = tc.RunCommandOnNode(0, line)
 	assert.NoErrorf(t, err, "fail to collect cluster support bundle: %v: %s: %s", err, stdout, stderr)
 
+	t.Logf("%s: creating test redactor spec for CLI support bundle", time.Now().Format(time.RFC3339))
+	line = []string{"create-test-redactor.sh"}
+	stdout, stderr, err = tc.RunCommandOnNode(0, line)
+	assert.NoErrorf(t, err, "fail to create test redactor spec: %v: %s: %s", err, stdout, stderr)
+
 	t.Logf("%s: collecting support bundle with the embedded-cluster binary", time.Now().Format(time.RFC3339))
 	line = []string{"embedded-cluster", "support-bundle"}
 	stdout, stderr, err = tc.RunCommandOnNode(0, line)


### PR DESCRIPTION
## Summary

The \"embedded-cluster support-bundle\" command now applies the same KOTS redactor specs that the Admin Console uses, including the default redactor spec that KOTS \"GetBundleCommand\" currently omits.

## Changes

- Build the \"--redactors\" URI list from the three KOTS redactor secrets in the kotsadm namespace:
  - \"secret/kotsadm/kotsadm-redact-spec/redact-spec\" (Admin Console custom redactors)
  - \"secret/kotsadm/kotsadm-<appSlug>-redact-spec/redact-spec\" (app-specific redactors)
  - \"secret/kotsadm/kotsadm-redact-default-spec/default-redactor\" (default redactors)
- Check each secret's existence before including its URI, so the command still works before the app has been deployed.
- Log a warning when the app-specific redactor secret is missing.
- Gracefully continue without redactors if the Kubernetes client cannot be created.
- Use \"rc.SetEnv()\" in PreRunE so KUBECONFIG is set correctly for the Kubernetes clientset.
- Add unit tests for redactor URI construction.
- Extend e2e validation to create a test redactor and verify the CLI-generated bundle redacts a known value.

## Verification

- \"make vet\" passes.
- \"make unit-tests\" passes.
- e2e tests require the CI environment and were not run locally.

## Related

- Shortcut story: https://app.shortcut.com/replicated/story/139425
- KOTS GetBundleCommand default-redactor omission is being tracked/fixed separately.