### PR TITLE
Preserve pod logs dir in vendor worker profiles

### DIFF
--- a/pkg-new/k0s/k0s.go
+++ b/pkg-new/k0s/k0s.go
@@ -147,16 +147,18 @@ func (k *K0s) NewK0sConfig(networkInterface string, isAirgap bool, podCIDR strin
 		}
 	}
 
-	// Set before overrides so a vendor- or end user-supplied worker profile still wins.
+	cfg, err = applyUnsupportedOverrides(cfg, eucfg)
+	if err != nil {
+		return nil, fmt.Errorf("unable to apply unsupported overrides: %w", err)
+	}
+
+	// Apply this after the merge patches: workerProfiles is an array, so a vendor- or
+	// end user-supplied profile replaces any profile we added beforehand. An explicit
+	// podLogsDir in a profile still takes precedence.
 	if podLogsDir != "" && config.SupportsPodLogsDir() {
 		if err := setPodLogsDir(cfg, podLogsDir); err != nil {
 			return nil, fmt.Errorf("unable to set pod logs dir: %w", err)
 		}
-	}
-
-	cfg, err = applyUnsupportedOverrides(cfg, eucfg)
-	if err != nil {
-		return nil, fmt.Errorf("unable to apply unsupported overrides: %w", err)
 	}
 
 	if isAirgap {
@@ -195,18 +197,44 @@ func (k *K0s) WriteK0sConfig(ctx context.Context, cfg *k0sv1beta1.ClusterConfig)
 }
 
 // setPodLogsDir points kubelet at a pod log directory under the k0s data dir, so pod logs land
-// on the filesystem kubelet measures disk pressure on and eviction can account for them. It uses
-// the "default" worker profile, which is the profile every node reads unless installed with an
-// explicit --profile.
+// on the filesystem kubelet measures disk pressure on and eviction can account for them. It adds
+// the setting to every configured profile, since a vendor-selected profile may be used instead of
+// "default". It preserves an explicitly configured podLogsDir and creates the default profile
+// when no profile is configured.
 func setPodLogsDir(cfg *k0sv1beta1.ClusterConfig, podLogsDir string) error {
-	values, err := json.Marshal(map[string]string{"podLogsDir": podLogsDir})
+	podLogsDirValue, err := json.Marshal(podLogsDir)
 	if err != nil {
-		return fmt.Errorf("marshal worker profile values: %w", err)
+		return fmt.Errorf("marshal pod logs dir: %w", err)
 	}
-	cfg.Spec.WorkerProfiles = append(cfg.Spec.WorkerProfiles, k0sv1beta1.WorkerProfile{
-		Name:   "default",
-		Config: &runtime.RawExtension{Raw: values},
-	})
+
+	if len(cfg.Spec.WorkerProfiles) == 0 {
+		cfg.Spec.WorkerProfiles = append(cfg.Spec.WorkerProfiles, k0sv1beta1.WorkerProfile{Name: "default"})
+	}
+
+	for i := range cfg.Spec.WorkerProfiles {
+		profile := &cfg.Spec.WorkerProfiles[i]
+		values := map[string]json.RawMessage{}
+		if profile.Config != nil && len(profile.Config.Raw) > 0 {
+			if err := json.Unmarshal(profile.Config.Raw, &values); err != nil {
+				return fmt.Errorf("unmarshal worker profile %q values: %w", profile.Name, err)
+			}
+		}
+		if values == nil {
+			values = map[string]json.RawMessage{}
+		}
+		if _, ok := values["podLogsDir"]; ok {
+			continue
+		}
+
+		values["podLogsDir"] = podLogsDirValue
+
+		profileValues, err := json.Marshal(values)
+		if err != nil {
+			return fmt.Errorf("marshal worker profile %q values: %w", profile.Name, err)
+		}
+		profile.Config = &runtime.RawExtension{Raw: profileValues}
+	}
+
 	return nil
 }
 

--- a/pkg-new/k0s/k0s_test.go
+++ b/pkg-new/k0s/k0s_test.go
@@ -78,6 +78,86 @@ func TestPatchK0sConfig(t *testing.T) {
 	}
 }
 
