### PR TITLE
feat: store pod logs under the data dir on new installs

### DIFF
--- a/cmd/installer/cli/install.go
+++ b/cmd/installer/cli/install.go
@@ -578,7 +578,7 @@ func buildRuntimeConfig(flags *installFlags, installCfg *installConfig, rc runti
 }
 
 func buildNetworkSpec(flags *installFlags, installCfg *installConfig) (ecv1beta1.NetworkSpec, error) {
-	k0sCfg, err := buildK0sConfig(flags, installCfg)
+	k0sCfg, err := buildK0sConfig(flags, installCfg, "")
 	if err != nil {
 		return ecv1beta1.NetworkSpec{}, fmt.Errorf("create k0s config: %w", err)
 	}
@@ -718,8 +718,8 @@ func runInstall(ctx context.Context, flags installFlags, installCfg *installConf
 }
 
 // Hop: buildK0sConfig builds k0s cluster configuration from install flags and config
-func buildK0sConfig(flags *installFlags, installCfg *installConfig) (*k0sv1beta1.ClusterConfig, error) {
-	return k0s.NewK0sConfig(flags.networkInterface, installCfg.isAirgap, flags.cidrConfig.PodCIDR, flags.cidrConfig.ServiceCIDR, installCfg.endUserConfig, nil)
+func buildK0sConfig(flags *installFlags, installCfg *installConfig, podLogsDir string) (*k0sv1beta1.ClusterConfig, error) {
+	return k0s.NewK0sConfig(flags.networkInterface, installCfg.isAirgap, flags.cidrConfig.PodCIDR, flags.cidrConfig.ServiceCIDR, podLogsDir, installCfg.endUserConfig, nil)
 }
 
 // Hop: buildHelmClientOptions builds helm client options from install config and runtime config
@@ -1040,7 +1040,7 @@ func installAndStartCluster(ctx context.Context, flags installFlags, installCfg 
 
 	logrus.Debugf("creating k0s configuration file")
 
-	cfg, err := buildK0sConfig(&flags, installCfg)
+	cfg, err := buildK0sConfig(&flags, installCfg, rc.EmbeddedClusterPodLogsSubDir())
 	if err != nil {
 		return nil, fmt.Errorf("unable to build k0s config: %w", err)
 	}

--- a/cmd/installer/cli/install_test.go
+++ b/cmd/installer/cli/install_test.go
@@ -1444,6 +1444,7 @@ func Test_buildK0sConfig(t *testing.T) {
 		name       string
 		flags      *installFlags
 		installCfg *installConfig
+		podLogsDir string
 		wantErr    bool
 		validate   func(*testing.T, *k0sv1beta1.ClusterConfig)
 	}{
@@ -1515,13 +1516,47 @@ func Test_buildK0sConfig(t *testing.T) {
 				req.Equal("172.17.0.0/20", cfg.Spec.Network.ServiceCIDR)
 			},
 		},
+		{
+			name: "pod logs dir sets the default worker profile",
+			flags: &installFlags{
+				cidrConfig: &newconfig.CIDRConfig{
+					PodCIDR:     "10.0.0.0/24",
+					ServiceCIDR: "10.1.0.0/24",
+				},
+			},
+			installCfg: &installConfig{},
+			podLogsDir: "/var/lib/embedded-cluster/k0s/pod-logs",
+			wantErr:    false,
+			validate: func(t *testing.T, cfg *k0sv1beta1.ClusterConfig) {
+				req := require.New(t)
+				req.Len(cfg.Spec.WorkerProfiles, 1)
+				req.Equal("default", cfg.Spec.WorkerProfiles[0].Name)
+				req.NotNil(cfg.Spec.WorkerProfiles[0].Config)
+				req.JSONEq(`{"podLogsDir":"/var/lib/embedded-cluster/k0s/pod-logs"}`, string(cfg.Spec.WorkerProfiles[0].Config.Raw))
+			},
+		},
+		{
+			name: "no pod logs dir leaves worker profiles unset",
+			flags: &installFlags{
+				cidrConfig: &newconfig.CIDRConfig{
+					PodCIDR:     "10.0.0.0/24",
+					ServiceCIDR: "10.1.0.0/24",
+				},
+			},
+			installCfg: &installConfig{},
+			podLogsDir: "",
+			wantErr:    false,
+			validate: func(t *testing.T, cfg *k0sv1beta1.ClusterConfig) {
+				require.New(t).Empty(cfg.Spec.WorkerProfiles)
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := require.New(t)
 
-			cfg, err := buildK0sConfig(tt.flags, tt.installCfg)
+			cfg, err := buildK0sConfig(tt.flags, tt.installCfg, tt.podLogsDir)
 
 			if tt.wantErr {
 				req.Error(err)

--- a/pkg-new/k0s/interface.go
+++ b/pkg-new/k0s/interface.go
@@ -40,7 +40,7 @@ type K0sInterface interface {
 	GetStatus(ctx context.Context) (*K0sStatus, error)
 	Install(rc runtimeconfig.RuntimeConfig, hostname string) error
 	IsInstalled() (bool, error)
-	NewK0sConfig(networkInterface string, isAirgap bool, podCIDR string, serviceCIDR string, eucfg *ecv1beta1.Config, mutate func(*k0sv1beta1.ClusterConfig) error) (*k0sv1beta1.ClusterConfig, error)
+	NewK0sConfig(networkInterface string, isAirgap bool, podCIDR string, serviceCIDR string, podLogsDir string, eucfg *ecv1beta1.Config, mutate func(*k0sv1beta1.ClusterConfig) error) (*k0sv1beta1.ClusterConfig, error)
 	WriteK0sConfig(ctx context.Context, cfg *k0sv1beta1.ClusterConfig) error
 	PatchK0sConfig(path string, patch string) error
 	WaitForK0s() error
@@ -62,8 +62,8 @@ func IsInstalled() (bool, error) {
 	return _k0s.IsInstalled()
 }
 
-func NewK0sConfig(networkInterface string, isAirgap bool, podCIDR string, serviceCIDR string, eucfg *ecv1beta1.Config, mutate func(*k0sv1beta1.ClusterConfig) error) (*k0sv1beta1.ClusterConfig, error) {
-	return _k0s.NewK0sConfig(networkInterface, isAirgap, podCIDR, serviceCIDR, eucfg, mutate)
+func NewK0sConfig(networkInterface string, isAirgap bool, podCIDR string, serviceCIDR string, podLogsDir string, eucfg *ecv1beta1.Config, mutate func(*k0sv1beta1.ClusterConfig) error) (*k0sv1beta1.ClusterConfig, error) {
+	return _k0s.NewK0sConfig(networkInterface, isAirgap, podCIDR, serviceCIDR, podLogsDir, eucfg, mutate)
 }
 
 func WriteK0sConfig(ctx context.Context, cfg *k0sv1beta1.ClusterConfig) error {

--- a/pkg-new/k0s/k0s.go
+++ b/pkg-new/k0s/k0s.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -117,7 +118,7 @@ func (k *K0s) IsInstalled() (bool, error) {
 }
 
 // NewK0sConfig creates a new k0sv1beta1.ClusterConfig object from the input parameters.
-func (k *K0s) NewK0sConfig(networkInterface string, isAirgap bool, podCIDR string, serviceCIDR string, eucfg *ecv1beta1.Config, mutate func(*k0sv1beta1.ClusterConfig) error) (*k0sv1beta1.ClusterConfig, error) {
+func (k *K0s) NewK0sConfig(networkInterface string, isAirgap bool, podCIDR string, serviceCIDR string, podLogsDir string, eucfg *ecv1beta1.Config, mutate func(*k0sv1beta1.ClusterConfig) error) (*k0sv1beta1.ClusterConfig, error) {
 	var embCfgSpec *ecv1beta1.ConfigSpec
 	if embCfg := release.GetEmbeddedClusterConfig(); embCfg != nil {
 		embCfgSpec = &embCfg.Spec
@@ -143,6 +144,13 @@ func (k *K0s) NewK0sConfig(networkInterface string, isAirgap bool, podCIDR strin
 	if mutate != nil {
 		if err := mutate(cfg); err != nil {
 			return nil, err
+		}
+	}
+
+	// Set before overrides so a vendor- or end user-supplied worker profile still wins.
+	if podLogsDir != "" && config.SupportsPodLogsDir() {
+		if err := setPodLogsDir(cfg, podLogsDir); err != nil {
+			return nil, fmt.Errorf("unable to set pod logs dir: %w", err)
 		}
 	}
 
@@ -183,6 +191,22 @@ func (k *K0s) WriteK0sConfig(ctx context.Context, cfg *k0sv1beta1.ClusterConfig)
 		return fmt.Errorf("unable to write config file: %w", err)
 	}
 
+	return nil
+}
+
+// setPodLogsDir points kubelet at a pod log directory under the k0s data dir, so pod logs land
+// on the filesystem kubelet measures disk pressure on and eviction can account for them. It uses
+// the "default" worker profile, which is the profile every node reads unless installed with an
+// explicit --profile.
+func setPodLogsDir(cfg *k0sv1beta1.ClusterConfig, podLogsDir string) error {
+	values, err := json.Marshal(map[string]string{"podLogsDir": podLogsDir})
+	if err != nil {
+		return fmt.Errorf("marshal worker profile values: %w", err)
+	}
+	cfg.Spec.WorkerProfiles = append(cfg.Spec.WorkerProfiles, k0sv1beta1.WorkerProfile{
+		Name:   "default",
+		Config: &runtime.RawExtension{Raw: values},
+	})
 	return nil
 }
 

--- a/pkg-new/upgrade/upgrade_test.go
+++ b/pkg-new/upgrade/upgrade_test.go
@@ -381,6 +381,116 @@ config:
 				assert.Contains(t, updatedConfig.Spec.Images.CoreDNS.Image, "registry.com/")
 			},
 		},
+		{
+			// A cluster installed with the pod log directory keeps it across upgrades: the
+			// upgrade path never rewrites workerProfiles unless an override says so.
+			name: "keeps the pod logs worker profile when no overrides are set",
+			currentConfig: &k0sv1beta1.ClusterConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "k0s",
+					Namespace: "kube-system",
+				},
+				Spec: &k0sv1beta1.ClusterSpec{
+					Network: &k0sv1beta1.Network{
+						ServiceCIDR: "10.96.0.0/12",
+					},
+					WorkerProfiles: []k0sv1beta1.WorkerProfile{
+						{
+							Name:   "default",
+							Config: &runtime.RawExtension{Raw: []byte(`{"podLogsDir":"/var/lib/embedded-cluster/k0s/pod-logs"}`)},
+						},
+					},
+				},
+			},
+			installation: &ecv1beta1.Installation{
+				Spec: ecv1beta1.InstallationSpec{
+					Config: &ecv1beta1.ConfigSpec{
+						Domains: ecv1beta1.Domains{
+							ProxyRegistryDomain: "registry.com",
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, updatedConfig *k0sv1beta1.ClusterConfig) {
+				require.Len(t, updatedConfig.Spec.WorkerProfiles, 1)
+				assert.Equal(t, "default", updatedConfig.Spec.WorkerProfiles[0].Name)
+				assert.JSONEq(t, `{"podLogsDir":"/var/lib/embedded-cluster/k0s/pod-logs"}`, string(updatedConfig.Spec.WorkerProfiles[0].Config.Raw))
+			},
+		},
+		{
+			// The pod log directory is set at install time only, so upgrading a cluster that
+			// never had it must not introduce one.
+			name: "does not add a pod logs worker profile to an existing cluster",
+			currentConfig: &k0sv1beta1.ClusterConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "k0s",
+					Namespace: "kube-system",
+				},
+				Spec: &k0sv1beta1.ClusterSpec{
+					Network: &k0sv1beta1.Network{
+						ServiceCIDR: "10.96.0.0/12",
+					},
+				},
+			},
+			installation: &ecv1beta1.Installation{
+				Spec: ecv1beta1.InstallationSpec{
+					Config: &ecv1beta1.ConfigSpec{
+						Domains: ecv1beta1.Domains{
+							ProxyRegistryDomain: "registry.com",
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, updatedConfig *k0sv1beta1.ClusterConfig) {
+				assert.Empty(t, updatedConfig.Spec.WorkerProfiles)
+			},
+		},
+		{
+			// Documents the accepted trade-off: workerProfiles is a list and overrides replace
+			// it wholesale, so a vendor profile takes the pod log directory with it.
+			name: "vendor worker profile override replaces the pod logs profile",
+			currentConfig: &k0sv1beta1.ClusterConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "k0s",
+					Namespace: "kube-system",
+				},
+				Spec: &k0sv1beta1.ClusterSpec{
+					Network: &k0sv1beta1.Network{
+						ServiceCIDR: "10.96.0.0/12",
+					},
+					WorkerProfiles: []k0sv1beta1.WorkerProfile{
+						{
+							Name:   "default",
+							Config: &runtime.RawExtension{Raw: []byte(`{"podLogsDir":"/var/lib/embedded-cluster/k0s/pod-logs"}`)},
+						},
+					},
+				},
+			},
+			installation: &ecv1beta1.Installation{
+				Spec: ecv1beta1.InstallationSpec{
+					Config: &ecv1beta1.ConfigSpec{
+						Domains: ecv1beta1.Domains{
+							ProxyRegistryDomain: "registry.com",
+						},
+						UnsupportedOverrides: ecv1beta1.UnsupportedOverrides{
+							K0s: `
+config:
+  spec:
+    workerProfiles:
+    - name: ip-forward
+      values:
+        allowedUnsafeSysctls:
+        - net.ipv4.ip_forward
+`,
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, updatedConfig *k0sv1beta1.ClusterConfig) {
+				require.Len(t, updatedConfig.Spec.WorkerProfiles, 1)
+				assert.Equal(t, "ip-forward", updatedConfig.Spec.WorkerProfiles[0].Name)
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,8 +9,10 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	jsonpatch "github.com/evanphx/json-patch"
 	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+	"github.com/k0sproject/k0s/pkg/constant"
 	embeddedclusterv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
 	"github.com/sirupsen/logrus"
 	"go.yaml.in/yaml/v3"
@@ -20,6 +22,19 @@ import (
 	"github.com/replicatedhq/embedded-cluster/pkg/release"
 	"github.com/replicatedhq/embedded-cluster/pkg/runtimeconfig"
 )
+
+// podLogsDirMinVersion is the first Kubernetes version that honors the kubelet podLogsDir
+// setting. Below it the field is silently dropped, so we don't set it at all.
+var podLogsDirMinVersion = semver.MustParse("1.30")
+
+// SupportsPodLogsDir reports whether the bundled Kubernetes version honors podLogsDir.
+func SupportsPodLogsDir() bool {
+	v, err := semver.NewVersion(constant.KubernetesMajorMinorVersion)
+	if err != nil {
+		return false
+	}
+	return !v.LessThan(podLogsDirMinVersion)
+}
 
 const (
 	DefaultVendorChartOrder = 10

--- a/pkg/dryrun/k0s.go
+++ b/pkg/dryrun/k0s.go
@@ -36,8 +36,8 @@ func (c *K0s) IsInstalled() (bool, error) {
 	return c.Status != nil, nil
 }
 
-func (c *K0s) NewK0sConfig(networkInterface string, isAirgap bool, podCIDR string, serviceCIDR string, eucfg *ecv1beta1.Config, mutate func(*k0sv1beta1.ClusterConfig) error) (*k0sv1beta1.ClusterConfig, error) {
-	return c.k0s.NewK0sConfig(networkInterface, isAirgap, podCIDR, serviceCIDR, eucfg, mutate) // actual implementation accounts for dryrun
+func (c *K0s) NewK0sConfig(networkInterface string, isAirgap bool, podCIDR string, serviceCIDR string, podLogsDir string, eucfg *ecv1beta1.Config, mutate func(*k0sv1beta1.ClusterConfig) error) (*k0sv1beta1.ClusterConfig, error) {
+	return c.k0s.NewK0sConfig(networkInterface, isAirgap, podCIDR, serviceCIDR, podLogsDir, eucfg, mutate) // actual implementation accounts for dryrun
 }
 
 func (c *K0s) WriteK0sConfig(ctx context.Context, cfg *k0sv1beta1.ClusterConfig) error {

--- a/pkg/runtimeconfig/interface.go
+++ b/pkg/runtimeconfig/interface.go
@@ -19,6 +19,7 @@ type RuntimeConfig interface {
 	EmbeddedClusterChartsSubDirNoCreate() string
 	EmbeddedClusterImagesSubDir() string
 	EmbeddedClusterK0sSubDir() string
+	EmbeddedClusterPodLogsSubDir() string
 	EmbeddedClusterSeaweedFSSubDir() string
 	EmbeddedClusterOpenEBSLocalSubDir() string
 	PathToEmbeddedClusterBinary(name string) string

--- a/pkg/runtimeconfig/mock.go
+++ b/pkg/runtimeconfig/mock.go
@@ -74,6 +74,12 @@ func (m *MockRuntimeConfig) EmbeddedClusterK0sSubDir() string {
 	return args.String(0)
 }
 
+// EmbeddedClusterPodLogsSubDir mocks the EmbeddedClusterPodLogsSubDir method
+func (m *MockRuntimeConfig) EmbeddedClusterPodLogsSubDir() string {
+	args := m.Called()
+	return args.String(0)
+}
+
 // EmbeddedClusterSeaweedFSSubDir mocks the EmbeddedClusterSeaweedFSSubDir method
 func (m *MockRuntimeConfig) EmbeddedClusterSeaweedFSSubDir() string {
 	args := m.Called()

--- a/pkg/runtimeconfig/runtimeconfig.go
+++ b/pkg/runtimeconfig/runtimeconfig.go
@@ -150,6 +150,12 @@ func (rc *runtimeConfig) EmbeddedClusterK0sSubDir() string {
 	return filepath.Join(rc.EmbeddedClusterHomeDirectory(), "k0s")
 }
 
+// EmbeddedClusterPodLogsSubDir returns the path to the directory where kubelet writes pod logs.
+// It sits under the k0s data dir so pod logs share the filesystem kubelet measures disk pressure on.
+func (rc *runtimeConfig) EmbeddedClusterPodLogsSubDir() string {
+	return filepath.Join(rc.EmbeddedClusterK0sSubDir(), "pod-logs")
+}
+
 // EmbeddedClusterSeaweedFSSubDir returns the path to the directory where seaweedfs data is stored.
 func (rc *runtimeConfig) EmbeddedClusterSeaweedFSSubDir() string {
 	return filepath.Join(rc.EmbeddedClusterHomeDirectory(), "seaweedfs")

--- a/tests/dryrun/assets/cluster-config-no-worker-profiles.yaml
+++ b/tests/dryrun/assets/cluster-config-no-worker-profiles.yaml
@@ -1,0 +1,56 @@
+apiVersion: embeddedcluster.replicated.com/v1beta1
+kind: Config
+metadata:
+  name: "testconfig"
+spec:
+  version: "testversion"
+  domains:
+    replicatedAppDomain: "fake-endpoint.com"
+    proxyRegistryDomain: "fake-replicated-proxy.test.net"
+  roles:
+    controller:
+      name: test-controller-role
+      labels:
+        test-label-key: test-label-value
+        another-label: another-value
+  unsupportedOverrides:
+    k0s: |
+      config:
+        metadata:
+          name: testing-overrides-k0s-name
+        spec:
+          telemetry:
+            enabled: false
+          api:
+            extraArgs:
+              test-key: test-value
+    builtInExtensions:
+      - name: admin-console
+        values: |
+          labels:
+            release-custom-label: release-clustom-value
+          kotsadm:
+            resources:
+              limits:
+                memory: 4Gi
+              requests:
+                cpu: 200m
+                memory: 300Mi
+          rqlite:
+            resources:
+              limits:
+                memory: 3Gi
+              requests:
+                cpu: 150m
+                memory: 512Mi
+  extensions:
+    helm:
+      charts:
+        - name: goldpinger
+          chartname: oci://ec-e2e-proxy.testcluster.net/anonymous/public.ecr.aws/q7i7m9q2/embedded-cluster-charts/goldpinger
+          namespace: goldpinger
+          version: 6.1.2
+          order: 11
+          values: |
+            image:
+              repository: ec-e2e-proxy.testcluster.net/anonymous/bloomberg/goldpinger

--- a/tests/dryrun/install_test.go
+++ b/tests/dryrun/install_test.go
@@ -330,6 +330,44 @@ func TestCustomDataDir(t *testing.T) {
 	t.Logf("%s: test complete", time.Now().Format(time.RFC3339))
 }
 
+// TestPodLogsDir validates that a fresh install points kubelet at a pod log directory under the
+// data dir, so pod logs land on the filesystem kubelet measures disk pressure on.
+func TestPodLogsDir(t *testing.T) {
+	hcli := &helm.MockClient{}
+
+	mock.InOrder(
+		// 4 addons + Goldpinger extension
+		hcli.On("Install", mock.Anything, mock.Anything).Times(5).Return(nil, nil),
+		hcli.On("Close").Once().Return(nil),
+	)
+
+	dr := dryrunInstallWithClusterConfig(t,
+		&dryrun.Client{HelmClient: hcli},
+		clusterConfigNoWorkerProfilesData,
+		"--data-dir", "/custom/data/dir",
+	)
+
+	// --- validate k0s cluster config --- //
+	k0sConfig := readK0sConfig(t)
+
+	require.Len(t, k0sConfig.Spec.WorkerProfiles, 1, "the default worker profile should be set")
+	assert.Equal(t, "default", k0sConfig.Spec.WorkerProfiles[0].Name)
+	require.NotNil(t, k0sConfig.Spec.WorkerProfiles[0].Config)
+	assert.JSONEq(t,
+		`{"podLogsDir":"/custom/data/dir/k0s/pod-logs"}`,
+		string(k0sConfig.Spec.WorkerProfiles[0].Config.Raw),
+		"pod logs dir should follow --data-dir",
+	)
+
+	// --- validate commands --- //
+	assertCommands(t, dr.Commands,
+		[]interface{}{
+			regexp.MustCompile(`k0s install controller .* --profile=default`),
+		},
+		false,
+	)
+}
+
 func TestCustomPortsInstallation(t *testing.T) {
 	hcli := &helm.MockClient{}
 

--- a/tests/dryrun/util.go
+++ b/tests/dryrun/util.go
@@ -52,6 +52,9 @@ var (
 	//go:embed assets/cluster-config-nodomains.yaml
 	clusterConfigNoDomainsData string
 
+	//go:embed assets/cluster-config-no-worker-profiles.yaml
+	clusterConfigNoWorkerProfilesData string
+
 	//go:embed assets/cluster-config-with-velero-plugins.yaml
 	clusterConfigWithVeleroPluginsData string
 


### PR DESCRIPTION
## Problem

kubelet measures disk pressure on the filesystem holding its own root directory, which Embedded Cluster places under `--data-dir`. Pod logs stay at `/var/log/pods`.

So when the data dir is a separate mount — the layout we recommend for space — `/var` can fill to 100% while kubelet reports plenty of `nodefs` space and never evicts anything. A full `/var` takes containerd, the admin console, and support bundle collection with it.

## Change

Set `podLogsDir` to `{data-dir}/k0s/pod-logs` on the `default` worker profile at install time. `default` is the profile every node reads unless installed with an explicit `--profile`, so no per-node change is needed.

It is applied before `applyUnsupportedOverrides`, so a vendor- or end-user-supplied `workerProfiles` still wins. Gated on Kubernetes >= 1.30, below which `podLogsDir` does not exist.

**New installs only.** The upgrade path never rewrites `workerProfiles`, so the log path never moves under a running cluster and existing clusters do not gain one.

## Tests

Unit and dryrun coverage: the profile is written with the data-dir-derived path and `--profile=default` is passed to `k0s install`; upgrades keep it, never introduce it, and a vendor `workerProfiles` override replaces it.

No e2e coverage — every e2e release manifest defines its own `ip-forward` profile, which replaces ours and is what the node gets selected into, so no existing e2e test can reach this path.

## Follow-ups

- Docs: the new path, and the "do not use `default`" guidance this makes wrong.
- A preflight warning when `/var/log` and the data dir are on different filesystems, which would reach existing clusters too.
- Vendors who define a worker profile keep the bug; setting `podLogsDir` on every profile rather than only `default` would fix that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)