### PR TITLE
fix: use Kubernetes-specific local artifact mirror compat aliases

### DIFF
--- a/securebuild/package/local-artifact-mirror-k8s1.34/melange.yaml
+++ b/securebuild/package/local-artifact-mirror-k8s1.34/melange.yaml
@@ -67,7 +67,7 @@ subpackages:
       runtime:
         - ${{package.name}}
       provides:
-        - local-artifact-mirror-compat=${{package.full-version}}
+        - local-artifact-mirror-k8s1.34-compat=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/local/bin

--- a/securebuild/package/local-artifact-mirror-k8s1.35/melange.yaml
+++ b/securebuild/package/local-artifact-mirror-k8s1.35/melange.yaml
@@ -67,7 +67,7 @@ subpackages:
       runtime:
         - ${{package.name}}
       provides:
-        - local-artifact-mirror-compat=${{package.full-version}}
+        - local-artifact-mirror-k8s1.35-compat=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/local/bin

--- a/securebuild/package/local-artifact-mirror-k8s1.36/melange.yaml
+++ b/securebuild/package/local-artifact-mirror-k8s1.36/melange.yaml
@@ -67,7 +67,7 @@ subpackages:
       runtime:
         - ${{package.name}}
       provides:
-        - local-artifact-mirror-compat=${{package.full-version}}
+        - local-artifact-mirror-k8s1.36-compat=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/local/bin


### PR DESCRIPTION
#### What this PR does / why we need it:

Local artifact mirror image builds fail because the APKO definitions request Kubernetes-specific compat aliases, while the package recipes only provide `local-artifact-mirror-compat`.

Replace that generic alias with the matching Kubernetes-specific alias in the 1.34, 1.35, and 1.36 recipes. For example, the 1.36 compat subpackage now provides `local-artifact-mirror-k8s1.36-compat`, matching its APKO definition. The updated packages must be rebuilt and published before image builds can resolve the aliases.

#### Which issue(s) this PR fixes:

NONE

#### Does this PR require a test?

NONE. Parsed all three changed YAML recipes and verified that each compat subpackage provides only the Kubernetes-specific alias requested by its APKO definition. `git diff --check` passed. Package builds were not run.

#### Does this PR require a release note?

New features:
```release-notes-features
NONE
```

Bug fixes:
```release-notes-fixes
NONE
```

Improvements:
```release-notes-improvements
NONE
```

#### Does this PR require documentation?

NONE
