### PR TITLE
Don't include EC images in backup

### DIFF
--- a/cmd/installer/cli/restore.go
+++ b/cmd/installer/cli/restore.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	apitypes "github.com/replicatedhq/embedded-cluster/api/types"
 	"github.com/replicatedhq/embedded-cluster/cmd/installer/kotscli"
@@ -26,6 +27,7 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg-new/kubernetesinstallation"
 	"github.com/replicatedhq/embedded-cluster/pkg-new/preflights"
 	"github.com/replicatedhq/embedded-cluster/pkg/addons"
+	"github.com/replicatedhq/embedded-cluster/pkg/addons/seaweedfs"
 	addontypes "github.com/replicatedhq/embedded-cluster/pkg/addons/types"
 	"github.com/replicatedhq/embedded-cluster/pkg/disasterrecovery"
 	"github.com/replicatedhq/embedded-cluster/pkg/helm"
@@ -62,6 +64,7 @@ const (
 	ecRestoreStateWaitForNodes         ecRestoreState = "wait-for-nodes"
 	ecRestoreStateRestoreSeaweedFS     ecRestoreState = "restore-seaweedfs"
 	ecRestoreStateRestoreRegistry      ecRestoreState = "restore-registry"
+	ecRestoreStatePopulateRegistry     ecRestoreState = "populate-registry-from-airgap-bundle"
 	ecRestoreStateAdminConsoleEnableHA ecRestoreState = "admin-console-enable-ha"
 	ecRestoreStateRestoreECO           ecRestoreState = "restore-embedded-cluster-operator"
 	ecRestoreStateRestoreExtensions    ecRestoreState = "restore-extensions"
@@ -76,6 +79,7 @@ var ecRestoreStates = []ecRestoreState{
 	ecRestoreStateWaitForNodes,
 	ecRestoreStateRestoreSeaweedFS,
 	ecRestoreStateRestoreRegistry,
+	ecRestoreStatePopulateRegistry,
 	ecRestoreStateAdminConsoleEnableHA,
 	ecRestoreStateRestoreECO,
 	ecRestoreStateRestoreExtensions,
@@ -279,6 +283,20 @@ func runRestore(ctx context.Context, appSlug, appTitle string, flags installFlag
 		}
 
 		err = runRestoreRegistry(ctx, installCfg, backupToRestore)
+		if err != nil {
+			return err
+		}
+
+		fallthrough
+
+	case ecRestoreStatePopulateRegistry:
+		logrus.Debugf("setting restore state to %q", ecRestoreStatePopulateRegistry)
+		err := setECRestoreState(ctx, ecRestoreStatePopulateRegistry, backupToRestore.GetName())
+		if err != nil {
+			return fmt.Errorf("unable to set restore state: %w", err)
+		}
+
+		err = runPopulateRegistry(ctx, appSlug, flags.airgapBundle, backupToRestore)
 		if err != nil {
 			return err
 		}
@@ -707,6 +725,142 @@ func runRestoreRegistry(ctx context.Context, installCfg *installConfig, backupTo
 	}
 
 	return nil
+}
+
+type dockerConfig struct {
+	Auths map[string]dockerConfigEntry `json:"auths"`
+}
+
+type dockerConfigEntry struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+func runPopulateRegistry(ctx context.Context, appSlug, airgapBundle string, backupToRestore *disasterrecovery.ReplicatedBackup) error {
+	kcli, err := kubeutils.KubeClient()
+	if err != nil {
+		return fmt.Errorf("unable to create kube client: %w", err)
+	}
+	in, err := kubeutils.GetLatestInstallation(ctx, kcli)
+	if err != nil {
+		return fmt.Errorf("get latest installation: %w", err)
+	}
+	if in.Annotations[constants.EmbeddedRegistryDataSourceAnnotation] != constants.EmbeddedRegistryDataSourceAirgapBundle {
+		return nil
+	}
+	highAvailability, err := isHighAvailabilityReplicatedBackup(*backupToRestore)
+	if err != nil {
+		return err
+	}
+	if highAvailability {
+		if err := ensureSeaweedFSRegistryBucket(ctx, kcli); err != nil {
+			return fmt.Errorf("ensure SeaweedFS registry bucket: %w", err)
+		}
+	}
+
+	registryAddress, ok := backupToRestore.GetAnnotation("kots.io/embedded-registry")
+	if !ok {
+		return fmt.Errorf("unable to read registry address from backup")
+	}
+	kotsadmNamespace, err := runtimeconfig.KotsadmNamespace(ctx, kcli)
+	if err != nil {
+		return fmt.Errorf("get kotsadm namespace: %w", err)
+	}
+	username, password, err := registryCredentialsFromSecrets(ctx, kcli, kotsadmNamespace, registryAddress)
+	if err != nil {
+		return err
+	}
+	loading := spinner.Start()
+	defer loading.Close()
+	loading.Infof("Restoring registry data")
+	if err := kotscli.PushImages(kotscli.PushImagesOptions{
+		AirgapBundle:     airgapBundle,
+		Namespace:        kotsadmNamespace,
+		RegistryAddress:  fmt.Sprintf("%s/%s", strings.TrimSuffix(registryAddress, "/"), appSlug),
+		RegistryUsername: username,
+		RegistryPassword: password,
+		ClusterID:        in.Spec.ClusterID,
+		Stdout:           loading,
+	}); err != nil {
+		return fmt.Errorf("populate embedded registry: %w", err)
+	}
+	loading.Infof("Embedded registry populated!")
+	return nil
+}
+
+// ensureSeaweedFSRegistryBucket recreates the chart-managed registry bucket because restored filer storage is intentionally empty.
+func ensureSeaweedFSRegistryBucket(ctx context.Context, kcli client.Client) error {
+	accessKey, secretKey, err := seaweedfs.GetS3RWCreds(ctx, kcli)
+	if err != nil {
+		return fmt.Errorf("get SeaweedFS S3 credentials: %w", err)
+	}
+
+	var svc corev1.Service
+	if err := kcli.Get(ctx, client.ObjectKey{
+		Namespace: constants.SeaweedFSNamespace,
+		Name:      "ec-seaweedfs-s3",
+	}, &svc); err != nil {
+		return fmt.Errorf("get SeaweedFS S3 service: %w", err)
+	}
+	if svc.Spec.ClusterIP == "" || svc.Spec.ClusterIP == corev1.ClusterIPNone {
+		return fmt.Errorf("SeaweedFS S3 service has no cluster IP")
+	}
+	if len(svc.Spec.Ports) == 0 {
+		return fmt.Errorf("SeaweedFS S3 service has no ports")
+	}
+
+	cfg, err := config.LoadDefaultConfig(ctx,
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, "")),
+		config.WithRegion("us-east-1"),
+	)
+	if err != nil {
+		return fmt.Errorf("load S3 config: %w", err)
+	}
+	s3Client := s3.NewFromConfig(cfg, func(options *s3.Options) {
+		options.UsePathStyle = true
+		options.BaseEndpoint = aws.String(fmt.Sprintf("http://%s:%d", svc.Spec.ClusterIP, svc.Spec.Ports[0].Port))
+	})
+
+	_, err = s3Client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: ptr.To("registry")})
+	if err != nil {
+		var alreadyExists *s3types.BucketAlreadyExists
+		var alreadyOwned *s3types.BucketAlreadyOwnedByYou
+		if !errors.As(err, &alreadyExists) && !errors.As(err, &alreadyOwned) {
+			return fmt.Errorf("create registry bucket: %w", err)
+		}
+	}
+	return nil
+}
+
+func registryCredentialsFromSecrets(ctx context.Context, kcli client.Client, namespace, registryAddress string) (string, string, error) {
+	var secrets corev1.SecretList
+	if err := kcli.List(ctx, &secrets, client.InNamespace(namespace)); err != nil {
+		return "", "", fmt.Errorf("list registry credential secrets: %w", err)
+	}
+
+	for _, secret := range secrets.Items {
+		data, ok := secret.Data[corev1.DockerConfigJsonKey]
+		if !ok {
+			continue
+		}
+		var cfg dockerConfig
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			continue
+		}
+		for address, credentials := range cfg.Auths {
+			if normalizeRegistryAddress(address) == normalizeRegistryAddress(registryAddress) && credentials.Username != "" && credentials.Password != "" {
+				return credentials.Username, credentials.Password, nil
+			}
+		}
+	}
+	return "", "", fmt.Errorf("unable to find restored credentials for registry %q", registryAddress)
+}
+
+func normalizeRegistryAddress(address string) string {
+	address = strings.TrimSpace(address)
+	address = strings.TrimPrefix(address, "https://")
+	address = strings.TrimPrefix(address, "http://")
+	return strings.TrimSuffix(address, "/")
 }
 
 func runRestoreECO(ctx context.Context, backupToRestore *disasterrecovery.ReplicatedBackup) error {

--- a/cmd/installer/cli/restore_registry_test.go
+++ b/cmd/installer/cli/restore_registry_test.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestRegistryCredentialsFromSecrets(t *testing.T) {
+	cli := fake.NewClientBuilder().WithObjects(
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "unrelated", Namespace: "kotsadm"},
+			Data: map[string][]byte{
+				corev1.DockerConfigJsonKey: []byte(`{"auths":{"other.registry:5000":{"username":"other","password":"secret"}}}`),
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "arbitrary-restored-name", Namespace: "kotsadm"},
+			Data: map[string][]byte{
+				corev1.DockerConfigJsonKey: []byte(`{"auths":{"https://10.96.0.10:5000/":{"username":"embedded-cluster","password":"restored-password"}}}`),
+			},
+		},
+	).Build()
+
+	username, password, err := registryCredentialsFromSecrets(context.Background(), cli, "kotsadm", "10.96.0.10:5000")
+	require.NoError(t, err)
+	assert.Equal(t, "embedded-cluster", username)
+	assert.Equal(t, "restored-password", password)
+}
+
+func TestRegistryCredentialsFromSecretsNotFound(t *testing.T) {
+	cli := fake.NewClientBuilder().Build()
+
+	_, _, err := registryCredentialsFromSecrets(context.Background(), cli, "kotsadm", "10.96.0.10:5000")
+	require.ErrorContains(t, err, `unable to find restored credentials for registry "10.96.0.10:5000"`)
+}

