### PR TITLE
fix(e2e): retry with page reload when upgrade version row is not available

### DIFF
--- a/e2e/playwright/tests/deploy-upgrade/test.spec.ts
+++ b/e2e/playwright/tests/deploy-upgrade/test.spec.ts
@@ -38,8 +38,25 @@ async function runDeployUpgradeWithRetry(page: Page, maxRetries = 3) {
 }
 
 async function initiateUpgrade(page: Page) {
-  await page.getByRole('link', { name: 'Version history', exact: true }).click();
-  await page.locator('.available-update-row', { hasText: process.env.APP_UPGRADE_VERSION }).getByRole('button', { name: 'Deploy', exact: true }).click();
+  // The admin console only fetches available updates once, when the Version
+  // history page mounts. That fetch can hang indefinitely (no upstream
+  // timeout), so poll with page reloads instead of waiting for a single fetch.
+  const deployButton = page.locator('.available-update-row', { hasText: process.env.APP_UPGRADE_VERSION }).getByRole('button', { name: 'Deploy', exact: true });
+  const maxAttempts = 8; // 8 * 90s = 12 min, within the 15 min test timeout
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    await page.getByRole('link', { name: 'Version history', exact: true }).click();
+    try {
+      await deployButton.waitFor({ state: 'visible', timeout: 90 * 1000 });
+      await deployButton.click();
+      return;
+    } catch (e) {
+      if (!(e instanceof Error && e.name === 'TimeoutError') || attempt === maxAttempts) {
+        throw e;
+      }
+      console.log(`upgrade version not available after ${attempt} attempt(s), reloading version history page`);
+      await page.reload();
+    }
+  }
 }
 
 async function fillConfigForm(iframe: FrameLocator) {


### PR DESCRIPTION
## Problem

`TestSingleNodeDisasterRecovery` (and other tests using the `deploy-upgrade` playwright spec) flakes at the very last step: the test waits 15 minutes for the upgrade version row to appear on the Version history page and times out.

Root cause (details in [sc-139518](https://app.shortcut.com/replicated/story/139518)):

- The admin console fetches available updates **exactly once**, when the Version history page mounts (`GET /api/v1/app/{slug}/updates`).
- That handler does synchronous, un-timed outbound HTTP calls to the app service (license sync + fetch updates). In the [failed run](https://github.com/replicatedhq/embedded-cluster/actions/runs/33966903090/job/101310926935), the goroutine dump shows all 3 handler goroutines blocked 15 minutes on the same stalled HTTP/2 connection, and the playwright trace shows all `/updates` requests never received a response.
- With no response, the UI shows a spinner forever and the row can never appear — the 15-minute timeout is guaranteed to be hit.

## Fix (test side)

Poll with page reloads in `initiateUpgrade`: wait up to 90s for the row, reload the Version history page (re-triggering the fetch) and retry, up to 8 attempts (12 min max, within the existing 15 min test timeout). A single hung upstream fetch no longer fails the test.

The kotsadm-side fix (HTTP timeouts, reporting mutex, UI retry) is tracked in [sc-139518](https://app.shortcut.com/replicated/story/139518).

## Verification

- `npx playwright test --list` passes (spec compiles).