+func TestSetPodLogsDir(t *testing.T) {
+	tests := []struct {
+		name     string
+		profiles k0sv1beta1.WorkerProfiles
+		want     k0sv1beta1.WorkerProfiles
+	}{
+		{
+			name: "adds the default profile when no profile exists",
+			want: k0sv1beta1.WorkerProfiles{
+				{
+					Name:   "default",
+					Config: &runtime.RawExtension{Raw: []byte(`{"podLogsDir":"/custom/k0s/pod-logs"}`)},
+				},
+			},
+		},
+		{
+			name: "adds pod logs dir to a vendor profile",
+			profiles: k0sv1beta1.WorkerProfiles{
+				{
+					Name:   "vendor-profile",
+					Config: &runtime.RawExtension{Raw: []byte(`{"maxPods":250}`)},
+				},
+			},
+			want: k0sv1beta1.WorkerProfiles{
+				{
+					Name:   "vendor-profile",
+					Config: &runtime.RawExtension{Raw: []byte(`{"maxPods":250,"podLogsDir":"/custom/k0s/pod-logs"}`)},
+				},
+			},
+		},
+		{
+			name: "preserves an explicitly overridden pod logs dir",
+			profiles: k0sv1beta1.WorkerProfiles{
+				{
+					Name:   "vendor-profile",
+					Config: &runtime.RawExtension{Raw: []byte(`{"podLogsDir":"/var/log/pods"}`)},
+				},
+			},
+			want: k0sv1beta1.WorkerProfiles{
+				{
+					Name:   "vendor-profile",
+					Config: &runtime.RawExtension{Raw: []byte(`{"podLogsDir":"/var/log/pods"}`)},
+				},
+			},
+		},
+		{
+			name: "adds pod logs dir to every profile without an explicit value",
+			profiles: k0sv1beta1.WorkerProfiles{
+				{
+					Name:   "ip-forward",
+					Config: &runtime.RawExtension{Raw: []byte(`{"allowedUnsafeSysctls":["net.ipv4.ip_forward"]}`)},
+				},
+				{
+					Name:   "custom-pod-logs",
+					Config: &runtime.RawExtension{Raw: []byte(`{"podLogsDir":"/vendor/pod-logs"}`)},
+				},
+			},
+			want: k0sv1beta1.WorkerProfiles{
+				{
+					Name:   "ip-forward",
+					Config: &runtime.RawExtension{Raw: []byte(`{"allowedUnsafeSysctls":["net.ipv4.ip_forward"],"podLogsDir":"/custom/k0s/pod-logs"}`)},
+				},
+				{
+					Name:   "custom-pod-logs",
+					Config: &runtime.RawExtension{Raw: []byte(`{"podLogsDir":"/vendor/pod-logs"}`)},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &k0sv1beta1.ClusterConfig{Spec: &k0sv1beta1.ClusterSpec{WorkerProfiles: tt.profiles}}
+
+			require.NoError(t, setPodLogsDir(cfg, "/custom/k0s/pod-logs"))
+			require.Equal(t, tt.want, cfg.Spec.WorkerProfiles)
+		})
+	}
+}
+
 func parseTestsYAML[T any](t *testing.T, prefix string) map[string]T {
 	entries, err := testData.ReadDir("testdata")
 	require.NoError(t, err)

--- a/tests/dryrun/install_test.go
+++ b/tests/dryrun/install_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -230,7 +231,7 @@ func testDefaultInstallationImpl(t *testing.T) {
 	assert.Equal(t, "test-value", k0sConfig.Spec.API.ExtraArgs["test-key"], "api extraArgs should contain test-key from unsupported-overrides")
 
 	// worker profiles
-	require.Len(t, k0sConfig.Spec.WorkerProfiles, 1, "workerProfiles should have one profile from unsupported-overrides")
+	require.Len(t, k0sConfig.Spec.WorkerProfiles, 1, "workerProfiles should retain the unsupported override")
 	assert.Equal(t, "ip-forward", k0sConfig.Spec.WorkerProfiles[0].Name, "workerProfile name should be set from unsupported-overrides")
 	require.NotNil(t, k0sConfig.Spec.WorkerProfiles[0].Config, "workerProfile config should exist")
 
@@ -239,6 +240,7 @@ func testDefaultInstallationImpl(t *testing.T) {
 	require.NoError(t, err, "should be able to unmarshal workerProfile config")
 	sysctls := profileConfig["allowedUnsafeSysctls"].([]interface{})
 	assert.Equal(t, "net.ipv4.ip_forward", sysctls[0], "allowedUnsafeSysctls should contain net.ipv4.ip_forward from unsupported-overrides")
+	assert.Equal(t, "/var/lib/embedded-cluster/k0s/pod-logs", profileConfig["podLogsDir"])
 }
 
 func TestCustomDataDir(t *testing.T) {
@@ -365,6 +367,81 @@ func TestPodLogsDir(t *testing.T) {
 			regexp.MustCompile(`k0s install controller .* --profile=default`),
 		},
 		false,
+	)
+}
+
+func TestPodLogsDirWithWorkerProfileOverride(t *testing.T) {
+	hcli := &helm.MockClient{}
+
+	mock.InOrder(
+		// 4 addons + Goldpinger extension
+		hcli.On("Install", mock.Anything, mock.Anything).Times(5).Return(nil, nil),
+		hcli.On("Close").Once().Return(nil),
+	)
+
+	dr := dryrunInstallWithClusterConfig(t,
+		&dryrun.Client{HelmClient: hcli},
+		clusterConfigWithWorkerProfiles(`
+            - name: vendor-max-pods
+              values:
+                maxPods: 250`),
+		"--data-dir", "/custom/data/dir",
+	)
+
+	k0sConfig := readK0sConfig(t)
+	require.Len(t, k0sConfig.Spec.WorkerProfiles, 1)
+	assert.Equal(t, "vendor-max-pods", k0sConfig.Spec.WorkerProfiles[0].Name)
+	require.NotNil(t, k0sConfig.Spec.WorkerProfiles[0].Config)
+	assert.JSONEq(t,
+		`{"maxPods":250,"podLogsDir":"/custom/data/dir/k0s/pod-logs"}`,
+		string(k0sConfig.Spec.WorkerProfiles[0].Config.Raw),
+		"pod logs dir should be added without replacing the vendor's worker profile settings",
+	)
+	assertCommands(t, dr.Commands,
+		[]interface{}{regexp.MustCompile(`k0s install controller .* --profile=vendor-max-pods`)},
+		false,
+	)
+}
+
+func TestPodLogsDirExplicitWorkerProfileOverride(t *testing.T) {
+	hcli := &helm.MockClient{}
+
+	mock.InOrder(
+		// 4 addons + Goldpinger extension
+		hcli.On("Install", mock.Anything, mock.Anything).Times(5).Return(nil, nil),
+		hcli.On("Close").Once().Return(nil),
+	)
+
+	dr := dryrunInstallWithClusterConfig(t,
+		&dryrun.Client{HelmClient: hcli},
+		clusterConfigWithWorkerProfiles(`
+            - name: vendor-pod-logs
+              values:
+                maxPods: 250
+                podLogsDir: /var/log/pods`),
+		"--data-dir", "/custom/data/dir",
+	)
+
+	k0sConfig := readK0sConfig(t)
+	require.Len(t, k0sConfig.Spec.WorkerProfiles, 1)
+	assert.Equal(t, "vendor-pod-logs", k0sConfig.Spec.WorkerProfiles[0].Name)
+	require.NotNil(t, k0sConfig.Spec.WorkerProfiles[0].Config)
+	assert.JSONEq(t,
+		`{"maxPods":250,"podLogsDir":"/var/log/pods"}`,
+		string(k0sConfig.Spec.WorkerProfiles[0].Config.Raw),
+		"an explicit pod logs dir should take precedence over the computed data-dir path",
+	)
+	assertCommands(t, dr.Commands,
+		[]interface{}{regexp.MustCompile(`k0s install controller .* --profile=vendor-pod-logs`)},
+		false,
+	)
+}
+
+func clusterConfigWithWorkerProfiles(workerProfiles string) string {
+	return strings.Replace(clusterConfigNoWorkerProfilesData,
+		"          api:\n",
+		"          workerProfiles:\n"+workerProfiles+"\n          api:\n",
+		1,
 	)
 }
 


### PR DESCRIPTION
## Why this is needed
Vendor and end-user k0s overrides replace the entire workerProfiles array. Because Embedded Cluster previously added podLogsDir before those overrides, a vendor setting something routine like maxPods could silently remove the computed pod-log path.

That sends logs back to /var/log/pods and bypasses the disk-pressure and eviction accounting this feature was meant to support. Vendors cannot reliably restore the computed path themselves because it depends on the data directory chosen at install time.

This affects new installs only: the k0s configuration and worker profiles are written at install time and are not changed during upgrades.

## What changed
- Apply vendor and end-user overrides before setting the computed pod log directory.
- Add podLogsDir to every resulting worker profile that does not explicitly set it.
- Preserve a vendor-provided podLogsDir so they can deliberately choose a different location.
- Create the default profile only when no worker profile exists.

## Testing
- go test ./pkg-new/k0s -count=1
- Added dry-run coverage for named vendor profiles, maxPods, and an explicit podLogsDir override.
- The dry-run package cannot link locally because of the existing macOS linker section-size limit.