--- a/e2e/scripts/check-airgap-post-ha-state.sh
+++ b/e2e/scripts/check-airgap-post-ha-state.sh
@@ -7,7 +7,7 @@ DIR=/usr/local/bin
 main() {
     local version="appver-$1"
     local k8s_version="$2"
-    local from_restore="${2:-}"
+    local from_restore="${3:-}"
 
     sleep 10 # wait for kubectl to become available
 
@@ -68,31 +68,33 @@ main() {
 
     if [ "$from_restore" == "true" ]; then
         # ensure volumes were restored
+        pod_volume_restores="$(kubectl get podvolumerestore -n velero -o json)"
+
         echo "checking kotsadm volume restore"
-        if ! kubectl get podvolumerestore -n velero | grep kotsadm | grep -c backup | grep -q 1; then
+        if ! jq -e '[.items[] | select(.spec.pod.namespace == "kotsadm" and .spec.volume == "backup" and .status.phase == "Completed")] | length == 1' <<<"$pod_volume_restores" >/dev/null; then
             echo "kotsadm volumes were not properly restored"
-            kubectl get podvolumerestore -n velero | grep kotsadm || true
+            kubectl get podvolumerestore -n velero
             exit 1
         fi
         
-        echo "checking seaweedfs-filer data volume restores"
-        if ! kubectl get podvolumerestore -n velero | grep seaweedfs-filer | grep -c data-filer | grep -q 3; then
-            echo "seaweedfs-filer data volumes were not properly restored (expected 3)"
-            kubectl get podvolumerestore -n velero | grep seaweedfs-filer | grep data-filer || true
+        echo "checking seaweedfs-filer data volumes were not restored"
+        if ! jq -e '[.items[] | select((.spec.pod.name | startswith("seaweedfs-filer-")) and .spec.volume == "data-filer")] | length == 0' <<<"$pod_volume_restores" >/dev/null; then
+            echo "seaweedfs-filer data volumes were restored unexpectedly"
+            kubectl get podvolumerestore -n velero
             exit 1
         fi
         
         echo "checking seaweedfs-filer log volume restores"
-        if ! kubectl get podvolumerestore -n velero | grep seaweedfs-filer | grep -c seaweedfs-filer-log-volume | grep -q 3; then
+        if ! jq -e '[.items[] | select((.spec.pod.name | startswith("seaweedfs-filer-")) and .spec.volume == "seaweedfs-filer-log-volume" and .status.phase == "Completed")] | length == 3' <<<"$pod_volume_restores" >/dev/null; then
             echo "seaweedfs-filer log volumes were not properly restored (expected 3)"
-            kubectl get podvolumerestore -n velero | grep seaweedfs-filer | grep seaweedfs-filer-log-volume || true
+            kubectl get podvolumerestore -n velero
             exit 1
         fi
         
-        echo "checking seaweedfs-volume data restores"
-        if ! kubectl get podvolumerestore -n velero | grep seaweedfs-volume | grep -c data | grep -q 3; then
-            echo "seaweedfs-volume data volumes were not properly restored (expected 3)"
-            kubectl get podvolumerestore -n velero | grep seaweedfs-volume | grep data || true
+        echo "checking seaweedfs-volume data volumes were not restored"
+        if ! jq -e '[.items[] | select((.spec.pod.name | startswith("seaweedfs-volume-")) and .spec.volume == "data")] | length == 0' <<<"$pod_volume_restores" >/dev/null; then
+            echo "seaweedfs-volume data volumes were restored unexpectedly"
+            kubectl get podvolumerestore -n velero
             exit 1
         fi
     fi

--- a/e2e/scripts/restore-installation-airgap.exp
+++ b/e2e/scripts/restore-installation-airgap.exp
@@ -186,6 +186,14 @@ expect {
 }
 
 expect {
+    -timeout 900 "Embedded registry populated!" {}
+    timeout {
+      puts "\n\nFailed to populate the embedded registry."
+      exit 1
+    }
+}
+
+expect {
     -timeout 240 "Embedded cluster operator restored!" {}
     timeout {
       puts "\n\nFailed to restore embedded cluster operator."

--- a/e2e/scripts/restore-multi-node-airgap-phase2.exp
+++ b/e2e/scripts/restore-multi-node-airgap-phase2.exp
@@ -75,6 +75,14 @@ expect {
 }
 
 expect {
+    -timeout 900 "Embedded registry populated!" {}
+    timeout {
+      puts "\n\nFailed to populate the embedded registry."
+      exit 1
+    }
+}
+
+expect {
     -timeout 240 "High availability enabled for the Admin Console!" {}
     timeout {
       puts "\n\nFailed to enable high availability for the admin console."

--- a/pkg-new/constants/constants.go
+++ b/pkg-new/constants/constants.go
@@ -10,4 +10,9 @@ const (
 
 const (
 	EcRestoreStateCMName = "embedded-cluster-restore-state"
+
+	// EmbeddedRegistryDataSourceAnnotation marks installation resources whose immutable registry
+	// data is rebuilt from the airgap bundle instead of being restored from volume backups.
+	EmbeddedRegistryDataSourceAnnotation   = "kots.io/embedded-registry-data-source"
+	EmbeddedRegistryDataSourceAirgapBundle = "airgap-bundle"
 )

--- a/pkg/addons/registry/static/values.tpl.yaml
+++ b/pkg/addons/registry/static/values.tpl.yaml
@@ -28,8 +28,6 @@ persistence:
   enabled: true
   size: 10Gi
   storageClass: openebs-hostpath
-podAnnotations:
-  backup.velero.io/backup-volumes: data
 replicaCount: 1
 storage: filesystem
 service:

--- a/pkg/addons/seaweedfs/static/values.tpl.yaml
+++ b/pkg/addons/seaweedfs/static/values.tpl.yaml
@@ -66,8 +66,6 @@ volume:
 {{- if .ReplaceImages }}
   imageOverride: '{{ ImageString (index .Images "seaweedfs") }}'
 {{- end }}
-  podAnnotations:
-    backup.velero.io/backup-volumes: data
   affinity: |
     # schedule on control-plane nodes
     nodeAffinity:
@@ -106,7 +104,7 @@ filer:
   imageOverride: '{{ ImageString (index .Images "seaweedfs") }}'
 {{- end }}
   podAnnotations:
-    backup.velero.io/backup-volumes: data-filer,seaweedfs-filer-log-volume
+    backup.velero.io/backup-volumes: seaweedfs-filer-log-volume
   affinity: |
     # schedule on control-plane nodes
     nodeAffinity:

--- a/pkg/disasterrecovery/backup.go
+++ b/pkg/disasterrecovery/backup.go
@@ -20,7 +20,6 @@ import (
 const (
 	// BackupIsECAnnotation is the annotation used to store if the backup is from an EC install.
 	BackupIsECAnnotation = "kots.io/embedded-cluster"
-
 	// InstanceBackupAnnotation is the annotation used to indicate that a backup is a legacy
 	// instance backup.
 	InstanceBackupAnnotation = "kots.io/instance"

--- a/pkg/kubeutils/installation.go
+++ b/pkg/kubeutils/installation.go
@@ -246,6 +246,12 @@ func CreateInstallation(ctx context.Context, cli client.Client, in *ecv1beta1.In
 		in.Labels = map[string]string{}
 	}
 	in.Labels["replicated.com/disaster-recovery"] = "ec-install"
+	if in.Spec.AirGap {
+		if in.Annotations == nil {
+			in.Annotations = map[string]string{}
+		}
+		in.Annotations[constants.EmbeddedRegistryDataSourceAnnotation] = constants.EmbeddedRegistryDataSourceAirgapBundle
+	}
 
 	backoff := wait.Backoff{Steps: 5, Duration: 2 * time.Second, Factor: 1.0, Jitter: 0.1}
 	return wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {

--- a/pkg/kubeutils/installation_test.go
+++ b/pkg/kubeutils/installation_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-logr/logr/testr"
 	"github.com/google/uuid"
 	ecv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"github.com/replicatedhq/embedded-cluster/pkg-new/constants"
 	"github.com/replicatedhq/embedded-cluster/pkg/crds"
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	"github.com/stretchr/testify/assert"
@@ -21,10 +22,40 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/yaml"
 )
+
+func TestCreateInstallationRegistryDataSourceAnnotation(t *testing.T) {
+	tests := []struct {
+		name       string
+		isAirgap   bool
+		wantMarker bool
+	}{
+		{name: "online", isAirgap: false, wantMarker: false},
+		{name: "airgap", isAirgap: true, wantMarker: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cli := fake.NewClientBuilder().Build()
+			in := &ecv1beta1.Installation{
+				ObjectMeta: metav1.ObjectMeta{Name: tt.name},
+				Spec:       ecv1beta1.InstallationSpec{AirGap: tt.isAirgap},
+			}
+			require.NoError(t, CreateInstallation(context.Background(), cli, in))
+
+			var got ecv1beta1.Installation
+			require.NoError(t, cli.Get(context.Background(), client.ObjectKey{Name: tt.name}, &got))
+			value, ok := got.Annotations[constants.EmbeddedRegistryDataSourceAnnotation]
+			assert.Equal(t, tt.wantMarker, ok)
+			if tt.wantMarker {
+				assert.Equal(t, constants.EmbeddedRegistryDataSourceAirgapBundle, value)
+			}
+		})
+	}
+}
 
 func Test_lessThanECVersion115(t *testing.T) {
 	type args struct {
@@ -232,6 +263,7 @@ func TestRecordInstallation(t *testing.T) {
 			wantErr: false,
 			validate: func(t *testing.T, installation *ecv1beta1.Installation) {
 				assert.False(t, installation.Spec.AirGap)
+				assert.NotContains(t, installation.Annotations, constants.EmbeddedRegistryDataSourceAnnotation)
 				assert.Equal(t, int64(0), installation.Spec.AirgapUncompressedSize)
 				assert.Equal(t, "1.15.0+k8s-1.30", installation.Spec.Config.Version)
 				assert.Equal(t, "https://replicated.app", installation.Spec.MetricsBaseURL)
@@ -267,6 +299,7 @@ func TestRecordInstallation(t *testing.T) {
 			wantErr: false,
 			validate: func(t *testing.T, installation *ecv1beta1.Installation) {
 				assert.True(t, installation.Spec.AirGap)
+				assert.Equal(t, constants.EmbeddedRegistryDataSourceAirgapBundle, installation.Annotations[constants.EmbeddedRegistryDataSourceAnnotation])
 				assert.Equal(t, int64(1234567890), installation.Spec.AirgapUncompressedSize)
 				assert.Equal(t, "1.16.0+k8s-1.31", installation.Spec.Config.Version)
 				assert.Equal(t, "https://staging.replicated.app", installation.Spec.MetricsBaseURL)
@@ -302,6 +335,7 @@ func TestRecordInstallation(t *testing.T) {
 			wantErr: false,
 			validate: func(t *testing.T, installation *ecv1beta1.Installation) {
 				assert.True(t, installation.Spec.AirGap)
+				assert.Equal(t, constants.EmbeddedRegistryDataSourceAirgapBundle, installation.Annotations[constants.EmbeddedRegistryDataSourceAnnotation])
 				assert.Equal(t, int64(9876543210), installation.Spec.AirgapUncompressedSize)
 				assert.Equal(t, "1.18.0+k8s-1.33", installation.Spec.Config.Version)
 				assert.Equal(t, "https://custom.replicated.app", installation.Spec.MetricsBaseURL)


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Exclude registry data from snapshots. Snapshot restore requires the same application bundle that is being restored. In case of air gap installation, the bundle also contains all the necessary images, which can be pushed into registry during the restore process.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. One release note per line. Blank lines will be ignored.
-->
New features:
 ```release-notes-features
 
 ```
 Bug fixes:
 ```release-notes-fixes
 
 ```
 Improvements:
 ```release-notes-improvements
Air-gapped disaster recovery backups are now faster and smaller by excluding registry data that can be reconstructed from the air gap bundle during restore.
 ```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
